### PR TITLE
[PR-C1] feat(core): implement semantic identities, kinds, schemas, and shapes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,8 @@ jobs:
     needs: impact
     if: needs.impact.outputs.static_contracts_required == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    # Temporary headroom while the C1 architecture suite is stabilized.
+    timeout-minutes: 15
     env:
       CARGO_INCREMENTAL: 0
       CARGO_PROFILE_TEST_DEBUG: "0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,6 +761,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,7 +810,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -860,8 +878,18 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -921,7 +949,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -1497,6 +1525,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2080,7 +2117,7 @@ dependencies = [
  "mech-timer",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "toml_edit",
  "windows-sys 0.61.2",
@@ -2149,6 +2186,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "sha2 0.11.0",
  "tabled",
 ]
 
@@ -2170,7 +2208,7 @@ dependencies = [
  "num-traits",
  "paste",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "web-time",
 ]
 
@@ -2249,7 +2287,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
  "trybuild",
  "uuid",
@@ -2303,7 +2341,7 @@ dependencies = [
  "mech-string",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3422,7 +3460,7 @@ dependencies = [
  "js-sys",
  "lzma-rust",
  "nt-time",
- "sha2",
+ "sha2 0.10.9",
  "wasm-bindgen",
 ]
 
@@ -3434,7 +3472,7 @@ checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3445,7 +3483,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]

--- a/benchmarks/runtime/gate-b/b2-resident-turn.json
+++ b/benchmarks/runtime/gate-b/b2-resident-turn.json
@@ -1,18 +1,18 @@
 {
   "b1_progression": {
     "limit_multiplier": 1.05,
-    "limit_ns_per_turn": 259.0853160184973,
+    "limit_ns_per_turn": 256.9543830871582,
     "passed": true,
-    "resident_kernel_ns_per_turn": 90.26945949245143,
-    "resident_kernel_ratio": 0.8801083173121869,
-    "resident_kernel_vs_raw_epoch": 0.36583675958041184,
-    "rust_epoch_ns_per_turn": 246.74792001761642,
-    "rust_kernel_ns_per_turn": 102.56630657477537
+    "resident_kernel_ns_per_turn": 100.97939221270673,
+    "resident_kernel_ratio": 0.981049429172642,
+    "resident_kernel_vs_raw_epoch": 0.4126349609198047,
+    "rust_epoch_ns_per_turn": 244.7184600830078,
+    "rust_kernel_ns_per_turn": 102.92997397477379
   },
   "b2_decision": {
     "conditional_attribution": null,
     "decision": "Pass",
-    "executor_tax_ns": 202.0937852074259,
+    "executor_tax_ns": 195.4713425343171,
     "hard_gates": {
       "constant_publication": true,
       "correctness": true,
@@ -25,16 +25,16 @@
       "tail_stability": true,
       "zero_allocation": true
     },
-    "high_epoch_over_low_epoch_median_ratio": 1.0006389195929932,
-    "history_100k_over_history_0_median_ratio": 1.0020690289853063,
-    "history_1k_over_history_0_median_ratio": 1.0003214859048637,
-    "legacy_gap_closure": 0.9945923105078902,
-    "numpy_ratio": 0.014056930367226172,
+    "high_epoch_over_low_epoch_median_ratio": 0.9979227382221013,
+    "history_100k_over_history_0_median_ratio": 1.0063871010852192,
+    "history_1k_over_history_0_median_ratio": 1.0031794571445067,
+    "legacy_gap_closure": 0.9937288493736265,
+    "numpy_ratio": 0.014051982014868352,
     "numpy_target": true,
-    "raw_epoch_ratio": 1.1848660960505937,
-    "recording_tax_ns": 173.67423775432567,
-    "scheduler_tax_ns": 28.419547453100222,
-    "tail_ratio": 1.0015773771153091
+    "raw_epoch_ratio": 1.211395064542612,
+    "recording_tax_ns": 177.63218044443022,
+    "scheduler_tax_ns": 17.839162089886884,
+    "tail_ratio": 1.0005617152848103
   },
   "benchmark_arguments": [
     "cargo",
@@ -57,14 +57,14 @@
     "10000"
   ],
   "derived": {
-    "legacy_denominator_ns_per_turn": 8435.27069163603,
-    "mech_legacy_atomic_ns_per_turn": 8682.018611653646,
+    "legacy_denominator_ns_per_turn": 8249.247665405273,
+    "mech_legacy_atomic_ns_per_turn": 8493.966125488281,
     "positive": true,
-    "rust_epoch_ns_per_turn": 246.74792001761642
+    "rust_epoch_ns_per_turn": 244.7184600830078
   },
   "gate": "B",
-  "git_branch": "perf/runtime-resident-ekf-efficacy",
-  "git_commit": "bb3aa18d77cd8726fc6771b791ebd8cc7dea9fdd",
+  "git_branch": "feat/core-semantic-foundations",
+  "git_commit": "501a40d9b1e634c62d5c8565aa2a14ff9aa13237",
   "lanes": [
     {
       "allocation": {
@@ -99,8 +99,8 @@
         "records_retained_before_timing": 0
       },
       "timing": {
-        "median_ns_per_turn": 8682.018611653646,
-        "p95_ns_per_turn": 8755.59219909668
+        "median_ns_per_turn": 8493.966125488281,
+        "p95_ns_per_turn": 8517.089626736111
       },
       "turns_per_sample": 4096
     },
@@ -137,17 +137,17 @@
         "records_retained_before_timing": 0
       },
       "timing": {
-        "median_ns_per_turn": 34547.00895182292,
-        "p95_ns_per_turn": 34713.677779134116
+        "median_ns_per_turn": 33590.13704427083,
+        "p95_ns_per_turn": 33654.50233968099
       },
       "turns_per_sample": 4096
     },
     {
       "allocation": {
-        "allocated_bytes_per_turn": 568014.171875,
-        "allocations_per_turn": 5047.662353515625,
-        "episode_allocated_bytes": 2326586048,
-        "episode_allocation_count": 20675225
+        "allocated_bytes_per_turn": 568019.9375,
+        "allocations_per_turn": 5047.6923828125,
+        "episode_allocated_bytes": 2326609664,
+        "episode_allocation_count": 20675348
       },
       "correctness": true,
       "instances": 64,
@@ -175,8 +175,8 @@
         "records_retained_before_timing": 0
       },
       "timing": {
-        "median_ns_per_turn": 315144.41931152344,
-        "p95_ns_per_turn": 316674.3144897461
+        "median_ns_per_turn": 307012.6953125,
+        "p95_ns_per_turn": 308058.21536865237
       },
       "turns_per_sample": 4096
     },
@@ -213,8 +213,8 @@
         "records_retained_before_timing": 0
       },
       "timing": {
-        "median_ns_per_turn": 8820.038592529298,
-        "p95_ns_per_turn": 8879.694102478028
+        "median_ns_per_turn": 8431.893379720052,
+        "p95_ns_per_turn": 8455.191897583007
       },
       "turns_per_sample": 4096
     },
@@ -251,8 +251,8 @@
         "records_retained_before_timing": 0
       },
       "timing": {
-        "median_ns_per_turn": 90.26945949245143,
-        "p95_ns_per_turn": 90.67700541728252
+        "median_ns_per_turn": 100.97939221270673,
+        "p95_ns_per_turn": 101.05640817353219
       },
       "turns_per_sample": 4096
     },
@@ -289,8 +289,8 @@
         "records_retained_before_timing": 0
       },
       "timing": {
-        "median_ns_per_turn": 658.670415969122,
-        "p95_ns_per_turn": 662.6643672252836
+        "median_ns_per_turn": 668.7274145943778,
+        "p95_ns_per_turn": 670.2401345214844
       },
       "turns_per_sample": 4096
     },
@@ -327,8 +327,8 @@
         "records_retained_before_timing": 0
       },
       "timing": {
-        "median_ns_per_turn": 5074.559934828016,
-        "p95_ns_per_turn": 5078.158612060547
+        "median_ns_per_turn": 5115.8505472819015,
+        "p95_ns_per_turn": 5117.014921061198
       },
       "turns_per_sample": 4096
     },
@@ -365,8 +365,8 @@
         "records_retained_before_timing": 0
       },
       "timing": {
-        "median_ns_per_turn": 3857.809248352051,
-        "p95_ns_per_turn": 3860.495324707031
+        "median_ns_per_turn": 3863.901032511393,
+        "p95_ns_per_turn": 3865.6957934570314
       },
       "turns_per_sample": 4096
     },
@@ -403,8 +403,8 @@
         "records_retained_before_timing": 0
       },
       "timing": {
-        "median_ns_per_turn": 118.68900694555165,
-        "p95_ns_per_turn": 119.55135901314871
+        "median_ns_per_turn": 118.81855430259361,
+        "p95_ns_per_turn": 118.87546802417653
       },
       "turns_per_sample": 4096
     },
@@ -441,8 +441,8 @@
         "records_retained_before_timing": 0
       },
       "timing": {
-        "median_ns_per_turn": 292.3632446998773,
-        "p95_ns_per_turn": 292.82441179142444
+        "median_ns_per_turn": 296.45073474702383,
+        "p95_ns_per_turn": 296.6172556559245
       },
       "turns_per_sample": 4096
     },
@@ -479,8 +479,8 @@
         "records_retained_before_timing": 0
       },
       "timing": {
-        "median_ns_per_turn": 292.55004130518716,
-        "p95_ns_per_turn": 292.74378769985464
+        "median_ns_per_turn": 295.83492896670384,
+        "p95_ns_per_turn": 297.5053303552052
       },
       "turns_per_sample": 4096
     },
@@ -517,8 +517,8 @@
         "records_retained_before_timing": 1000
       },
       "timing": {
-        "median_ns_per_turn": 292.45723536214854,
-        "p95_ns_per_turn": 292.72996307266715
+        "median_ns_per_turn": 297.39328715360955,
+        "p95_ns_per_turn": 300.0099749805481
       },
       "turns_per_sample": 4096
     },
@@ -555,8 +555,8 @@
         "records_retained_before_timing": 100000
       },
       "timing": {
-        "median_ns_per_turn": 292.96815272739957,
-        "p95_ns_per_turn": 293.2680892944336
+        "median_ns_per_turn": 298.3441955566406,
+        "p95_ns_per_turn": 299.7076424008324
       },
       "turns_per_sample": 4096
     },
@@ -593,8 +593,8 @@
         "records_retained_before_timing": 0
       },
       "timing": {
-        "median_ns_per_turn": 37040.43572998047,
-        "p95_ns_per_turn": 37046.10489501953
+        "median_ns_per_turn": 37019.782958984375,
+        "p95_ns_per_turn": 37402.5133178711
       },
       "turns_per_sample": 4096
     },
@@ -631,8 +631,8 @@
         "records_retained_before_timing": null
       },
       "timing": {
-        "median_ns_per_turn": 20798.5126953125,
-        "p95_ns_per_turn": 20875.262451171875
+        "median_ns_per_turn": 21096.720336914062,
+        "p95_ns_per_turn": 21369.779931640624
       },
       "turns_per_sample": 4096
     },
@@ -669,8 +669,8 @@
         "records_retained_before_timing": null
       },
       "timing": {
-        "median_ns_per_turn": 161391.0421142578,
-        "p95_ns_per_turn": 162486.77113037108
+        "median_ns_per_turn": 163948.9237060547,
+        "p95_ns_per_turn": 164907.5140991211
       },
       "turns_per_sample": 4096
     },
@@ -707,8 +707,8 @@
         "records_retained_before_timing": null
       },
       "timing": {
-        "median_ns_per_turn": 1295971.2575683594,
-        "p95_ns_per_turn": 1302969.670666504
+        "median_ns_per_turn": 1297939.9973144531,
+        "p95_ns_per_turn": 1311197.6252319335
       },
       "turns_per_sample": 4096
     },
@@ -745,8 +745,8 @@
         "records_retained_before_timing": 0
       },
       "timing": {
-        "median_ns_per_turn": 246.74792001761642,
-        "p95_ns_per_turn": 246.99667886305997
+        "median_ns_per_turn": 244.7184600830078,
+        "p95_ns_per_turn": 245.10851117647613
       },
       "turns_per_sample": 4096
     },
@@ -783,8 +783,8 @@
         "records_retained_before_timing": 0
       },
       "timing": {
-        "median_ns_per_turn": 1393.8555859375,
-        "p95_ns_per_turn": 1394.712113647461
+        "median_ns_per_turn": 1366.7692260742188,
+        "p95_ns_per_turn": 1374.1418328857421
       },
       "turns_per_sample": 4096
     },
@@ -821,8 +821,8 @@
         "records_retained_before_timing": 0
       },
       "timing": {
-        "median_ns_per_turn": 10573.925255475726,
-        "p95_ns_per_turn": 10584.814434814452
+        "median_ns_per_turn": 10386.620413208007,
+        "p95_ns_per_turn": 10393.649809265136
       },
       "turns_per_sample": 4096
     },
@@ -859,8 +859,8 @@
         "records_retained_before_timing": 0
       },
       "timing": {
-        "median_ns_per_turn": 34928.34480794271,
-        "p95_ns_per_turn": 35209.873962402344
+        "median_ns_per_turn": 34900.83825683594,
+        "p95_ns_per_turn": 34908.40073649088
       },
       "turns_per_sample": 4096
     },
@@ -897,8 +897,8 @@
         "records_retained_before_timing": 0
       },
       "timing": {
-        "median_ns_per_turn": 102.56630657477537,
-        "p95_ns_per_turn": 102.71644867952847
+        "median_ns_per_turn": 102.92997397477379,
+        "p95_ns_per_turn": 103.03495442245946
       },
       "turns_per_sample": 4096
     },
@@ -935,8 +935,8 @@
         "records_retained_before_timing": 0
       },
       "timing": {
-        "median_ns_per_turn": 775.4906441824777,
-        "p95_ns_per_turn": 801.4443363613552
+        "median_ns_per_turn": 775.723930754485,
+        "p95_ns_per_turn": 776.3695649888781
       },
       "turns_per_sample": 4096
     },
@@ -973,21 +973,21 @@
         "records_retained_before_timing": 0
       },
       "timing": {
-        "median_ns_per_turn": 6181.268360279224,
-        "p95_ns_per_turn": 6273.83397623698
+        "median_ns_per_turn": 6202.690832519531,
+        "p95_ns_per_turn": 6209.535029602051
       },
       "turns_per_sample": 4096
     }
   ],
   "machine": {
     "architecture": "arm64",
-    "identity": "MacBook Air, Mac15,13, Apple M3",
+    "identity": "MacBook Air (Mac15,13), Apple M3, 8 cores, 16 GB",
     "os": "macOS-26.2-arm64-arm-64bit"
   },
   "phase": "B2-resident-turn",
-  "raw_criterion_directory": "/private/tmp/mech-b2-v04/target/criterion",
-  "raw_output": "/private/tmp/mech-b2-v04/target/gate-b-benchmark-runs/bb3aa18d77cd8726fc6771b791ebd8cc7dea9fdd/b0-controls.log",
-  "raw_structural_probe_output": "/private/tmp/mech-b2-v04/target/gate-b-benchmark-runs/bb3aa18d77cd8726fc6771b791ebd8cc7dea9fdd/b0-structural.log",
+  "raw_criterion_directory": "/private/tmp/mech-c1/target/criterion",
+  "raw_output": "/private/tmp/mech-c1/target/gate-b-benchmark-runs/501a40d9b1e634c62d5c8565aa2a14ff9aa13237/b0-controls.log",
+  "raw_structural_probe_output": "/private/tmp/mech-c1/target/gate-b-benchmark-runs/501a40d9b1e634c62d5c8565aa2a14ff9aa13237/b0-structural.log",
   "sample_protocol": {
     "correctness_included_in_timing": false,
     "criterion_sample_size": 10,

--- a/docs/design/value-semantics-and-migration.md
+++ b/docs/design/value-semantics-and-migration.md
@@ -307,11 +307,14 @@ the exact declaration name. Package versions and dependency-source identities
 are excluded so a compatible package release does not silently change durable
 keys. Local crate/dependency aliases and re-export paths are excluded: every
 re-export resolves back to the defining declaration before path construction.
-Duplicate package names elsewhere in the Cargo resolution do not invalidate a
-nominal identity. A collision is rejected before `NominalKey` construction
-only when more than one resolved package with the same declared name defines a
-nominal declaration reachable in the current compilation. A filesystem path
-or process-local numeric hash is never a nominal identity.
+Only nominal declarations included in one `ProgramArtifact` participate in
+collision detection. Declarations are grouped by complete
+`CanonicalNominalPath`; the same full path from two distinct Cargo package IDs
+is `AmbiguousNominalDeclarationV1`, while different full paths from same-name
+packages are legal. Duplicate dependency names elsewhere in `Cargo.lock` are
+irrelevant. A Cargo package ID is only an internal collision discriminator and
+is never encoded in `NominalKey`. A filesystem path or process-local numeric
+hash is never a nominal identity.
 
 The checked-in golden-vector document is independently frozen by the canonical
 JSON SHA-256 `0be9531a4514ef359bedc3172f6ea327c28bcaab0fa493d9725d430799343a9f`,

--- a/scripts/check-gate-b-contract.py
+++ b/scripts/check-gate-b-contract.py
@@ -18,6 +18,7 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 GATE_B_DIR = ROOT / "benchmarks/runtime/gate-b"
+B2_EVIDENCE_FLOOR = "d5e41f6fd43c9d21c5858d80dab50e7ce64e9a10"
 TRACE_SHA256 = "ab901e1d115aa92166dc2a6d45a28732e6a548363b829997aa410ae4c2d77c8b"
 REFERENCE_HASH = "ddca8ab17cb390839d4c77e7cecc5203122f249685f5a28c36fd342cf303a758"
 EPISODE_LENGTH = 4_096
@@ -35,6 +36,22 @@ THREAD_VARIABLES = (
 
 def read_text(path: Path) -> str:
     return path.read_text(encoding="utf-8")
+
+
+def commit_descends_from(
+    commit: str,
+    floor: str = B2_EVIDENCE_FLOOR,
+    root: Path = ROOT,
+) -> bool:
+    """Return whether commit exists and is a descendant of the frozen B2 floor."""
+    result = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", floor, commit],
+        cwd=root,
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return result.returncode == 0
 
 
 def import_roots(source: str) -> set[str]:
@@ -485,6 +502,8 @@ def static_contract_errors(root: Path = ROOT) -> list[str]:
         "git\", \"merge-base",
         "MECH_GATE_B_STRUCTURAL_ONLY",
         "legacy_denominator",
+        f'B2_EVIDENCE_FLOOR = "{B2_EVIDENCE_FLOOR}"',
+        'choices=("B2-resident-turn",)',
     ):
         if frozen not in runner:
             errors.append(f"Gate B runner attribution/fairness contract lost: {frozen}")
@@ -671,13 +690,24 @@ def report_contract_errors(
                     errors.append(f"raw epoch {instances} reports wrong {field}")
 
     if report["phase"] in {"B1-resident-kernel", "B2-resident-turn"}:
-        expected_branch = (
-            "feat/engine-resident-ekf-substrate"
-            if report["phase"] == "B1-resident-kernel"
-            else "perf/runtime-resident-ekf-efficacy"
-        )
-        if report["git_branch"] != expected_branch:
+        if (
+            report["phase"] == "B1-resident-kernel"
+            and report["git_branch"] != "feat/engine-resident-ekf-substrate"
+        ):
             errors.append("B1 evidence is attributed to the wrong branch")
+        if (
+            report["phase"] == "B2-resident-turn"
+            and report["git_branch"] != "perf/runtime-resident-ekf-efficacy"
+        ):
+            if expected_commit is None:
+                errors.append(
+                    "B2 descendant refresh evidence requires an exact expected commit"
+                )
+            elif not commit_descends_from(commit):
+                errors.append(
+                    f"B2 descendant refresh commit {commit} does not descend from "
+                    f"the frozen evidence floor {B2_EVIDENCE_FLOOR}"
+                )
         for instances in SCALED_INSTANCES:
             key = ("mech-resident-kernel", instances, 0, 1)
             if key not in lanes:

--- a/scripts/check-value-system-contract.py
+++ b/scripts/check-value-system-contract.py
@@ -42,6 +42,48 @@ CANONICAL_REFERENCE_PATH = ROOT / "scripts/tests/canonical_encoding_v1_reference
 EXPECTED_LEGACY_SCANNER_SHA256 = (
     "9624eb89c01085cc5e412506b30671f442ba53b057c228b3fbcd113cc77ad834"
 )
+EXPECTED_HASH_CONTRACTS_V1 = {
+    "NominalKey": {
+        "algorithm": "SHA-256",
+        "bytes": 32,
+        "domain_separator_utf8": "mech-nominal-v1\0",
+        "input": [
+            "domain-separator",
+            "U8-nominal-kind-tag",
+            "U32-segment-count",
+            "each-segment-as-Utf8",
+        ],
+    },
+    "SchemaKey": {
+        "algorithm": "SHA-256",
+        "bytes": 32,
+        "domain_separator_utf8": "mech-schema-v1\0",
+        "input": ["domain-separator", "canonical-schema-bytes"],
+    },
+    "KeyHash": {
+        "algorithm": "SHA-256",
+        "bytes": 32,
+        "domain_separator_utf8": "mech-key-v1\0",
+        "input": [
+            "domain-separator",
+            "SchemaKey",
+            "canonical-shape-bytes",
+            "canonical-key-payload-bytes",
+        ],
+    },
+    "ValueHash": {
+        "algorithm": "SHA-256",
+        "bytes": 32,
+        "domain_separator_utf8": "mech-value-v1\0",
+        "durability": "durable-snapshot-identity",
+        "input": [
+            "domain-separator",
+            "SchemaKey",
+            "canonical-shape-bytes",
+            "canonical-payload-bytes",
+        ],
+    },
+}
 
 
 def load_module(name: str, path: Path):
@@ -2017,6 +2059,11 @@ def canonical_encoding_failures(
         "TypeOf": 17,
     }
     schema_checks = (
+        (
+            "complete hash contracts",
+            canonical.get("hashes"),
+            EXPECTED_HASH_CONTRACTS_V1,
+        ),
         (
             "SchemaKey hash contract",
             canonical.get("hashes", {}).get("SchemaKey"),

--- a/scripts/check-value-system-contract.py
+++ b/scripts/check-value-system-contract.py
@@ -1379,6 +1379,19 @@ def production_corpus(root: Path) -> Iterable[tuple[Path, str]]:
         yield path, GENERATOR.production_source(source)
 
 
+def analyzed_production_corpus(
+    root: Path,
+) -> list[tuple[Path, str, str, list[Any]]]:
+    """Read, mask, and tokenize each production source exactly once per audit."""
+    analyzed: list[tuple[Path, str, str, list[Any]]] = []
+    for path, source in production_corpus(root):
+        searchable = GENERATOR.mask_non_code(source)
+        analyzed.append(
+            (path, source, searchable, GENERATOR.rust_tokens(source, searchable))
+        )
+    return analyzed
+
+
 def local_conversion_aliases(tokens: list[Any]) -> dict[str, set[str]]:
     return GENERATOR.LEGACY_SCANNER.transparent_conversion_aliases(tokens)
 
@@ -1456,15 +1469,685 @@ def module_file_or_descendant(root: Path, resolved: Path, name: str) -> bool:
     return resolved == file_path or directory in resolved.parents
 
 
+FINALIZED_SEMANTIC_SERDE_TYPES = {
+    "src/core/src/nominal.rs": {"CanonicalNominalPath"},
+    "src/core/src/dimension.rs": {"DimensionParameter"},
+    "src/core/src/kind_scheme.rs": {"KindScheme"},
+    "src/core/src/schema/mod.rs": {"Schema"},
+    "src/core/src/schema/shape.rs": {"ShapeInstance"},
+}
+OPEN_SEMANTIC_SERDE_TYPES = {
+    "src/core/src/dimension.rs": {
+        "DimensionExpr",
+        "DimensionParameterDeclaration",
+    },
+    "src/core/src/kind_expr.rs": {"KindExpr"},
+    "src/core/src/kind_scheme.rs": {
+        "KindParameter",
+        "InputKindScheme",
+        "KindConstraint",
+    },
+    "src/core/src/schema/mod.rs": {"SchemaDraft", "SchemaBody"},
+}
+NON_SERDE_SEMANTIC_TYPES = {
+    "src/core/src/schema/table.rs": {"SchemaHandle"},
+}
+FINALIZED_SEMANTIC_TYPE_NAMES = set().union(
+    *FINALIZED_SEMANTIC_SERDE_TYPES.values(),
+    *NON_SERDE_SEMANTIC_TYPES.values(),
+)
+STANDARD_INTERIOR_MUTABILITY_IDENTIFIERS = {
+    "UnsafeCell",
+    "SyncUnsafeCell",
+    "Cell",
+    "RefCell",
+    "OnceCell",
+    "LazyCell",
+    "Mutex",
+    "RwLock",
+    "Once",
+    "OnceLock",
+    "LazyLock",
+    "Barrier",
+    "Condvar",
+    "AtomicBool",
+    "AtomicI8",
+    "AtomicI16",
+    "AtomicI32",
+    "AtomicI64",
+    "AtomicI128",
+    "AtomicIsize",
+    "AtomicU8",
+    "AtomicU16",
+    "AtomicU32",
+    "AtomicU64",
+    "AtomicU128",
+    "AtomicUsize",
+    "AtomicPtr",
+}
+SEMANTIC_FORBIDDEN_IDENTIFIERS = STANDARD_INTERIOR_MUTABILITY_IDENTIFIERS | {
+    "Kind",
+    "Value",
+    "ValueKind",
+    "Ref",
+    "ValRef",
+    "MutableReference",
+    "ReactiveCellId",
+    "ValueStateJournal",
+    "ReactiveTurnJournal",
+    "RuntimeExecutionTransaction",
+    "StateArena",
+    "nalgebra",
+    "DMatrix",
+}
+
+
+def rust_type_identifiers(tokens: Iterable[Any]) -> set[str]:
+    return {
+        GENERATOR.canonical_identifier(token.value)
+        for token in tokens
+        if re.fullmatch(r"(?:r#)?[A-Za-z_][A-Za-z0-9_]*", token.value)
+    }
+
+
+def field_type_dependencies(tokens: list[Any]) -> set[str]:
+    dependencies: set[str] = set()
+    for field in GENERATOR.LEGACY_SCANNER.split_top_level_tokens(tokens):
+        colon = next(
+            (index for index, token in enumerate(field) if token.value == ":"),
+            None,
+        )
+        field_type = field[colon + 1 :] if colon is not None else field
+        dependencies.update(rust_type_identifiers(field_type))
+    return dependencies
+
+
+def declared_type_dependencies(tokens: list[Any]) -> dict[str, set[str]]:
+    declarations: dict[str, set[str]] = {}
+    for alias in GENERATOR.LEGACY_SCANNER.type_alias_declarations(tokens):
+        if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", alias.name) is None:
+            continue
+        declarations.setdefault(alias.name, set()).update(
+            rust_type_identifiers(alias.rhs) - set(alias.parameters)
+        )
+
+    offset = 0
+    while offset + 1 < len(tokens):
+        declaration_kind = GENERATOR.canonical_identifier(tokens[offset].value)
+        if declaration_kind not in {"struct", "enum", "union"}:
+            offset += 1
+            continue
+        name_token = tokens[offset + 1]
+        if re.fullmatch(r"(?:r#)?[A-Za-z_][A-Za-z0-9_]*", name_token.value) is None:
+            offset += 1
+            continue
+        name = GENERATOR.canonical_identifier(name_token.value)
+        opening = next(
+            (
+                index
+                for index in range(offset + 2, len(tokens))
+                if tokens[index].value in {"{", "(", ";"}
+            ),
+            None,
+        )
+        if opening is None or tokens[opening].value == ";":
+            offset += 2
+            continue
+        delimiter = tokens[opening].value
+        closing = GENERATOR.balanced_token_end(
+            tokens, opening, delimiter, "}" if delimiter == "{" else ")"
+        )
+        if closing is None:
+            offset += 2
+            continue
+        body = list(tokens[opening + 1 : closing])
+        dependencies: set[str] = set()
+        if declaration_kind in {"struct", "union"}:
+            dependencies = field_type_dependencies(body)
+        else:
+            for variant in GENERATOR.LEGACY_SCANNER.split_top_level_tokens(body):
+                payload = next(
+                    (
+                        index
+                        for index, token in enumerate(variant[1:], start=1)
+                        if token.value in {"(", "{"}
+                    ),
+                    None,
+                )
+                if payload is None:
+                    continue
+                payload_delimiter = variant[payload].value
+                payload_end = GENERATOR.balanced_token_end(
+                    variant,
+                    payload,
+                    payload_delimiter,
+                    "}" if payload_delimiter == "{" else ")",
+                )
+                if payload_end is None:
+                    continue
+                payload_tokens = list(variant[payload + 1 : payload_end])
+                dependencies.update(
+                    field_type_dependencies(payload_tokens)
+                    if payload_delimiter == "{"
+                    else rust_type_identifiers(payload_tokens)
+                )
+        declarations.setdefault(name, set()).update(dependencies)
+        offset = closing + 1
+    return declarations
+
+
+def finalized_semantic_type_aliases(
+    corpus: list[tuple[Path, str, str, list[Any]]],
+) -> set[str]:
+    """Resolve aliases and renamed imports that denote a finalized C1 type."""
+    declarations: dict[str, set[str]] = {}
+    for _path, _source, _searchable, tokens in corpus:
+        for alias in GENERATOR.LEGACY_SCANNER.type_alias_declarations(tokens):
+            declarations.setdefault(alias.name, set()).update(
+                rust_type_identifiers(alias.rhs) - set(alias.parameters)
+            )
+        for binding in GENERATOR.LEGACY_SCANNER.use_bindings(tokens):
+            if binding.path and not binding.glob:
+                declarations.setdefault(binding.local, set()).add(binding.path[-1])
+
+    aliases = set(FINALIZED_SEMANTIC_TYPE_NAMES)
+    changed = True
+    while changed:
+        changed = False
+        for name, dependencies in declarations.items():
+            if name not in aliases and dependencies & aliases:
+                aliases.add(name)
+                changed = True
+    return aliases
+
+
+def manual_deserialize_impls(
+    tokens: list[Any], target_aliases: set[str]
+) -> list[tuple[int, str, str]]:
+    """Find Deserialize implementations whose self type is a finalized C1 type."""
+    trait_aliases = GENERATOR.LEGACY_SCANNER.imported_trait_aliases(
+        tokens, {"Deserialize"}
+    )
+    implementations: list[tuple[int, str, str]] = []
+    for opening, token in enumerate(tokens):
+        if token.value != "impl":
+            continue
+        index = opening + 1
+        if index < len(tokens) and tokens[index].value == "<":
+            generic_end = GENERATOR.balanced_token_end(tokens, index, "<", ">")
+            if generic_end is None:
+                continue
+            index = generic_end + 1
+        header_end = index
+        while header_end < len(tokens) and tokens[header_end].value not in {"{", ";"}:
+            header_end += 1
+        for_indexes = [
+            position
+            for position in range(index, header_end)
+            if tokens[position].value == "for"
+        ]
+        if not for_indexes:
+            continue
+        for_index = for_indexes[-1]
+
+        trait_tokens = list(tokens[index:for_index])
+        if any(item.value == "!" for item in trait_tokens):
+            continue
+        trait_generic = next(
+            (
+                position
+                for position, item in enumerate(trait_tokens)
+                if item.value == "<"
+            ),
+            len(trait_tokens),
+        )
+        trait_names = [
+            GENERATOR.canonical_identifier(item.value)
+            for item in trait_tokens[:trait_generic]
+            if re.fullmatch(r"(?:r#)?[A-Za-z_][A-Za-z0-9_]*", item.value)
+        ]
+        if not trait_names or trait_names[-1] not in trait_aliases:
+            continue
+
+        self_end = for_index + 1
+        while self_end < header_end and tokens[self_end].value != "where":
+            self_end += 1
+        self_tokens = GENERATOR.LEGACY_SCANNER.strip_outer_parentheses(
+            tokens[for_index + 1 : self_end]
+        )
+        self_generic = next(
+            (
+                position
+                for position, item in enumerate(self_tokens)
+                if item.value == "<"
+            ),
+            len(self_tokens),
+        )
+        self_names = [
+            GENERATOR.canonical_identifier(item.value)
+            for item in self_tokens[:self_generic]
+            if re.fullmatch(r"(?:r#)?[A-Za-z_][A-Za-z0-9_]*", item.value)
+        ]
+        if not self_names or self_names[-1] not in target_aliases:
+            continue
+        implementations.append(
+            (
+                token.line,
+                self_names[-1],
+                " ".join(item.value for item in tokens[opening:header_end]),
+            )
+        )
+    return implementations
+
+
+def transitive_semantic_forbidden_names(
+    corpus: list[tuple[Path, str, str, list[Any]]],
+) -> set[str]:
+    declarations: dict[str, set[str]] = {}
+    for _path, _source, _searchable, tokens in corpus:
+        local = declared_type_dependencies(tokens)
+        for name, dependencies in local.items():
+            declarations.setdefault(name, set()).update(dependencies)
+        for binding in GENERATOR.LEGACY_SCANNER.use_bindings(tokens):
+            if (
+                binding.path
+                and not binding.glob
+                and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", binding.local)
+                and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", binding.path[-1])
+            ):
+                declarations.setdefault(binding.local, set()).add(binding.path[-1])
+
+    forbidden = set(SEMANTIC_FORBIDDEN_IDENTIFIERS)
+    changed = True
+    while changed:
+        changed = False
+        for name, dependencies in declarations.items():
+            if name not in forbidden and dependencies & forbidden:
+                forbidden.add(name)
+                changed = True
+    return forbidden
+
+
+def semantic_serde_attribute(source: str, type_name: str) -> str | None:
+    declaration = re.search(rf"\bpub\s+(?:struct|enum)\s+{type_name}\b", source)
+    if declaration is None:
+        return None
+    attribute_start = source.rfind(
+        '#[cfg_attr(feature = "serde", derive(', 0, declaration.start()
+    )
+    if attribute_start < 0:
+        return ""
+    attribute_end = source.find(")]", attribute_start, declaration.start())
+    if attribute_end < 0:
+        return ""
+    return source[attribute_start : attribute_end + 2]
+
+
+def semantic_builder_segment(
+    searchable: str, start_marker: str, end_marker: str
+) -> str | None:
+    start = searchable.find(start_marker)
+    if start < 0:
+        return None
+    end = searchable.find(end_marker, start + len(start_marker))
+    return searchable[start:] if end < 0 else searchable[start:end]
+
+
+def skip_outer_attributes(source: str, offset: int) -> int:
+    while True:
+        whitespace = re.match(r"\s*", source[offset:])
+        assert whitespace is not None
+        offset += whitespace.end()
+        if offset >= len(source) or source[offset] != "#":
+            return offset
+        attribute = offset + 1
+        while attribute < len(source) and source[attribute].isspace():
+            attribute += 1
+        if attribute < len(source) and source[attribute] == "!":
+            attribute += 1
+            while attribute < len(source) and source[attribute].isspace():
+                attribute += 1
+        if attribute >= len(source) or source[attribute] != "[":
+            return offset
+        depth = 1
+        attribute += 1
+        while attribute < len(source) and depth:
+            if source[attribute] == "[":
+                depth += 1
+            elif source[attribute] == "]":
+                depth -= 1
+            attribute += 1
+        if depth:
+            return offset
+        offset = attribute
+
+
+def top_level_character_positions(source: str, character: str) -> list[int]:
+    depths = {"(": 0, "[": 0, "{": 0}
+    closers = {")": "(", "]": "[", "}": "{"}
+    positions: list[int] = []
+    for offset, current in enumerate(source):
+        if current in depths:
+            depths[current] += 1
+        elif current in closers:
+            opening = closers[current]
+            if depths[opening]:
+                depths[opening] -= 1
+        elif current == character and not any(depths.values()):
+            positions.append(offset)
+    return positions
+
+
+def strip_outer_pattern_parentheses(pattern: str) -> str:
+    result = pattern.strip()
+    while result.startswith("("):
+        depth = 0
+        closing = None
+        for offset, character in enumerate(result):
+            if character == "(":
+                depth += 1
+            elif character == ")":
+                depth -= 1
+                if depth == 0:
+                    closing = offset
+                    break
+        if closing != len(result) - 1:
+            break
+        result = result[1:-1].strip()
+    return result
+
+
+def pattern_has_top_level_guard(pattern: str) -> bool:
+    depths = {"(": 0, "[": 0, "{": 0}
+    closers = {")": "(", "]": "[", "}": "{"}
+    offset = 0
+    while offset < len(pattern):
+        character = pattern[offset]
+        if character in depths:
+            depths[character] += 1
+            offset += 1
+            continue
+        if character in closers:
+            opening = closers[character]
+            if depths[opening]:
+                depths[opening] -= 1
+            offset += 1
+            continue
+        if not any(depths.values()) and (character.isalpha() or character == "_"):
+            end = offset + 1
+            while end < len(pattern) and (
+                pattern[end].isalnum() or pattern[end] == "_"
+            ):
+                end += 1
+            if pattern[offset:end] == "if" and pattern[max(0, offset - 2) : offset] != "r#":
+                return True
+            offset = end
+            continue
+        offset += 1
+    return False
+
+
+def irrefutable_pattern(pattern: str) -> bool:
+    candidate = strip_outer_pattern_parentheses(pattern)
+    separators = top_level_character_positions(candidate, "|")
+    alternatives = [
+        candidate[start:end].strip()
+        for start, end in zip(
+            [0, *(position + 1 for position in separators)],
+            [*separators, len(candidate)],
+        )
+        if candidate[start:end].strip()
+    ]
+    if separators:
+        return any(irrefutable_pattern(alternative) for alternative in alternatives)
+
+    bindings = top_level_character_positions(candidate, "@")
+    if bindings:
+        binding = bindings[0]
+        left = re.sub(r"^(?:(?:ref|mut)\s+)+", "", candidate[:binding].strip())
+        return bool(
+            re.fullmatch(r"(?:r#)?[a-z_][A-Za-z0-9_]*", left)
+            and irrefutable_pattern(candidate[binding + 1 :])
+        )
+
+    candidate = re.sub(r"^(?:(?:ref|mut)\s+)+", "", candidate).strip()
+    return bool(
+        candidate == "_"
+        or re.fullmatch(r"(?:r#)?[a-z_][A-Za-z0-9_]*", candidate)
+    )
+
+
+def match_arm_pattern(source: str, offset: int) -> tuple[str, int] | None:
+    start = skip_outer_attributes(source, offset)
+    depths = {"(": 0, "[": 0, "{": 0}
+    closers = {")": "(", "]": "[", "}": "{"}
+    cursor = start
+    while cursor < len(source):
+        character = source[cursor]
+        if character in depths:
+            depths[character] += 1
+        elif character in closers:
+            opening = closers[character]
+            if depths[opening]:
+                depths[opening] -= 1
+            elif character == "}":
+                return None
+        elif not any(depths.values()):
+            if character == "=" and cursor + 1 < len(source) and source[cursor + 1] == ">":
+                return source[start:cursor].strip(), start
+            if character in {",", ";"}:
+                return None
+        cursor += 1
+    return None
+
+
+def legacy_adapter_catch_all(source: str) -> int | None:
+    for boundary in re.finditer(r"^|[,{}]", source, re.MULTILINE):
+        arm = match_arm_pattern(source, boundary.end())
+        if arm is None:
+            continue
+        pattern, offset = arm
+        if not pattern_has_top_level_guard(pattern) and irrefutable_pattern(pattern):
+            return offset
+    return None
+
+
 def future_boundary_failures(root: Path) -> list[Failure]:
     root = root.resolve()
     failures: list[Failure] = []
     schema_dependency = re.compile(r"\b(?:mech_runtime|mech_engine|crate::runtime|crate::engine)\b")
-    for path, source in production_corpus(root):
+    corpus = analyzed_production_corpus(root)
+    semantic_forbidden_names = transitive_semantic_forbidden_names(corpus)
+    finalized_type_aliases = finalized_semantic_type_aliases(corpus)
+    for path, source, searchable, tokens in corpus:
         resolved = path.resolve()
         relative = path.relative_to(root).as_posix()
-        searchable = GENERATOR.mask_non_code(source)
-        tokens = GENERATOR.rust_tokens(source, searchable)
+        for line, type_name, implementation in manual_deserialize_impls(
+            tokens, finalized_type_aliases
+        ):
+            failures.append(
+                failure(
+                    "C1-FINALIZED-SERDE-BOUNDARY",
+                    type_name,
+                    relative,
+                    "no Deserialize implementation; construction requires the validated API",
+                    implementation,
+                    "src/core/tests/semantic_serde_contract.rs",
+                    line,
+                )
+            )
+        for type_name in FINALIZED_SEMANTIC_SERDE_TYPES.get(relative, set()):
+            attribute = semantic_serde_attribute(source, type_name)
+            if attribute is not None and attribute != '#[cfg_attr(feature = "serde", derive(Serialize))]':
+                failures.append(
+                    failure(
+                        "C1-FINALIZED-SERDE-BOUNDARY",
+                        type_name,
+                        relative,
+                        "Serialize only; construction requires the validated API",
+                        attribute or "missing serde derive",
+                        "src/core/tests/semantic_serde_contract.rs",
+                    )
+                )
+        for type_name in OPEN_SEMANTIC_SERDE_TYPES.get(relative, set()):
+            attribute = semantic_serde_attribute(source, type_name)
+            if attribute is not None and attribute != '#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]':
+                failures.append(
+                    failure(
+                        "C1-OPEN-SERDE-BOUNDARY",
+                        type_name,
+                        relative,
+                        "Serialize + Deserialize on open semantic syntax",
+                        attribute or "missing serde derive",
+                        "src/core/tests/semantic_serde_contract.rs",
+                    )
+                )
+        for type_name in NON_SERDE_SEMANTIC_TYPES.get(relative, set()):
+            attribute = semantic_serde_attribute(source, type_name)
+            if attribute:
+                failures.append(
+                    failure(
+                        "C1-EPHEMERAL-HANDLE-SERDE-BOUNDARY",
+                        type_name,
+                        relative,
+                        "no standalone Serde construction for builder-local handles",
+                        attribute,
+                        "src/core/tests/schema_contract.rs",
+                    )
+                )
+        builder_spec = {
+            "src/core/src/dimension.rs": (
+                "pub fn declare(",
+                "pub fn declarations(",
+                "Result<DimensionParameterId, SemanticModelError>",
+            ),
+            "src/core/src/schema/table.rs": (
+                "pub fn insert(",
+                "pub fn finish(",
+                "Result<SchemaHandle, SemanticModelError>",
+            ),
+        }.get(relative)
+        if builder_spec is not None:
+            start_marker, end_marker, result_type = builder_spec
+            segment = semantic_builder_segment(searchable, start_marker, end_marker)
+            if segment is not None:
+                panic_api = re.search(r"\b(?:assert|panic)\s*!|\.\s*expect\s*\(", segment)
+                compact_segment = "".join(segment.split())
+                compact_result = "".join(result_type.split())
+                if panic_api is not None or compact_result not in compact_segment:
+                    actual = (
+                        panic_api.group(0)
+                        if panic_api is not None
+                        else "missing structured Result signature"
+                    )
+                    failures.append(
+                        failure(
+                            "C1-SEMANTIC-BUILDER-ERROR",
+                            start_marker,
+                            relative,
+                            f"{result_type} without assert!/panic!/expect",
+                            actual,
+                            "src/core/tests/dimension_contract.rs",
+                        )
+                    )
+        c1_semantic_module = any(
+            module_file_or_descendant(root, resolved, name)
+            for name in (
+                "semantic_identity",
+                "nominal",
+                "dimension",
+                "kind_expr",
+                "kind_scheme",
+                "schema",
+            )
+        )
+        if c1_semantic_module:
+            direct_forbidden = next(
+                (
+                    token
+                    for token in tokens
+                    if GENERATOR.canonical_identifier(token.value)
+                    in SEMANTIC_FORBIDDEN_IDENTIFIERS
+                ),
+                None,
+            )
+            declared_dependencies = set().union(
+                *declared_type_dependencies(tokens).values()
+            )
+            imported_dependencies = {
+                binding.local
+                for binding in GENERATOR.LEGACY_SCANNER.use_bindings(tokens)
+                if binding.path
+                and not binding.glob
+                and binding.path[-1] in semantic_forbidden_names
+            }
+            transitive_forbidden = next(
+                iter(
+                    sorted(
+                        (declared_dependencies | imported_dependencies)
+                        & (semantic_forbidden_names - SEMANTIC_FORBIDDEN_IDENTIFIERS)
+                    )
+                ),
+                None,
+            )
+            physical = re.search(
+                r"\bbuffer\s+strategy\b|\bstride\b|\bcapacity\b", searchable
+            )
+            if direct_forbidden is not None or transitive_forbidden is not None or physical is not None:
+                symbol = (
+                    direct_forbidden.value
+                    if direct_forbidden is not None
+                    else transitive_forbidden
+                    if transitive_forbidden is not None
+                    else physical.group(0)
+                )
+                transitive_token = (
+                    next(
+                        (
+                            token
+                            for token in tokens
+                            if GENERATOR.canonical_identifier(token.value)
+                            == transitive_forbidden
+                        ),
+                        None,
+                    )
+                    if transitive_forbidden is not None
+                    else None
+                )
+                failures.append(
+                    failure(
+                        "C1-SEMANTIC-BOUNDARY",
+                        symbol,
+                        relative,
+                        "semantic model independent of mutable values, resident state, and physical layout",
+                        "forbidden production dependency",
+                        "src/core/src/legacy_adapter/",
+                        direct_forbidden.line
+                        if direct_forbidden is not None
+                        else transitive_token.line
+                        if transitive_token is not None
+                        else source.count("\n", 0, physical.start()) + 1,
+                        direct_forbidden.column
+                        if direct_forbidden is not None
+                        else transitive_token.column
+                        if transitive_token is not None
+                        else None,
+                    )
+                )
+        if module_file_or_descendant(root, resolved, "legacy_adapter"):
+            catch_all = legacy_adapter_catch_all(searchable)
+            if catch_all is not None:
+                failures.append(
+                    failure(
+                        "C1-LEGACY-ADAPTER-EXHAUSTIVE",
+                        "catch-all match arm",
+                        relative,
+                        "explicit outcome for every current Kind and ValueKind variant",
+                        "binding or wildcard fallback",
+                        "src/core/src/legacy_adapter/",
+                        source.count("\n", 0, catch_all) + 1,
+                    )
+                )
         if module_file_or_descendant(root, resolved, "snapshot"):
             resolver = GENERATOR.LEGACY_SCANNER.TransparentTypeResolver(
                 tokens, relative=relative
@@ -1552,6 +2235,52 @@ def future_boundary_failures(root: Path) -> list[Failure]:
                     "tests/architecture/value-system/migration.json",
                 )
             )
+    canonical_test = root / "src/core/tests/canonical_schema_vectors.rs"
+    if canonical_test.is_file():
+        canonical_source = canonical_test.read_text(encoding="utf-8")
+        for marker in (".finalize()", ".instantiate_shape("):
+            if marker not in canonical_source:
+                failures.append(
+                    failure(
+                        "C1-FINALIZED-CONSTRUCTION",
+                        marker,
+                        canonical_test.relative_to(root).as_posix(),
+                        "canonical conformance constructs finalized values through validation APIs",
+                        "validation marker absent",
+                        "src/core/tests/semantic_serde_contract.rs",
+                    )
+                )
+    validation_routes = {
+        "src/core/src/kind_expr.rs": (
+            "validate_kind_structure(kind)?;",
+            "KindNameCategory::RecordField",
+            "KindNameCategory::TableColumn",
+        ),
+        "src/core/src/kind_scheme.rs": ("validate_kind_structure(kind)?;",),
+        "src/core/src/legacy_adapter/kind.rs": (
+            "validate_legacy_kind_resolution(&kind, &dimension_parameters)?;",
+            "canonicalize_dimension_environment(declarations, &all_declarations)?;",
+            "normalize_dimension(dimension, declarations.len())",
+        ),
+        "src/core/src/schema/shape.rs": (".checked_mul(extent)",),
+    }
+    for relative, markers in validation_routes.items():
+        path = root / relative
+        if not path.is_file():
+            continue
+        source = path.read_text(encoding="utf-8")
+        for marker in markers:
+            if marker not in source:
+                failures.append(
+                    failure(
+                        "C1-VALIDATED-CONSTRUCTION-ROUTE",
+                        marker,
+                        relative,
+                        "C1 semantic construction retains every validated entry route",
+                        "validation marker absent",
+                        "src/core/tests/semantic_serde_contract.rs",
+                    )
+                )
     return failures
 
 

--- a/scripts/check-value-system-contract.py
+++ b/scripts/check-value-system-contract.py
@@ -2037,7 +2037,7 @@ def canonical_encoding_failures(
             "nominal path segment derivation",
             canonical.get("nominal_identity", {}).get("segment_derivation"),
             {
-                "collision_rule": "duplicate-resolved-package-names-are-rejected-only-when-more-than-one-such-package-defines-a-nominal-declaration-reachable-in-the-current-compilation",
+                "collision_rule": "same-complete-CanonicalNominalPath-from-distinct-Cargo-package-IDs-in-one-ProgramArtifact-is-AmbiguousNominalDeclarationV1",
                 "crate_aliases": "excluded",
                 "module_source": "defining-module-canonical-namespace-relative-to-package-root",
                 "package_name_source": "resolved-package-manifest-declared-name-exact-Utf8",

--- a/scripts/check-value-system-contract.py
+++ b/scripts/check-value-system-contract.py
@@ -137,15 +137,6 @@ DESTINATIONS = {
     "legacy-dispatch",
     "rejected-legacy-form",
 }
-STATUS_EXPECTED = {
-    "inventoried": True,
-    "semantics_frozen": True,
-    "implemented": False,
-    "artifact_migrated": False,
-    "ports_migrated": False,
-    "resident_storage_migrated": False,
-    "legacy_removed": False,
-}
 IMPLEMENTATION_GATES = {"C1", "C2", "C3", "C4", "D", "final-cutover"}
 AMBIGUOUS_TARGET = re.compile(
     r"-or-|\beither\b|\bone-of\b|\b(?:tbd|unknown|unclassified|maybe)\b",
@@ -160,6 +151,18 @@ TARGET_PROJECTION_FIELDS = (
     "key_semantics",
     "runtime_storage",
 )
+
+
+def expected_target_status(target: dict[str, Any]) -> dict[str, bool]:
+    return {
+        "inventoried": True,
+        "semantics_frozen": True,
+        "implemented": target["implementation_gate"] == "C1",
+        "artifact_migrated": False,
+        "ports_migrated": False,
+        "resident_storage_migrated": False,
+        "legacy_removed": False,
+    }
 
 
 @dataclass(frozen=True)
@@ -436,13 +439,14 @@ def family_contract_failures(
                         f"{migration_path}:families[{identifier}].targets",
                     )
                 )
-            if target.get("status") != STATUS_EXPECTED:
+            expected_status = expected_target_status(target)
+            if target.get("status") != expected_status:
                 failures.append(
                     failure(
                         "C0-TARGET-STATUS",
                         target_id,
                         str(migration_path),
-                        repr(STATUS_EXPECTED),
+                        repr(expected_status),
                         repr(target.get("status")),
                         f"{migration_path}:families[{identifier}].targets",
                     )

--- a/scripts/run-gate-b-benchmarks.py
+++ b/scripts/run-gate-b-benchmarks.py
@@ -24,6 +24,7 @@ FROZEN_B1_BRANCH = "feat/engine-resident-ekf-substrate"
 FROZEN_B1_BASE = "c4f7cb1d27b9645b3f669d944c7e49bcd0829ccc"
 B2_BRANCH = "perf/runtime-resident-ekf-efficacy"
 FROZEN_B2_BASE = "75d0775209c8ee0eae5480facba3a9b2c9c12143"
+B2_EVIDENCE_FLOOR = "d5e41f6fd43c9d21c5858d80dab50e7ce64e9a10"
 EPISODE_LENGTH = 4_096
 SCALED_INSTANCES = (1, 8, 64)
 THREAD_VARIABLES = (
@@ -690,12 +691,17 @@ def worktree_changes() -> str:
     return command_output(["git", "status", "--porcelain=v1", "--untracked-files=all"])
 
 
-def frozen_base_error(commit: str, branch: str) -> str | None:
-    expected_base = {
-        FROZEN_B0_BRANCH: FROZEN_BASE,
-        FROZEN_B1_BRANCH: FROZEN_B1_BASE,
-        B2_BRANCH: FROZEN_B2_BASE,
-    }.get(branch)
+def frozen_base_error(
+    commit: str, branch: str, phase: str | None = None
+) -> str | None:
+    if phase == "B2-resident-turn":
+        expected_base = B2_EVIDENCE_FLOOR
+    else:
+        expected_base = {
+            FROZEN_B0_BRANCH: FROZEN_BASE,
+            FROZEN_B1_BRANCH: FROZEN_B1_BASE,
+            B2_BRANCH: FROZEN_B2_BASE,
+        }.get(branch)
     if expected_base is None:
         return f"Gate B controls cannot run on unapproved branch {branch}"
     merge_base = command_output(["git", "merge-base", commit, expected_base])
@@ -733,6 +739,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--warm-up-time", type=float, default=1.0)
     parser.add_argument("--measurement-time", type=float, default=3.0)
     parser.add_argument(
+        "--phase",
+        choices=("B2-resident-turn",),
+        help="refresh the complete B2 evidence lane set on a descendant branch",
+    )
+    parser.add_argument(
         "--machine-label",
         help="stable controlled-machine model label when automatic detection is unavailable",
     )
@@ -763,7 +774,7 @@ def main() -> int:
 
     commit = command_output(["git", "rev-parse", "HEAD"])
     branch = command_output(["git", "symbolic-ref", "--short", "HEAD"])
-    base_error = frozen_base_error(commit, branch)
+    base_error = frozen_base_error(commit, branch, args.phase)
     if base_error:
         print(base_error, file=sys.stderr)
         return 2
@@ -872,7 +883,8 @@ def main() -> int:
     summary = {
         "schema_version": 1,
         "gate": "B",
-        "phase": (
+        "phase": args.phase
+        or (
             "B0-controls"
             if branch == FROZEN_B0_BRANCH
             else "B1-resident-kernel"
@@ -936,7 +948,7 @@ def main() -> int:
     }
     if branch == FROZEN_B1_BRANCH:
         summary["b1_progression"] = b1_progression(lanes)
-    if branch == B2_BRANCH:
+    if branch == B2_BRANCH or args.phase == "B2-resident-turn":
         summary["b1_progression"] = b1_progression(lanes)
         summary["b2_decision"] = b2_decision(lanes)
     rendered = json.dumps(summary, indent=2, sort_keys=True) + "\n"
@@ -958,7 +970,9 @@ def main() -> int:
             file=sys.stderr,
         )
         return 4
-    if branch == B2_BRANCH and summary["b2_decision"]["decision"] == "Fail":
+    if (
+        branch == B2_BRANCH or args.phase == "B2-resident-turn"
+    ) and summary["b2_decision"]["decision"] == "Fail":
         print(
             "Gate B B2 stop: complete resident turn failed one or more hard gates",
             file=sys.stderr,

--- a/scripts/tests/test_check_gate_b_contract.py
+++ b/scripts/tests/test_check_gate_b_contract.py
@@ -3,6 +3,7 @@ import importlib.util
 import sys
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 SCRIPT = Path(__file__).resolve().parents[1] / "check-gate-b-contract.py"
@@ -324,6 +325,57 @@ class GateBContractCheckerTests(unittest.TestCase):
 
     def test_valid_b2_report_recomputes_complete_turn_decision(self):
         self.assertEqual(CHECKER.report_contract_errors(valid_b2_report()), [])
+
+    def test_b2_descendant_refresh_requires_and_accepts_exact_commit(self):
+        report = valid_b2_report()
+        report["git_branch"] = "feat/core-semantic-foundations"
+        self.assertIn(
+            "B2 descendant refresh evidence requires an exact expected commit",
+            CHECKER.report_contract_errors(report),
+        )
+        with mock.patch.object(CHECKER, "commit_descends_from", return_value=True):
+            self.assertEqual(
+                CHECKER.report_contract_errors(report, report["git_commit"]),
+                [],
+            )
+
+    def test_b2_descendant_refresh_rejects_unrelated_commit(self):
+        report = valid_b2_report()
+        report["git_branch"] = "feat/core-semantic-foundations"
+        with mock.patch.object(CHECKER, "commit_descends_from", return_value=False):
+            errors = CHECKER.report_contract_errors(report, report["git_commit"])
+        self.assertTrue(any("does not descend" in error for error in errors))
+
+    def test_b2_frozen_historical_branch_does_not_require_ancestry_lookup(self):
+        report = valid_b2_report()
+        with mock.patch.object(CHECKER, "commit_descends_from") as ancestry:
+            self.assertEqual(CHECKER.report_contract_errors(report), [])
+        ancestry.assert_not_called()
+
+    def test_commit_ancestry_distinguishes_descendant_unrelated_and_missing(self):
+        for return_code, expected in ((0, True), (1, False), (128, False)):
+            with self.subTest(return_code=return_code):
+                completed = mock.Mock(returncode=return_code)
+                with mock.patch.object(
+                    CHECKER.subprocess, "run", return_value=completed
+                ) as run:
+                    self.assertEqual(
+                        CHECKER.commit_descends_from("a" * 40),
+                        expected,
+                    )
+                run.assert_called_once_with(
+                    [
+                        "git",
+                        "merge-base",
+                        "--is-ancestor",
+                        CHECKER.B2_EVIDENCE_FLOOR,
+                        "a" * 40,
+                    ],
+                    cwd=CHECKER.ROOT,
+                    check=False,
+                    stdout=CHECKER.subprocess.DEVNULL,
+                    stderr=CHECKER.subprocess.DEVNULL,
+                )
 
     def test_b2_rejects_forged_decision_metric(self):
         report = valid_b2_report()

--- a/scripts/tests/test_check_value_system_contract.py
+++ b/scripts/tests/test_check_value_system_contract.py
@@ -100,15 +100,16 @@ fn classified_uses() {
 
 
 def target(identifier, category, gate, representation=None):
-    return {
+    result = {
         "id": identifier,
         "semantic_category": category,
         "representation": representation or identifier,
         "implementation_gate": gate,
         "key_semantics": "not-keyable",
         "runtime_storage": "not-applicable",
-        "status": copy.deepcopy(CHECKER.STATUS_EXPECTED),
     }
+    result["status"] = CHECKER.expected_target_status(result)
+    return result
 
 
 class ReviewedContractsTests(unittest.TestCase):
@@ -250,7 +251,9 @@ class ReviewedContractsTests(unittest.TestCase):
         for family in self.migration["families"]:
             for item in family["targets"]:
                 self.assertIsNone(CHECKER.AMBIGUOUS_TARGET.search(json.dumps(item)))
-                self.assertEqual(item["status"], CHECKER.STATUS_EXPECTED)
+                self.assertEqual(
+                    item["status"], CHECKER.expected_target_status(item)
+                )
 
     def test_type_contract_source_inventory_is_exact(self):
         self.assertEqual(
@@ -1310,6 +1313,247 @@ class BoundaryAndReportingTests(unittest.TestCase):
                 )
             ),
         )
+
+    def test_c1_semantic_modules_reject_mutable_value_and_layout_dependencies(self):
+        for relative, source in (
+            ("src/core/src/semantic_identity.rs", "struct Bad(ValueKind);\n"),
+            ("src/core/src/nominal.rs", "use crate::Ref;\n"),
+            ("src/core/src/dimension.rs", "struct Bad(ReactiveCellId);\n"),
+            ("src/core/src/kind_expr.rs", "use nalgebra::DMatrix;\n"),
+            ("src/core/src/kind_scheme.rs", "struct Bad(StateArena);\n"),
+            ("src/core/src/schema/new.rs", "struct Bad(ValueStateJournal);\n"),
+            ("src/core/src/schema/new.rs", "fn stride() {}\n"),
+        ):
+            with self.subTest(relative=relative, source=source):
+                self.assertIn(
+                    "C1-SEMANTIC-BOUNDARY",
+                    self.ids(self.root_with(relative, source)),
+                )
+
+    def test_c1_semantic_modules_resolve_transitive_aliases_and_wrappers(self):
+        root = self.root_with(
+            "src/core/src/storage_alias.rs",
+            "pub struct Hidden(StateArena);\npub type Reexport = Hidden;\n",
+        )
+        semantic = root / "src/core/src/schema/hidden.rs"
+        semantic.parent.mkdir(parents=True, exist_ok=True)
+        semantic.write_text(
+            "use crate::storage_alias::Reexport as Innocent;\n"
+            "pub struct Bad(Innocent);\n",
+            encoding="utf-8",
+        )
+        self.assertIn("C1-SEMANTIC-BOUNDARY", self.ids(root))
+
+    def test_c1_semantic_modules_reject_standard_interior_mutability(self):
+        for type_name in (
+            "UnsafeCell",
+            "Cell",
+            "RefCell",
+            "Mutex",
+            "RwLock",
+            "Once",
+            "OnceCell",
+            "OnceLock",
+            "LazyCell",
+            "LazyLock",
+            "Barrier",
+            "Condvar",
+            "AtomicU64",
+            "AtomicPtr",
+        ):
+            with self.subTest(type_name=type_name):
+                field_type = (
+                    type_name
+                    if type_name in {"Once", "Barrier", "Condvar", "AtomicU64"}
+                    else f"{type_name}<u8>"
+                )
+                source = f"pub struct Bad({field_type});\n"
+                self.assertIn(
+                    "C1-SEMANTIC-BOUNDARY",
+                    self.ids(self.root_with("src/core/src/schema/interior.rs", source)),
+                )
+
+    def test_c1_semantic_modules_reject_renamed_and_wrapped_interior_mutability(self):
+        root = self.root_with(
+            "src/core/src/interior_wrapper.rs",
+            "use std::sync::Mutex as Lock;\npub struct Hidden(Lock<u8>);\n",
+        )
+        semantic = root / "src/core/src/schema/interior.rs"
+        semantic.parent.mkdir(parents=True, exist_ok=True)
+        semantic.write_text(
+            "use crate::interior_wrapper::Hidden as ApparentlyImmutable;\n"
+            "pub struct Bad(ApparentlyImmutable);\n",
+            encoding="utf-8",
+        )
+        self.assertIn("C1-SEMANTIC-BOUNDARY", self.ids(root))
+
+    def test_finalized_semantic_types_cannot_regain_derived_deserialize(self):
+        for relative, type_name in (
+            ("src/core/src/nominal.rs", "CanonicalNominalPath"),
+            ("src/core/src/dimension.rs", "DimensionParameter"),
+            ("src/core/src/kind_scheme.rs", "KindScheme"),
+            ("src/core/src/schema/mod.rs", "Schema"),
+            ("src/core/src/schema/shape.rs", "ShapeInstance"),
+        ):
+            with self.subTest(type_name=type_name):
+                source = (
+                    '#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]\n'
+                    '#[derive(Clone)]\n'
+                    f"pub struct {type_name};\n"
+                )
+                self.assertIn(
+                    "C1-FINALIZED-SERDE-BOUNDARY",
+                    self.ids(self.root_with(relative, source)),
+                )
+
+    def test_finalized_semantic_types_cannot_gain_manual_deserialize(self):
+        for relative, type_name in (
+            ("src/core/src/nominal.rs", "CanonicalNominalPath"),
+            ("src/core/src/dimension.rs", "DimensionParameter"),
+            ("src/core/src/kind_scheme.rs", "KindScheme"),
+            ("src/core/src/schema/mod.rs", "Schema"),
+            ("src/core/src/schema/shape.rs", "ShapeInstance"),
+            ("src/core/src/schema/table.rs", "SchemaHandle"),
+        ):
+            with self.subTest(relative=relative, type_name=type_name):
+                source = f"impl<'de> Deserialize<'de> for {type_name} {{}}\n"
+                self.assertIn(
+                    "C1-FINALIZED-SERDE-BOUNDARY",
+                    self.ids(self.root_with(relative, source)),
+                )
+
+    def test_manual_deserialize_check_resolves_qualified_and_aliased_names(self):
+        cases = (
+            (
+                "src/core/src/schema/mod.rs",
+                "impl<'de> serde::de::Deserialize<'de> for crate::Schema {}\n",
+            ),
+            (
+                "src/core/src/schema/shape.rs",
+                "use serde::de::Deserialize as Decode;\n"
+                "impl<'de> Decode<'de> for ShapeInstance {}\n",
+            ),
+            (
+                "src/core/src/kind_scheme.rs",
+                "type Hidden = KindScheme;\n"
+                "impl<'de> Deserialize<'de> for Hidden {}\n",
+            ),
+        )
+        for relative, source in cases:
+            with self.subTest(relative=relative, source=source):
+                self.assertIn(
+                    "C1-FINALIZED-SERDE-BOUNDARY",
+                    self.ids(self.root_with(relative, source)),
+                )
+
+    def test_non_final_semantic_types_may_implement_deserialize(self):
+        source = "impl<'de> Deserialize<'de> for SchemaDraft {}\n"
+        self.assertNotIn(
+            "C1-FINALIZED-SERDE-BOUNDARY",
+            self.ids(self.root_with("src/core/src/schema/mod.rs", source)),
+        )
+
+    def test_open_semantic_syntax_must_keep_deserialize(self):
+        source = (
+            '#[cfg_attr(feature = "serde", derive(Serialize))]\n'
+            '#[derive(Clone)]\n'
+            "pub enum KindExpr { Id }\n"
+        )
+        self.assertIn(
+            "C1-OPEN-SERDE-BOUNDARY",
+            self.ids(self.root_with("src/core/src/kind_expr.rs", source)),
+        )
+
+    def test_schema_handles_cannot_gain_standalone_serde_construction(self):
+        source = (
+            '#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]\n'
+            '#[derive(Clone)]\n'
+            "pub struct SchemaHandle(u32);\n"
+        )
+        self.assertIn(
+            "C1-EPHEMERAL-HANDLE-SERDE-BOUNDARY",
+            self.ids(self.root_with("src/core/src/schema/table.rs", source)),
+        )
+
+    def test_semantic_builders_cannot_panic_on_identity_or_input(self):
+        for relative, source in (
+            (
+                "src/core/src/dimension.rs",
+                "pub fn declare() -> DimensionParameterId { assert!(false); todo!() }\n"
+                "pub fn declarations() {}\n",
+            ),
+            (
+                "src/core/src/schema/table.rs",
+                "pub fn insert() -> SchemaHandle { value.expect(\"id\") }\n"
+                "pub fn finish() {}\n",
+            ),
+        ):
+            with self.subTest(relative=relative):
+                self.assertIn(
+                    "C1-SEMANTIC-BUILDER-ERROR",
+                    self.ids(self.root_with(relative, source)),
+                )
+
+    def test_canonical_vectors_must_use_validated_finalization_and_shape_apis(self):
+        root = self.root_with(
+            "src/core/tests/canonical_schema_vectors.rs",
+            "fn vectors() { draft.finalize(); }\n",
+        )
+        self.assertIn("C1-FINALIZED-CONSTRUCTION", self.ids(root))
+
+    def test_c1_validation_routes_cannot_be_removed(self):
+        for relative, source in (
+            ("src/core/src/kind_expr.rs", "fn canonical_closed_kind_bytes() {}\n"),
+            ("src/core/src/kind_scheme.rs", "fn new() {}\n"),
+            ("src/core/src/legacy_adapter/kind.rs", "fn kind_expr_from_legacy() {}\n"),
+            ("src/core/src/schema/shape.rs", "fn evaluate_body_extents() {}\n"),
+        ):
+            with self.subTest(relative=relative):
+                self.assertIn(
+                    "C1-VALIDATED-CONSTRUCTION-ROUTE",
+                    self.ids(self.root_with(relative, source)),
+                )
+
+    def test_legacy_adapter_is_the_explicit_kind_value_kind_exception(self):
+        root = self.root_with(
+            "src/core/src/legacy_adapter/kind.rs",
+            "fn adapt(kind: Kind, value: ValueKind) {}\n",
+        )
+        self.assertNotIn("C1-SEMANTIC-BOUNDARY", self.ids(root))
+
+    def test_legacy_adapter_cannot_hide_future_variants_behind_catch_all(self):
+        for fallback in (
+            "_ => ()",
+            "other => drop(other)",
+            "other @ _ => drop(other)",
+            "_ | Kind::Any => ()",
+            "Kind::Any | _ => ()",
+            "| Kind::Any | _ => ()",
+            "(other) | Kind::Any => drop(other)",
+            "other @ (_ | Kind::Any) => drop(other)",
+            "#[allow(unreachable_patterns)] (_ | Kind::Any) => ()",
+            "#[allow(unused_variables)] other => drop(other)",
+            "#[cfg_attr(feature = \"strict\", allow(unused_variables))] mut other => drop(other)",
+            "#[cfg(any())] #[allow(unused_variables)] ref other @ _ => drop(other)",
+        ):
+            with self.subTest(fallback=fallback):
+                root = self.root_with(
+                    "src/core/src/legacy_adapter/kind.rs",
+                    f"fn adapt(kind: Kind) {{ match kind {{ Kind::Any => (), {fallback} }} }}\n",
+                )
+                self.assertIn("C1-LEGACY-ADAPTER-EXHAUSTIVE", self.ids(root))
+
+    def test_legacy_adapter_allows_explicit_or_patterns_and_guarded_wildcards(self):
+        for fallback in (
+            "Kind::Any | Kind::Empty => ()",
+            "_ if condition => ()",
+        ):
+            with self.subTest(fallback=fallback):
+                root = self.root_with(
+                    "src/core/src/legacy_adapter/kind.rs",
+                    f"fn adapt(kind: Kind) {{ match kind {{ {fallback} }} }}\n",
+                )
+                self.assertNotIn("C1-LEGACY-ADAPTER-EXHAUSTIVE", self.ids(root))
 
     def test_legacy_adapter_may_mention_both_representations(self):
         root = self.root_with("src/core/src/legacy_adapter/convert.rs", "fn convert(_: LegacyValue) -> snapshot::Value { todo!() }\n")

--- a/scripts/tests/test_run_gate_b_benchmarks.py
+++ b/scripts/tests/test_run_gate_b_benchmarks.py
@@ -26,6 +26,13 @@ class GateBBenchmarkRunnerTests(unittest.TestCase):
         self.assertEqual(arguments.sample_size, 10)
         self.assertEqual(arguments.warm_up_time, 1.0)
         self.assertEqual(arguments.measurement_time, 3.0)
+        self.assertIsNone(arguments.phase)
+
+    def test_only_b2_has_an_explicit_evidence_refresh_phase(self):
+        arguments = self.parse_args("--phase", "B2-resident-turn")
+        self.assertEqual(arguments.phase, "B2-resident-turn")
+        with self.assertRaises(SystemExit):
+            self.parse_args("--phase", "B1-resident-kernel")
 
     def test_controlled_environment_forces_one_thread(self):
         environment = RUNNER.controlled_environment(
@@ -137,6 +144,28 @@ class GateBBenchmarkRunnerTests(unittest.TestCase):
             self.assertIsNone(
                 RUNNER.frozen_base_error("c" * 40, RUNNER.FROZEN_B1_BRANCH)
             )
+
+    def test_b2_refresh_phase_allows_any_descendant_branch(self):
+        with patch.object(
+            RUNNER,
+            "command_output",
+            return_value=RUNNER.B2_EVIDENCE_FLOOR,
+        ):
+            self.assertIsNone(
+                RUNNER.frozen_base_error(
+                    "d" * 40,
+                    "feat/core-semantic-foundations",
+                    "B2-resident-turn",
+                )
+            )
+        with patch.object(RUNNER, "command_output", return_value="e" * 40):
+            error = RUNNER.frozen_base_error(
+                "d" * 40,
+                "feat/core-semantic-foundations",
+                "B2-resident-turn",
+            )
+        self.assertIn(RUNNER.B2_EVIDENCE_FLOOR, error)
+        self.assertIn("unapproved branch", RUNNER.frozen_base_error("d" * 40, "other"))
 
     def test_lane_record_normalizes_by_host_turn_not_instance(self):
         probe = {

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -152,6 +152,7 @@ swizzle = ["subscript"]
 
 [dependencies]
 seahash = "4.1.0"
+sha2 = { version = "0.11.0", default-features = false }
 paste = "1.0.15"
 byteorder = {version = "1.5.0", optional = true}
 fxhash = { version = "0.2.1", default-features = false, optional = true }

--- a/src/core/src/dimension.rs
+++ b/src/core/src/dimension.rs
@@ -668,7 +668,6 @@ mod vector_tests {
             Err(SemanticModelError::UnknownDimensionParameterV1 { .. })
         ));
     }
-
     #[test]
     fn test_only_limit_proves_dimension_parameter_identity_exhaustion() {
         let mut builder = DimensionEnvironmentBuilder::new();

--- a/src/core/src/dimension.rs
+++ b/src/core/src/dimension.rs
@@ -1,0 +1,689 @@
+//! Symbolic dimensions and canonical dimension environments.
+
+use crate::{DimensionParameterId, SemanticIdentityKind, SemanticModelError};
+
+#[cfg(feature = "no_std")]
+use alloc::{boxed::Box, collections::BTreeSet, vec, vec::Vec};
+#[cfg(not(feature = "no_std"))]
+use std::{boxed::Box, collections::BTreeSet, vec, vec::Vec};
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum DimensionLifetime {
+    CompileTime,
+    Activation,
+    Turn,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum DimensionParameterOrigin {
+    Explicit,
+    Inferred,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum DimensionOperator {
+    Add,
+    Multiply,
+    Min,
+    Max,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum DimensionExpr {
+    Hole,
+    Constant(u64),
+    Parameter(DimensionParameterId),
+    Add(Box<[DimensionExpr]>),
+    Multiply(Box<[DimensionExpr]>),
+    Min(Box<[DimensionExpr]>),
+    Max(Box<[DimensionExpr]>),
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DimensionParameterDeclaration {
+    pub id: DimensionParameterId,
+    pub origin: DimensionParameterOrigin,
+    pub lifetime: DimensionLifetime,
+    pub lower_bound: DimensionExpr,
+    pub upper_bound: Option<DimensionExpr>,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DimensionParameter {
+    lifetime: DimensionLifetime,
+    lower_bound: DimensionExpr,
+    upper_bound: Option<DimensionExpr>,
+}
+
+impl DimensionParameter {
+    pub const fn lifetime(&self) -> DimensionLifetime {
+        self.lifetime
+    }
+
+    pub const fn lower_bound(&self) -> &DimensionExpr {
+        &self.lower_bound
+    }
+
+    pub const fn upper_bound(&self) -> Option<&DimensionExpr> {
+        self.upper_bound.as_ref()
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ExtentEvolution {
+    Fixed,
+    ActivationFixed,
+    TurnBounded,
+    TurnUnbounded,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct DimensionEnvironmentBuilder {
+    declarations: Vec<DimensionParameterDeclaration>,
+}
+
+impl DimensionEnvironmentBuilder {
+    pub const fn new() -> Self {
+        Self {
+            declarations: Vec::new(),
+        }
+    }
+
+    pub fn declare(
+        &mut self,
+        origin: DimensionParameterOrigin,
+        lifetime: DimensionLifetime,
+        lower_bound: DimensionExpr,
+        upper_bound: Option<DimensionExpr>,
+    ) -> Result<DimensionParameterId, SemanticModelError> {
+        self.declare_with_limit(origin, lifetime, lower_bound, upper_bound, usize::MAX)
+    }
+
+    fn declare_with_limit(
+        &mut self,
+        origin: DimensionParameterOrigin,
+        lifetime: DimensionLifetime,
+        lower_bound: DimensionExpr,
+        upper_bound: Option<DimensionExpr>,
+        parameter_limit: usize,
+    ) -> Result<DimensionParameterId, SemanticModelError> {
+        if lifetime == DimensionLifetime::CompileTime {
+            return Err(SemanticModelError::CompileTimeDimensionParameterV1);
+        }
+        if self.declarations.len() >= parameter_limit {
+            return Err(SemanticModelError::IdentityExhausted {
+                identity: SemanticIdentityKind::DimensionParameterId,
+            });
+        }
+        let ordinal = u32::try_from(self.declarations.len()).map_err(|_| {
+            SemanticModelError::IdentityExhausted {
+                identity: SemanticIdentityKind::DimensionParameterId,
+            }
+        })?;
+        let id = DimensionParameterId::new(ordinal);
+        self.declarations.push(DimensionParameterDeclaration {
+            id,
+            origin,
+            lifetime,
+            lower_bound,
+            upper_bound,
+        });
+        Ok(id)
+    }
+
+    pub fn declarations(&self) -> &[DimensionParameterDeclaration] {
+        &self.declarations
+    }
+
+    pub fn into_declarations(self) -> Box<[DimensionParameterDeclaration]> {
+        self.declarations.into_boxed_slice()
+    }
+}
+
+pub(crate) struct CanonicalDimensionEnvironment {
+    pub(crate) parameters: Box<[DimensionParameter]>,
+    pub(crate) old_to_new: Vec<Option<DimensionParameterId>>,
+}
+
+pub(crate) fn collect_dimension_references(
+    expression: &DimensionExpr,
+    references: &mut Vec<DimensionParameterId>,
+) {
+    match expression {
+        DimensionExpr::Hole | DimensionExpr::Constant(_) => {}
+        DimensionExpr::Parameter(id) => references.push(*id),
+        DimensionExpr::Add(children)
+        | DimensionExpr::Multiply(children)
+        | DimensionExpr::Min(children)
+        | DimensionExpr::Max(children) => {
+            for child in children {
+                collect_dimension_references(child, references);
+            }
+        }
+    }
+}
+
+pub(crate) fn rewrite_dimension_references(
+    expression: &DimensionExpr,
+    old_to_new: &[Option<DimensionParameterId>],
+) -> Result<DimensionExpr, SemanticModelError> {
+    Ok(match expression {
+        DimensionExpr::Hole => DimensionExpr::Hole,
+        DimensionExpr::Constant(value) => DimensionExpr::Constant(*value),
+        DimensionExpr::Parameter(id) => DimensionExpr::Parameter(
+            old_to_new
+                .get(id.get() as usize)
+                .and_then(|value| *value)
+                .ok_or(SemanticModelError::UnknownDimensionParameterV1 { id: *id })?,
+        ),
+        DimensionExpr::Add(children) => DimensionExpr::Add(rewrite_children(children, old_to_new)?),
+        DimensionExpr::Multiply(children) => {
+            DimensionExpr::Multiply(rewrite_children(children, old_to_new)?)
+        }
+        DimensionExpr::Min(children) => DimensionExpr::Min(rewrite_children(children, old_to_new)?),
+        DimensionExpr::Max(children) => DimensionExpr::Max(rewrite_children(children, old_to_new)?),
+    })
+}
+
+fn rewrite_children(
+    children: &[DimensionExpr],
+    old_to_new: &[Option<DimensionParameterId>],
+) -> Result<Box<[DimensionExpr]>, SemanticModelError> {
+    children
+        .iter()
+        .map(|child| rewrite_dimension_references(child, old_to_new))
+        .collect::<Result<Vec<_>, _>>()
+        .map(Vec::into_boxed_slice)
+}
+
+pub(crate) fn canonicalize_dimension_environment(
+    declarations: &[DimensionParameterDeclaration],
+    root_references: &[DimensionParameterId],
+) -> Result<CanonicalDimensionEnvironment, SemanticModelError> {
+    validate_declaration_ids(declarations)?;
+    let count = declarations.len();
+    let mut normalized_bounds = Vec::with_capacity(count);
+    let mut dependencies = Vec::with_capacity(count);
+    for declaration in declarations {
+        if declaration.lifetime == DimensionLifetime::CompileTime {
+            return Err(SemanticModelError::CompileTimeDimensionParameterV1);
+        }
+        let lower = normalize_dimension(&declaration.lower_bound, count)?;
+        let upper = declaration
+            .upper_bound
+            .as_ref()
+            .map(|value| normalize_dimension(value, count))
+            .transpose()?;
+        let mut references = Vec::new();
+        collect_dimension_references(&lower, &mut references);
+        if let Some(upper) = &upper {
+            collect_dimension_references(upper, &mut references);
+        }
+        normalized_bounds.push((lower, upper));
+        dependencies.push(references);
+    }
+    ensure_known_references(root_references, count)?;
+
+    let mut state = vec![0_u8; count];
+    let mut occurrence = Vec::new();
+    for id in root_references {
+        visit_parameter(
+            id.get() as usize,
+            &dependencies,
+            &mut state,
+            &mut occurrence,
+        )?;
+    }
+    let reachable = occurrence.iter().copied().collect::<BTreeSet<_>>();
+    let mut retained = declarations
+        .iter()
+        .enumerate()
+        .filter_map(|(index, declaration)| {
+            (declaration.origin == DimensionParameterOrigin::Explicit && reachable.contains(&index))
+                .then_some(index)
+        })
+        .collect::<Vec<_>>();
+    for old in occurrence {
+        if declarations[old].origin == DimensionParameterOrigin::Inferred
+            && !retained.contains(&old)
+        {
+            retained.push(old);
+        }
+    }
+
+    let mut old_to_new = vec![None; count];
+    for (new, old) in retained.iter().copied().enumerate() {
+        old_to_new[old] = Some(DimensionParameterId::new(new as u32));
+    }
+    for old in retained.iter().copied() {
+        let parameter = old_to_new[old].expect("retained parameter has an ordinal");
+        for referenced in dependencies[old].iter().copied() {
+            let referenced_new =
+                old_to_new[referenced.get() as usize].expect("reachable dependency has an ordinal");
+            if referenced_new.get() >= parameter.get() {
+                return Err(SemanticModelError::ForwardDimensionParameterReferenceV1 {
+                    parameter,
+                    referenced: referenced_new,
+                });
+            }
+        }
+    }
+
+    let retained_count = retained.len();
+    let mut parameters = Vec::with_capacity(retained_count);
+    for old in retained {
+        let declaration = &declarations[old];
+        let (normalized_lower, normalized_upper) = &normalized_bounds[old];
+        let lower = rewrite_dimension_references(normalized_lower, &old_to_new)?;
+        let upper = normalized_upper
+            .as_ref()
+            .map(|value| rewrite_dimension_references(value, &old_to_new))
+            .transpose()?;
+        parameters.push(DimensionParameter {
+            lifetime: declaration.lifetime,
+            lower_bound: normalize_dimension(&lower, retained_count)?,
+            upper_bound: upper
+                .as_ref()
+                .map(|value| normalize_dimension(value, retained_count))
+                .transpose()?,
+        });
+    }
+    Ok(CanonicalDimensionEnvironment {
+        parameters: parameters.into_boxed_slice(),
+        old_to_new,
+    })
+}
+
+pub(crate) fn validate_declaration_ids(
+    declarations: &[DimensionParameterDeclaration],
+) -> Result<(), SemanticModelError> {
+    let mut seen = BTreeSet::new();
+    for (index, declaration) in declarations.iter().enumerate() {
+        if !seen.insert(declaration.id) {
+            return Err(SemanticModelError::DuplicateDimensionParameter { id: declaration.id });
+        }
+        if declaration.id.get() as usize != index {
+            return Err(SemanticModelError::UnknownDimensionParameterV1 { id: declaration.id });
+        }
+    }
+    Ok(())
+}
+
+fn ensure_known_references(
+    references: &[DimensionParameterId],
+    count: usize,
+) -> Result<(), SemanticModelError> {
+    for id in references {
+        if id.get() as usize >= count {
+            return Err(SemanticModelError::UnknownDimensionParameterV1 { id: *id });
+        }
+    }
+    Ok(())
+}
+
+fn visit_parameter(
+    ordinal: usize,
+    dependencies: &[Vec<DimensionParameterId>],
+    state: &mut [u8],
+    occurrence: &mut Vec<usize>,
+) -> Result<(), SemanticModelError> {
+    match state[ordinal] {
+        1 => return Err(SemanticModelError::CyclicDimensionParameterBoundsV1),
+        2 => return Ok(()),
+        _ => {}
+    }
+    state[ordinal] = 1;
+    occurrence.push(ordinal);
+    for dependency in &dependencies[ordinal] {
+        visit_parameter(dependency.get() as usize, dependencies, state, occurrence)?;
+    }
+    state[ordinal] = 2;
+    Ok(())
+}
+
+pub fn normalize_dimension(
+    expression: &DimensionExpr,
+    parameter_count: usize,
+) -> Result<DimensionExpr, SemanticModelError> {
+    match expression {
+        DimensionExpr::Hole => Err(SemanticModelError::UnresolvedDimensionHole),
+        DimensionExpr::Constant(value) => Ok(DimensionExpr::Constant(*value)),
+        DimensionExpr::Parameter(id) => {
+            if id.get() as usize >= parameter_count {
+                Err(SemanticModelError::UnknownDimensionParameterV1 { id: *id })
+            } else {
+                Ok(DimensionExpr::Parameter(*id))
+            }
+        }
+        DimensionExpr::Add(children) => normalize_sum(children, parameter_count),
+        DimensionExpr::Multiply(children) => normalize_product(children, parameter_count),
+        DimensionExpr::Min(children) => {
+            normalize_min_max(DimensionOperator::Min, children, parameter_count)
+        }
+        DimensionExpr::Max(children) => {
+            normalize_min_max(DimensionOperator::Max, children, parameter_count)
+        }
+    }
+}
+
+fn normalize_sum(
+    children: &[DimensionExpr],
+    parameter_count: usize,
+) -> Result<DimensionExpr, SemanticModelError> {
+    let mut operands = Vec::new();
+    for child in children {
+        match normalize_dimension(child, parameter_count)? {
+            DimensionExpr::Add(nested) => operands.extend(Vec::from(nested)),
+            other => operands.push(other),
+        }
+    }
+    let mut constant = 0_u64;
+    let mut remaining = Vec::new();
+    for operand in operands {
+        if let DimensionExpr::Constant(value) = operand {
+            constant = constant
+                .checked_add(value)
+                .ok_or(SemanticModelError::DimensionOverflowV1)?;
+        } else {
+            remaining.push(operand);
+        }
+    }
+    if constant != 0 {
+        remaining.push(DimensionExpr::Constant(constant));
+    }
+    finish_commutative(DimensionOperator::Add, remaining)
+}
+
+fn normalize_product(
+    children: &[DimensionExpr],
+    parameter_count: usize,
+) -> Result<DimensionExpr, SemanticModelError> {
+    let mut operands = Vec::new();
+    for child in children {
+        match normalize_dimension(child, parameter_count)? {
+            DimensionExpr::Multiply(nested) => operands.extend(Vec::from(nested)),
+            other => operands.push(other),
+        }
+    }
+    if operands
+        .iter()
+        .any(|operand| matches!(operand, DimensionExpr::Constant(0)))
+    {
+        return Ok(DimensionExpr::Constant(0));
+    }
+    let mut constant = 1_u64;
+    let mut remaining = Vec::new();
+    for operand in operands {
+        if let DimensionExpr::Constant(value) = operand {
+            constant = constant
+                .checked_mul(value)
+                .ok_or(SemanticModelError::DimensionOverflowV1)?;
+        } else {
+            remaining.push(operand);
+        }
+    }
+    if constant != 1 {
+        remaining.push(DimensionExpr::Constant(constant));
+    }
+    finish_commutative(DimensionOperator::Multiply, remaining)
+}
+
+fn normalize_min_max(
+    operator: DimensionOperator,
+    children: &[DimensionExpr],
+    parameter_count: usize,
+) -> Result<DimensionExpr, SemanticModelError> {
+    let mut operands = Vec::new();
+    for child in children {
+        let normalized = normalize_dimension(child, parameter_count)?;
+        match (operator, normalized) {
+            (DimensionOperator::Min, DimensionExpr::Min(nested))
+            | (DimensionOperator::Max, DimensionExpr::Max(nested)) => {
+                operands.extend(Vec::from(nested))
+            }
+            (_, other) => operands.push(other),
+        }
+    }
+    operands.sort_by_key(encode_normalized_dimension);
+    operands.dedup_by(|left, right| {
+        encode_normalized_dimension(left) == encode_normalized_dimension(right)
+    });
+    if operands.is_empty() {
+        return Err(SemanticModelError::EmptyMinMaxV1 { operator });
+    }
+    finish_commutative(operator, operands)
+}
+
+fn finish_commutative(
+    operator: DimensionOperator,
+    mut operands: Vec<DimensionExpr>,
+) -> Result<DimensionExpr, SemanticModelError> {
+    operands.sort_by_key(encode_normalized_dimension);
+    match operands.len() {
+        0 => Ok(DimensionExpr::Constant(match operator {
+            DimensionOperator::Add => 0,
+            DimensionOperator::Multiply => 1,
+            DimensionOperator::Min | DimensionOperator::Max => {
+                return Err(SemanticModelError::EmptyMinMaxV1 { operator });
+            }
+        })),
+        1 => Ok(operands.pop().expect("one operand")),
+        _ => {
+            let operands = operands.into_boxed_slice();
+            Ok(match operator {
+                DimensionOperator::Add => DimensionExpr::Add(operands),
+                DimensionOperator::Multiply => DimensionExpr::Multiply(operands),
+                DimensionOperator::Min => DimensionExpr::Min(operands),
+                DimensionOperator::Max => DimensionExpr::Max(operands),
+            })
+        }
+    }
+}
+
+pub(crate) fn encode_normalized_dimension(expression: &DimensionExpr) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    encode_normalized_dimension_into(expression, &mut bytes);
+    bytes
+}
+
+pub(crate) fn encode_normalized_dimension_into(expression: &DimensionExpr, bytes: &mut Vec<u8>) {
+    match expression {
+        DimensionExpr::Hole => unreachable!("holes are not canonical"),
+        DimensionExpr::Constant(value) => {
+            bytes.push(0x01);
+            bytes.extend_from_slice(&value.to_le_bytes());
+        }
+        DimensionExpr::Parameter(id) => {
+            bytes.push(0x02);
+            bytes.extend_from_slice(&id.get().to_le_bytes());
+        }
+        DimensionExpr::Add(children)
+        | DimensionExpr::Multiply(children)
+        | DimensionExpr::Min(children)
+        | DimensionExpr::Max(children) => {
+            bytes.push(match expression {
+                DimensionExpr::Add(_) => 0x03,
+                DimensionExpr::Multiply(_) => 0x04,
+                DimensionExpr::Min(_) => 0x05,
+                DimensionExpr::Max(_) => 0x06,
+                _ => unreachable!(),
+            });
+            bytes.extend_from_slice(&(children.len() as u32).to_le_bytes());
+            for child in children {
+                let encoded = encode_normalized_dimension(child);
+                bytes.extend_from_slice(&(encoded.len() as u64).to_le_bytes());
+                bytes.extend_from_slice(&encoded);
+            }
+        }
+    }
+}
+
+pub(crate) fn encode_dimension_parameters(parameters: &[DimensionParameter], bytes: &mut Vec<u8>) {
+    for parameter in parameters {
+        bytes.push(match parameter.lifetime {
+            DimensionLifetime::Activation => 0x01,
+            DimensionLifetime::Turn => 0x02,
+            DimensionLifetime::CompileTime => unreachable!("compile-time parameters are rejected"),
+        });
+        let lower = encode_normalized_dimension(&parameter.lower_bound);
+        bytes.extend_from_slice(&(lower.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(&lower);
+        match &parameter.upper_bound {
+            None => bytes.push(0),
+            Some(upper) => {
+                bytes.push(1);
+                let upper = encode_normalized_dimension(upper);
+                bytes.extend_from_slice(&(upper.len() as u64).to_le_bytes());
+                bytes.extend_from_slice(&upper);
+            }
+        }
+    }
+}
+
+pub fn extent_evolution(parameters: &[DimensionParameter]) -> ExtentEvolution {
+    if parameters.is_empty() {
+        return ExtentEvolution::Fixed;
+    }
+    let turn_parameters = parameters
+        .iter()
+        .filter(|parameter| parameter.lifetime == DimensionLifetime::Turn)
+        .collect::<Vec<_>>();
+    if turn_parameters.is_empty() {
+        ExtentEvolution::ActivationFixed
+    } else if turn_parameters
+        .iter()
+        .all(|parameter| parameter.upper_bound.is_some())
+    {
+        ExtentEvolution::TurnBounded
+    } else {
+        ExtentEvolution::TurnUnbounded
+    }
+}
+
+#[cfg(test)]
+mod vector_tests {
+    use super::*;
+
+    fn boxed(values: impl IntoIterator<Item = DimensionExpr>) -> Box<[DimensionExpr]> {
+        values.into_iter().collect::<Vec<_>>().into_boxed_slice()
+    }
+
+    fn decode_hex(value: &str) -> Vec<u8> {
+        value
+            .as_bytes()
+            .chunks_exact(2)
+            .map(|pair| {
+                let digit = |value| match value {
+                    b'0'..=b'9' => value - b'0',
+                    b'a'..=b'f' => value - b'a' + 10,
+                    _ => panic!("invalid test hex"),
+                };
+                (digit(pair[0]) << 4) | digit(pair[1])
+            })
+            .collect()
+    }
+
+    #[test]
+    fn all_positive_c0_dimension_vectors_match_exactly() {
+        let parameter = DimensionExpr::Parameter(DimensionParameterId::new(0));
+        let vectors = [
+            (
+                DimensionExpr::Add(boxed([
+                    DimensionExpr::Constant(4),
+                    DimensionExpr::Add(boxed([
+                        DimensionExpr::Add(boxed([
+                            DimensionExpr::Constant(1),
+                            DimensionExpr::Constant(2),
+                        ])),
+                        parameter.clone(),
+                    ])),
+                ])),
+                "0302000000090000000000000001070000000000000005000000000000000200000000",
+            ),
+            (
+                DimensionExpr::Multiply(boxed([
+                    DimensionExpr::Constant(2),
+                    DimensionExpr::Multiply(boxed([
+                        DimensionExpr::Constant(3),
+                        DimensionExpr::Multiply(boxed([
+                            DimensionExpr::Constant(1),
+                            parameter.clone(),
+                        ])),
+                    ])),
+                ])),
+                "0402000000090000000000000001060000000000000005000000000000000200000000",
+            ),
+            (
+                DimensionExpr::Min(boxed([
+                    parameter.clone(),
+                    DimensionExpr::Min(boxed([DimensionExpr::Constant(5), parameter.clone()])),
+                    DimensionExpr::Constant(5),
+                ])),
+                "0502000000090000000000000001050000000000000005000000000000000200000000",
+            ),
+            (
+                DimensionExpr::Max(boxed([
+                    DimensionExpr::Max(boxed([DimensionExpr::Constant(2), parameter.clone()])),
+                    DimensionExpr::Constant(2),
+                    parameter,
+                ])),
+                "0602000000090000000000000001020000000000000005000000000000000200000000",
+            ),
+        ];
+        for (expression, expected) in vectors {
+            let normalized = normalize_dimension(&expression, 1).unwrap();
+            assert_eq!(
+                encode_normalized_dimension(&normalized),
+                decode_hex(expected)
+            );
+        }
+    }
+
+    #[test]
+    fn all_negative_c0_dimension_vectors_return_the_frozen_errors() {
+        for expression in [
+            DimensionExpr::Add(boxed([
+                DimensionExpr::Constant(u64::MAX),
+                DimensionExpr::Constant(1),
+            ])),
+            DimensionExpr::Multiply(boxed([
+                DimensionExpr::Constant(u64::MAX),
+                DimensionExpr::Constant(2),
+            ])),
+        ] {
+            assert!(matches!(
+                normalize_dimension(&expression, 0),
+                Err(SemanticModelError::DimensionOverflowV1)
+            ));
+        }
+        assert!(matches!(
+            normalize_dimension(&DimensionExpr::Parameter(DimensionParameterId::new(1)), 1),
+            Err(SemanticModelError::UnknownDimensionParameterV1 { .. })
+        ));
+    }
+
+    #[test]
+    fn test_only_limit_proves_dimension_parameter_identity_exhaustion() {
+        let mut builder = DimensionEnvironmentBuilder::new();
+        assert!(matches!(
+            builder.declare_with_limit(
+                DimensionParameterOrigin::Explicit,
+                DimensionLifetime::Activation,
+                DimensionExpr::Constant(0),
+                None,
+                0,
+            ),
+            Err(SemanticModelError::IdentityExhausted {
+                identity: SemanticIdentityKind::DimensionParameterId,
+            })
+        ));
+        assert!(builder.declarations().is_empty());
+    }
+}

--- a/src/core/src/dimension.rs
+++ b/src/core/src/dimension.rs
@@ -668,6 +668,7 @@ mod vector_tests {
             Err(SemanticModelError::UnknownDimensionParameterV1 { .. })
         ));
     }
+
     #[test]
     fn test_only_limit_proves_dimension_parameter_identity_exhaustion() {
         let mut builder = DimensionEnvironmentBuilder::new();

--- a/src/core/src/kind_expr.rs
+++ b/src/core/src/kind_expr.rs
@@ -1,0 +1,588 @@
+//! Semantic kind expressions and the closed-kind canonical encoder.
+
+use crate::dimension::{
+    canonicalize_dimension_environment, collect_dimension_references, encode_dimension_parameters,
+    normalize_dimension, rewrite_dimension_references,
+};
+use crate::{
+    CanonicalNominalPath, DimensionExpr, DimensionParameterDeclaration, DimensionParameterId,
+    KindId, KindNameCategory, KindParameterId, NominalKey, SemanticModelError,
+};
+
+#[cfg(feature = "no_std")]
+use alloc::{boxed::Box, collections::BTreeSet, string::String, vec::Vec};
+#[cfg(not(feature = "no_std"))]
+use std::{boxed::Box, collections::BTreeSet, string::String, vec::Vec};
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum KindExpr {
+    Wildcard,
+    Never,
+    Hole,
+    Parameter(KindParameterId),
+    Named(KindId),
+    Id,
+    Index,
+    Atom(NominalKey),
+    Enum(NominalKey),
+    Matrix {
+        element: Box<KindExpr>,
+        dimensions: Box<[DimensionExpr]>,
+    },
+    Option(Box<KindExpr>),
+    Tuple(Box<[KindExpr]>),
+    Record(Box<[KindField]>),
+    Table {
+        columns: Box<[KindField]>,
+        rows: DimensionExpr,
+    },
+    Set {
+        element: Box<KindExpr>,
+        cardinality: DimensionExpr,
+    },
+    Map {
+        key: Box<KindExpr>,
+        value: Box<KindExpr>,
+        cardinality: DimensionExpr,
+    },
+    Reference(Box<KindExpr>),
+    TypeOf(Box<KindExpr>),
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct KindField {
+    pub name: String,
+    pub kind: KindExpr,
+}
+
+pub trait NamedKindPathResolver {
+    fn canonical_path(&self, id: KindId) -> Option<&CanonicalNominalPath>;
+}
+
+pub fn canonical_closed_kind_bytes(
+    kind: &KindExpr,
+    dimension_parameters: &[DimensionParameterDeclaration],
+    named_kinds: &dyn NamedKindPathResolver,
+) -> Result<Box<[u8]>, SemanticModelError> {
+    validate_kind_structure(kind)?;
+    let kind = normalize_kind_dimensions(kind.clone(), dimension_parameters.len())?;
+    let mut references = Vec::new();
+    collect_kind_dimension_references(&kind, &mut references);
+    let environment = canonicalize_dimension_environment(dimension_parameters, &references)?;
+    let rewritten = rewrite_kind_dimensions(&kind, &environment.old_to_new)?;
+    let rewritten = normalize_kind_dimensions(rewritten, environment.parameters.len())?;
+
+    let mut bytes = Vec::new();
+    bytes.push(0x01);
+    bytes.extend_from_slice(&(environment.parameters.len() as u32).to_le_bytes());
+    encode_dimension_parameters(&environment.parameters, &mut bytes);
+    let body = encode_kind_body(&rewritten, named_kinds)?;
+    push_node(&mut bytes, &body);
+    Ok(bytes.into_boxed_slice())
+}
+
+pub(crate) fn validate_kind_structure(kind: &KindExpr) -> Result<(), SemanticModelError> {
+    match kind {
+        KindExpr::Matrix { element, .. }
+        | KindExpr::Option(element)
+        | KindExpr::Set { element, .. }
+        | KindExpr::Reference(element)
+        | KindExpr::TypeOf(element) => validate_kind_structure(element)?,
+        KindExpr::Tuple(elements) => {
+            for element in elements {
+                validate_kind_structure(element)?;
+            }
+        }
+        KindExpr::Record(fields) => {
+            validate_kind_fields(fields, KindNameCategory::RecordField)?;
+        }
+        KindExpr::Table { columns, .. } => {
+            validate_kind_fields(columns, KindNameCategory::TableColumn)?;
+        }
+        KindExpr::Map { key, value, .. } => {
+            validate_kind_structure(key)?;
+            validate_kind_structure(value)?;
+        }
+        KindExpr::Wildcard
+        | KindExpr::Never
+        | KindExpr::Hole
+        | KindExpr::Parameter(_)
+        | KindExpr::Named(_)
+        | KindExpr::Id
+        | KindExpr::Index
+        | KindExpr::Atom(_)
+        | KindExpr::Enum(_) => {}
+    }
+    Ok(())
+}
+
+fn validate_kind_fields(
+    fields: &[KindField],
+    category: KindNameCategory,
+) -> Result<(), SemanticModelError> {
+    let mut names = BTreeSet::new();
+    for field in fields {
+        if !names.insert(&field.name) {
+            return Err(SemanticModelError::DuplicateKindName {
+                category,
+                name: field.name.clone(),
+            });
+        }
+        validate_kind_structure(&field.kind)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn collect_kind_dimension_references(
+    kind: &KindExpr,
+    references: &mut Vec<DimensionParameterId>,
+) {
+    match kind {
+        KindExpr::Wildcard
+        | KindExpr::Never
+        | KindExpr::Hole
+        | KindExpr::Parameter(_)
+        | KindExpr::Named(_)
+        | KindExpr::Id
+        | KindExpr::Index
+        | KindExpr::Atom(_)
+        | KindExpr::Enum(_) => {}
+        KindExpr::Matrix {
+            element,
+            dimensions,
+        } => {
+            collect_kind_dimension_references(element, references);
+            for dimension in dimensions {
+                collect_dimension_references(dimension, references);
+            }
+        }
+        KindExpr::Option(element) | KindExpr::Reference(element) | KindExpr::TypeOf(element) => {
+            collect_kind_dimension_references(element, references);
+        }
+        KindExpr::Tuple(elements) => {
+            for element in elements {
+                collect_kind_dimension_references(element, references);
+            }
+        }
+        KindExpr::Record(fields) => collect_field_dimension_references(fields, references),
+        KindExpr::Table { columns, rows } => {
+            collect_field_dimension_references(columns, references);
+            collect_dimension_references(rows, references);
+        }
+        KindExpr::Set {
+            element,
+            cardinality,
+        } => {
+            collect_kind_dimension_references(element, references);
+            collect_dimension_references(cardinality, references);
+        }
+        KindExpr::Map {
+            key,
+            value,
+            cardinality,
+        } => {
+            collect_kind_dimension_references(key, references);
+            collect_kind_dimension_references(value, references);
+            collect_dimension_references(cardinality, references);
+        }
+    }
+}
+
+fn collect_field_dimension_references(
+    fields: &[KindField],
+    references: &mut Vec<DimensionParameterId>,
+) {
+    for field in fields {
+        collect_kind_dimension_references(&field.kind, references);
+    }
+}
+
+pub(crate) fn visit_kind_parameters(
+    kind: &KindExpr,
+    visit: &mut impl FnMut(KindParameterId) -> Result<(), SemanticModelError>,
+) -> Result<(), SemanticModelError> {
+    match kind {
+        KindExpr::Hole => return Err(SemanticModelError::UnresolvedKindHole),
+        KindExpr::Parameter(id) => visit(*id)?,
+        KindExpr::Matrix { element, .. }
+        | KindExpr::Option(element)
+        | KindExpr::Set { element, .. }
+        | KindExpr::Reference(element)
+        | KindExpr::TypeOf(element) => visit_kind_parameters(element, visit)?,
+        KindExpr::Tuple(elements) => {
+            for element in elements {
+                visit_kind_parameters(element, visit)?;
+            }
+        }
+        KindExpr::Record(fields)
+        | KindExpr::Table {
+            columns: fields, ..
+        } => {
+            for field in fields {
+                visit_kind_parameters(&field.kind, visit)?;
+            }
+        }
+        KindExpr::Map { key, value, .. } => {
+            visit_kind_parameters(key, visit)?;
+            visit_kind_parameters(value, visit)?;
+        }
+        KindExpr::Wildcard
+        | KindExpr::Never
+        | KindExpr::Named(_)
+        | KindExpr::Id
+        | KindExpr::Index
+        | KindExpr::Atom(_)
+        | KindExpr::Enum(_) => {}
+    }
+    Ok(())
+}
+
+pub(crate) fn visit_kind_dimensions(
+    kind: &KindExpr,
+    visit: &mut impl FnMut(&DimensionExpr) -> Result<(), SemanticModelError>,
+) -> Result<(), SemanticModelError> {
+    match kind {
+        KindExpr::Matrix {
+            element,
+            dimensions,
+        } => {
+            visit_kind_dimensions(element, visit)?;
+            for dimension in dimensions {
+                visit(dimension)?;
+            }
+        }
+        KindExpr::Option(element) | KindExpr::Reference(element) | KindExpr::TypeOf(element) => {
+            visit_kind_dimensions(element, visit)?;
+        }
+        KindExpr::Tuple(elements) => {
+            for element in elements {
+                visit_kind_dimensions(element, visit)?;
+            }
+        }
+        KindExpr::Record(fields) => {
+            for field in fields {
+                visit_kind_dimensions(&field.kind, visit)?;
+            }
+        }
+        KindExpr::Table { columns, rows } => {
+            for field in columns {
+                visit_kind_dimensions(&field.kind, visit)?;
+            }
+            visit(rows)?;
+        }
+        KindExpr::Set {
+            element,
+            cardinality,
+        } => {
+            visit_kind_dimensions(element, visit)?;
+            visit(cardinality)?;
+        }
+        KindExpr::Map {
+            key,
+            value,
+            cardinality,
+        } => {
+            visit_kind_dimensions(key, visit)?;
+            visit_kind_dimensions(value, visit)?;
+            visit(cardinality)?;
+        }
+        KindExpr::Wildcard
+        | KindExpr::Never
+        | KindExpr::Hole
+        | KindExpr::Parameter(_)
+        | KindExpr::Named(_)
+        | KindExpr::Id
+        | KindExpr::Index
+        | KindExpr::Atom(_)
+        | KindExpr::Enum(_) => {}
+    }
+    Ok(())
+}
+
+fn rewrite_kind_dimensions(
+    kind: &KindExpr,
+    old_to_new: &[Option<DimensionParameterId>],
+) -> Result<KindExpr, SemanticModelError> {
+    Ok(match kind {
+        KindExpr::Wildcard => KindExpr::Wildcard,
+        KindExpr::Never => KindExpr::Never,
+        KindExpr::Hole => KindExpr::Hole,
+        KindExpr::Parameter(id) => KindExpr::Parameter(*id),
+        KindExpr::Named(id) => KindExpr::Named(*id),
+        KindExpr::Id => KindExpr::Id,
+        KindExpr::Index => KindExpr::Index,
+        KindExpr::Atom(key) => KindExpr::Atom(*key),
+        KindExpr::Enum(key) => KindExpr::Enum(*key),
+        KindExpr::Matrix {
+            element,
+            dimensions,
+        } => KindExpr::Matrix {
+            element: Box::new(rewrite_kind_dimensions(element, old_to_new)?),
+            dimensions: dimensions
+                .iter()
+                .map(|value| rewrite_dimension_references(value, old_to_new))
+                .collect::<Result<Vec<_>, _>>()?
+                .into_boxed_slice(),
+        },
+        KindExpr::Option(element) => {
+            KindExpr::Option(Box::new(rewrite_kind_dimensions(element, old_to_new)?))
+        }
+        KindExpr::Tuple(elements) => KindExpr::Tuple(
+            elements
+                .iter()
+                .map(|value| rewrite_kind_dimensions(value, old_to_new))
+                .collect::<Result<Vec<_>, _>>()?
+                .into_boxed_slice(),
+        ),
+        KindExpr::Record(fields) => KindExpr::Record(rewrite_fields(fields, old_to_new)?),
+        KindExpr::Table { columns, rows } => KindExpr::Table {
+            columns: rewrite_fields(columns, old_to_new)?,
+            rows: rewrite_dimension_references(rows, old_to_new)?,
+        },
+        KindExpr::Set {
+            element,
+            cardinality,
+        } => KindExpr::Set {
+            element: Box::new(rewrite_kind_dimensions(element, old_to_new)?),
+            cardinality: rewrite_dimension_references(cardinality, old_to_new)?,
+        },
+        KindExpr::Map {
+            key,
+            value,
+            cardinality,
+        } => KindExpr::Map {
+            key: Box::new(rewrite_kind_dimensions(key, old_to_new)?),
+            value: Box::new(rewrite_kind_dimensions(value, old_to_new)?),
+            cardinality: rewrite_dimension_references(cardinality, old_to_new)?,
+        },
+        KindExpr::Reference(element) => {
+            KindExpr::Reference(Box::new(rewrite_kind_dimensions(element, old_to_new)?))
+        }
+        KindExpr::TypeOf(element) => {
+            KindExpr::TypeOf(Box::new(rewrite_kind_dimensions(element, old_to_new)?))
+        }
+    })
+}
+
+fn rewrite_fields(
+    fields: &[KindField],
+    old_to_new: &[Option<DimensionParameterId>],
+) -> Result<Box<[KindField]>, SemanticModelError> {
+    fields
+        .iter()
+        .map(|field| {
+            Ok(KindField {
+                name: field.name.clone(),
+                kind: rewrite_kind_dimensions(&field.kind, old_to_new)?,
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(Vec::into_boxed_slice)
+}
+
+fn normalize_kind_dimensions(
+    kind: KindExpr,
+    parameter_count: usize,
+) -> Result<KindExpr, SemanticModelError> {
+    Ok(match kind {
+        KindExpr::Matrix {
+            element,
+            dimensions,
+        } => KindExpr::Matrix {
+            element: Box::new(normalize_kind_dimensions(*element, parameter_count)?),
+            dimensions: dimensions
+                .iter()
+                .map(|value| normalize_dimension(value, parameter_count))
+                .collect::<Result<Vec<_>, _>>()?
+                .into_boxed_slice(),
+        },
+        KindExpr::Option(element) => KindExpr::Option(Box::new(normalize_kind_dimensions(
+            *element,
+            parameter_count,
+        )?)),
+        KindExpr::Tuple(elements) => KindExpr::Tuple(
+            elements
+                .into_vec()
+                .into_iter()
+                .map(|value| normalize_kind_dimensions(value, parameter_count))
+                .collect::<Result<Vec<_>, _>>()?
+                .into_boxed_slice(),
+        ),
+        KindExpr::Record(fields) => KindExpr::Record(normalize_fields(fields, parameter_count)?),
+        KindExpr::Table { columns, rows } => KindExpr::Table {
+            columns: normalize_fields(columns, parameter_count)?,
+            rows: normalize_dimension(&rows, parameter_count)?,
+        },
+        KindExpr::Set {
+            element,
+            cardinality,
+        } => KindExpr::Set {
+            element: Box::new(normalize_kind_dimensions(*element, parameter_count)?),
+            cardinality: normalize_dimension(&cardinality, parameter_count)?,
+        },
+        KindExpr::Map {
+            key,
+            value,
+            cardinality,
+        } => KindExpr::Map {
+            key: Box::new(normalize_kind_dimensions(*key, parameter_count)?),
+            value: Box::new(normalize_kind_dimensions(*value, parameter_count)?),
+            cardinality: normalize_dimension(&cardinality, parameter_count)?,
+        },
+        KindExpr::Reference(element) => KindExpr::Reference(Box::new(normalize_kind_dimensions(
+            *element,
+            parameter_count,
+        )?)),
+        KindExpr::TypeOf(element) => KindExpr::TypeOf(Box::new(normalize_kind_dimensions(
+            *element,
+            parameter_count,
+        )?)),
+        other => other,
+    })
+}
+
+fn normalize_fields(
+    fields: Box<[KindField]>,
+    parameter_count: usize,
+) -> Result<Box<[KindField]>, SemanticModelError> {
+    fields
+        .into_vec()
+        .into_iter()
+        .map(|field| {
+            Ok(KindField {
+                name: field.name,
+                kind: normalize_kind_dimensions(field.kind, parameter_count)?,
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(Vec::into_boxed_slice)
+}
+
+fn encode_kind_body(
+    kind: &KindExpr,
+    named_kinds: &dyn NamedKindPathResolver,
+) -> Result<Vec<u8>, SemanticModelError> {
+    let mut bytes = Vec::new();
+    match kind {
+        KindExpr::Wildcard => bytes.push(0x01),
+        KindExpr::Never => bytes.push(0x02),
+        KindExpr::Hole => return Err(SemanticModelError::UnresolvedKindHole),
+        KindExpr::Parameter(id) => {
+            return Err(SemanticModelError::KindParameterNotClosed { id: *id });
+        }
+        KindExpr::Named(id) => {
+            bytes.push(0x04);
+            let path = named_kinds
+                .canonical_path(*id)
+                .ok_or(SemanticModelError::UnknownNamedKind { id: *id })?;
+            bytes.extend_from_slice(&path.canonical_bytes());
+        }
+        KindExpr::Id => bytes.push(0x05),
+        KindExpr::Index => bytes.push(0x06),
+        KindExpr::Atom(key) => {
+            bytes.push(0x07);
+            bytes.extend_from_slice(key.as_bytes());
+        }
+        KindExpr::Enum(key) => {
+            bytes.push(0x08);
+            bytes.extend_from_slice(key.as_bytes());
+        }
+        KindExpr::Matrix {
+            element,
+            dimensions,
+        } => {
+            bytes.push(0x09);
+            push_encoded_kind(&mut bytes, element, named_kinds)?;
+            bytes.extend_from_slice(&(dimensions.len() as u32).to_le_bytes());
+            for dimension in dimensions {
+                let encoded = crate::dimension::encode_normalized_dimension(dimension);
+                push_node(&mut bytes, &encoded);
+            }
+        }
+        KindExpr::Option(element) => {
+            bytes.push(0x0a);
+            push_encoded_kind(&mut bytes, element, named_kinds)?;
+        }
+        KindExpr::Tuple(elements) => {
+            bytes.push(0x0b);
+            bytes.extend_from_slice(&(elements.len() as u32).to_le_bytes());
+            for element in elements {
+                push_encoded_kind(&mut bytes, element, named_kinds)?;
+            }
+        }
+        KindExpr::Record(fields) => {
+            bytes.push(0x0c);
+            encode_fields(&mut bytes, fields, named_kinds)?;
+        }
+        KindExpr::Table { columns, rows } => {
+            bytes.push(0x0d);
+            encode_fields(&mut bytes, columns, named_kinds)?;
+            let rows = crate::dimension::encode_normalized_dimension(rows);
+            push_node(&mut bytes, &rows);
+        }
+        KindExpr::Set {
+            element,
+            cardinality,
+        } => {
+            bytes.push(0x0e);
+            push_encoded_kind(&mut bytes, element, named_kinds)?;
+            let cardinality = crate::dimension::encode_normalized_dimension(cardinality);
+            push_node(&mut bytes, &cardinality);
+        }
+        KindExpr::Map {
+            key,
+            value,
+            cardinality,
+        } => {
+            bytes.push(0x0f);
+            push_encoded_kind(&mut bytes, key, named_kinds)?;
+            push_encoded_kind(&mut bytes, value, named_kinds)?;
+            let cardinality = crate::dimension::encode_normalized_dimension(cardinality);
+            push_node(&mut bytes, &cardinality);
+        }
+        KindExpr::Reference(element) => {
+            bytes.push(0x10);
+            push_encoded_kind(&mut bytes, element, named_kinds)?;
+        }
+        KindExpr::TypeOf(element) => {
+            bytes.push(0x11);
+            push_encoded_kind(&mut bytes, element, named_kinds)?;
+        }
+    }
+    Ok(bytes)
+}
+
+fn push_encoded_kind(
+    bytes: &mut Vec<u8>,
+    kind: &KindExpr,
+    named_kinds: &dyn NamedKindPathResolver,
+) -> Result<(), SemanticModelError> {
+    let encoded = encode_kind_body(kind, named_kinds)?;
+    push_node(bytes, &encoded);
+    Ok(())
+}
+
+fn encode_fields(
+    bytes: &mut Vec<u8>,
+    fields: &[KindField],
+    named_kinds: &dyn NamedKindPathResolver,
+) -> Result<(), SemanticModelError> {
+    bytes.extend_from_slice(&(fields.len() as u32).to_le_bytes());
+    for field in fields {
+        push_utf8(bytes, &field.name);
+        push_encoded_kind(bytes, &field.kind, named_kinds)?;
+    }
+    Ok(())
+}
+
+fn push_utf8(bytes: &mut Vec<u8>, value: &str) {
+    bytes.extend_from_slice(&(value.len() as u64).to_le_bytes());
+    bytes.extend_from_slice(value.as_bytes());
+}
+
+fn push_node(bytes: &mut Vec<u8>, value: &[u8]) {
+    bytes.extend_from_slice(&(value.len() as u64).to_le_bytes());
+    bytes.extend_from_slice(value);
+}

--- a/src/core/src/kind_scheme.rs
+++ b/src/core/src/kind_scheme.rs
@@ -1,0 +1,190 @@
+//! Quantified semantic kind schemes.
+
+use crate::dimension::{canonicalize_dimension_environment, normalize_dimension};
+use crate::kind_expr::{validate_kind_structure, visit_kind_dimensions, visit_kind_parameters};
+use crate::{
+    DimensionExpr, DimensionParameterDeclaration, DimensionParameterId, KindExpr, KindParameterId,
+    SemanticModelError,
+};
+
+#[cfg(feature = "no_std")]
+use alloc::{boxed::Box, collections::BTreeSet, vec::Vec};
+#[cfg(not(feature = "no_std"))]
+use std::{boxed::Box, collections::BTreeSet, vec::Vec};
+
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct KindScheme {
+    kind_parameters: Box<[KindParameter]>,
+    dimension_parameters: Box<[DimensionParameterDeclaration]>,
+    inputs: InputKindScheme,
+    outputs: Box<[KindExpr]>,
+    constraints: Box<[KindConstraint]>,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct KindParameter {
+    pub id: KindParameterId,
+    pub upper_bound: Option<KindExpr>,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum InputKindScheme {
+    Fixed(Box<[KindExpr]>),
+    Variadic {
+        prefix: Box<[KindExpr]>,
+        repeated: KindExpr,
+        min_repetitions: u32,
+    },
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum KindConstraint {
+    Equal(KindExpr, KindExpr),
+    Convertible(KindExpr, KindExpr),
+    Keyable(KindExpr),
+    DimensionEqual(DimensionExpr, DimensionExpr),
+    DimensionLessEqual(DimensionExpr, DimensionExpr),
+}
+
+impl KindScheme {
+    pub fn new(
+        kind_parameters: Box<[KindParameter]>,
+        dimension_parameters: Box<[DimensionParameterDeclaration]>,
+        inputs: InputKindScheme,
+        outputs: Box<[KindExpr]>,
+        constraints: Box<[KindConstraint]>,
+    ) -> Result<Self, SemanticModelError> {
+        validate_kind_parameter_declarations(&kind_parameters)?;
+        let all_dimensions = (0..dimension_parameters.len())
+            .map(|index| DimensionParameterId::new(index as u32))
+            .collect::<Vec<_>>();
+        canonicalize_dimension_environment(&dimension_parameters, &all_dimensions)?;
+
+        let kind_count = kind_parameters.len();
+        let dimension_count = dimension_parameters.len();
+        for (index, parameter) in kind_parameters.iter().enumerate() {
+            if let Some(upper_bound) = &parameter.upper_bound {
+                validate_kind(
+                    upper_bound,
+                    kind_count,
+                    dimension_count,
+                    Some(KindParameterId::new(index as u32)),
+                )?;
+            }
+        }
+        match &inputs {
+            InputKindScheme::Fixed(inputs) => {
+                for input in inputs {
+                    validate_kind(input, kind_count, dimension_count, None)?;
+                }
+            }
+            InputKindScheme::Variadic {
+                prefix, repeated, ..
+            } => {
+                for input in prefix {
+                    validate_kind(input, kind_count, dimension_count, None)?;
+                }
+                validate_kind(repeated, kind_count, dimension_count, None)?;
+            }
+        }
+        for output in &outputs {
+            validate_kind(output, kind_count, dimension_count, None)?;
+        }
+        for constraint in &constraints {
+            validate_constraint(constraint, kind_count, dimension_count)?;
+        }
+
+        Ok(Self {
+            kind_parameters,
+            dimension_parameters,
+            inputs,
+            outputs,
+            constraints,
+        })
+    }
+
+    pub fn kind_parameters(&self) -> &[KindParameter] {
+        &self.kind_parameters
+    }
+
+    pub fn dimension_parameters(&self) -> &[DimensionParameterDeclaration] {
+        &self.dimension_parameters
+    }
+
+    pub const fn inputs(&self) -> &InputKindScheme {
+        &self.inputs
+    }
+
+    pub fn outputs(&self) -> &[KindExpr] {
+        &self.outputs
+    }
+
+    pub fn constraints(&self) -> &[KindConstraint] {
+        &self.constraints
+    }
+}
+
+fn validate_kind_parameter_declarations(
+    parameters: &[KindParameter],
+) -> Result<(), SemanticModelError> {
+    let mut seen = BTreeSet::new();
+    for (index, parameter) in parameters.iter().enumerate() {
+        if !seen.insert(parameter.id) {
+            return Err(SemanticModelError::DuplicateKindParameter { id: parameter.id });
+        }
+        if parameter.id.get() as usize != index {
+            return Err(SemanticModelError::UnknownKindParameter { id: parameter.id });
+        }
+    }
+    Ok(())
+}
+
+fn validate_kind(
+    kind: &KindExpr,
+    kind_count: usize,
+    dimension_count: usize,
+    upper_bound_of: Option<KindParameterId>,
+) -> Result<(), SemanticModelError> {
+    validate_kind_structure(kind)?;
+    visit_kind_parameters(kind, &mut |referenced| {
+        if referenced.get() as usize >= kind_count {
+            return Err(SemanticModelError::UnknownKindParameter { id: referenced });
+        }
+        if let Some(parameter) = upper_bound_of {
+            if referenced.get() >= parameter.get() {
+                return Err(SemanticModelError::ForwardKindParameterReference {
+                    parameter,
+                    referenced,
+                });
+            }
+        }
+        Ok(())
+    })?;
+    visit_kind_dimensions(kind, &mut |dimension| {
+        normalize_dimension(dimension, dimension_count).map(|_| ())
+    })
+}
+
+fn validate_constraint(
+    constraint: &KindConstraint,
+    kind_count: usize,
+    dimension_count: usize,
+) -> Result<(), SemanticModelError> {
+    match constraint {
+        KindConstraint::Equal(left, right) | KindConstraint::Convertible(left, right) => {
+            validate_kind(left, kind_count, dimension_count, None)?;
+            validate_kind(right, kind_count, dimension_count, None)
+        }
+        KindConstraint::Keyable(kind) => validate_kind(kind, kind_count, dimension_count, None),
+        KindConstraint::DimensionEqual(left, right)
+        | KindConstraint::DimensionLessEqual(left, right) => {
+            normalize_dimension(left, dimension_count)?;
+            normalize_dimension(right, dimension_count)?;
+            Ok(())
+        }
+    }
+}

--- a/src/core/src/legacy_adapter/kind.rs
+++ b/src/core/src/legacy_adapter/kind.rs
@@ -1,0 +1,520 @@
+use super::{
+    LegacyExtentRole, LegacyExtentSite, LegacyKindResolution, LegacyNominalResolution,
+    LegacyResolvedExtent, LegacySemanticContext, LegacyTypePathSegment, LegacyTypeSource,
+    LegacyValueKindTag,
+};
+use crate::dimension::{canonicalize_dimension_environment, normalize_dimension};
+use crate::kind::Kind;
+use crate::kind_expr::{validate_kind_structure, visit_kind_dimensions};
+use crate::value::ValueKind;
+use crate::{
+    DimensionEnvironmentBuilder, DimensionExpr, DimensionParameterDeclaration, FloatWidth,
+    IntegerWidth, KindExpr, KindField, NominalKind, Schema, SchemaBody, SchemaDraft, SchemaField,
+    SemanticModelError,
+};
+
+#[cfg(feature = "no_std")]
+use alloc::{boxed::Box, string::String, vec::Vec};
+#[cfg(not(feature = "no_std"))]
+use std::{boxed::Box, string::String, vec::Vec};
+
+pub fn kind_expr_from_legacy(
+    kind: &Kind,
+    context: &mut dyn LegacySemanticContext,
+) -> Result<LegacyKindResolution, SemanticModelError> {
+    let mut dimensions = DimensionEnvironmentBuilder::new();
+    let kind = kind_from_legacy(kind, context, &mut dimensions, &mut Vec::new())?;
+    let dimension_parameters = dimensions.into_declarations();
+    validate_legacy_kind_resolution(&kind, &dimension_parameters)?;
+    Ok(LegacyKindResolution {
+        kind,
+        dimension_parameters,
+    })
+}
+
+fn validate_legacy_kind_resolution(
+    kind: &KindExpr,
+    declarations: &[DimensionParameterDeclaration],
+) -> Result<(), SemanticModelError> {
+    validate_kind_structure(kind)?;
+    let all_declarations = declarations
+        .iter()
+        .map(|declaration| declaration.id)
+        .collect::<Vec<_>>();
+    canonicalize_dimension_environment(declarations, &all_declarations)?;
+    visit_kind_dimensions(kind, &mut |dimension| {
+        normalize_dimension(dimension, declarations.len()).map(|_| ())
+    })
+}
+
+pub fn schema_from_legacy_value_kind(
+    kind: &ValueKind,
+    context: &mut dyn LegacySemanticContext,
+) -> Result<Schema, SemanticModelError> {
+    let mut dimensions = DimensionEnvironmentBuilder::new();
+    let body = schema_body_from_legacy(kind, context, &mut dimensions, &mut Vec::new())?;
+    SchemaDraft {
+        dimension_parameters: dimensions.into_declarations(),
+        body,
+    }
+    .finalize()
+}
+
+fn kind_from_legacy(
+    kind: &Kind,
+    context: &mut dyn LegacySemanticContext,
+    dimensions: &mut DimensionEnvironmentBuilder,
+    path: &mut Vec<LegacyTypePathSegment>,
+) -> Result<KindExpr, SemanticModelError> {
+    Ok(match kind {
+        Kind::Any => KindExpr::Wildcard,
+        Kind::None => KindExpr::Never,
+        Kind::Empty => KindExpr::Hole,
+        Kind::Scalar(legacy_id) => KindExpr::Named(context.resolve_named_kind(*legacy_id)?),
+        Kind::Id => KindExpr::Id,
+        Kind::Index => KindExpr::Index,
+        Kind::Atom(legacy_id, legacy_name) => {
+            match context.resolve_nominal(NominalKind::Atom, *legacy_id, legacy_name)? {
+                LegacyNominalResolution::Atom { key } => KindExpr::Atom(key),
+                LegacyNominalResolution::Enum { .. } => {
+                    return Err(SemanticModelError::LegacyExtentResolutionKindMismatch);
+                }
+            }
+        }
+        Kind::Enum(legacy_id, legacy_name) => {
+            match context.resolve_nominal(NominalKind::Enum, *legacy_id, legacy_name)? {
+                LegacyNominalResolution::Enum { key, .. } => KindExpr::Enum(key),
+                LegacyNominalResolution::Atom { .. } => {
+                    return Err(SemanticModelError::LegacyExtentResolutionKindMismatch);
+                }
+            }
+        }
+        Kind::Matrix(element, legacy_dimensions) => {
+            let element = with_path(path, LegacyTypePathSegment::MatrixElement, |path| {
+                kind_from_legacy(element, context, dimensions, path)
+            })?;
+            let dimensions = if legacy_dimensions.is_empty() {
+                require_dimensions(context, dimensions, LegacyTypeSource::Kind, path)?
+            } else {
+                legacy_dimensions
+                    .iter()
+                    .map(|value| checked_extent(*value).map(DimensionExpr::Constant))
+                    .collect::<Result<Vec<_>, _>>()?
+                    .into_boxed_slice()
+            };
+            KindExpr::Matrix {
+                element: Box::new(element),
+                dimensions,
+            }
+        }
+        Kind::Option(element) => KindExpr::Option(Box::new(with_path(
+            path,
+            LegacyTypePathSegment::OptionElement,
+            |path| kind_from_legacy(element, context, dimensions, path),
+        )?)),
+        Kind::Tuple(elements) => KindExpr::Tuple(
+            elements
+                .iter()
+                .enumerate()
+                .map(|(index, element)| {
+                    with_path(
+                        path,
+                        LegacyTypePathSegment::TupleElement(checked_index(index)?),
+                        |path| kind_from_legacy(element, context, dimensions, path),
+                    )
+                })
+                .collect::<Result<Vec<_>, _>>()?
+                .into_boxed_slice(),
+        ),
+        Kind::Record(fields) => KindExpr::Record(kind_fields_from_legacy(
+            fields,
+            LegacyTypePathSegment::RecordField,
+            context,
+            dimensions,
+            path,
+        )?),
+        Kind::Table(columns, rows) => {
+            let columns = kind_fields_from_legacy(
+                columns,
+                LegacyTypePathSegment::TableColumn,
+                context,
+                dimensions,
+                path,
+            )?;
+            let rows = if *rows == 0 {
+                require_cardinality(
+                    context,
+                    dimensions,
+                    LegacyTypeSource::Kind,
+                    path,
+                    LegacyExtentRole::TableRows,
+                )?
+            } else {
+                DimensionExpr::Constant(checked_extent(*rows)?)
+            };
+            KindExpr::Table { columns, rows }
+        }
+        Kind::Set(element, size) => {
+            let element = with_path(path, LegacyTypePathSegment::SetElement, |path| {
+                kind_from_legacy(element, context, dimensions, path)
+            })?;
+            let cardinality = match size {
+                Some(size) => DimensionExpr::Constant(checked_extent(*size)?),
+                None => require_cardinality(
+                    context,
+                    dimensions,
+                    LegacyTypeSource::Kind,
+                    path,
+                    LegacyExtentRole::SetCardinality,
+                )?,
+            };
+            KindExpr::Set {
+                element: Box::new(element),
+                cardinality,
+            }
+        }
+        Kind::Map(key, value) => {
+            let key = with_path(path, LegacyTypePathSegment::MapKey, |path| {
+                kind_from_legacy(key, context, dimensions, path)
+            })?;
+            let value = with_path(path, LegacyTypePathSegment::MapValue, |path| {
+                kind_from_legacy(value, context, dimensions, path)
+            })?;
+            let cardinality = require_cardinality(
+                context,
+                dimensions,
+                LegacyTypeSource::Kind,
+                path,
+                LegacyExtentRole::MapCardinality,
+            )?;
+            KindExpr::Map {
+                key: Box::new(key),
+                value: Box::new(value),
+                cardinality,
+            }
+        }
+        Kind::Reference(element) => KindExpr::Reference(Box::new(kind_from_legacy(
+            element, context, dimensions, path,
+        )?)),
+        Kind::Kind(element) => KindExpr::TypeOf(Box::new(with_path(
+            path,
+            LegacyTypePathSegment::TypeOf,
+            |path| kind_from_legacy(element, context, dimensions, path),
+        )?)),
+    })
+}
+
+fn kind_fields_from_legacy(
+    fields: &[(String, Kind)],
+    segment: fn(u32) -> LegacyTypePathSegment,
+    context: &mut dyn LegacySemanticContext,
+    dimensions: &mut DimensionEnvironmentBuilder,
+    path: &mut Vec<LegacyTypePathSegment>,
+) -> Result<Box<[KindField]>, SemanticModelError> {
+    fields
+        .iter()
+        .enumerate()
+        .map(|(index, (name, kind))| {
+            Ok(KindField {
+                name: name.clone(),
+                kind: with_path(path, segment(checked_index(index)?), |path| {
+                    kind_from_legacy(kind, context, dimensions, path)
+                })?,
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(Vec::into_boxed_slice)
+}
+
+fn schema_body_from_legacy(
+    kind: &ValueKind,
+    context: &mut dyn LegacySemanticContext,
+    dimensions: &mut DimensionEnvironmentBuilder,
+    path: &mut Vec<LegacyTypePathSegment>,
+) -> Result<SchemaBody, SemanticModelError> {
+    Ok(match kind {
+        ValueKind::U8 => SchemaBody::UnsignedInteger(IntegerWidth::W8),
+        ValueKind::U16 => SchemaBody::UnsignedInteger(IntegerWidth::W16),
+        ValueKind::U32 => SchemaBody::UnsignedInteger(IntegerWidth::W32),
+        ValueKind::U64 => SchemaBody::UnsignedInteger(IntegerWidth::W64),
+        ValueKind::U128 => SchemaBody::UnsignedInteger(IntegerWidth::W128),
+        ValueKind::I8 => SchemaBody::SignedInteger(IntegerWidth::W8),
+        ValueKind::I16 => SchemaBody::SignedInteger(IntegerWidth::W16),
+        ValueKind::I32 => SchemaBody::SignedInteger(IntegerWidth::W32),
+        ValueKind::I64 => SchemaBody::SignedInteger(IntegerWidth::W64),
+        ValueKind::I128 => SchemaBody::SignedInteger(IntegerWidth::W128),
+        ValueKind::F32 => SchemaBody::FloatingPoint(FloatWidth::W32),
+        ValueKind::F64 => SchemaBody::FloatingPoint(FloatWidth::W64),
+        ValueKind::C64 => SchemaBody::Complex(FloatWidth::W64),
+        ValueKind::R64 => SchemaBody::Rational64,
+        ValueKind::String => SchemaBody::String,
+        ValueKind::Bool => SchemaBody::Bool,
+        ValueKind::Id => SchemaBody::Id,
+        ValueKind::Index => SchemaBody::Index,
+        ValueKind::Empty | ValueKind::Any | ValueKind::None | ValueKind::Reference(_) => {
+            return Err(SemanticModelError::NonInstantiableLegacyValueKind {
+                kind: legacy_value_kind_tag(kind),
+            });
+        }
+        ValueKind::Matrix(element, legacy_dimensions) => {
+            let element = with_path(path, LegacyTypePathSegment::MatrixElement, |path| {
+                schema_body_from_legacy(element, context, dimensions, path)
+            })?;
+            let dimensions = if legacy_dimensions.is_empty() {
+                require_dimensions(context, dimensions, LegacyTypeSource::ValueKind, path)?
+            } else {
+                legacy_dimensions
+                    .iter()
+                    .map(|value| checked_extent(*value).map(DimensionExpr::Constant))
+                    .collect::<Result<Vec<_>, _>>()?
+                    .into_boxed_slice()
+            };
+            SchemaBody::Matrix {
+                element: Box::new(element),
+                dimensions,
+            }
+        }
+        ValueKind::Enum(legacy_id, legacy_name) => {
+            match context.resolve_nominal(NominalKind::Enum, *legacy_id, legacy_name)? {
+                LegacyNominalResolution::Enum { key, variants } => {
+                    SchemaBody::Enum { key, variants }
+                }
+                LegacyNominalResolution::Atom { .. } => {
+                    return Err(SemanticModelError::LegacyExtentResolutionKindMismatch);
+                }
+            }
+        }
+        ValueKind::Record(fields) => SchemaBody::Record(schema_fields_from_legacy(
+            fields,
+            LegacyTypePathSegment::RecordField,
+            context,
+            dimensions,
+            path,
+        )?),
+        ValueKind::Map(key, value) => {
+            let key = with_path(path, LegacyTypePathSegment::MapKey, |path| {
+                schema_body_from_legacy(key, context, dimensions, path)
+            })?;
+            let value = with_path(path, LegacyTypePathSegment::MapValue, |path| {
+                schema_body_from_legacy(value, context, dimensions, path)
+            })?;
+            let cardinality = require_cardinality(
+                context,
+                dimensions,
+                LegacyTypeSource::ValueKind,
+                path,
+                LegacyExtentRole::MapCardinality,
+            )?;
+            SchemaBody::Map {
+                key: Box::new(key),
+                value: Box::new(value),
+                cardinality,
+            }
+        }
+        ValueKind::Atom(legacy_id, legacy_name) => {
+            match context.resolve_nominal(NominalKind::Atom, *legacy_id, legacy_name)? {
+                LegacyNominalResolution::Atom { key } => SchemaBody::Atom(key),
+                LegacyNominalResolution::Enum { .. } => {
+                    return Err(SemanticModelError::LegacyExtentResolutionKindMismatch);
+                }
+            }
+        }
+        ValueKind::Table(columns, rows) => {
+            let columns = schema_fields_from_legacy(
+                columns,
+                LegacyTypePathSegment::TableColumn,
+                context,
+                dimensions,
+                path,
+            )?;
+            let rows = if *rows == 0 {
+                require_cardinality(
+                    context,
+                    dimensions,
+                    LegacyTypeSource::ValueKind,
+                    path,
+                    LegacyExtentRole::TableRows,
+                )?
+            } else {
+                DimensionExpr::Constant(checked_extent(*rows)?)
+            };
+            SchemaBody::Table { columns, rows }
+        }
+        ValueKind::Tuple(elements) => SchemaBody::Tuple(
+            elements
+                .iter()
+                .enumerate()
+                .map(|(index, element)| {
+                    with_path(
+                        path,
+                        LegacyTypePathSegment::TupleElement(checked_index(index)?),
+                        |path| schema_body_from_legacy(element, context, dimensions, path),
+                    )
+                })
+                .collect::<Result<Vec<_>, _>>()?
+                .into_boxed_slice(),
+        ),
+        ValueKind::Set(element, size) => {
+            let element = with_path(path, LegacyTypePathSegment::SetElement, |path| {
+                schema_body_from_legacy(element, context, dimensions, path)
+            })?;
+            let cardinality = match size {
+                Some(size) => DimensionExpr::Constant(checked_extent(*size)?),
+                None => require_cardinality(
+                    context,
+                    dimensions,
+                    LegacyTypeSource::ValueKind,
+                    path,
+                    LegacyExtentRole::SetCardinality,
+                )?,
+            };
+            SchemaBody::Set {
+                element: Box::new(element),
+                cardinality,
+            }
+        }
+        ValueKind::Option(element) => SchemaBody::Option(Box::new(with_path(
+            path,
+            LegacyTypePathSegment::OptionElement,
+            |path| schema_body_from_legacy(element, context, dimensions, path),
+        )?)),
+        ValueKind::Kind(_) => SchemaBody::ReifiedType,
+    })
+}
+
+fn schema_fields_from_legacy(
+    fields: &[(String, ValueKind)],
+    segment: fn(u32) -> LegacyTypePathSegment,
+    context: &mut dyn LegacySemanticContext,
+    dimensions: &mut DimensionEnvironmentBuilder,
+    path: &mut Vec<LegacyTypePathSegment>,
+) -> Result<Box<[SchemaField]>, SemanticModelError> {
+    fields
+        .iter()
+        .enumerate()
+        .map(|(index, (name, kind))| {
+            Ok(SchemaField {
+                name: name.clone(),
+                schema: with_path(path, segment(checked_index(index)?), |path| {
+                    schema_body_from_legacy(kind, context, dimensions, path)
+                })?,
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(Vec::into_boxed_slice)
+}
+
+fn require_dimensions(
+    context: &mut dyn LegacySemanticContext,
+    dimensions: &mut DimensionEnvironmentBuilder,
+    source: LegacyTypeSource,
+    path: &[LegacyTypePathSegment],
+) -> Result<Box<[DimensionExpr]>, SemanticModelError> {
+    let site = LegacyExtentSite {
+        source,
+        path: path.to_vec().into_boxed_slice(),
+        role: LegacyExtentRole::MatrixDimensions,
+    };
+    match context.resolve_unspecified_extent(&site, dimensions)? {
+        LegacyResolvedExtent::Dimensions(values) if !values.is_empty() => Ok(values),
+        LegacyResolvedExtent::Dimensions(_) | LegacyResolvedExtent::Cardinality(_) => {
+            Err(SemanticModelError::LegacyExtentResolutionKindMismatch)
+        }
+    }
+}
+
+fn require_cardinality(
+    context: &mut dyn LegacySemanticContext,
+    dimensions: &mut DimensionEnvironmentBuilder,
+    source: LegacyTypeSource,
+    path: &[LegacyTypePathSegment],
+    role: LegacyExtentRole,
+) -> Result<DimensionExpr, SemanticModelError> {
+    let site = LegacyExtentSite {
+        source,
+        path: path.to_vec().into_boxed_slice(),
+        role,
+    };
+    match context.resolve_unspecified_extent(&site, dimensions)? {
+        LegacyResolvedExtent::Cardinality(value) => Ok(value),
+        LegacyResolvedExtent::Dimensions(_) => {
+            Err(SemanticModelError::LegacyExtentResolutionKindMismatch)
+        }
+    }
+}
+
+fn with_path<T>(
+    path: &mut Vec<LegacyTypePathSegment>,
+    segment: LegacyTypePathSegment,
+    f: impl FnOnce(&mut Vec<LegacyTypePathSegment>) -> Result<T, SemanticModelError>,
+) -> Result<T, SemanticModelError> {
+    path.push(segment);
+    let result = f(path);
+    path.pop();
+    result
+}
+
+fn checked_extent(value: usize) -> Result<u64, SemanticModelError> {
+    checked_extent_value(value as u128)
+}
+
+fn checked_extent_value(value: u128) -> Result<u64, SemanticModelError> {
+    u64::try_from(value).map_err(|_| SemanticModelError::LegacyExtentOutOfRange { value })
+}
+
+fn checked_index(value: usize) -> Result<u32, SemanticModelError> {
+    u32::try_from(value).map_err(|_| SemanticModelError::LegacyExtentOutOfRange {
+        value: value as u128,
+    })
+}
+
+fn legacy_value_kind_tag(kind: &ValueKind) -> LegacyValueKindTag {
+    match kind {
+        ValueKind::U8 => LegacyValueKindTag::U8,
+        ValueKind::U16 => LegacyValueKindTag::U16,
+        ValueKind::U32 => LegacyValueKindTag::U32,
+        ValueKind::U64 => LegacyValueKindTag::U64,
+        ValueKind::U128 => LegacyValueKindTag::U128,
+        ValueKind::I8 => LegacyValueKindTag::I8,
+        ValueKind::I16 => LegacyValueKindTag::I16,
+        ValueKind::I32 => LegacyValueKindTag::I32,
+        ValueKind::I64 => LegacyValueKindTag::I64,
+        ValueKind::I128 => LegacyValueKindTag::I128,
+        ValueKind::F32 => LegacyValueKindTag::F32,
+        ValueKind::F64 => LegacyValueKindTag::F64,
+        ValueKind::C64 => LegacyValueKindTag::C64,
+        ValueKind::R64 => LegacyValueKindTag::R64,
+        ValueKind::String => LegacyValueKindTag::String,
+        ValueKind::Bool => LegacyValueKindTag::Bool,
+        ValueKind::Id => LegacyValueKindTag::Id,
+        ValueKind::Index => LegacyValueKindTag::Index,
+        ValueKind::Empty => LegacyValueKindTag::Empty,
+        ValueKind::Any => LegacyValueKindTag::Any,
+        ValueKind::None => LegacyValueKindTag::None,
+        ValueKind::Matrix(_, _) => LegacyValueKindTag::Matrix,
+        ValueKind::Enum(_, _) => LegacyValueKindTag::Enum,
+        ValueKind::Record(_) => LegacyValueKindTag::Record,
+        ValueKind::Map(_, _) => LegacyValueKindTag::Map,
+        ValueKind::Atom(_, _) => LegacyValueKindTag::Atom,
+        ValueKind::Table(_, _) => LegacyValueKindTag::Table,
+        ValueKind::Tuple(_) => LegacyValueKindTag::Tuple,
+        ValueKind::Reference(_) => LegacyValueKindTag::Reference,
+        ValueKind::Set(_, _) => LegacyValueKindTag::Set,
+        ValueKind::Option(_) => LegacyValueKindTag::Option,
+        ValueKind::Kind(_) => LegacyValueKindTag::Kind,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_extent_conversion_is_checked_before_narrowing() {
+        assert_eq!(checked_extent_value(u64::MAX as u128).unwrap(), u64::MAX);
+        assert!(matches!(
+            checked_extent_value(u64::MAX as u128 + 1),
+            Err(SemanticModelError::LegacyExtentOutOfRange { .. })
+        ));
+    }
+}

--- a/src/core/src/legacy_adapter/mod.rs
+++ b/src/core/src/legacy_adapter/mod.rs
@@ -1,0 +1,132 @@
+//! Explicit boundary adapters from the current mutable value model.
+
+mod kind;
+
+pub use self::kind::*;
+
+use crate::{
+    DimensionEnvironmentBuilder, DimensionExpr, DimensionParameterDeclaration, EnumVariantSchema,
+    KindId, NominalKey, NominalKind, SemanticModelError,
+};
+
+#[cfg(feature = "no_std")]
+use alloc::{boxed::Box, string::String};
+#[cfg(not(feature = "no_std"))]
+use std::{boxed::Box, string::String};
+
+pub trait LegacySemanticContext {
+    fn resolve_named_kind(&mut self, legacy_id: u64) -> Result<KindId, SemanticModelError>;
+
+    fn resolve_nominal(
+        &mut self,
+        nominal_kind: NominalKind,
+        legacy_id: u64,
+        legacy_name: &str,
+    ) -> Result<LegacyNominalResolution, SemanticModelError>;
+
+    fn resolve_unspecified_extent(
+        &mut self,
+        site: &LegacyExtentSite,
+        dimensions: &mut DimensionEnvironmentBuilder,
+    ) -> Result<LegacyResolvedExtent, SemanticModelError>;
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum LegacyNominalResolution {
+    Atom {
+        key: NominalKey,
+    },
+    Enum {
+        key: NominalKey,
+        variants: Box<[EnumVariantSchema]>,
+    },
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum LegacyResolvedExtent {
+    Dimensions(Box<[DimensionExpr]>),
+    Cardinality(DimensionExpr),
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum LegacyTypeSource {
+    Kind,
+    ValueKind,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum LegacyExtentRole {
+    MatrixDimensions,
+    TableRows,
+    SetCardinality,
+    MapCardinality,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct LegacyExtentSite {
+    pub source: LegacyTypeSource,
+    pub path: Box<[LegacyTypePathSegment]>,
+    pub role: LegacyExtentRole,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum LegacyTypePathSegment {
+    MatrixElement,
+    OptionElement,
+    TupleElement(u32),
+    RecordField(u32),
+    TableColumn(u32),
+    SetElement,
+    MapKey,
+    MapValue,
+    TypeOf,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum LegacyValueKindTag {
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
+    I8,
+    I16,
+    I32,
+    I64,
+    I128,
+    F32,
+    F64,
+    C64,
+    R64,
+    String,
+    Bool,
+    Id,
+    Index,
+    Empty,
+    Any,
+    None,
+    Matrix,
+    Enum,
+    Record,
+    Map,
+    Atom,
+    Table,
+    Tuple,
+    Reference,
+    Set,
+    Option,
+    Kind,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LegacyKindResolution {
+    pub kind: crate::KindExpr,
+    pub dimension_parameters: Box<[DimensionParameterDeclaration]>,
+}

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -116,11 +116,14 @@ pub mod execution;
 pub mod function;
 pub mod kind;
 pub mod nodes;
+pub mod nominal;
 #[cfg(feature = "functions")]
 pub mod reactive_transaction;
 #[cfg(feature = "resident-execution")]
 #[doc(hidden)]
 pub mod resident_execution;
+pub mod semantic_error;
+pub mod semantic_identity;
 pub mod state_journal;
 pub mod structures;
 pub mod value;
@@ -144,12 +147,15 @@ pub use self::kind::*;
 #[cfg(feature = "mika")]
 pub use self::mika::*;
 pub use self::nodes::*;
+pub use self::nominal::*;
 pub use self::program::*;
 #[cfg(feature = "functions")]
 pub use self::reactive_transaction::*;
 #[cfg(feature = "resident-execution")]
 #[doc(hidden)]
 pub use self::resident_execution::*;
+pub use self::semantic_error::*;
+pub use self::semantic_identity::*;
 pub use self::state_journal::*;
 pub use self::stdlib::*;
 pub use self::structures::*;

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -109,25 +109,18 @@ use tabled::{
     settings::{Alignment, Modify, Panel, Span, Style, object::Rows},
 };
 
-pub mod dimension;
 pub mod element;
 pub mod error;
 pub mod execution;
 #[cfg(feature = "functions")]
 pub mod function;
 pub mod kind;
-pub mod kind_expr;
-pub mod kind_scheme;
 pub mod nodes;
-pub mod nominal;
 #[cfg(feature = "functions")]
 pub mod reactive_transaction;
 #[cfg(feature = "resident-execution")]
 #[doc(hidden)]
 pub mod resident_execution;
-pub mod schema;
-pub mod semantic_error;
-pub mod semantic_identity;
 pub mod state_journal;
 pub mod structures;
 pub mod value;
@@ -142,19 +135,15 @@ pub mod program;
 pub mod stdlib;
 pub mod types;
 
-pub use self::dimension::*;
 pub use self::element::*;
 pub use self::error::*;
 pub use self::execution::*;
 #[cfg(feature = "functions")]
 pub use self::function::*;
 pub use self::kind::*;
-pub use self::kind_expr::*;
-pub use self::kind_scheme::*;
 #[cfg(feature = "mika")]
 pub use self::mika::*;
 pub use self::nodes::*;
-pub use self::nominal::*;
 pub use self::program::*;
 #[cfg(feature = "functions")]
 pub use self::reactive_transaction::*;
@@ -169,6 +158,21 @@ pub use self::stdlib::*;
 pub use self::structures::*;
 pub use self::types::*;
 pub use self::value::*;
+
+pub mod dimension;
+pub mod kind_expr;
+pub mod kind_scheme;
+pub mod legacy_adapter;
+pub mod nominal;
+pub mod schema;
+pub mod semantic_error;
+pub mod semantic_identity;
+
+pub use self::dimension::*;
+pub use self::kind_expr::*;
+pub use self::kind_scheme::*;
+pub use self::legacy_adapter::*;
+pub use self::nominal::*;
 
 // Mech Source Code
 // ---------------------------------------------------------------------------

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -109,12 +109,15 @@ use tabled::{
     settings::{Alignment, Modify, Panel, Span, Style, object::Rows},
 };
 
+pub mod dimension;
 pub mod element;
 pub mod error;
 pub mod execution;
 #[cfg(feature = "functions")]
 pub mod function;
 pub mod kind;
+pub mod kind_expr;
+pub mod kind_scheme;
 pub mod nodes;
 pub mod nominal;
 #[cfg(feature = "functions")]
@@ -138,12 +141,15 @@ pub mod program;
 pub mod stdlib;
 pub mod types;
 
+pub use self::dimension::*;
 pub use self::element::*;
 pub use self::error::*;
 pub use self::execution::*;
 #[cfg(feature = "functions")]
 pub use self::function::*;
 pub use self::kind::*;
+pub use self::kind_expr::*;
+pub use self::kind_scheme::*;
 #[cfg(feature = "mika")]
 pub use self::mika::*;
 pub use self::nodes::*;

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -125,6 +125,7 @@ pub mod reactive_transaction;
 #[cfg(feature = "resident-execution")]
 #[doc(hidden)]
 pub mod resident_execution;
+pub mod schema;
 pub mod semantic_error;
 pub mod semantic_identity;
 pub mod state_journal;
@@ -160,6 +161,7 @@ pub use self::reactive_transaction::*;
 #[cfg(feature = "resident-execution")]
 #[doc(hidden)]
 pub use self::resident_execution::*;
+pub use self::schema::*;
 pub use self::semantic_error::*;
 pub use self::semantic_identity::*;
 pub use self::state_journal::*;

--- a/src/core/src/nominal.rs
+++ b/src/core/src/nominal.rs
@@ -1,0 +1,79 @@
+//! Canonical nominal paths and durable nominal keys.
+
+use crate::{NominalKey, NominalPathError, SemanticModelError};
+use sha2::{Digest, Sha256};
+
+#[cfg(feature = "no_std")]
+use alloc::{boxed::Box, string::String, vec::Vec};
+#[cfg(not(feature = "no_std"))]
+use std::{boxed::Box, string::String, vec::Vec};
+
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct CanonicalNominalPath {
+    segments: Box<[String]>,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[repr(u8)]
+pub enum NominalKind {
+    Atom = 0x01,
+    Enum = 0x02,
+}
+
+impl CanonicalNominalPath {
+    pub fn new(segments: impl Into<Box<[String]>>) -> Result<Self, SemanticModelError> {
+        let segments = segments.into();
+        if segments.is_empty() {
+            return Err(SemanticModelError::InvalidNominalPath {
+                segment: None,
+                reason: NominalPathError::EmptyPath,
+            });
+        }
+        for (index, segment) in segments.iter().enumerate() {
+            let reason = if segment.is_empty() {
+                Some(NominalPathError::EmptySegment)
+            } else if segment == "." {
+                Some(NominalPathError::DotSegment)
+            } else if segment == ".." {
+                Some(NominalPathError::DotDotSegment)
+            } else if segment.as_bytes().contains(&0) {
+                Some(NominalPathError::ContainsNul)
+            } else {
+                None
+            };
+            if let Some(reason) = reason {
+                return Err(SemanticModelError::InvalidNominalPath {
+                    segment: Some(index as u32),
+                    reason,
+                });
+            }
+        }
+        Ok(Self { segments })
+    }
+
+    pub fn segments(&self) -> &[String] {
+        &self.segments
+    }
+
+    pub fn canonical_bytes(&self) -> Box<[u8]> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&(self.segments.len() as u32).to_le_bytes());
+        for segment in &self.segments {
+            bytes.extend_from_slice(&(segment.len() as u64).to_le_bytes());
+            bytes.extend_from_slice(segment.as_bytes());
+        }
+        bytes.into_boxed_slice()
+    }
+}
+
+impl NominalKey {
+    pub fn from_path(kind: NominalKind, path: &CanonicalNominalPath) -> Self {
+        let mut hash = Sha256::new();
+        hash.update(b"mech-nominal-v1\0");
+        hash.update([kind as u8]);
+        hash.update(path.canonical_bytes());
+        Self::from_bytes(hash.finalize().into())
+    }
+}

--- a/src/core/src/resident_execution.rs
+++ b/src/core/src/resident_execution.rs
@@ -1,27 +1,6 @@
 //! Dependency-neutral identities for the experimental resident executor.
 
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[repr(transparent)]
-pub struct CellSlotId(pub u32);
-
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[repr(transparent)]
-pub struct SlotIndex(pub u32);
-
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[repr(transparent)]
-pub struct InstanceEpoch(pub u64);
-
-impl InstanceEpoch {
-    /// Returns the next unique resident epoch, or `None` after `u64::MAX`.
-    #[inline]
-    pub const fn checked_next(self) -> Option<Self> {
-        match self.0.checked_add(1) {
-            Some(next) => Some(Self(next)),
-            None => None,
-        }
-    }
-}
+pub use crate::semantic_identity::{CellSlotId, InstanceEpoch, SlotIndex};
 
 #[cfg(test)]
 mod tests {
@@ -41,7 +20,7 @@ mod tests {
             core::mem::size_of::<InstanceEpoch>(),
             core::mem::size_of::<u64>()
         );
-        assert_eq!(InstanceEpoch(41).checked_next(), Some(InstanceEpoch(42)));
-        assert_eq!(InstanceEpoch(u64::MAX).checked_next(), None);
+        assert_eq!(InstanceEpoch(41).checked_next(), Ok(InstanceEpoch(42)));
+        assert!(InstanceEpoch(u64::MAX).checked_next().is_err());
     }
 }

--- a/src/core/src/schema/encoding.rs
+++ b/src/core/src/schema/encoding.rs
@@ -1,0 +1,209 @@
+use super::{EnumVariantSchema, FloatWidth, IntegerWidth, Schema, SchemaBody, SchemaField};
+use crate::dimension::{encode_dimension_parameters, encode_normalized_dimension};
+use crate::{DimensionParameter, ExtentEvolution, SchemaKey, extent_evolution};
+use sha2::{Digest, Sha256};
+
+#[cfg(feature = "no_std")]
+use alloc::{boxed::Box, vec::Vec};
+#[cfg(not(feature = "no_std"))]
+use std::{boxed::Box, vec::Vec};
+
+struct CanonicalWriter {
+    bytes: Vec<u8>,
+}
+
+impl CanonicalWriter {
+    fn new() -> Self {
+        Self { bytes: Vec::new() }
+    }
+
+    fn write_u8(&mut self, value: u8) {
+        self.bytes.push(value);
+    }
+
+    fn write_u16_le(&mut self, value: u16) {
+        self.bytes.extend_from_slice(&value.to_le_bytes());
+    }
+
+    fn write_u32_le(&mut self, value: u32) {
+        self.bytes.extend_from_slice(&value.to_le_bytes());
+    }
+
+    fn write_u64_le(&mut self, value: u64) {
+        self.bytes.extend_from_slice(&value.to_le_bytes());
+    }
+
+    fn write_bytes(&mut self, value: &[u8]) {
+        self.bytes.extend_from_slice(value);
+    }
+
+    fn write_utf8(&mut self, value: &str) {
+        self.write_u64_le(value.len() as u64);
+        self.write_bytes(value.as_bytes());
+    }
+
+    fn write_node(&mut self, value: &[u8]) {
+        self.write_u64_le(value.len() as u64);
+        self.write_bytes(value);
+    }
+
+    fn finish(self) -> Box<[u8]> {
+        self.bytes.into_boxed_slice()
+    }
+}
+
+impl Schema {
+    pub fn canonical_bytes(&self) -> Box<[u8]> {
+        let mut writer = CanonicalWriter::new();
+        writer.write_u8(0x01);
+        writer.write_u32_le(self.dimension_parameters.len() as u32);
+        encode_dimension_parameters(&self.dimension_parameters, &mut writer.bytes);
+        let body = encode_schema_body(&self.body);
+        writer.write_node(&body);
+        writer.finish()
+    }
+
+    pub fn key(&self) -> SchemaKey {
+        let mut hash = Sha256::new();
+        hash.update(b"mech-schema-v1\0");
+        hash.update(self.canonical_bytes());
+        SchemaKey::from_bytes(hash.finalize().into())
+    }
+
+    pub fn is_keyable(&self) -> bool {
+        super::validation::is_body_keyable(&self.body)
+    }
+
+    pub fn extent_evolution(&self) -> ExtentEvolution {
+        extent_evolution(&self.dimension_parameters)
+    }
+
+    pub fn dimension_parameters(&self) -> &[DimensionParameter] {
+        &self.dimension_parameters
+    }
+
+    pub const fn body(&self) -> &SchemaBody {
+        &self.body
+    }
+}
+
+fn encode_schema_body(body: &SchemaBody) -> Box<[u8]> {
+    let mut writer = CanonicalWriter::new();
+    match body {
+        SchemaBody::Bool => writer.write_u8(0x01),
+        SchemaBody::UnsignedInteger(width) => {
+            writer.write_u8(0x02);
+            writer.write_u16_le(integer_width(*width));
+        }
+        SchemaBody::SignedInteger(width) => {
+            writer.write_u8(0x03);
+            writer.write_u16_le(integer_width(*width));
+        }
+        SchemaBody::FloatingPoint(width) => {
+            writer.write_u8(0x04);
+            writer.write_u16_le(float_width(*width));
+        }
+        SchemaBody::Complex(width) => {
+            writer.write_u8(0x05);
+            writer.write_u16_le(float_width(*width));
+        }
+        SchemaBody::Rational64 => {
+            writer.write_u8(0x06);
+            writer.write_u16_le(64);
+            writer.write_u16_le(64);
+        }
+        SchemaBody::String => writer.write_u8(0x07),
+        SchemaBody::Id => writer.write_u8(0x08),
+        SchemaBody::Index => writer.write_u8(0x09),
+        SchemaBody::Atom(key) => {
+            writer.write_u8(0x0a);
+            writer.write_bytes(key.as_bytes());
+        }
+        SchemaBody::Enum { key, variants } => {
+            writer.write_u8(0x0b);
+            writer.write_bytes(key.as_bytes());
+            encode_variants(&mut writer, variants);
+        }
+        SchemaBody::Option(element) => {
+            writer.write_u8(0x0c);
+            writer.write_node(&encode_schema_body(element));
+        }
+        SchemaBody::Tuple(elements) => {
+            writer.write_u8(0x0d);
+            writer.write_u32_le(elements.len() as u32);
+            for element in elements {
+                writer.write_node(&encode_schema_body(element));
+            }
+        }
+        SchemaBody::Record(fields) => {
+            writer.write_u8(0x0e);
+            encode_fields(&mut writer, fields);
+        }
+        SchemaBody::Matrix {
+            element,
+            dimensions,
+        } => {
+            writer.write_u8(0x0f);
+            writer.write_node(&encode_schema_body(element));
+            writer.write_u32_le(dimensions.len() as u32);
+            for dimension in dimensions {
+                writer.write_node(&encode_normalized_dimension(dimension));
+            }
+        }
+        SchemaBody::Table { columns, rows } => {
+            writer.write_u8(0x10);
+            encode_fields(&mut writer, columns);
+            writer.write_node(&encode_normalized_dimension(rows));
+        }
+        SchemaBody::Set {
+            element,
+            cardinality,
+        } => {
+            writer.write_u8(0x11);
+            writer.write_node(&encode_schema_body(element));
+            writer.write_node(&encode_normalized_dimension(cardinality));
+        }
+        SchemaBody::Map {
+            key,
+            value,
+            cardinality,
+        } => {
+            writer.write_u8(0x12);
+            writer.write_node(&encode_schema_body(key));
+            writer.write_node(&encode_schema_body(value));
+            writer.write_node(&encode_normalized_dimension(cardinality));
+        }
+        SchemaBody::ReifiedType => writer.write_u8(0x13),
+    }
+    writer.finish()
+}
+
+fn encode_variants(writer: &mut CanonicalWriter, variants: &[EnumVariantSchema]) {
+    writer.write_u32_le(variants.len() as u32);
+    for variant in variants {
+        writer.write_utf8(&variant.name);
+        match &variant.payload {
+            None => writer.write_u8(0),
+            Some(payload) => {
+                writer.write_u8(1);
+                writer.write_node(&encode_schema_body(payload));
+            }
+        }
+    }
+}
+
+fn encode_fields(writer: &mut CanonicalWriter, fields: &[SchemaField]) {
+    writer.write_u32_le(fields.len() as u32);
+    for field in fields {
+        writer.write_utf8(&field.name);
+        writer.write_node(&encode_schema_body(&field.schema));
+    }
+}
+
+const fn integer_width(width: IntegerWidth) -> u16 {
+    width as u16
+}
+
+const fn float_width(width: FloatWidth) -> u16 {
+    width as u16
+}

--- a/src/core/src/schema/mod.rs
+++ b/src/core/src/schema/mod.rs
@@ -1,0 +1,112 @@
+//! Finalized semantic schemas, shape instances, and deterministic schema tables.
+
+mod encoding;
+mod shape;
+mod table;
+mod validation;
+
+pub use self::shape::*;
+pub use self::table::*;
+
+use crate::{
+    DimensionExpr, DimensionParameter, DimensionParameterDeclaration, NominalKey,
+    SemanticModelError,
+};
+
+#[cfg(feature = "no_std")]
+use alloc::{boxed::Box, string::String};
+#[cfg(not(feature = "no_std"))]
+use std::{boxed::Box, string::String};
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SchemaDraft {
+    pub dimension_parameters: Box<[DimensionParameterDeclaration]>,
+    pub body: SchemaBody,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Schema {
+    dimension_parameters: Box<[DimensionParameter]>,
+    body: SchemaBody,
+}
+
+impl SchemaDraft {
+    pub fn finalize(self) -> Result<Schema, SemanticModelError> {
+        validation::finalize_schema(self)
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SchemaBody {
+    Bool,
+    UnsignedInteger(IntegerWidth),
+    SignedInteger(IntegerWidth),
+    FloatingPoint(FloatWidth),
+    Complex(FloatWidth),
+    Rational64,
+    String,
+    Id,
+    Index,
+    Atom(NominalKey),
+    Enum {
+        key: NominalKey,
+        variants: Box<[EnumVariantSchema]>,
+    },
+    Option(Box<SchemaBody>),
+    Tuple(Box<[SchemaBody]>),
+    Record(Box<[SchemaField]>),
+    Matrix {
+        element: Box<SchemaBody>,
+        dimensions: Box<[DimensionExpr]>,
+    },
+    Table {
+        columns: Box<[SchemaField]>,
+        rows: DimensionExpr,
+    },
+    Set {
+        element: Box<SchemaBody>,
+        cardinality: DimensionExpr,
+    },
+    Map {
+        key: Box<SchemaBody>,
+        value: Box<SchemaBody>,
+        cardinality: DimensionExpr,
+    },
+    ReifiedType,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[repr(u16)]
+pub enum IntegerWidth {
+    W8 = 8,
+    W16 = 16,
+    W32 = 32,
+    W64 = 64,
+    W128 = 128,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[repr(u16)]
+pub enum FloatWidth {
+    W32 = 32,
+    W64 = 64,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SchemaField {
+    pub name: String,
+    pub schema: SchemaBody,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EnumVariantSchema {
+    pub name: String,
+    pub payload: Option<SchemaBody>,
+}

--- a/src/core/src/schema/shape.rs
+++ b/src/core/src/schema/shape.rs
@@ -1,0 +1,191 @@
+use super::{Schema, SchemaBody};
+use crate::{DimensionExpr, DimensionOperator, DimensionParameterId, SemanticModelError};
+
+#[cfg(feature = "no_std")]
+use alloc::{boxed::Box, vec::Vec};
+#[cfg(not(feature = "no_std"))]
+use std::{boxed::Box, vec::Vec};
+
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ShapeInstance {
+    parameter_values: Box<[u64]>,
+}
+
+impl Schema {
+    pub fn instantiate_shape(
+        &self,
+        parameter_values: Box<[u64]>,
+    ) -> Result<ShapeInstance, SemanticModelError> {
+        if parameter_values.len() != self.dimension_parameters.len() {
+            return Err(SemanticModelError::ShapeParameterCountMismatchV1 {
+                expected: self.dimension_parameters.len() as u32,
+                actual: parameter_values.len() as u32,
+            });
+        }
+        for (index, (parameter, value)) in self
+            .dimension_parameters
+            .iter()
+            .zip(parameter_values.iter().copied())
+            .enumerate()
+        {
+            let resolved = &parameter_values[..index];
+            let lower = evaluate_dimension(parameter.lower_bound(), resolved)?;
+            let upper = parameter
+                .upper_bound()
+                .map(|bound| evaluate_dimension(bound, resolved))
+                .transpose()?;
+            if value < lower || upper.is_some_and(|upper| value > upper) {
+                return Err(SemanticModelError::ShapeBoundViolationV1 {
+                    parameter: DimensionParameterId::new(index as u32),
+                    value,
+                    lower,
+                    upper,
+                });
+            }
+        }
+        evaluate_body_extents(&self.body, &parameter_values)?;
+        Ok(ShapeInstance { parameter_values })
+    }
+}
+
+impl ShapeInstance {
+    pub fn parameter_values(&self) -> &[u64] {
+        &self.parameter_values
+    }
+
+    pub fn canonical_bytes(&self) -> Box<[u8]> {
+        let mut bytes = Vec::new();
+        bytes.push(0x01);
+        bytes.extend_from_slice(&(self.parameter_values.len() as u32).to_le_bytes());
+        for value in &self.parameter_values {
+            bytes.extend_from_slice(&value.to_le_bytes());
+        }
+        bytes.into_boxed_slice()
+    }
+}
+
+pub(crate) fn evaluate_dimension(
+    expression: &DimensionExpr,
+    values: &[u64],
+) -> Result<u64, SemanticModelError> {
+    match expression {
+        DimensionExpr::Hole => Err(SemanticModelError::UnresolvedDimensionHole),
+        DimensionExpr::Constant(value) => Ok(*value),
+        DimensionExpr::Parameter(id) => values
+            .get(id.get() as usize)
+            .copied()
+            .ok_or(SemanticModelError::UnknownDimensionParameterV1 { id: *id }),
+        DimensionExpr::Add(operands) => {
+            let mut result = 0_u64;
+            for operand in operands {
+                result = result
+                    .checked_add(evaluate_dimension(operand, values)?)
+                    .ok_or(SemanticModelError::DimensionOverflowV1)?;
+            }
+            Ok(result)
+        }
+        DimensionExpr::Multiply(operands) => {
+            let mut result = 1_u64;
+            for operand in operands {
+                result = result
+                    .checked_mul(evaluate_dimension(operand, values)?)
+                    .ok_or(SemanticModelError::DimensionOverflowV1)?;
+            }
+            Ok(result)
+        }
+        DimensionExpr::Min(operands) => evaluate_min_max(DimensionOperator::Min, operands, values),
+        DimensionExpr::Max(operands) => evaluate_min_max(DimensionOperator::Max, operands, values),
+    }
+}
+
+fn evaluate_min_max(
+    operator: DimensionOperator,
+    operands: &[DimensionExpr],
+    values: &[u64],
+) -> Result<u64, SemanticModelError> {
+    let mut operands = operands.iter();
+    let first = operands
+        .next()
+        .ok_or(SemanticModelError::EmptyMinMaxV1 { operator })?;
+    let mut result = evaluate_dimension(first, values)?;
+    for operand in operands {
+        let operand = evaluate_dimension(operand, values)?;
+        result = match operator {
+            DimensionOperator::Min => result.min(operand),
+            DimensionOperator::Max => result.max(operand),
+            DimensionOperator::Add | DimensionOperator::Multiply => unreachable!(),
+        };
+    }
+    Ok(result)
+}
+
+fn evaluate_body_extents(body: &SchemaBody, values: &[u64]) -> Result<(), SemanticModelError> {
+    match body {
+        SchemaBody::Enum { variants, .. } => {
+            for variant in variants {
+                if let Some(payload) = &variant.payload {
+                    evaluate_body_extents(payload, values)?;
+                }
+            }
+        }
+        SchemaBody::Option(element) => evaluate_body_extents(element, values)?,
+        SchemaBody::Tuple(elements) => {
+            for element in elements {
+                evaluate_body_extents(element, values)?;
+            }
+        }
+        SchemaBody::Record(fields) => {
+            for field in fields {
+                evaluate_body_extents(&field.schema, values)?;
+            }
+        }
+        SchemaBody::Matrix {
+            element,
+            dimensions,
+        } => {
+            evaluate_body_extents(element, values)?;
+            let mut element_count = 1_u64;
+            for dimension in dimensions {
+                let extent = evaluate_dimension(dimension, values)?;
+                element_count = element_count
+                    .checked_mul(extent)
+                    .ok_or(SemanticModelError::DimensionOverflowV1)?;
+            }
+        }
+        SchemaBody::Table { columns, rows } => {
+            for column in columns {
+                evaluate_body_extents(&column.schema, values)?;
+            }
+            evaluate_dimension(rows, values)?;
+        }
+        SchemaBody::Set {
+            element,
+            cardinality,
+        } => {
+            evaluate_body_extents(element, values)?;
+            evaluate_dimension(cardinality, values)?;
+        }
+        SchemaBody::Map {
+            key,
+            value,
+            cardinality,
+        } => {
+            evaluate_body_extents(key, values)?;
+            evaluate_body_extents(value, values)?;
+            evaluate_dimension(cardinality, values)?;
+        }
+        SchemaBody::Bool
+        | SchemaBody::UnsignedInteger(_)
+        | SchemaBody::SignedInteger(_)
+        | SchemaBody::FloatingPoint(_)
+        | SchemaBody::Complex(_)
+        | SchemaBody::Rational64
+        | SchemaBody::String
+        | SchemaBody::Id
+        | SchemaBody::Index
+        | SchemaBody::Atom(_)
+        | SchemaBody::ReifiedType => {}
+    }
+    Ok(())
+}

--- a/src/core/src/schema/table.rs
+++ b/src/core/src/schema/table.rs
@@ -1,0 +1,275 @@
+use super::Schema;
+use crate::{SchemaId, SchemaKey, SemanticIdentityKind, SemanticModelError};
+
+#[cfg(feature = "no_std")]
+use alloc::{boxed::Box, collections::BTreeMap, vec, vec::Vec};
+#[cfg(not(feature = "no_std"))]
+use std::{boxed::Box, collections::BTreeMap, vec, vec::Vec};
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct SchemaHandle {
+    ordinal: u32,
+    key: SchemaKey,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SchemaTableBuilder {
+    schemas: Vec<Schema>,
+}
+
+#[derive(Clone, Debug)]
+pub struct SchemaTableBuild {
+    pub table: SchemaTable,
+    remap: Box<[SchemaId]>,
+    handle_keys: Box<[SchemaKey]>,
+}
+
+#[derive(Clone, Debug)]
+pub struct SchemaTable {
+    entries: Box<[SchemaEntry]>,
+}
+
+#[derive(Clone, Debug)]
+pub struct SchemaEntry {
+    schema: Schema,
+    key: SchemaKey,
+    canonical_bytes: Box<[u8]>,
+}
+
+impl SchemaTableBuilder {
+    pub const fn new() -> Self {
+        Self {
+            schemas: Vec::new(),
+        }
+    }
+
+    pub fn insert(&mut self, schema: Schema) -> Result<SchemaHandle, SemanticModelError> {
+        self.insert_with_limit(schema, usize::MAX)
+    }
+
+    fn insert_with_limit(
+        &mut self,
+        schema: Schema,
+        handle_limit: usize,
+    ) -> Result<SchemaHandle, SemanticModelError> {
+        if self.schemas.len() >= handle_limit {
+            return Err(SemanticModelError::IdentityExhausted {
+                identity: SemanticIdentityKind::SchemaHandle,
+            });
+        }
+        let ordinal = u32::try_from(self.schemas.len()).map_err(|_| {
+            SemanticModelError::IdentityExhausted {
+                identity: SemanticIdentityKind::SchemaHandle,
+            }
+        })?;
+        let handle = SchemaHandle {
+            ordinal,
+            key: schema.key(),
+        };
+        self.schemas.push(schema);
+        Ok(handle)
+    }
+
+    pub fn finish(self) -> Result<SchemaTableBuild, SemanticModelError> {
+        self.finish_with(u32::MAX as usize, Schema::key)
+    }
+
+    fn finish_with(
+        self,
+        unique_limit: usize,
+        key_for: impl Fn(&Schema) -> SchemaKey,
+    ) -> Result<SchemaTableBuild, SemanticModelError> {
+        let handle_keys = self
+            .schemas
+            .iter()
+            .map(Schema::key)
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        let mut pending = self
+            .schemas
+            .into_iter()
+            .enumerate()
+            .map(|(handle, schema)| (schema.canonical_bytes(), handle, schema))
+            .collect::<Vec<_>>();
+        pending.sort_by(|left, right| left.0.cmp(&right.0).then(left.1.cmp(&right.1)));
+
+        let mut remap = vec![SchemaId::new(0); pending.len()];
+        let mut entries: Vec<SchemaEntry> = Vec::new();
+        let mut keys: BTreeMap<SchemaKey, Box<[u8]>> = BTreeMap::new();
+        for (canonical_bytes, handle, schema) in pending {
+            if entries
+                .last()
+                .is_some_and(|entry| entry.canonical_bytes == canonical_bytes)
+            {
+                remap[handle] = SchemaId::new((entries.len() - 1) as u32);
+                continue;
+            }
+            if entries.len() >= unique_limit {
+                return Err(SemanticModelError::SchemaIdExhausted);
+            }
+            let id = u32::try_from(entries.len())
+                .map(SchemaId::new)
+                .map_err(|_| SemanticModelError::SchemaIdExhausted)?;
+            let key = key_for(&schema);
+            if let Some(existing) = keys.get(&key) {
+                if existing.as_ref() != canonical_bytes.as_ref() {
+                    return Err(SemanticModelError::SchemaKeyCollision { key });
+                }
+            }
+            keys.insert(key, canonical_bytes.clone());
+            remap[handle] = id;
+            entries.push(SchemaEntry {
+                schema,
+                key,
+                canonical_bytes,
+            });
+        }
+        Ok(SchemaTableBuild {
+            table: SchemaTable {
+                entries: entries.into_boxed_slice(),
+            },
+            remap: remap.into_boxed_slice(),
+            handle_keys,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{IntegerWidth, SchemaBody, SchemaDraft};
+
+    fn schema(body: SchemaBody) -> Schema {
+        SchemaDraft {
+            dimension_parameters: Vec::new().into_boxed_slice(),
+            body,
+        }
+        .finalize()
+        .unwrap()
+    }
+
+    #[test]
+    fn test_only_limit_proves_schema_id_exhaustion() {
+        let mut builder = SchemaTableBuilder::new();
+        builder.insert(schema(SchemaBody::Bool)).unwrap();
+        builder
+            .insert(schema(SchemaBody::UnsignedInteger(IntegerWidth::W8)))
+            .unwrap();
+        assert!(matches!(
+            builder.finish_with(1, Schema::key),
+            Err(SemanticModelError::SchemaIdExhausted)
+        ));
+    }
+
+    #[test]
+    fn test_only_limit_proves_schema_handle_identity_exhaustion() {
+        let mut builder = SchemaTableBuilder::new();
+        builder
+            .insert_with_limit(schema(SchemaBody::Bool), 1)
+            .unwrap();
+        assert!(matches!(
+            builder.insert_with_limit(schema(SchemaBody::UnsignedInteger(IntegerWidth::W8)), 1,),
+            Err(SemanticModelError::IdentityExhausted {
+                identity: SemanticIdentityKind::SchemaHandle,
+            })
+        ));
+        assert_eq!(builder.schemas.len(), 1);
+    }
+
+    #[test]
+    fn test_only_hash_hook_proves_collision_rejection() {
+        let mut builder = SchemaTableBuilder::new();
+        builder.insert(schema(SchemaBody::Bool)).unwrap();
+        builder
+            .insert(schema(SchemaBody::UnsignedInteger(IntegerWidth::W8)))
+            .unwrap();
+        let forced = SchemaKey::from_bytes([7; 32]);
+        assert!(matches!(
+            builder.finish_with(u32::MAX as usize, |_| forced),
+            Err(SemanticModelError::SchemaKeyCollision { key }) if key == forced
+        ));
+    }
+
+    #[test]
+    fn resolve_rejects_out_of_range_and_foreign_handles() {
+        let bool_schema = schema(SchemaBody::Bool);
+        let string_schema = schema(SchemaBody::String);
+
+        let mut first = SchemaTableBuilder::new();
+        let first_bool = first.insert(bool_schema.clone()).unwrap();
+        let first = first.finish().unwrap();
+
+        let mut second = SchemaTableBuilder::new();
+        let second_string = second.insert(string_schema).unwrap();
+        let second = second.finish().unwrap();
+
+        assert!(first.resolve(first_bool).is_ok());
+        assert!(matches!(
+            first.resolve(second_string),
+            Err(SemanticModelError::InvalidSchemaHandleV1)
+        ));
+        assert!(matches!(
+            second.resolve(SchemaHandle {
+                ordinal: u32::MAX,
+                key: bool_schema.key(),
+            }),
+            Err(SemanticModelError::InvalidSchemaHandleV1)
+        ));
+    }
+}
+
+impl SchemaTableBuild {
+    pub fn resolve(&self, handle: SchemaHandle) -> Result<SchemaId, SemanticModelError> {
+        let ordinal = handle.ordinal as usize;
+        if self.handle_keys.get(ordinal) != Some(&handle.key) {
+            return Err(SemanticModelError::InvalidSchemaHandleV1);
+        }
+        self.remap
+            .get(ordinal)
+            .copied()
+            .ok_or(SemanticModelError::InvalidSchemaHandleV1)
+    }
+
+    pub fn into_parts(self) -> (SchemaTable, Box<[SchemaId]>) {
+        (self.table, self.remap)
+    }
+}
+
+impl SchemaTable {
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn get(&self, id: SchemaId) -> Option<&Schema> {
+        self.entry(id).map(SchemaEntry::schema)
+    }
+
+    pub fn entry(&self, id: SchemaId) -> Option<&SchemaEntry> {
+        self.entries.get(id.get() as usize)
+    }
+
+    pub fn find_by_key(&self, key: SchemaKey) -> Option<SchemaId> {
+        self.entries
+            .iter()
+            .position(|entry| entry.key == key)
+            .map(|index| SchemaId::new(index as u32))
+    }
+}
+
+impl SchemaEntry {
+    pub const fn schema(&self) -> &Schema {
+        &self.schema
+    }
+
+    pub const fn key(&self) -> SchemaKey {
+        self.key
+    }
+
+    pub fn canonical_bytes(&self) -> &[u8] {
+        &self.canonical_bytes
+    }
+}

--- a/src/core/src/schema/validation.rs
+++ b/src/core/src/schema/validation.rs
@@ -1,0 +1,388 @@
+use super::{EnumVariantSchema, Schema, SchemaBody, SchemaDraft, SchemaField};
+use crate::dimension::{
+    canonicalize_dimension_environment, collect_dimension_references, normalize_dimension,
+    rewrite_dimension_references,
+};
+use crate::{DimensionParameterId, SchemaNameCategory, SemanticModelError};
+
+#[cfg(feature = "no_std")]
+use alloc::{boxed::Box, collections::BTreeSet, string::String, vec::Vec};
+#[cfg(not(feature = "no_std"))]
+use std::{boxed::Box, collections::BTreeSet, string::String, vec::Vec};
+
+pub(super) fn finalize_schema(draft: SchemaDraft) -> Result<Schema, SemanticModelError> {
+    validate_names_and_keyability(&draft.body)?;
+    let body = normalize_body_dimensions(draft.body, draft.dimension_parameters.len())?;
+    let mut references = Vec::new();
+    collect_body_dimension_references(&body, &mut references);
+    let environment = canonicalize_dimension_environment(&draft.dimension_parameters, &references)?;
+    let body = rewrite_body_dimensions(&body, &environment.old_to_new)?;
+    let body = normalize_body_dimensions(body, environment.parameters.len())?;
+    validate_names_and_keyability(&body)?;
+    Ok(Schema {
+        dimension_parameters: environment.parameters,
+        body,
+    })
+}
+
+fn validate_names_and_keyability(body: &SchemaBody) -> Result<(), SemanticModelError> {
+    match body {
+        SchemaBody::Enum { variants, .. } => {
+            validate_unique_names(
+                variants.iter().map(|variant| &variant.name),
+                SchemaNameCategory::EnumVariant,
+            )?;
+            for variant in variants {
+                if let Some(payload) = &variant.payload {
+                    validate_names_and_keyability(payload)?;
+                }
+            }
+        }
+        SchemaBody::Option(element) => validate_names_and_keyability(element)?,
+        SchemaBody::Tuple(elements) => {
+            for element in elements {
+                validate_names_and_keyability(element)?;
+            }
+        }
+        SchemaBody::Record(fields) => {
+            validate_unique_names(
+                fields.iter().map(|field| &field.name),
+                SchemaNameCategory::RecordField,
+            )?;
+            for field in fields {
+                validate_names_and_keyability(&field.schema)?;
+            }
+        }
+        SchemaBody::Matrix { element, .. } => validate_names_and_keyability(element)?,
+        SchemaBody::Table { columns, .. } => {
+            validate_unique_names(
+                columns.iter().map(|field| &field.name),
+                SchemaNameCategory::TableColumn,
+            )?;
+            for column in columns {
+                validate_names_and_keyability(&column.schema)?;
+            }
+        }
+        SchemaBody::Set { element, .. } => {
+            validate_names_and_keyability(element)?;
+            if !is_body_keyable(element) {
+                return Err(SemanticModelError::SchemaNotKeyableV1);
+            }
+        }
+        SchemaBody::Map { key, value, .. } => {
+            validate_names_and_keyability(key)?;
+            if !is_body_keyable(key) {
+                return Err(SemanticModelError::SchemaNotKeyableV1);
+            }
+            validate_names_and_keyability(value)?;
+        }
+        SchemaBody::Bool
+        | SchemaBody::UnsignedInteger(_)
+        | SchemaBody::SignedInteger(_)
+        | SchemaBody::FloatingPoint(_)
+        | SchemaBody::Complex(_)
+        | SchemaBody::Rational64
+        | SchemaBody::String
+        | SchemaBody::Id
+        | SchemaBody::Index
+        | SchemaBody::Atom(_)
+        | SchemaBody::ReifiedType => {}
+    }
+    Ok(())
+}
+
+fn validate_unique_names<'a>(
+    names: impl IntoIterator<Item = &'a String>,
+    category: SchemaNameCategory,
+) -> Result<(), SemanticModelError> {
+    let mut seen = BTreeSet::new();
+    for name in names {
+        if !seen.insert(name) {
+            return Err(SemanticModelError::DuplicateSchemaNameV1 {
+                category,
+                name: name.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn is_body_keyable(body: &SchemaBody) -> bool {
+    match body {
+        SchemaBody::Bool
+        | SchemaBody::UnsignedInteger(_)
+        | SchemaBody::SignedInteger(_)
+        | SchemaBody::FloatingPoint(_)
+        | SchemaBody::Rational64
+        | SchemaBody::String
+        | SchemaBody::Id
+        | SchemaBody::Index
+        | SchemaBody::Atom(_) => true,
+        SchemaBody::Enum { variants, .. } => variants
+            .iter()
+            .all(|variant| variant.payload.as_ref().is_none_or(is_body_keyable)),
+        SchemaBody::Option(element) => is_body_keyable(element),
+        SchemaBody::Tuple(elements) => elements.iter().all(is_body_keyable),
+        SchemaBody::Record(fields) => fields.iter().all(|field| is_body_keyable(&field.schema)),
+        SchemaBody::Complex(_)
+        | SchemaBody::Matrix { .. }
+        | SchemaBody::Table { .. }
+        | SchemaBody::Set { .. }
+        | SchemaBody::Map { .. }
+        | SchemaBody::ReifiedType => false,
+    }
+}
+
+pub(super) fn collect_body_dimension_references(
+    body: &SchemaBody,
+    references: &mut Vec<DimensionParameterId>,
+) {
+    match body {
+        SchemaBody::Enum { variants, .. } => {
+            for variant in variants {
+                if let Some(payload) = &variant.payload {
+                    collect_body_dimension_references(payload, references);
+                }
+            }
+        }
+        SchemaBody::Option(element) => collect_body_dimension_references(element, references),
+        SchemaBody::Tuple(elements) => {
+            for element in elements {
+                collect_body_dimension_references(element, references);
+            }
+        }
+        SchemaBody::Record(fields) => collect_field_dimension_references(fields, references),
+        SchemaBody::Matrix {
+            element,
+            dimensions,
+        } => {
+            collect_body_dimension_references(element, references);
+            for dimension in dimensions {
+                collect_dimension_references(dimension, references);
+            }
+        }
+        SchemaBody::Table { columns, rows } => {
+            collect_field_dimension_references(columns, references);
+            collect_dimension_references(rows, references);
+        }
+        SchemaBody::Set {
+            element,
+            cardinality,
+        } => {
+            collect_body_dimension_references(element, references);
+            collect_dimension_references(cardinality, references);
+        }
+        SchemaBody::Map {
+            key,
+            value,
+            cardinality,
+        } => {
+            collect_body_dimension_references(key, references);
+            collect_body_dimension_references(value, references);
+            collect_dimension_references(cardinality, references);
+        }
+        SchemaBody::Bool
+        | SchemaBody::UnsignedInteger(_)
+        | SchemaBody::SignedInteger(_)
+        | SchemaBody::FloatingPoint(_)
+        | SchemaBody::Complex(_)
+        | SchemaBody::Rational64
+        | SchemaBody::String
+        | SchemaBody::Id
+        | SchemaBody::Index
+        | SchemaBody::Atom(_)
+        | SchemaBody::ReifiedType => {}
+    }
+}
+
+fn collect_field_dimension_references(
+    fields: &[SchemaField],
+    references: &mut Vec<DimensionParameterId>,
+) {
+    for field in fields {
+        collect_body_dimension_references(&field.schema, references);
+    }
+}
+
+fn rewrite_body_dimensions(
+    body: &SchemaBody,
+    old_to_new: &[Option<DimensionParameterId>],
+) -> Result<SchemaBody, SemanticModelError> {
+    Ok(match body {
+        SchemaBody::Bool => SchemaBody::Bool,
+        SchemaBody::UnsignedInteger(width) => SchemaBody::UnsignedInteger(*width),
+        SchemaBody::SignedInteger(width) => SchemaBody::SignedInteger(*width),
+        SchemaBody::FloatingPoint(width) => SchemaBody::FloatingPoint(*width),
+        SchemaBody::Complex(width) => SchemaBody::Complex(*width),
+        SchemaBody::Rational64 => SchemaBody::Rational64,
+        SchemaBody::String => SchemaBody::String,
+        SchemaBody::Id => SchemaBody::Id,
+        SchemaBody::Index => SchemaBody::Index,
+        SchemaBody::Atom(key) => SchemaBody::Atom(*key),
+        SchemaBody::Enum { key, variants } => SchemaBody::Enum {
+            key: *key,
+            variants: variants
+                .iter()
+                .map(|variant| {
+                    Ok(EnumVariantSchema {
+                        name: variant.name.clone(),
+                        payload: variant
+                            .payload
+                            .as_ref()
+                            .map(|payload| rewrite_body_dimensions(payload, old_to_new))
+                            .transpose()?,
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?
+                .into_boxed_slice(),
+        },
+        SchemaBody::Option(element) => {
+            SchemaBody::Option(Box::new(rewrite_body_dimensions(element, old_to_new)?))
+        }
+        SchemaBody::Tuple(elements) => SchemaBody::Tuple(
+            elements
+                .iter()
+                .map(|element| rewrite_body_dimensions(element, old_to_new))
+                .collect::<Result<Vec<_>, _>>()?
+                .into_boxed_slice(),
+        ),
+        SchemaBody::Record(fields) => SchemaBody::Record(rewrite_fields(fields, old_to_new)?),
+        SchemaBody::Matrix {
+            element,
+            dimensions,
+        } => SchemaBody::Matrix {
+            element: Box::new(rewrite_body_dimensions(element, old_to_new)?),
+            dimensions: dimensions
+                .iter()
+                .map(|dimension| rewrite_dimension_references(dimension, old_to_new))
+                .collect::<Result<Vec<_>, _>>()?
+                .into_boxed_slice(),
+        },
+        SchemaBody::Table { columns, rows } => SchemaBody::Table {
+            columns: rewrite_fields(columns, old_to_new)?,
+            rows: rewrite_dimension_references(rows, old_to_new)?,
+        },
+        SchemaBody::Set {
+            element,
+            cardinality,
+        } => SchemaBody::Set {
+            element: Box::new(rewrite_body_dimensions(element, old_to_new)?),
+            cardinality: rewrite_dimension_references(cardinality, old_to_new)?,
+        },
+        SchemaBody::Map {
+            key,
+            value,
+            cardinality,
+        } => SchemaBody::Map {
+            key: Box::new(rewrite_body_dimensions(key, old_to_new)?),
+            value: Box::new(rewrite_body_dimensions(value, old_to_new)?),
+            cardinality: rewrite_dimension_references(cardinality, old_to_new)?,
+        },
+        SchemaBody::ReifiedType => SchemaBody::ReifiedType,
+    })
+}
+
+fn rewrite_fields(
+    fields: &[SchemaField],
+    old_to_new: &[Option<DimensionParameterId>],
+) -> Result<Box<[SchemaField]>, SemanticModelError> {
+    fields
+        .iter()
+        .map(|field| {
+            Ok(SchemaField {
+                name: field.name.clone(),
+                schema: rewrite_body_dimensions(&field.schema, old_to_new)?,
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(Vec::into_boxed_slice)
+}
+
+fn normalize_body_dimensions(
+    body: SchemaBody,
+    parameter_count: usize,
+) -> Result<SchemaBody, SemanticModelError> {
+    Ok(match body {
+        SchemaBody::Enum { key, variants } => SchemaBody::Enum {
+            key,
+            variants: variants
+                .into_vec()
+                .into_iter()
+                .map(|variant| {
+                    Ok(EnumVariantSchema {
+                        name: variant.name,
+                        payload: variant
+                            .payload
+                            .map(|payload| normalize_body_dimensions(payload, parameter_count))
+                            .transpose()?,
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?
+                .into_boxed_slice(),
+        },
+        SchemaBody::Option(element) => SchemaBody::Option(Box::new(normalize_body_dimensions(
+            *element,
+            parameter_count,
+        )?)),
+        SchemaBody::Tuple(elements) => SchemaBody::Tuple(
+            elements
+                .into_vec()
+                .into_iter()
+                .map(|element| normalize_body_dimensions(element, parameter_count))
+                .collect::<Result<Vec<_>, _>>()?
+                .into_boxed_slice(),
+        ),
+        SchemaBody::Record(fields) => {
+            SchemaBody::Record(normalize_fields(fields, parameter_count)?)
+        }
+        SchemaBody::Matrix {
+            element,
+            dimensions,
+        } => SchemaBody::Matrix {
+            element: Box::new(normalize_body_dimensions(*element, parameter_count)?),
+            dimensions: dimensions
+                .iter()
+                .map(|dimension| normalize_dimension(dimension, parameter_count))
+                .collect::<Result<Vec<_>, _>>()?
+                .into_boxed_slice(),
+        },
+        SchemaBody::Table { columns, rows } => SchemaBody::Table {
+            columns: normalize_fields(columns, parameter_count)?,
+            rows: normalize_dimension(&rows, parameter_count)?,
+        },
+        SchemaBody::Set {
+            element,
+            cardinality,
+        } => SchemaBody::Set {
+            element: Box::new(normalize_body_dimensions(*element, parameter_count)?),
+            cardinality: normalize_dimension(&cardinality, parameter_count)?,
+        },
+        SchemaBody::Map {
+            key,
+            value,
+            cardinality,
+        } => SchemaBody::Map {
+            key: Box::new(normalize_body_dimensions(*key, parameter_count)?),
+            value: Box::new(normalize_body_dimensions(*value, parameter_count)?),
+            cardinality: normalize_dimension(&cardinality, parameter_count)?,
+        },
+        other => other,
+    })
+}
+
+fn normalize_fields(
+    fields: Box<[SchemaField]>,
+    parameter_count: usize,
+) -> Result<Box<[SchemaField]>, SemanticModelError> {
+    fields
+        .into_vec()
+        .into_iter()
+        .map(|field| {
+            Ok(SchemaField {
+                name: field.name,
+                schema: normalize_body_dimensions(field.schema, parameter_count)?,
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(Vec::into_boxed_slice)
+}

--- a/src/core/src/semantic_error.rs
+++ b/src/core/src/semantic_error.rs
@@ -1,8 +1,8 @@
 //! Errors raised while constructing or canonicalizing semantic model values.
 
 use crate::{
-    DimensionOperator, DimensionParameterId, KindId, KindParameterId, MechError, MechErrorKind,
-    SchemaKey,
+    DimensionOperator, DimensionParameterId, KindId, KindParameterId, LegacyExtentSite,
+    LegacyValueKindTag, MechError, MechErrorKind, NominalKind, SchemaKey,
 };
 
 #[cfg(feature = "no_std")]
@@ -128,6 +128,24 @@ pub enum SemanticModelError {
     InvalidSchemaHandleV1,
     SchemaKeyCollision {
         key: SchemaKey,
+    },
+    LegacyNamedKindUnresolved {
+        legacy_id: u64,
+    },
+    LegacyNominalUnresolved {
+        kind: NominalKind,
+        legacy_id: u64,
+        legacy_name: String,
+    },
+    LegacyExtentUnresolved {
+        site: LegacyExtentSite,
+    },
+    LegacyExtentOutOfRange {
+        value: u128,
+    },
+    LegacyExtentResolutionKindMismatch,
+    NonInstantiableLegacyValueKind {
+        kind: LegacyValueKindTag,
     },
 }
 

--- a/src/core/src/semantic_error.rs
+++ b/src/core/src/semantic_error.rs
@@ -1,6 +1,8 @@
 //! Errors raised while constructing or canonicalizing semantic model values.
 
-use crate::{MechError, MechErrorKind};
+use crate::{
+    DimensionOperator, DimensionParameterId, KindId, KindParameterId, MechError, MechErrorKind,
+};
 
 #[cfg(feature = "no_std")]
 use alloc::string::String;
@@ -64,6 +66,44 @@ pub enum SemanticModelError {
         segment: Option<u32>,
         reason: NominalPathError,
     },
+    UnknownNamedKind {
+        id: KindId,
+    },
+    UnknownKindParameter {
+        id: KindParameterId,
+    },
+    DuplicateKindParameter {
+        id: KindParameterId,
+    },
+    ForwardKindParameterReference {
+        parameter: KindParameterId,
+        referenced: KindParameterId,
+    },
+    UnknownDimensionParameterV1 {
+        id: DimensionParameterId,
+    },
+    DuplicateDimensionParameter {
+        id: DimensionParameterId,
+    },
+    CyclicDimensionParameterBoundsV1,
+    ForwardDimensionParameterReferenceV1 {
+        parameter: DimensionParameterId,
+        referenced: DimensionParameterId,
+    },
+    CompileTimeDimensionParameterV1,
+    DimensionOverflowV1,
+    EmptyMinMaxV1 {
+        operator: DimensionOperator,
+    },
+    UnresolvedDimensionHole,
+    UnresolvedKindHole,
+    KindParameterNotClosed {
+        id: KindParameterId,
+    },
+    NonInstantiableKind {
+        kind: NonInstantiableKind,
+    },
+    InvalidVariadicKindScheme,
     DuplicateKindName {
         category: KindNameCategory,
         name: String,

--- a/src/core/src/semantic_error.rs
+++ b/src/core/src/semantic_error.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     DimensionOperator, DimensionParameterId, KindId, KindParameterId, MechError, MechErrorKind,
+    SchemaKey,
 };
 
 #[cfg(feature = "no_std")]
@@ -107,6 +108,26 @@ pub enum SemanticModelError {
     DuplicateKindName {
         category: KindNameCategory,
         name: String,
+    },
+    DuplicateSchemaNameV1 {
+        category: SchemaNameCategory,
+        name: String,
+    },
+    SchemaNotKeyableV1,
+    ShapeParameterCountMismatchV1 {
+        expected: u32,
+        actual: u32,
+    },
+    ShapeBoundViolationV1 {
+        parameter: DimensionParameterId,
+        value: u64,
+        lower: u64,
+        upper: Option<u64>,
+    },
+    SchemaIdExhausted,
+    InvalidSchemaHandleV1,
+    SchemaKeyCollision {
+        key: SchemaKey,
     },
 }
 

--- a/src/core/src/semantic_error.rs
+++ b/src/core/src/semantic_error.rs
@@ -1,0 +1,87 @@
+//! Errors raised while constructing or canonicalizing semantic model values.
+
+use crate::{MechError, MechErrorKind};
+
+#[cfg(feature = "no_std")]
+use alloc::string::String;
+#[cfg(not(feature = "no_std"))]
+use std::string::String;
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SemanticIdentityKind {
+    ReactiveInstanceGeneration,
+    InstanceEpoch,
+    PlanGeneration,
+    LayoutGeneration,
+    DimensionParameterId,
+    SchemaHandle,
+    SchemaId,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NominalPathError {
+    EmptyPath,
+    EmptySegment,
+    DotSegment,
+    DotDotSegment,
+    ContainsNul,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NonInstantiableKind {
+    Wildcard,
+    Never,
+    Hole,
+    Parameter,
+    Reference,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SchemaNameCategory {
+    EnumVariant,
+    RecordField,
+    TableColumn,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum KindNameCategory {
+    RecordField,
+    TableColumn,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SemanticModelError {
+    IdentityExhausted {
+        identity: SemanticIdentityKind,
+    },
+    InvalidNominalPath {
+        segment: Option<u32>,
+        reason: NominalPathError,
+    },
+    DuplicateKindName {
+        category: KindNameCategory,
+        name: String,
+    },
+}
+
+impl MechErrorKind for SemanticModelError {
+    fn name(&self) -> &str {
+        "SemanticModelError"
+    }
+
+    fn message(&self) -> String {
+        format!("Semantic model error: {:?}", self)
+    }
+}
+
+impl From<SemanticModelError> for MechError {
+    fn from(error: SemanticModelError) -> Self {
+        MechError::new(error, None).with_compiler_loc()
+    }
+}

--- a/src/core/src/semantic_identity.rs
+++ b/src/core/src/semantic_identity.rs
@@ -1,0 +1,197 @@
+//! Final semantic, program, schema, and resident identities.
+
+use crate::{SemanticIdentityKind, SemanticModelError};
+
+macro_rules! opaque_u32_id {
+    ($name:ident) => {
+        #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+        #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+        #[repr(transparent)]
+        pub struct $name(u32);
+
+        impl $name {
+            pub const fn new(raw: u32) -> Self {
+                Self(raw)
+            }
+
+            pub const fn get(self) -> u32 {
+                self.0
+            }
+        }
+    };
+}
+
+macro_rules! opaque_hash_id {
+    ($name:ident) => {
+        #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+        #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+        #[repr(transparent)]
+        pub struct $name([u8; 32]);
+
+        impl $name {
+            pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+                Self(bytes)
+            }
+
+            pub const fn as_bytes(&self) -> &[u8; 32] {
+                &self.0
+            }
+
+            pub const fn into_bytes(self) -> [u8; 32] {
+                self.0
+            }
+        }
+    };
+}
+
+opaque_hash_id!(ProgramRevision);
+opaque_hash_id!(SchemaKey);
+opaque_hash_id!(NominalKey);
+
+opaque_u32_id!(KindId);
+opaque_u32_id!(KindParameterId);
+opaque_u32_id!(DimensionParameterId);
+opaque_u32_id!(SchemaId);
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[repr(transparent)]
+pub struct CellSlotId(pub u32);
+
+impl CellSlotId {
+    pub const fn new(raw: u32) -> Self {
+        Self(raw)
+    }
+
+    pub const fn get(self) -> u32 {
+        self.0
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[repr(transparent)]
+pub struct SlotIndex(pub u32);
+
+impl SlotIndex {
+    pub const fn new(raw: u32) -> Self {
+        Self(raw)
+    }
+
+    pub const fn get(self) -> u32 {
+        self.0
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ReactiveInstanceId {
+    index: u32,
+    generation: u32,
+}
+
+impl ReactiveInstanceId {
+    pub const fn new(index: u32, generation: u32) -> Self {
+        Self { index, generation }
+    }
+
+    pub const fn index(self) -> u32 {
+        self.index
+    }
+
+    pub const fn generation(self) -> u32 {
+        self.generation
+    }
+
+    pub fn checked_next_generation(self) -> Result<Self, SemanticModelError> {
+        Ok(Self {
+            index: self.index,
+            generation: self.generation.checked_add(1).ok_or(
+                SemanticModelError::IdentityExhausted {
+                    identity: SemanticIdentityKind::ReactiveInstanceGeneration,
+                },
+            )?,
+        })
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct CellId {
+    instance: ReactiveInstanceId,
+    slot: CellSlotId,
+}
+
+impl CellId {
+    pub const fn new(instance: ReactiveInstanceId, slot: CellSlotId) -> Self {
+        Self { instance, slot }
+    }
+
+    pub const fn instance(self) -> ReactiveInstanceId {
+        self.instance
+    }
+
+    pub const fn slot(self) -> CellSlotId {
+        self.slot
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[repr(transparent)]
+pub struct InstanceEpoch(pub u64);
+
+impl InstanceEpoch {
+    pub const ZERO: Self = Self(0);
+
+    pub const fn new(raw: u64) -> Self {
+        Self(raw)
+    }
+
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+
+    #[inline]
+    pub fn checked_next(self) -> Result<Self, SemanticModelError> {
+        self.0
+            .checked_add(1)
+            .map(Self)
+            .ok_or(SemanticModelError::IdentityExhausted {
+                identity: SemanticIdentityKind::InstanceEpoch,
+            })
+    }
+}
+
+macro_rules! opaque_generation {
+    ($name:ident, $kind:ident) => {
+        #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+        #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+        #[repr(transparent)]
+        pub struct $name(u64);
+
+        impl $name {
+            pub const ZERO: Self = Self(0);
+
+            pub const fn new(raw: u64) -> Self {
+                Self(raw)
+            }
+
+            pub const fn get(self) -> u64 {
+                self.0
+            }
+
+            pub fn checked_next(self) -> Result<Self, SemanticModelError> {
+                self.0
+                    .checked_add(1)
+                    .map(Self)
+                    .ok_or(SemanticModelError::IdentityExhausted {
+                        identity: SemanticIdentityKind::$kind,
+                    })
+            }
+        }
+    };
+}
+
+opaque_generation!(PlanGeneration, PlanGeneration);
+opaque_generation!(LayoutGeneration, LayoutGeneration);

--- a/src/core/tests/canonical_schema_vectors.rs
+++ b/src/core/tests/canonical_schema_vectors.rs
@@ -1,4 +1,30 @@
+#![cfg(feature = "serde")]
+
 use mech_core::*;
+use serde_json::Value;
+use std::{fs, path::Path};
+
+fn vectors() -> Value {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/architecture/value-system/canonical-encoding-v1-vectors.json");
+    serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap()
+}
+
+fn required<'a>(value: &'a Value, key: &str) -> &'a Value {
+    value.get(key).unwrap_or_else(|| panic!("missing {key}"))
+}
+
+fn required_str<'a>(value: &'a Value, key: &str) -> &'a str {
+    required(value, key)
+        .as_str()
+        .unwrap_or_else(|| panic!("{key} is not a string"))
+}
+
+fn required_u64(value: &Value, key: &str) -> u64 {
+    required(value, key)
+        .as_u64()
+        .unwrap_or_else(|| panic!("{key} is not a u64"))
+}
 
 fn decode_hex(value: &str) -> Vec<u8> {
     value
@@ -15,80 +41,256 @@ fn decode_hex(value: &str) -> Vec<u8> {
         .collect()
 }
 
-fn assert_vector(body: SchemaBody, bytes: &str, key: &str) {
-    let schema = SchemaDraft {
-        dimension_parameters: Vec::new().into_boxed_slice(),
-        body,
+fn dimension(value: &Value) -> DimensionExpr {
+    match required_str(value, "kind") {
+        "Hole" => DimensionExpr::Hole,
+        "Constant" => DimensionExpr::Constant(required_u64(value, "value")),
+        "Parameter" => DimensionExpr::Parameter(DimensionParameterId::new(
+            required_u64(value, "ordinal").try_into().unwrap(),
+        )),
+        "Add" => DimensionExpr::Add(dimensions(required(value, "operands"))),
+        "Multiply" => DimensionExpr::Multiply(dimensions(required(value, "operands"))),
+        "Min" => DimensionExpr::Min(dimensions(required(value, "operands"))),
+        "Max" => DimensionExpr::Max(dimensions(required(value, "operands"))),
+        other => panic!("unknown dimension expression {other}"),
     }
-    .finalize()
-    .unwrap();
-    assert_eq!(schema.canonical_bytes().as_ref(), decode_hex(bytes));
-    assert_eq!(schema.key().as_bytes().as_slice(), decode_hex(key));
 }
 
-#[test]
-fn scalar_and_ordered_record_vectors_match_the_c0_reference() {
-    assert_vector(
-        SchemaBody::Bool,
-        "0100000000010000000000000001",
-        "ae4fd11fd6195a3547c6aa0a5dc7e31a491ae0a604d1ff6543ed6472e88cbadb",
-    );
-    assert_vector(
-        SchemaBody::UnsignedInteger(IntegerWidth::W128),
-        "01000000000300000000000000028000",
-        "d7a42bd125b7d8730457b898e2697fe026852b65c3a8ae75db5f6ce86ef8dca4",
-    );
-    assert_vector(
-        SchemaBody::Rational64,
-        "010000000005000000000000000640004000",
-        "0df89d0ebf468c6d0e29db5d6acce2ba19a91e143dcb27ec5c04c77952b88559",
-    );
-    assert_vector(
-        SchemaBody::Record(
-            vec![
-                SchemaField {
-                    name: "b".to_owned(),
-                    schema: SchemaBody::Bool,
-                },
-                SchemaField {
-                    name: "a".to_owned(),
-                    schema: SchemaBody::UnsignedInteger(IntegerWidth::W16),
-                },
-            ]
-            .into_boxed_slice(),
-        ),
-        "01000000002b000000000000000e020000000100000000000000620100000000000000010100000000000000610300000000000000021000",
-        "f2aceea905a04a37501c92be87409061e2d25b85d8be13823efc5f62ed619cd7",
-    );
+fn dimensions(value: &Value) -> Box<[DimensionExpr]> {
+    value
+        .as_array()
+        .expect("dimensions are an array")
+        .iter()
+        .map(dimension)
+        .collect::<Vec<_>>()
+        .into_boxed_slice()
 }
 
-#[test]
-fn parameterized_matrix_vector_matches_the_c0_reference() {
-    let schema = SchemaDraft {
-        dimension_parameters: vec![DimensionParameterDeclaration {
-            id: DimensionParameterId::new(0),
-            origin: DimensionParameterOrigin::Explicit,
-            lifetime: DimensionLifetime::Activation,
-            lower_bound: DimensionExpr::Constant(1),
-            upper_bound: Some(DimensionExpr::Constant(8)),
-        }]
-        .into_boxed_slice(),
-        body: SchemaBody::Matrix {
-            element: Box::new(SchemaBody::FloatingPoint(FloatWidth::W64)),
-            dimensions: vec![DimensionExpr::Parameter(DimensionParameterId::new(0))]
+fn integer_width(value: u64) -> Result<IntegerWidth, &'static str> {
+    match value {
+        8 => Ok(IntegerWidth::W8),
+        16 => Ok(IntegerWidth::W16),
+        32 => Ok(IntegerWidth::W32),
+        64 => Ok(IntegerWidth::W64),
+        128 => Ok(IntegerWidth::W128),
+        _ => Err("InvalidSchemaWidthV1"),
+    }
+}
+
+fn float_width(value: u64) -> Result<FloatWidth, &'static str> {
+    match value {
+        32 => Ok(FloatWidth::W32),
+        64 => Ok(FloatWidth::W64),
+        _ => Err("InvalidSchemaWidthV1"),
+    }
+}
+
+fn schema_body(value: &Value) -> Result<SchemaBody, &'static str> {
+    Ok(match required_str(value, "kind") {
+        "Bool" => SchemaBody::Bool,
+        "UnsignedInteger" => {
+            SchemaBody::UnsignedInteger(integer_width(required_u64(value, "bit_width"))?)
+        }
+        "SignedInteger" => {
+            SchemaBody::SignedInteger(integer_width(required_u64(value, "bit_width"))?)
+        }
+        "FloatingPoint" => {
+            SchemaBody::FloatingPoint(float_width(required_u64(value, "bit_width"))?)
+        }
+        "Complex" => SchemaBody::Complex(float_width(required_u64(value, "component_bit_width"))?),
+        "Rational" => {
+            if required_u64(value, "numerator_width") != 64
+                || required_u64(value, "denominator_width") != 64
+            {
+                return Err("InvalidSchemaWidthV1");
+            }
+            SchemaBody::Rational64
+        }
+        "String" => SchemaBody::String,
+        "Id" => SchemaBody::Id,
+        "Index" => SchemaBody::Index,
+        "Atom" => SchemaBody::Atom(nominal_key(value, NominalKind::Atom)),
+        "Enum" => SchemaBody::Enum {
+            key: nominal_key(value, NominalKind::Enum),
+            variants: required(value, "variants")
+                .as_array()
+                .expect("variants are an array")
+                .iter()
+                .map(|variant| {
+                    Ok(EnumVariantSchema {
+                        name: required_str(variant, "name").to_owned(),
+                        payload: variant.get("payload").map(schema_body).transpose()?,
+                    })
+                })
+                .collect::<Result<Vec<_>, &'static str>>()?
                 .into_boxed_slice(),
         },
+        "Option" => SchemaBody::Option(Box::new(schema_body(required(value, "element"))?)),
+        "Tuple" => SchemaBody::Tuple(
+            required(value, "elements")
+                .as_array()
+                .expect("elements are an array")
+                .iter()
+                .map(schema_body)
+                .collect::<Result<Vec<_>, _>>()?
+                .into_boxed_slice(),
+        ),
+        "Record" => SchemaBody::Record(schema_fields(required(value, "fields"))?),
+        "Matrix" => SchemaBody::Matrix {
+            element: Box::new(schema_body(required(value, "element"))?),
+            dimensions: dimensions(required(value, "dimensions")),
+        },
+        "Table" => SchemaBody::Table {
+            columns: schema_fields(required(value, "columns"))?,
+            rows: dimension(required(value, "row_count")),
+        },
+        "Set" => SchemaBody::Set {
+            element: Box::new(schema_body(required(value, "element"))?),
+            cardinality: dimension(required(value, "cardinality")),
+        },
+        "Map" => SchemaBody::Map {
+            key: Box::new(schema_body(required(value, "key"))?),
+            value: Box::new(schema_body(required(value, "value"))?),
+            cardinality: dimension(required(value, "cardinality")),
+        },
+        "ReifiedType" => SchemaBody::ReifiedType,
+        other => panic!("unknown schema body {other}"),
+    })
+}
+
+fn schema_fields(value: &Value) -> Result<Box<[SchemaField]>, &'static str> {
+    value
+        .as_array()
+        .expect("fields are an array")
+        .iter()
+        .map(|field| {
+            Ok(SchemaField {
+                name: required_str(field, "name").to_owned(),
+                schema: schema_body(required(field, "schema"))?,
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(Vec::into_boxed_slice)
+}
+
+fn nominal_key(value: &Value, kind: NominalKind) -> NominalKey {
+    let path = required(value, "nominal_path")
+        .as_array()
+        .expect("nominal path is an array")
+        .iter()
+        .map(|segment| segment.as_str().unwrap().to_owned())
+        .collect::<Vec<_>>()
+        .into_boxed_slice();
+    NominalKey::from_path(kind, &CanonicalNominalPath::new(path).unwrap())
+}
+
+fn dimension_parameters(input: &Value) -> Box<[DimensionParameterDeclaration]> {
+    input
+        .get("dimension_parameters")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[])
+        .iter()
+        .enumerate()
+        .map(|(index, parameter)| DimensionParameterDeclaration {
+            id: DimensionParameterId::new(index.try_into().unwrap()),
+            origin: if parameter
+                .get("explicit")
+                .and_then(Value::as_bool)
+                .unwrap_or(true)
+            {
+                DimensionParameterOrigin::Explicit
+            } else {
+                DimensionParameterOrigin::Inferred
+            },
+            lifetime: match required_str(parameter, "lifetime") {
+                "Activation" => DimensionLifetime::Activation,
+                "Turn" => DimensionLifetime::Turn,
+                other => panic!("unknown dimension lifetime {other}"),
+            },
+            lower_bound: dimension(required(parameter, "lower_bound")),
+            upper_bound: parameter.get("upper_bound").map(dimension),
+        })
+        .collect::<Vec<_>>()
+        .into_boxed_slice()
+}
+
+fn semantic_error_name(error: &SemanticModelError) -> &'static str {
+    match error {
+        SemanticModelError::DuplicateSchemaNameV1 { .. } => "DuplicateSchemaNameV1",
+        other => panic!("unexpected semantic error {other:?}"),
     }
-    .finalize()
-    .unwrap();
-    assert_eq!(
-        schema.canonical_bytes().as_ref(),
-        decode_hex(
-            "01010000000109000000000000000101000000000000000109000000000000000108000000000000001d000000000000000f03000000000000000440000100000005000000000000000200000000"
-        )
-    );
-    assert_eq!(
-        schema.key().as_bytes().as_slice(),
-        decode_hex("d65fa2b13ee39e3af34c266530cac9afe6b8b27cc2653c63ee65474588839aae")
-    );
+}
+
+#[test]
+fn every_positive_c0_value_vector_matches_schema_key_and_shape_bytes() {
+    let vectors = vectors();
+    let vectors = required(&vectors, "value_vectors")
+        .as_array()
+        .expect("value vectors are an array");
+    assert_eq!(vectors.len(), 11);
+    for vector in vectors {
+        let id = required_str(vector, "id");
+        let input = required(vector, "input");
+        let expected = required(vector, "expected");
+        let schema = SchemaDraft {
+            dimension_parameters: dimension_parameters(input),
+            body: schema_body(required(input, "schema")).unwrap(),
+        }
+        .finalize()
+        .unwrap_or_else(|error| panic!("{id}: {error:?}"));
+        assert_eq!(
+            schema.canonical_bytes().as_ref(),
+            decode_hex(required_str(expected, "schema_hex")),
+            "{id}: schema bytes"
+        );
+        assert_eq!(
+            schema.key().as_bytes().as_slice(),
+            decode_hex(required_str(expected, "schema_key_hex")),
+            "{id}: schema key"
+        );
+        let shape_values = required(input, "shape_values")
+            .as_array()
+            .expect("shape values are an array")
+            .iter()
+            .map(|value| value.as_u64().unwrap())
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        let shape = schema
+            .instantiate_shape(shape_values)
+            .unwrap_or_else(|error| panic!("{id}: {error:?}"));
+        assert_eq!(
+            shape.canonical_bytes().as_ref(),
+            decode_hex(required_str(expected, "shape_hex")),
+            "{id}: shape bytes"
+        );
+    }
+}
+
+#[test]
+fn every_invalid_c0_schema_vector_returns_its_frozen_error() {
+    let vectors = vectors();
+    let vectors = required(&vectors, "invalid_schema_vectors")
+        .as_array()
+        .expect("invalid schema vectors are an array");
+    assert_eq!(vectors.len(), 8);
+    for vector in vectors {
+        let id = required_str(vector, "id");
+        let expected = required_str(required(vector, "expected"), "error");
+        let input = required(vector, "input");
+        let body = match schema_body(required(input, "schema")) {
+            Ok(body) => body,
+            Err(error) => {
+                assert_eq!(error, expected, "{id}");
+                continue;
+            }
+        };
+        let error = SchemaDraft {
+            dimension_parameters: dimension_parameters(input),
+            body,
+        }
+        .finalize()
+        .expect_err("invalid schema unexpectedly finalized");
+        assert_eq!(semantic_error_name(&error), expected, "{id}");
+    }
 }

--- a/src/core/tests/canonical_schema_vectors.rs
+++ b/src/core/tests/canonical_schema_vectors.rs
@@ -1,0 +1,94 @@
+use mech_core::*;
+
+fn decode_hex(value: &str) -> Vec<u8> {
+    value
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|pair| {
+            let digit = |value| match value {
+                b'0'..=b'9' => value - b'0',
+                b'a'..=b'f' => value - b'a' + 10,
+                _ => panic!("invalid test hex"),
+            };
+            (digit(pair[0]) << 4) | digit(pair[1])
+        })
+        .collect()
+}
+
+fn assert_vector(body: SchemaBody, bytes: &str, key: &str) {
+    let schema = SchemaDraft {
+        dimension_parameters: Vec::new().into_boxed_slice(),
+        body,
+    }
+    .finalize()
+    .unwrap();
+    assert_eq!(schema.canonical_bytes().as_ref(), decode_hex(bytes));
+    assert_eq!(schema.key().as_bytes().as_slice(), decode_hex(key));
+}
+
+#[test]
+fn scalar_and_ordered_record_vectors_match_the_c0_reference() {
+    assert_vector(
+        SchemaBody::Bool,
+        "0100000000010000000000000001",
+        "ae4fd11fd6195a3547c6aa0a5dc7e31a491ae0a604d1ff6543ed6472e88cbadb",
+    );
+    assert_vector(
+        SchemaBody::UnsignedInteger(IntegerWidth::W128),
+        "01000000000300000000000000028000",
+        "d7a42bd125b7d8730457b898e2697fe026852b65c3a8ae75db5f6ce86ef8dca4",
+    );
+    assert_vector(
+        SchemaBody::Rational64,
+        "010000000005000000000000000640004000",
+        "0df89d0ebf468c6d0e29db5d6acce2ba19a91e143dcb27ec5c04c77952b88559",
+    );
+    assert_vector(
+        SchemaBody::Record(
+            vec![
+                SchemaField {
+                    name: "b".to_owned(),
+                    schema: SchemaBody::Bool,
+                },
+                SchemaField {
+                    name: "a".to_owned(),
+                    schema: SchemaBody::UnsignedInteger(IntegerWidth::W16),
+                },
+            ]
+            .into_boxed_slice(),
+        ),
+        "01000000002b000000000000000e020000000100000000000000620100000000000000010100000000000000610300000000000000021000",
+        "f2aceea905a04a37501c92be87409061e2d25b85d8be13823efc5f62ed619cd7",
+    );
+}
+
+#[test]
+fn parameterized_matrix_vector_matches_the_c0_reference() {
+    let schema = SchemaDraft {
+        dimension_parameters: vec![DimensionParameterDeclaration {
+            id: DimensionParameterId::new(0),
+            origin: DimensionParameterOrigin::Explicit,
+            lifetime: DimensionLifetime::Activation,
+            lower_bound: DimensionExpr::Constant(1),
+            upper_bound: Some(DimensionExpr::Constant(8)),
+        }]
+        .into_boxed_slice(),
+        body: SchemaBody::Matrix {
+            element: Box::new(SchemaBody::FloatingPoint(FloatWidth::W64)),
+            dimensions: vec![DimensionExpr::Parameter(DimensionParameterId::new(0))]
+                .into_boxed_slice(),
+        },
+    }
+    .finalize()
+    .unwrap();
+    assert_eq!(
+        schema.canonical_bytes().as_ref(),
+        decode_hex(
+            "01010000000109000000000000000101000000000000000109000000000000000108000000000000001d000000000000000f03000000000000000440000100000005000000000000000200000000"
+        )
+    );
+    assert_eq!(
+        schema.key().as_bytes().as_slice(),
+        decode_hex("d65fa2b13ee39e3af34c266530cac9afe6b8b27cc2653c63ee65474588839aae")
+    );
+}

--- a/src/core/tests/dimension_contract.rs
+++ b/src/core/tests/dimension_contract.rs
@@ -1,0 +1,225 @@
+use mech_core::*;
+
+fn boxed(values: impl IntoIterator<Item = DimensionExpr>) -> Box<[DimensionExpr]> {
+    values.into_iter().collect::<Vec<_>>().into_boxed_slice()
+}
+
+#[test]
+fn arithmetic_normalization_matches_the_v1_reference_rules() {
+    let parameter = DimensionParameterId::new(0);
+    let normalized = normalize_dimension(
+        &DimensionExpr::Add(boxed([
+            DimensionExpr::Constant(0),
+            DimensionExpr::Add(boxed([
+                DimensionExpr::Constant(2),
+                DimensionExpr::Parameter(parameter),
+            ])),
+            DimensionExpr::Constant(3),
+        ])),
+        1,
+    )
+    .unwrap();
+    assert_eq!(
+        normalized,
+        DimensionExpr::Add(boxed([
+            DimensionExpr::Constant(5),
+            DimensionExpr::Parameter(parameter),
+        ]))
+    );
+
+    assert_eq!(
+        normalize_dimension(
+            &DimensionExpr::Multiply(boxed([
+                DimensionExpr::Constant(u64::MAX),
+                DimensionExpr::Constant(0),
+            ])),
+            0,
+        )
+        .unwrap(),
+        DimensionExpr::Constant(0)
+    );
+    assert!(matches!(
+        normalize_dimension(
+            &DimensionExpr::Add(boxed([
+                DimensionExpr::Constant(u64::MAX),
+                DimensionExpr::Constant(1),
+            ])),
+            0,
+        ),
+        Err(SemanticModelError::DimensionOverflowV1)
+    ));
+}
+
+#[test]
+fn min_max_flatten_sort_deduplicate_and_reject_empty() {
+    let expression = DimensionExpr::Min(boxed([
+        DimensionExpr::Constant(7),
+        DimensionExpr::Min(boxed([
+            DimensionExpr::Constant(2),
+            DimensionExpr::Constant(7),
+        ])),
+    ]));
+    assert_eq!(
+        normalize_dimension(&expression, 0).unwrap(),
+        DimensionExpr::Min(boxed([
+            DimensionExpr::Constant(2),
+            DimensionExpr::Constant(7),
+        ]))
+    );
+    assert!(matches!(
+        normalize_dimension(&DimensionExpr::Max(boxed([])), 0),
+        Err(SemanticModelError::EmptyMinMaxV1 {
+            operator: DimensionOperator::Max
+        })
+    ));
+}
+
+#[test]
+fn dimension_builder_is_dense_and_compile_time_parameters_are_rejected() {
+    let mut environment = DimensionEnvironmentBuilder::new();
+    assert_eq!(
+        environment
+            .declare(
+                DimensionParameterOrigin::Explicit,
+                DimensionLifetime::Activation,
+                DimensionExpr::Constant(1),
+                None,
+            )
+            .unwrap()
+            .get(),
+        0
+    );
+    assert_eq!(
+        environment
+            .declare(
+                DimensionParameterOrigin::Inferred,
+                DimensionLifetime::Turn,
+                DimensionExpr::Constant(0),
+                Some(DimensionExpr::Constant(9)),
+            )
+            .unwrap()
+            .get(),
+        1
+    );
+    assert_eq!(environment.declarations().len(), 2);
+
+    let mut environment = DimensionEnvironmentBuilder::new();
+    assert!(matches!(
+        environment.declare(
+            DimensionParameterOrigin::Explicit,
+            DimensionLifetime::CompileTime,
+            DimensionExpr::Constant(1),
+            None,
+        ),
+        Err(SemanticModelError::CompileTimeDimensionParameterV1)
+    ));
+    assert!(environment.declarations().is_empty());
+}
+
+struct NoNamedKinds;
+
+impl NamedKindPathResolver for NoNamedKinds {
+    fn canonical_path(&self, _id: KindId) -> Option<&CanonicalNominalPath> {
+        None
+    }
+}
+
+#[test]
+fn closed_kind_bytes_use_the_frozen_envelope_tags_and_framing() {
+    let kind = KindExpr::Matrix {
+        element: Box::new(KindExpr::Id),
+        dimensions: boxed([DimensionExpr::Add(boxed([
+            DimensionExpr::Constant(3),
+            DimensionExpr::Constant(4),
+        ]))]),
+    };
+    let bytes = canonical_closed_kind_bytes(&kind, &[], &NoNamedKinds).unwrap();
+    assert_eq!(
+        bytes.as_ref(),
+        &[
+            0x01, 0x00, 0x00, 0x00, 0x00, // envelope and parameter count
+            0x1f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // body frame
+            0x09, // Matrix
+            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05, // Id node
+            0x01, 0x00, 0x00, 0x00, // one dimension
+            0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // dimension node
+            0x01, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ]
+    );
+}
+
+#[test]
+fn closed_kind_encoding_rejects_holes_parameters_and_unknown_names() {
+    assert!(matches!(
+        canonical_closed_kind_bytes(&KindExpr::Hole, &[], &NoNamedKinds),
+        Err(SemanticModelError::UnresolvedKindHole)
+    ));
+    assert!(matches!(
+        canonical_closed_kind_bytes(
+            &KindExpr::Parameter(KindParameterId::new(4)),
+            &[],
+            &NoNamedKinds
+        ),
+        Err(SemanticModelError::KindParameterNotClosed { .. })
+    ));
+    assert!(matches!(
+        canonical_closed_kind_bytes(&KindExpr::Named(KindId::new(3)), &[], &NoNamedKinds),
+        Err(SemanticModelError::UnknownNamedKind { .. })
+    ));
+}
+
+#[test]
+fn closed_kind_encoding_rejects_duplicate_names_and_preserves_field_order() {
+    let field = |name: &str, kind| KindField {
+        name: name.to_owned(),
+        kind,
+    };
+    let duplicate = KindExpr::Option(Box::new(KindExpr::Record(
+        vec![field("x", KindExpr::Id), field("x", KindExpr::Index)].into_boxed_slice(),
+    )));
+    assert!(matches!(
+        canonical_closed_kind_bytes(&duplicate, &[], &NoNamedKinds),
+        Err(SemanticModelError::DuplicateKindName {
+            category: KindNameCategory::RecordField,
+            ..
+        })
+    ));
+
+    let first = KindExpr::Record(
+        vec![field("a", KindExpr::Id), field("b", KindExpr::Index)].into_boxed_slice(),
+    );
+    let reversed = KindExpr::Record(
+        vec![field("b", KindExpr::Index), field("a", KindExpr::Id)].into_boxed_slice(),
+    );
+    assert_ne!(
+        canonical_closed_kind_bytes(&first, &[], &NoNamedKinds).unwrap(),
+        canonical_closed_kind_bytes(&reversed, &[], &NoNamedKinds).unwrap(),
+    );
+}
+
+#[test]
+fn closed_kind_normalizes_before_parameter_reachability() {
+    let parameter = DimensionParameterId::new(0);
+    let declarations = vec![DimensionParameterDeclaration {
+        id: parameter,
+        origin: DimensionParameterOrigin::Explicit,
+        lifetime: DimensionLifetime::Turn,
+        lower_bound: DimensionExpr::Constant(0),
+        upper_bound: None,
+    }];
+    let reduced = KindExpr::Matrix {
+        element: Box::new(KindExpr::Id),
+        dimensions: boxed([DimensionExpr::Multiply(boxed([
+            DimensionExpr::Constant(0),
+            DimensionExpr::Parameter(parameter),
+        ]))]),
+    };
+    let constant = KindExpr::Matrix {
+        element: Box::new(KindExpr::Id),
+        dimensions: boxed([DimensionExpr::Constant(0)]),
+    };
+    assert_eq!(
+        canonical_closed_kind_bytes(&reduced, &declarations, &NoNamedKinds).unwrap(),
+        canonical_closed_kind_bytes(&constant, &[], &NoNamedKinds).unwrap()
+    );
+}

--- a/src/core/tests/kind_scheme_contract.rs
+++ b/src/core/tests/kind_scheme_contract.rs
@@ -1,0 +1,186 @@
+use mech_core::*;
+
+fn empty_fixed() -> InputKindScheme {
+    InputKindScheme::Fixed(Vec::new().into_boxed_slice())
+}
+
+#[test]
+fn empty_and_variadic_schemes_are_structurally_valid() {
+    let empty = KindScheme::new(
+        Vec::new().into_boxed_slice(),
+        Vec::new().into_boxed_slice(),
+        empty_fixed(),
+        Vec::new().into_boxed_slice(),
+        Vec::new().into_boxed_slice(),
+    )
+    .unwrap();
+    assert!(empty.outputs().is_empty());
+
+    KindScheme::new(
+        vec![KindParameter {
+            id: KindParameterId::new(0),
+            upper_bound: Some(KindExpr::Wildcard),
+        }]
+        .into_boxed_slice(),
+        Vec::new().into_boxed_slice(),
+        InputKindScheme::Variadic {
+            prefix: vec![KindExpr::Id].into_boxed_slice(),
+            repeated: KindExpr::Parameter(KindParameterId::new(0)),
+            min_repetitions: 0,
+        },
+        vec![KindExpr::Never].into_boxed_slice(),
+        Vec::new().into_boxed_slice(),
+    )
+    .unwrap();
+}
+
+#[test]
+fn kind_parameters_are_dense_unique_and_only_reference_earlier_bounds() {
+    assert!(matches!(
+        KindScheme::new(
+            vec![
+                KindParameter {
+                    id: KindParameterId::new(0),
+                    upper_bound: None,
+                },
+                KindParameter {
+                    id: KindParameterId::new(0),
+                    upper_bound: None,
+                },
+            ]
+            .into_boxed_slice(),
+            Vec::new().into_boxed_slice(),
+            empty_fixed(),
+            Vec::new().into_boxed_slice(),
+            Vec::new().into_boxed_slice(),
+        ),
+        Err(SemanticModelError::DuplicateKindParameter { .. })
+    ));
+
+    assert!(matches!(
+        KindScheme::new(
+            vec![KindParameter {
+                id: KindParameterId::new(0),
+                upper_bound: Some(KindExpr::Parameter(KindParameterId::new(0))),
+            }]
+            .into_boxed_slice(),
+            Vec::new().into_boxed_slice(),
+            empty_fixed(),
+            Vec::new().into_boxed_slice(),
+            Vec::new().into_boxed_slice(),
+        ),
+        Err(SemanticModelError::ForwardKindParameterReference { .. })
+    ));
+}
+
+#[test]
+fn holes_and_unknown_parameters_are_rejected_everywhere() {
+    assert!(matches!(
+        KindScheme::new(
+            Vec::new().into_boxed_slice(),
+            Vec::new().into_boxed_slice(),
+            InputKindScheme::Fixed(vec![KindExpr::Hole].into_boxed_slice()),
+            Vec::new().into_boxed_slice(),
+            Vec::new().into_boxed_slice(),
+        ),
+        Err(SemanticModelError::UnresolvedKindHole)
+    ));
+    assert!(matches!(
+        KindScheme::new(
+            Vec::new().into_boxed_slice(),
+            Vec::new().into_boxed_slice(),
+            empty_fixed(),
+            vec![KindExpr::Parameter(KindParameterId::new(0))].into_boxed_slice(),
+            Vec::new().into_boxed_slice(),
+        ),
+        Err(SemanticModelError::UnknownKindParameter { .. })
+    ));
+}
+
+#[test]
+fn dimension_bounds_are_dense_acyclic_and_backward_only() {
+    let parameters = vec![
+        DimensionParameterDeclaration {
+            id: DimensionParameterId::new(0),
+            origin: DimensionParameterOrigin::Explicit,
+            lifetime: DimensionLifetime::Activation,
+            lower_bound: DimensionExpr::Parameter(DimensionParameterId::new(1)),
+            upper_bound: None,
+        },
+        DimensionParameterDeclaration {
+            id: DimensionParameterId::new(1),
+            origin: DimensionParameterOrigin::Explicit,
+            lifetime: DimensionLifetime::Activation,
+            lower_bound: DimensionExpr::Parameter(DimensionParameterId::new(0)),
+            upper_bound: None,
+        },
+    ];
+    assert!(matches!(
+        KindScheme::new(
+            Vec::new().into_boxed_slice(),
+            parameters.into_boxed_slice(),
+            empty_fixed(),
+            Vec::new().into_boxed_slice(),
+            Vec::new().into_boxed_slice(),
+        ),
+        Err(SemanticModelError::CyclicDimensionParameterBoundsV1)
+    ));
+}
+
+#[test]
+fn kind_schemes_reject_duplicate_names_recursively() {
+    let duplicate_record = KindExpr::Record(
+        vec![
+            KindField {
+                name: "x".to_owned(),
+                kind: KindExpr::Id,
+            },
+            KindField {
+                name: "x".to_owned(),
+                kind: KindExpr::Index,
+            },
+        ]
+        .into_boxed_slice(),
+    );
+    assert!(matches!(
+        KindScheme::new(
+            Vec::new().into_boxed_slice(),
+            Vec::new().into_boxed_slice(),
+            InputKindScheme::Fixed(vec![duplicate_record].into_boxed_slice()),
+            Vec::new().into_boxed_slice(),
+            Vec::new().into_boxed_slice(),
+        ),
+        Err(SemanticModelError::DuplicateKindName {
+            category: KindNameCategory::RecordField,
+            ref name,
+        }) if name == "x"
+    ));
+
+    let nested_duplicate_table = KindExpr::Option(Box::new(KindExpr::Table {
+        columns: vec![
+            KindField {
+                name: "value".to_owned(),
+                kind: KindExpr::Id,
+            },
+            KindField {
+                name: "value".to_owned(),
+                kind: KindExpr::Index,
+            },
+        ]
+        .into_boxed_slice(),
+        rows: DimensionExpr::Constant(0),
+    }));
+    assert!(matches!(
+        KindScheme::new(
+            Vec::new().into_boxed_slice(),
+            Vec::new().into_boxed_slice(),
+            empty_fixed(),
+            vec![nested_duplicate_table].into_boxed_slice(),
+            Vec::new().into_boxed_slice(),
+        ),
+        Err(SemanticModelError::DuplicateKindName {
+            category: KindNameCategory::TableColumn,
+            ..
+        })
+    ));
+}

--- a/src/core/tests/legacy_kind_adapter_contract.rs
+++ b/src/core/tests/legacy_kind_adapter_contract.rs
@@ -202,6 +202,32 @@ fn unspecified_extents_are_context_controlled_and_allocate_dense_parameters() {
 }
 
 #[test]
+fn concrete_matrix_extents_are_constants_while_map_always_uses_context() {
+    let mut context = FakeContext::default();
+    let matrix =
+        kind_expr_from_legacy(&Kind::Matrix(Box::new(Kind::Id), vec![2, 3]), &mut context).unwrap();
+    let KindExpr::Matrix { dimensions, .. } = matrix.kind else {
+        panic!("expected matrix")
+    };
+    assert_eq!(
+        dimensions.as_ref(),
+        &[DimensionExpr::Constant(2), DimensionExpr::Constant(3)]
+    );
+    assert!(context.extent_sites.is_empty());
+
+    kind_expr_from_legacy(
+        &Kind::Map(Box::new(Kind::Id), Box::new(Kind::Index)),
+        &mut context,
+    )
+    .unwrap();
+    assert_eq!(context.extent_sites.len(), 1);
+    assert_eq!(
+        context.extent_sites[0].role,
+        LegacyExtentRole::MapCardinality
+    );
+}
+
+#[test]
 fn enum_variants_come_from_context_and_ambiguous_value_kinds_are_structured_errors() {
     let mut context = FakeContext::default();
     let schema =

--- a/src/core/tests/legacy_kind_adapter_contract.rs
+++ b/src/core/tests/legacy_kind_adapter_contract.rs
@@ -1,0 +1,387 @@
+use mech_core::kind::Kind;
+use mech_core::value::ValueKind;
+use mech_core::{
+    DimensionEnvironmentBuilder, DimensionExpr, DimensionLifetime, DimensionParameterId,
+    DimensionParameterOrigin, EnumVariantSchema, KindExpr, KindId, KindNameCategory,
+    LegacyExtentRole, LegacyExtentSite, LegacyNominalResolution, LegacyResolvedExtent,
+    LegacySemanticContext, LegacyTypeSource, LegacyValueKindTag, NominalKey, NominalKind,
+    SchemaBody, SemanticModelError, kind_expr_from_legacy, schema_from_legacy_value_kind,
+};
+
+#[derive(Default)]
+struct FakeContext {
+    extent_sites: Vec<LegacyExtentSite>,
+}
+
+impl LegacySemanticContext for FakeContext {
+    fn resolve_named_kind(&mut self, legacy_id: u64) -> Result<KindId, SemanticModelError> {
+        u32::try_from(legacy_id)
+            .map(KindId::new)
+            .map_err(|_| SemanticModelError::LegacyNamedKindUnresolved { legacy_id })
+    }
+
+    fn resolve_nominal(
+        &mut self,
+        nominal_kind: NominalKind,
+        legacy_id: u64,
+        _legacy_name: &str,
+    ) -> Result<LegacyNominalResolution, SemanticModelError> {
+        let key = NominalKey::from_bytes([legacy_id as u8; 32]);
+        Ok(match nominal_kind {
+            NominalKind::Atom => LegacyNominalResolution::Atom { key },
+            NominalKind::Enum => LegacyNominalResolution::Enum {
+                key,
+                variants: vec![
+                    EnumVariantSchema {
+                        name: "First".to_owned(),
+                        payload: None,
+                    },
+                    EnumVariantSchema {
+                        name: "Second".to_owned(),
+                        payload: Some(SchemaBody::Bool),
+                    },
+                ]
+                .into_boxed_slice(),
+            },
+        })
+    }
+
+    fn resolve_unspecified_extent(
+        &mut self,
+        site: &LegacyExtentSite,
+        dimensions: &mut DimensionEnvironmentBuilder,
+    ) -> Result<LegacyResolvedExtent, SemanticModelError> {
+        self.extent_sites.push(site.clone());
+        let id = dimensions.declare(
+            DimensionParameterOrigin::Inferred,
+            DimensionLifetime::Turn,
+            DimensionExpr::Constant(0),
+            Some(DimensionExpr::Constant(1024)),
+        )?;
+        Ok(match site.role {
+            LegacyExtentRole::MatrixDimensions => LegacyResolvedExtent::Dimensions(
+                vec![DimensionExpr::Parameter(id)].into_boxed_slice(),
+            ),
+            LegacyExtentRole::TableRows
+            | LegacyExtentRole::SetCardinality
+            | LegacyExtentRole::MapCardinality => {
+                LegacyResolvedExtent::Cardinality(DimensionExpr::Parameter(id))
+            }
+        })
+    }
+}
+
+#[test]
+fn all_seventeen_kind_variants_have_explicit_outcomes() {
+    let kinds = vec![
+        Kind::Any,
+        Kind::None,
+        Kind::Empty,
+        Kind::Scalar(4),
+        Kind::Id,
+        Kind::Index,
+        Kind::Atom(1, "Atom".to_owned()),
+        Kind::Enum(2, "Enum".to_owned()),
+        Kind::Matrix(Box::new(Kind::Id), vec![2, 3]),
+        Kind::Option(Box::new(Kind::Id)),
+        Kind::Tuple(vec![Kind::Id]),
+        Kind::Record(vec![("x".to_owned(), Kind::Id)]),
+        Kind::Table(vec![("x".to_owned(), Kind::Id)], 2),
+        Kind::Set(Box::new(Kind::Id), Some(2)),
+        Kind::Map(Box::new(Kind::Id), Box::new(Kind::Index)),
+        Kind::Reference(Box::new(Kind::Id)),
+        Kind::Kind(Box::new(Kind::Id)),
+    ];
+    assert_eq!(kinds.len(), 17);
+    let mut context = FakeContext::default();
+    let outcomes = kinds
+        .iter()
+        .map(|kind| kind_expr_from_legacy(kind, &mut context).unwrap().kind)
+        .collect::<Vec<_>>();
+    assert!(matches!(outcomes[0], KindExpr::Wildcard));
+    assert!(matches!(outcomes[1], KindExpr::Never));
+    assert!(matches!(outcomes[2], KindExpr::Hole));
+    assert!(matches!(outcomes[3], KindExpr::Named(_)));
+    assert!(matches!(outcomes[6], KindExpr::Atom(_)));
+    assert!(matches!(outcomes[7], KindExpr::Enum(_)));
+    assert!(matches!(outcomes[8], KindExpr::Matrix { .. }));
+    assert!(matches!(outcomes[14], KindExpr::Map { .. }));
+    assert!(matches!(outcomes[15], KindExpr::Reference(_)));
+    assert!(matches!(outcomes[16], KindExpr::TypeOf(_)));
+}
+
+#[test]
+fn all_thirty_two_value_kind_variants_map_or_error_explicitly() {
+    let kinds = vec![
+        ValueKind::U8,
+        ValueKind::U16,
+        ValueKind::U32,
+        ValueKind::U64,
+        ValueKind::U128,
+        ValueKind::I8,
+        ValueKind::I16,
+        ValueKind::I32,
+        ValueKind::I64,
+        ValueKind::I128,
+        ValueKind::F32,
+        ValueKind::F64,
+        ValueKind::C64,
+        ValueKind::R64,
+        ValueKind::String,
+        ValueKind::Bool,
+        ValueKind::Id,
+        ValueKind::Index,
+        ValueKind::Empty,
+        ValueKind::Any,
+        ValueKind::None,
+        ValueKind::Matrix(Box::new(ValueKind::Bool), vec![2]),
+        ValueKind::Enum(2, "Enum".to_owned()),
+        ValueKind::Record(vec![("x".to_owned(), ValueKind::Bool)]),
+        ValueKind::Map(Box::new(ValueKind::Bool), Box::new(ValueKind::String)),
+        ValueKind::Atom(1, "Atom".to_owned()),
+        ValueKind::Table(vec![("x".to_owned(), ValueKind::Bool)], 2),
+        ValueKind::Tuple(vec![ValueKind::Bool]),
+        ValueKind::Reference(Box::new(ValueKind::Bool)),
+        ValueKind::Set(Box::new(ValueKind::Bool), Some(2)),
+        ValueKind::Option(Box::new(ValueKind::Bool)),
+        ValueKind::Kind(Box::new(ValueKind::Bool)),
+    ];
+    assert_eq!(kinds.len(), 32);
+    let mut context = FakeContext::default();
+    for (index, kind) in kinds.iter().enumerate() {
+        let result = schema_from_legacy_value_kind(kind, &mut context);
+        if matches!(index, 18 | 19 | 20 | 28) {
+            assert!(matches!(
+                result,
+                Err(SemanticModelError::NonInstantiableLegacyValueKind { .. })
+            ));
+        } else {
+            result.unwrap();
+        }
+    }
+}
+
+#[test]
+fn unspecified_extents_are_context_controlled_and_allocate_dense_parameters() {
+    let kind = Kind::Tuple(vec![
+        Kind::Matrix(Box::new(Kind::Id), Vec::new()),
+        Kind::Set(Box::new(Kind::Id), None),
+        Kind::Table(Vec::new(), 0),
+        Kind::Map(Box::new(Kind::Id), Box::new(Kind::Index)),
+    ]);
+    let mut context = FakeContext::default();
+    let resolution = kind_expr_from_legacy(&kind, &mut context).unwrap();
+    assert_eq!(resolution.dimension_parameters.len(), 4);
+    assert_eq!(
+        context
+            .extent_sites
+            .iter()
+            .map(|site| site.role)
+            .collect::<Vec<_>>(),
+        [
+            LegacyExtentRole::MatrixDimensions,
+            LegacyExtentRole::SetCardinality,
+            LegacyExtentRole::TableRows,
+            LegacyExtentRole::MapCardinality,
+        ]
+    );
+    assert!(
+        context
+            .extent_sites
+            .iter()
+            .all(|site| site.source == LegacyTypeSource::Kind)
+    );
+    assert_eq!(
+        resolution
+            .dimension_parameters
+            .iter()
+            .map(|parameter| parameter.id.get())
+            .collect::<Vec<_>>(),
+        [0, 1, 2, 3]
+    );
+}
+
+#[test]
+fn enum_variants_come_from_context_and_ambiguous_value_kinds_are_structured_errors() {
+    let mut context = FakeContext::default();
+    let schema =
+        schema_from_legacy_value_kind(&ValueKind::Enum(9, "Choice".to_owned()), &mut context)
+            .unwrap();
+    let SchemaBody::Enum { variants, .. } = schema.body() else {
+        panic!("expected enum schema")
+    };
+    assert_eq!(
+        variants
+            .iter()
+            .map(|variant| variant.name.as_str())
+            .collect::<Vec<_>>(),
+        ["First", "Second"]
+    );
+
+    for (kind, expected) in [
+        (ValueKind::Any, LegacyValueKindTag::Any),
+        (ValueKind::None, LegacyValueKindTag::None),
+        (ValueKind::Empty, LegacyValueKindTag::Empty),
+        (
+            ValueKind::Reference(Box::new(ValueKind::Bool)),
+            LegacyValueKindTag::Reference,
+        ),
+    ] {
+        assert!(matches!(
+            schema_from_legacy_value_kind(&kind, &mut context),
+            Err(SemanticModelError::NonInstantiableLegacyValueKind { kind }) if kind == expected
+        ));
+    }
+}
+
+#[test]
+fn legacy_type_of_is_the_reified_type_schema() {
+    let mut context = FakeContext::default();
+    let schema =
+        schema_from_legacy_value_kind(&ValueKind::Kind(Box::new(ValueKind::Bool)), &mut context)
+            .unwrap();
+    assert_eq!(schema.body(), &SchemaBody::ReifiedType);
+}
+
+#[derive(Clone, Copy)]
+enum ExtentContextMode {
+    MissingDeclaration,
+    ForwardReference,
+    Cycle,
+    Hole,
+    Valid,
+}
+
+struct ExtentContext(ExtentContextMode);
+
+impl LegacySemanticContext for ExtentContext {
+    fn resolve_named_kind(&mut self, legacy_id: u64) -> Result<KindId, SemanticModelError> {
+        Ok(KindId::new(legacy_id as u32))
+    }
+
+    fn resolve_nominal(
+        &mut self,
+        nominal_kind: NominalKind,
+        legacy_id: u64,
+        legacy_name: &str,
+    ) -> Result<LegacyNominalResolution, SemanticModelError> {
+        Err(SemanticModelError::LegacyNominalUnresolved {
+            kind: nominal_kind,
+            legacy_id,
+            legacy_name: legacy_name.to_owned(),
+        })
+    }
+
+    fn resolve_unspecified_extent(
+        &mut self,
+        _site: &LegacyExtentSite,
+        dimensions: &mut DimensionEnvironmentBuilder,
+    ) -> Result<LegacyResolvedExtent, SemanticModelError> {
+        let dimension = match self.0 {
+            ExtentContextMode::MissingDeclaration => {
+                DimensionExpr::Parameter(DimensionParameterId::new(999))
+            }
+            ExtentContextMode::ForwardReference => {
+                let first = dimensions.declare(
+                    DimensionParameterOrigin::Inferred,
+                    DimensionLifetime::Turn,
+                    DimensionExpr::Parameter(DimensionParameterId::new(1)),
+                    None,
+                )?;
+                dimensions.declare(
+                    DimensionParameterOrigin::Inferred,
+                    DimensionLifetime::Turn,
+                    DimensionExpr::Constant(0),
+                    None,
+                )?;
+                DimensionExpr::Parameter(first)
+            }
+            ExtentContextMode::Cycle => {
+                let first = dimensions.declare(
+                    DimensionParameterOrigin::Inferred,
+                    DimensionLifetime::Turn,
+                    DimensionExpr::Parameter(DimensionParameterId::new(1)),
+                    None,
+                )?;
+                dimensions.declare(
+                    DimensionParameterOrigin::Inferred,
+                    DimensionLifetime::Turn,
+                    DimensionExpr::Parameter(first),
+                    None,
+                )?;
+                DimensionExpr::Parameter(first)
+            }
+            ExtentContextMode::Hole => DimensionExpr::Hole,
+            ExtentContextMode::Valid => DimensionExpr::Parameter(dimensions.declare(
+                DimensionParameterOrigin::Inferred,
+                DimensionLifetime::Turn,
+                DimensionExpr::Constant(0),
+                Some(DimensionExpr::Constant(1024)),
+            )?),
+        };
+        Ok(LegacyResolvedExtent::Dimensions(
+            vec![dimension].into_boxed_slice(),
+        ))
+    }
+}
+
+#[test]
+fn legacy_kind_adapter_validates_context_produced_dimensions() {
+    let unresolved_matrix = Kind::Matrix(Box::new(Kind::Id), Vec::new());
+    for (mode, expected) in [
+        (
+            ExtentContextMode::MissingDeclaration,
+            SemanticModelError::UnknownDimensionParameterV1 {
+                id: DimensionParameterId::new(999),
+            },
+        ),
+        (
+            ExtentContextMode::ForwardReference,
+            SemanticModelError::ForwardDimensionParameterReferenceV1 {
+                parameter: DimensionParameterId::new(0),
+                referenced: DimensionParameterId::new(1),
+            },
+        ),
+        (
+            ExtentContextMode::Cycle,
+            SemanticModelError::CyclicDimensionParameterBoundsV1,
+        ),
+        (
+            ExtentContextMode::Hole,
+            SemanticModelError::UnresolvedDimensionHole,
+        ),
+    ] {
+        assert_eq!(
+            kind_expr_from_legacy(&unresolved_matrix, &mut ExtentContext(mode)).unwrap_err(),
+            expected,
+        );
+    }
+
+    let valid = kind_expr_from_legacy(
+        &unresolved_matrix,
+        &mut ExtentContext(ExtentContextMode::Valid),
+    )
+    .unwrap();
+    assert_eq!(valid.dimension_parameters.len(), 1);
+    assert!(matches!(
+        valid.kind,
+        KindExpr::Matrix { ref dimensions, .. }
+            if dimensions.as_ref()
+                == [DimensionExpr::Parameter(DimensionParameterId::new(0))]
+    ));
+}
+
+#[test]
+fn legacy_kind_adapter_rejects_duplicate_names_recursively() {
+    let duplicate = Kind::Option(Box::new(Kind::Table(
+        vec![("x".to_owned(), Kind::Id), ("x".to_owned(), Kind::Index)],
+        1,
+    )));
+    assert!(matches!(
+        kind_expr_from_legacy(&duplicate, &mut FakeContext::default()),
+        Err(SemanticModelError::DuplicateKindName {
+            category: KindNameCategory::TableColumn,
+            ..
+        })
+    ));
+}

--- a/src/core/tests/schema_contract.rs
+++ b/src/core/tests/schema_contract.rs
@@ -1,0 +1,654 @@
+use mech_core::*;
+
+fn schema(body: SchemaBody) -> Schema {
+    SchemaDraft {
+        dimension_parameters: Vec::new().into_boxed_slice(),
+        body,
+    }
+    .finalize()
+    .unwrap()
+}
+
+fn nominal_key(byte: u8) -> NominalKey {
+    NominalKey::from_bytes([byte; 32])
+}
+
+#[test]
+fn duplicate_names_and_non_keyable_collection_members_fail() {
+    let duplicate = SchemaBody::Record(
+        vec![
+            SchemaField {
+                name: "x".to_owned(),
+                schema: SchemaBody::Bool,
+            },
+            SchemaField {
+                name: "x".to_owned(),
+                schema: SchemaBody::String,
+            },
+        ]
+        .into_boxed_slice(),
+    );
+    assert!(matches!(
+        SchemaDraft {
+            dimension_parameters: Vec::new().into_boxed_slice(),
+            body: duplicate,
+        }
+        .finalize(),
+        Err(SemanticModelError::DuplicateSchemaNameV1 {
+            category: SchemaNameCategory::RecordField,
+            ..
+        })
+    ));
+
+    for body in [
+        SchemaBody::Table {
+            columns: vec![
+                SchemaField {
+                    name: "x".to_owned(),
+                    schema: SchemaBody::Bool,
+                },
+                SchemaField {
+                    name: "x".to_owned(),
+                    schema: SchemaBody::String,
+                },
+            ]
+            .into_boxed_slice(),
+            rows: DimensionExpr::Constant(0),
+        },
+        SchemaBody::Enum {
+            key: nominal_key(1),
+            variants: vec![
+                EnumVariantSchema {
+                    name: "x".to_owned(),
+                    payload: None,
+                },
+                EnumVariantSchema {
+                    name: "x".to_owned(),
+                    payload: Some(SchemaBody::Bool),
+                },
+            ]
+            .into_boxed_slice(),
+        },
+    ] {
+        assert!(matches!(
+            SchemaDraft {
+                dimension_parameters: Vec::new().into_boxed_slice(),
+                body,
+            }
+            .finalize(),
+            Err(SemanticModelError::DuplicateSchemaNameV1 { .. })
+        ));
+    }
+
+    for body in [
+        SchemaBody::Set {
+            element: Box::new(SchemaBody::Complex(FloatWidth::W64)),
+            cardinality: DimensionExpr::Constant(1),
+        },
+        SchemaBody::Map {
+            key: Box::new(SchemaBody::Complex(FloatWidth::W32)),
+            value: Box::new(SchemaBody::Bool),
+            cardinality: DimensionExpr::Constant(1),
+        },
+    ] {
+        assert!(matches!(
+            SchemaDraft {
+                dimension_parameters: Vec::new().into_boxed_slice(),
+                body,
+            }
+            .finalize(),
+            Err(SemanticModelError::SchemaNotKeyableV1)
+        ));
+    }
+}
+
+#[test]
+fn every_scalar_width_has_its_exact_frozen_u16_payload() {
+    for (body, tag, width) in [
+        (SchemaBody::UnsignedInteger(IntegerWidth::W8), 0x02, 8),
+        (SchemaBody::UnsignedInteger(IntegerWidth::W16), 0x02, 16),
+        (SchemaBody::UnsignedInteger(IntegerWidth::W32), 0x02, 32),
+        (SchemaBody::UnsignedInteger(IntegerWidth::W64), 0x02, 64),
+        (SchemaBody::UnsignedInteger(IntegerWidth::W128), 0x02, 128),
+        (SchemaBody::SignedInteger(IntegerWidth::W8), 0x03, 8),
+        (SchemaBody::SignedInteger(IntegerWidth::W16), 0x03, 16),
+        (SchemaBody::SignedInteger(IntegerWidth::W32), 0x03, 32),
+        (SchemaBody::SignedInteger(IntegerWidth::W64), 0x03, 64),
+        (SchemaBody::SignedInteger(IntegerWidth::W128), 0x03, 128),
+        (SchemaBody::FloatingPoint(FloatWidth::W32), 0x04, 32),
+        (SchemaBody::FloatingPoint(FloatWidth::W64), 0x04, 64),
+        (SchemaBody::Complex(FloatWidth::W32), 0x05, 32),
+        (SchemaBody::Complex(FloatWidth::W64), 0x05, 64),
+    ] {
+        let bytes = schema(body).canonical_bytes();
+        assert_eq!(&bytes[13..], &[tag, width as u8, 0]);
+    }
+}
+
+#[test]
+fn enum_record_and_table_order_is_semantic_and_preserved() {
+    let left = schema(SchemaBody::Record(
+        vec![
+            SchemaField {
+                name: "a".to_owned(),
+                schema: SchemaBody::Bool,
+            },
+            SchemaField {
+                name: "b".to_owned(),
+                schema: SchemaBody::String,
+            },
+        ]
+        .into_boxed_slice(),
+    ));
+    let right = schema(SchemaBody::Record(
+        vec![
+            SchemaField {
+                name: "b".to_owned(),
+                schema: SchemaBody::String,
+            },
+            SchemaField {
+                name: "a".to_owned(),
+                schema: SchemaBody::Bool,
+            },
+        ]
+        .into_boxed_slice(),
+    ));
+    assert_ne!(left.canonical_bytes(), right.canonical_bytes());
+
+    let enum_left = schema(SchemaBody::Enum {
+        key: nominal_key(3),
+        variants: vec![
+            EnumVariantSchema {
+                name: "A".to_owned(),
+                payload: None,
+            },
+            EnumVariantSchema {
+                name: "B".to_owned(),
+                payload: Some(SchemaBody::Bool),
+            },
+        ]
+        .into_boxed_slice(),
+    });
+    let enum_right = schema(SchemaBody::Enum {
+        key: nominal_key(3),
+        variants: vec![
+            EnumVariantSchema {
+                name: "B".to_owned(),
+                payload: Some(SchemaBody::Bool),
+            },
+            EnumVariantSchema {
+                name: "A".to_owned(),
+                payload: None,
+            },
+        ]
+        .into_boxed_slice(),
+    });
+    assert_ne!(enum_left.key(), enum_right.key());
+
+    let table_left = schema(SchemaBody::Table {
+        columns: vec![
+            SchemaField {
+                name: "a".to_owned(),
+                schema: SchemaBody::Bool,
+            },
+            SchemaField {
+                name: "b".to_owned(),
+                schema: SchemaBody::String,
+            },
+        ]
+        .into_boxed_slice(),
+        rows: DimensionExpr::Constant(1),
+    });
+    let table_right = schema(SchemaBody::Table {
+        columns: vec![
+            SchemaField {
+                name: "b".to_owned(),
+                schema: SchemaBody::String,
+            },
+            SchemaField {
+                name: "a".to_owned(),
+                schema: SchemaBody::Bool,
+            },
+        ]
+        .into_boxed_slice(),
+        rows: DimensionExpr::Constant(1),
+    });
+    assert_ne!(table_left.canonical_bytes(), table_right.canonical_bytes());
+}
+
+fn bounded_matrix(lifetime: DimensionLifetime, upper: Option<u64>) -> Schema {
+    SchemaDraft {
+        dimension_parameters: vec![DimensionParameterDeclaration {
+            id: DimensionParameterId::new(0),
+            origin: DimensionParameterOrigin::Explicit,
+            lifetime,
+            lower_bound: DimensionExpr::Constant(1),
+            upper_bound: upper.map(DimensionExpr::Constant),
+        }]
+        .into_boxed_slice(),
+        body: SchemaBody::Matrix {
+            element: Box::new(SchemaBody::Bool),
+            dimensions: vec![DimensionExpr::Parameter(DimensionParameterId::new(0))]
+                .into_boxed_slice(),
+        },
+    }
+    .finalize()
+    .unwrap()
+}
+
+#[test]
+fn shape_counts_bounds_bytes_and_extent_evolution_are_exact() {
+    let bounded = bounded_matrix(DimensionLifetime::Activation, Some(8));
+    assert_eq!(bounded.extent_evolution(), ExtentEvolution::ActivationFixed);
+    assert!(matches!(
+        bounded.instantiate_shape(Vec::new().into_boxed_slice()),
+        Err(SemanticModelError::ShapeParameterCountMismatchV1 {
+            expected: 1,
+            actual: 0
+        })
+    ));
+    for value in [0, 9] {
+        assert!(matches!(
+            bounded.instantiate_shape(vec![value].into_boxed_slice()),
+            Err(SemanticModelError::ShapeBoundViolationV1 { .. })
+        ));
+    }
+    let shape = bounded
+        .instantiate_shape(vec![7].into_boxed_slice())
+        .unwrap();
+    assert_eq!(shape.parameter_values(), &[7]);
+    assert_eq!(
+        shape.canonical_bytes().as_ref(),
+        &[1, 1, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0]
+    );
+
+    assert_eq!(
+        schema(SchemaBody::Bool).extent_evolution(),
+        ExtentEvolution::Fixed
+    );
+    assert_eq!(
+        bounded_matrix(DimensionLifetime::Turn, Some(8)).extent_evolution(),
+        ExtentEvolution::TurnBounded
+    );
+    assert_eq!(
+        bounded_matrix(DimensionLifetime::Turn, None).extent_evolution(),
+        ExtentEvolution::TurnUnbounded
+    );
+}
+
+#[test]
+fn finalized_schemas_remove_unused_parameters_and_reject_holes() {
+    let unused = SchemaDraft {
+        dimension_parameters: vec![DimensionParameterDeclaration {
+            id: DimensionParameterId::new(0),
+            origin: DimensionParameterOrigin::Explicit,
+            lifetime: DimensionLifetime::Activation,
+            lower_bound: DimensionExpr::Constant(0),
+            upper_bound: None,
+        }]
+        .into_boxed_slice(),
+        body: SchemaBody::Bool,
+    }
+    .finalize()
+    .unwrap();
+    assert!(unused.dimension_parameters().is_empty());
+
+    assert!(matches!(
+        SchemaDraft {
+            dimension_parameters: Vec::new().into_boxed_slice(),
+            body: SchemaBody::Table {
+                columns: Vec::new().into_boxed_slice(),
+                rows: DimensionExpr::Hole,
+            },
+        }
+        .finalize(),
+        Err(SemanticModelError::UnresolvedDimensionHole)
+    ));
+}
+
+#[test]
+fn finalization_normalizes_before_parameter_reachability() {
+    let parameter = DimensionParameterId::new(0);
+    let reduced = SchemaDraft {
+        dimension_parameters: vec![DimensionParameterDeclaration {
+            id: parameter,
+            origin: DimensionParameterOrigin::Explicit,
+            lifetime: DimensionLifetime::Turn,
+            lower_bound: DimensionExpr::Constant(0),
+            upper_bound: None,
+        }]
+        .into_boxed_slice(),
+        body: SchemaBody::Matrix {
+            element: Box::new(SchemaBody::Bool),
+            dimensions: vec![DimensionExpr::Multiply(
+                vec![
+                    DimensionExpr::Constant(0),
+                    DimensionExpr::Parameter(parameter),
+                ]
+                .into_boxed_slice(),
+            )]
+            .into_boxed_slice(),
+        },
+    }
+    .finalize()
+    .unwrap();
+    let constant = schema(SchemaBody::Matrix {
+        element: Box::new(SchemaBody::Bool),
+        dimensions: vec![DimensionExpr::Constant(0)].into_boxed_slice(),
+    });
+    assert!(reduced.dimension_parameters().is_empty());
+    assert_eq!(reduced.key(), constant.key());
+    reduced
+        .instantiate_shape(Vec::new().into_boxed_slice())
+        .unwrap();
+
+    let dependent = DimensionParameterId::new(1);
+    let bounded = SchemaDraft {
+        dimension_parameters: vec![
+            DimensionParameterDeclaration {
+                id: parameter,
+                origin: DimensionParameterOrigin::Explicit,
+                lifetime: DimensionLifetime::Turn,
+                lower_bound: DimensionExpr::Multiply(
+                    vec![
+                        DimensionExpr::Constant(0),
+                        DimensionExpr::Parameter(dependent),
+                    ]
+                    .into_boxed_slice(),
+                ),
+                upper_bound: None,
+            },
+            DimensionParameterDeclaration {
+                id: dependent,
+                origin: DimensionParameterOrigin::Explicit,
+                lifetime: DimensionLifetime::Turn,
+                lower_bound: DimensionExpr::Constant(0),
+                upper_bound: None,
+            },
+        ]
+        .into_boxed_slice(),
+        body: SchemaBody::Matrix {
+            element: Box::new(SchemaBody::Bool),
+            dimensions: vec![DimensionExpr::Parameter(parameter)].into_boxed_slice(),
+        },
+    }
+    .finalize()
+    .unwrap();
+    assert_eq!(bounded.dimension_parameters().len(), 1);
+    assert_eq!(
+        bounded.dimension_parameters()[0].lower_bound(),
+        &DimensionExpr::Constant(0)
+    );
+}
+
+#[test]
+fn canonical_environment_orders_explicit_then_inferred_and_includes_bounds() {
+    let declarations = vec![
+        DimensionParameterDeclaration {
+            id: DimensionParameterId::new(0),
+            origin: DimensionParameterOrigin::Explicit,
+            lifetime: DimensionLifetime::Activation,
+            lower_bound: DimensionExpr::Constant(1),
+            upper_bound: None,
+        },
+        DimensionParameterDeclaration {
+            id: DimensionParameterId::new(1),
+            origin: DimensionParameterOrigin::Inferred,
+            lifetime: DimensionLifetime::Turn,
+            lower_bound: DimensionExpr::Parameter(DimensionParameterId::new(0)),
+            upper_bound: Some(DimensionExpr::Constant(9)),
+        },
+    ];
+    let finalized = SchemaDraft {
+        dimension_parameters: declarations.into_boxed_slice(),
+        body: SchemaBody::Matrix {
+            element: Box::new(SchemaBody::Bool),
+            dimensions: vec![DimensionExpr::Parameter(DimensionParameterId::new(1))]
+                .into_boxed_slice(),
+        },
+    }
+    .finalize()
+    .unwrap();
+    assert_eq!(finalized.dimension_parameters().len(), 2);
+    assert_eq!(
+        finalized.dimension_parameters()[1].lower_bound(),
+        &DimensionExpr::Parameter(DimensionParameterId::new(0))
+    );
+
+    let inferred = vec![
+        DimensionParameterDeclaration {
+            id: DimensionParameterId::new(0),
+            origin: DimensionParameterOrigin::Inferred,
+            lifetime: DimensionLifetime::Turn,
+            lower_bound: DimensionExpr::Constant(0),
+            upper_bound: None,
+        },
+        DimensionParameterDeclaration {
+            id: DimensionParameterId::new(1),
+            origin: DimensionParameterOrigin::Inferred,
+            lifetime: DimensionLifetime::Turn,
+            lower_bound: DimensionExpr::Constant(0),
+            upper_bound: None,
+        },
+    ];
+    let inferred = SchemaDraft {
+        dimension_parameters: inferred.into_boxed_slice(),
+        body: SchemaBody::Matrix {
+            element: Box::new(SchemaBody::Bool),
+            dimensions: vec![
+                DimensionExpr::Parameter(DimensionParameterId::new(1)),
+                DimensionExpr::Parameter(DimensionParameterId::new(0)),
+            ]
+            .into_boxed_slice(),
+        },
+    }
+    .finalize()
+    .unwrap();
+    let SchemaBody::Matrix { dimensions, .. } = inferred.body() else {
+        panic!("expected matrix")
+    };
+    assert_eq!(
+        dimensions.as_ref(),
+        &[
+            DimensionExpr::Parameter(DimensionParameterId::new(0)),
+            DimensionExpr::Parameter(DimensionParameterId::new(1)),
+        ]
+    );
+}
+
+#[test]
+fn canonical_environment_rejects_forward_references_and_cycles() {
+    let forward = vec![
+        DimensionParameterDeclaration {
+            id: DimensionParameterId::new(0),
+            origin: DimensionParameterOrigin::Explicit,
+            lifetime: DimensionLifetime::Activation,
+            lower_bound: DimensionExpr::Parameter(DimensionParameterId::new(1)),
+            upper_bound: None,
+        },
+        DimensionParameterDeclaration {
+            id: DimensionParameterId::new(1),
+            origin: DimensionParameterOrigin::Explicit,
+            lifetime: DimensionLifetime::Activation,
+            lower_bound: DimensionExpr::Constant(0),
+            upper_bound: None,
+        },
+    ];
+    let draft = |parameters: Vec<DimensionParameterDeclaration>| SchemaDraft {
+        dimension_parameters: parameters.into_boxed_slice(),
+        body: SchemaBody::Matrix {
+            element: Box::new(SchemaBody::Bool),
+            dimensions: vec![DimensionExpr::Parameter(DimensionParameterId::new(0))]
+                .into_boxed_slice(),
+        },
+    };
+    assert!(matches!(
+        draft(forward).finalize(),
+        Err(SemanticModelError::ForwardDimensionParameterReferenceV1 { .. })
+    ));
+
+    let cycle = vec![
+        DimensionParameterDeclaration {
+            id: DimensionParameterId::new(0),
+            origin: DimensionParameterOrigin::Explicit,
+            lifetime: DimensionLifetime::Activation,
+            lower_bound: DimensionExpr::Parameter(DimensionParameterId::new(1)),
+            upper_bound: None,
+        },
+        DimensionParameterDeclaration {
+            id: DimensionParameterId::new(1),
+            origin: DimensionParameterOrigin::Explicit,
+            lifetime: DimensionLifetime::Activation,
+            lower_bound: DimensionExpr::Parameter(DimensionParameterId::new(0)),
+            upper_bound: None,
+        },
+    ];
+    assert!(matches!(
+        draft(cycle).finalize(),
+        Err(SemanticModelError::CyclicDimensionParameterBoundsV1)
+    ));
+}
+
+#[test]
+fn cardinality_and_extent_evaluation_are_checked() {
+    let schema = SchemaDraft {
+        dimension_parameters: vec![DimensionParameterDeclaration {
+            id: DimensionParameterId::new(0),
+            origin: DimensionParameterOrigin::Explicit,
+            lifetime: DimensionLifetime::Turn,
+            lower_bound: DimensionExpr::Constant(0),
+            upper_bound: None,
+        }]
+        .into_boxed_slice(),
+        body: SchemaBody::Table {
+            columns: Vec::new().into_boxed_slice(),
+            rows: DimensionExpr::Multiply(
+                vec![
+                    DimensionExpr::Parameter(DimensionParameterId::new(0)),
+                    DimensionExpr::Constant(2),
+                ]
+                .into_boxed_slice(),
+            ),
+        },
+    }
+    .finalize()
+    .unwrap();
+    assert!(matches!(
+        schema.instantiate_shape(vec![u64::MAX].into_boxed_slice()),
+        Err(SemanticModelError::DimensionOverflowV1)
+    ));
+}
+
+#[test]
+fn matrix_shape_validation_checks_the_product_of_separate_dimensions() {
+    let constant_overflow = schema(SchemaBody::Matrix {
+        element: Box::new(SchemaBody::Bool),
+        dimensions: vec![
+            DimensionExpr::Constant(u64::MAX),
+            DimensionExpr::Constant(2),
+        ]
+        .into_boxed_slice(),
+    });
+    assert!(matches!(
+        constant_overflow.instantiate_shape(Vec::new().into_boxed_slice()),
+        Err(SemanticModelError::DimensionOverflowV1)
+    ));
+
+    let parameterized_overflow = SchemaDraft {
+        dimension_parameters: vec![DimensionParameterDeclaration {
+            id: DimensionParameterId::new(0),
+            origin: DimensionParameterOrigin::Explicit,
+            lifetime: DimensionLifetime::Turn,
+            lower_bound: DimensionExpr::Constant(0),
+            upper_bound: None,
+        }]
+        .into_boxed_slice(),
+        body: SchemaBody::Matrix {
+            element: Box::new(SchemaBody::Bool),
+            dimensions: vec![
+                DimensionExpr::Parameter(DimensionParameterId::new(0)),
+                DimensionExpr::Constant(2),
+            ]
+            .into_boxed_slice(),
+        },
+    }
+    .finalize()
+    .unwrap();
+    assert!(matches!(
+        parameterized_overflow.instantiate_shape(vec![u64::MAX].into_boxed_slice()),
+        Err(SemanticModelError::DimensionOverflowV1)
+    ));
+
+    let large_valid = schema(SchemaBody::Matrix {
+        element: Box::new(SchemaBody::Bool),
+        dimensions: vec![
+            DimensionExpr::Constant(u64::MAX / 2),
+            DimensionExpr::Constant(2),
+        ]
+        .into_boxed_slice(),
+    });
+    large_valid
+        .instantiate_shape(Vec::new().into_boxed_slice())
+        .unwrap();
+
+    let nested_overflow = schema(SchemaBody::Tuple(
+        vec![SchemaBody::Option(Box::new(SchemaBody::Matrix {
+            element: Box::new(SchemaBody::Bool),
+            dimensions: vec![
+                DimensionExpr::Constant(u64::MAX),
+                DimensionExpr::Constant(2),
+            ]
+            .into_boxed_slice(),
+        }))]
+        .into_boxed_slice(),
+    ));
+    assert!(matches!(
+        nested_overflow.instantiate_shape(Vec::new().into_boxed_slice()),
+        Err(SemanticModelError::DimensionOverflowV1)
+    ));
+}
+
+#[test]
+fn schema_table_ids_follow_canonical_bytes_not_insertion_order() {
+    let bool_schema = schema(SchemaBody::Bool);
+    let string_schema = schema(SchemaBody::String);
+
+    let mut first = SchemaTableBuilder::new();
+    let first_string = first.insert(string_schema.clone()).unwrap();
+    let first_bool = first.insert(bool_schema.clone()).unwrap();
+    let first_duplicate = first.insert(bool_schema.clone()).unwrap();
+    let first = first.finish().unwrap();
+
+    let mut second = SchemaTableBuilder::new();
+    let second_bool = second.insert(bool_schema.clone()).unwrap();
+    let second_string = second.insert(string_schema.clone()).unwrap();
+    let second = second.finish().unwrap();
+
+    assert_eq!(first.table.len(), 2);
+    assert_eq!(
+        first.resolve(first_bool).unwrap(),
+        first.resolve(first_duplicate).unwrap()
+    );
+    assert_eq!(
+        first.resolve(first_bool).unwrap(),
+        second.resolve(second_bool).unwrap(),
+        "Bool must retain the same canonical-byte ID"
+    );
+    assert_eq!(
+        first.resolve(first_string).unwrap(),
+        second.resolve(second_string).unwrap(),
+        "String must retain the same canonical-byte ID"
+    );
+    assert_eq!(
+        first.table.find_by_key(bool_schema.key()),
+        Some(first.resolve(first_bool).unwrap())
+    );
+    assert_eq!(
+        first.resolve(first_bool).unwrap().get() < first.resolve(first_string).unwrap().get(),
+        bool_schema.canonical_bytes() < string_schema.canonical_bytes()
+    );
+    assert!(matches!(
+        first.resolve(second_string),
+        Err(SemanticModelError::InvalidSchemaHandleV1)
+    ));
+}

--- a/src/core/tests/semantic_identity_contract.rs
+++ b/src/core/tests/semantic_identity_contract.rs
@@ -28,6 +28,18 @@ fn resident_ids_keep_their_exact_scalar_layout() {
     );
 }
 
+#[cfg(feature = "resident-execution")]
+#[test]
+fn resident_execution_paths_reexport_the_final_identity_types() {
+    fn accepts_slot(_: mech_core::resident_execution::CellSlotId) {}
+    fn accepts_index(_: mech_core::resident_execution::SlotIndex) {}
+    fn accepts_epoch(_: mech_core::resident_execution::InstanceEpoch) {}
+
+    accepts_slot(CellSlotId::new(1));
+    accepts_index(SlotIndex::new(2));
+    accepts_epoch(InstanceEpoch::new(3));
+}
+
 #[test]
 fn every_generation_increment_is_checked() {
     assert!(InstanceEpoch::new(u64::MAX).checked_next().is_err());

--- a/src/core/tests/semantic_identity_contract.rs
+++ b/src/core/tests/semantic_identity_contract.rs
@@ -1,0 +1,74 @@
+use mech_core::*;
+
+#[test]
+fn resident_ids_keep_their_exact_scalar_layout() {
+    assert_eq!(
+        core::mem::size_of::<CellSlotId>(),
+        core::mem::size_of::<u32>()
+    );
+    assert_eq!(
+        core::mem::align_of::<CellSlotId>(),
+        core::mem::align_of::<u32>()
+    );
+    assert_eq!(
+        core::mem::size_of::<SlotIndex>(),
+        core::mem::size_of::<u32>()
+    );
+    assert_eq!(
+        core::mem::align_of::<SlotIndex>(),
+        core::mem::align_of::<u32>()
+    );
+    assert_eq!(
+        core::mem::size_of::<InstanceEpoch>(),
+        core::mem::size_of::<u64>()
+    );
+    assert_eq!(
+        core::mem::align_of::<InstanceEpoch>(),
+        core::mem::align_of::<u64>()
+    );
+}
+
+#[test]
+fn every_generation_increment_is_checked() {
+    assert!(InstanceEpoch::new(u64::MAX).checked_next().is_err());
+    assert!(PlanGeneration::new(u64::MAX).checked_next().is_err());
+    assert!(LayoutGeneration::new(u64::MAX).checked_next().is_err());
+    assert!(
+        ReactiveInstanceId::new(4, u32::MAX)
+            .checked_next_generation()
+            .is_err()
+    );
+}
+
+#[test]
+fn cell_identity_includes_instance_generation_but_not_plan_generation() {
+    let before = ReactiveInstanceId::new(9, 1);
+    let after = before.checked_next_generation().unwrap();
+    assert_ne!(
+        CellId::new(before, CellSlotId(3)),
+        CellId::new(after, CellSlotId(3))
+    );
+    assert_eq!(before, ReactiveInstanceId::new(9, 1));
+    assert_eq!(PlanGeneration::new(12).get(), 12);
+}
+
+#[test]
+fn nominal_path_validation_and_hashing_are_canonical() {
+    for segments in [vec![], vec![""], vec!["."], vec![".."], vec!["a\0b"]] {
+        let owned = segments.into_iter().map(str::to_owned).collect::<Vec<_>>();
+        assert!(CanonicalNominalPath::new(owned.into_boxed_slice()).is_err());
+    }
+
+    let path = CanonicalNominalPath::new(
+        vec!["fixture".to_owned(), "Choice".to_owned()].into_boxed_slice(),
+    )
+    .unwrap();
+    assert_eq!(
+        NominalKey::from_path(NominalKind::Enum, &path).into_bytes(),
+        [
+            0x8f, 0x9a, 0x09, 0x64, 0x45, 0x0f, 0xe4, 0xb4, 0x28, 0x88, 0xa0, 0x7c, 0xb9, 0x0a,
+            0xa3, 0x31, 0x29, 0x45, 0x38, 0x13, 0xcc, 0xc9, 0xb9, 0x80, 0x5b, 0x95, 0x8c, 0xaf,
+            0x83, 0xfe, 0x7a, 0xd9,
+        ]
+    );
+}

--- a/src/core/tests/semantic_serde_contract.rs
+++ b/src/core/tests/semantic_serde_contract.rs
@@ -1,0 +1,74 @@
+#![cfg(feature = "serde")]
+
+use mech_core::*;
+use serde::{Serialize, de::DeserializeOwned};
+
+fn assert_serialize<T: Serialize>(value: &T) {
+    serde_json::to_value(value).unwrap();
+}
+
+fn assert_deserialize<T: DeserializeOwned>() {}
+
+#[test]
+fn open_semantic_syntax_remains_serializable_and_deserializable() {
+    assert_deserialize::<SchemaDraft>();
+    assert_deserialize::<SchemaBody>();
+    assert_deserialize::<DimensionExpr>();
+    assert_deserialize::<DimensionParameterDeclaration>();
+    assert_deserialize::<KindExpr>();
+    assert_deserialize::<KindParameter>();
+    assert_deserialize::<InputKindScheme>();
+    assert_deserialize::<KindConstraint>();
+
+    let draft = SchemaDraft {
+        dimension_parameters: Vec::new().into_boxed_slice(),
+        body: SchemaBody::Bool,
+    };
+    let encoded = serde_json::to_string(&draft).unwrap();
+    assert_eq!(
+        serde_json::from_str::<SchemaDraft>(&encoded).unwrap(),
+        draft
+    );
+}
+
+#[test]
+fn finalized_semantic_values_serialize_only_after_validated_construction() {
+    let path = CanonicalNominalPath::new(vec!["fixture".to_owned(), "Choice".to_owned()]).unwrap();
+    assert_serialize(&path);
+
+    let schema = SchemaDraft {
+        dimension_parameters: vec![DimensionParameterDeclaration {
+            id: DimensionParameterId::new(0),
+            origin: DimensionParameterOrigin::Explicit,
+            lifetime: DimensionLifetime::Turn,
+            lower_bound: DimensionExpr::Constant(0),
+            upper_bound: Some(DimensionExpr::Constant(8)),
+        }]
+        .into_boxed_slice(),
+        body: SchemaBody::Matrix {
+            element: Box::new(SchemaBody::Bool),
+            dimensions: vec![DimensionExpr::Parameter(DimensionParameterId::new(0))]
+                .into_boxed_slice(),
+        },
+    }
+    .finalize()
+    .unwrap();
+    let shape = schema
+        .instantiate_shape(vec![4].into_boxed_slice())
+        .unwrap();
+    assert_serialize(&schema);
+    assert_serialize(&schema.dimension_parameters()[0]);
+    assert_serialize(&shape);
+    assert!(!schema.canonical_bytes().is_empty());
+    assert!(!shape.canonical_bytes().is_empty());
+
+    let scheme = KindScheme::new(
+        Vec::new().into_boxed_slice(),
+        Vec::new().into_boxed_slice(),
+        InputKindScheme::Fixed(vec![KindExpr::Id].into_boxed_slice()),
+        vec![KindExpr::Index].into_boxed_slice(),
+        Vec::new().into_boxed_slice(),
+    )
+    .unwrap();
+    assert_serialize(&scheme);
+}

--- a/src/engine/src/resident/candidate.rs
+++ b/src/engine/src/resident/candidate.rs
@@ -53,7 +53,7 @@ impl ReactiveInstance {
         let working_epoch = self
             .next_epoch
             .ok_or(ResidentExecutionError::EpochExhausted)?;
-        self.next_epoch = working_epoch.checked_next();
+        self.next_epoch = working_epoch.checked_next().ok();
         let base_epoch = InstanceEpoch(self.published_epoch.load(Ordering::Acquire));
         let (published_buffer, candidate_buffer) =
             self.state.begin_candidate(base_epoch, working_epoch);

--- a/src/engine/src/resident/full_write.rs
+++ b/src/engine/src/resident/full_write.rs
@@ -149,7 +149,7 @@ impl ResidentFullWrite {
         let working_epoch = self
             .next_epoch
             .ok_or(ResidentExecutionError::EpochExhausted)?;
-        self.next_epoch = working_epoch.checked_next();
+        self.next_epoch = working_epoch.checked_next().ok();
         let published_epoch = InstanceEpoch(self.published_epoch.load(Ordering::Acquire));
         let published = self.published_index(published_epoch);
         debug_assert_eq!(self.buffer_epochs[published], Some(published_epoch));

--- a/tests/architecture/distributions/standard.json
+++ b/tests/architecture/distributions/standard.json
@@ -1,5 +1,5 @@
 {
-  "dependency_count": 401,
+  "dependency_count": 406,
   "distribution": "standard",
   "native_planning_owner_count": 5,
   "runtime_factory_count": 1300,
@@ -189,6 +189,6 @@
     "whos"
   ],
   "source_specializer_count": 63,
-  "surface_digest": "b058d645ca545d03240004e9dfff0663b27e42f6f44894081c58c0d9cfb76f0a",
+  "surface_digest": "6c0ec9b54e4de25b1a61b063cb4c5846c1a4fc4bb5e99f34db8f8347af32ee34",
   "surface_digest_algorithm": "sha256-canonical-selected-cargo-surface-v1"
 }

--- a/tests/architecture/value-system/canonical-encoding-v1-schema.json
+++ b/tests/architecture/value-system/canonical-encoding-v1-schema.json
@@ -358,7 +358,7 @@
         },
         "path": "non-empty-U32-counted-ordered-sequence-of-exact-Utf8-segments",
         "segment_derivation": {
-          "collision_rule": "duplicate-resolved-package-names-are-rejected-only-when-more-than-one-such-package-defines-a-nominal-declaration-reachable-in-the-current-compilation",
+          "collision_rule": "same-complete-CanonicalNominalPath-from-distinct-Cargo-package-IDs-in-one-ProgramArtifact-is-AmbiguousNominalDeclarationV1",
           "crate_aliases": "excluded",
           "module_source": "defining-module-canonical-namespace-relative-to-package-root",
           "package_name_source": "resolved-package-manifest-declared-name-exact-Utf8",

--- a/tests/architecture/value-system/canonical-encoding-v1.json
+++ b/tests/architecture/value-system/canonical-encoding-v1.json
@@ -333,7 +333,7 @@
     },
     "path": "non-empty-U32-counted-ordered-sequence-of-exact-Utf8-segments",
     "segment_derivation": {
-      "collision_rule": "duplicate-resolved-package-names-are-rejected-only-when-more-than-one-such-package-defines-a-nominal-declaration-reachable-in-the-current-compilation",
+      "collision_rule": "same-complete-CanonicalNominalPath-from-distinct-Cargo-package-IDs-in-one-ProgramArtifact-is-AmbiguousNominalDeclarationV1",
       "crate_aliases": "excluded",
       "module_source": "defining-module-canonical-namespace-relative-to-package-root",
       "package_name_source": "resolved-package-manifest-declared-name-exact-Utf8",

--- a/tests/architecture/value-system/current-inventory.json
+++ b/tests/architecture/value-system/current-inventory.json
@@ -257,6 +257,7 @@
     "src/cli/run_options.rs",
     "src/cli/runtime_plan.rs",
     "src/cli/serve_options.rs",
+    "src/core/src/dimension.rs",
     "src/core/src/element.rs",
     "src/core/src/error.rs",
     "src/core/src/execution.rs",
@@ -266,10 +267,15 @@
     "src/core/src/function/mod.rs",
     "src/core/src/function/signature.rs",
     "src/core/src/kind.rs",
+    "src/core/src/kind_expr.rs",
+    "src/core/src/kind_scheme.rs",
+    "src/core/src/legacy_adapter/kind.rs",
+    "src/core/src/legacy_adapter/mod.rs",
     "src/core/src/lib.rs",
     "src/core/src/mika.rs",
     "src/core/src/module_manifest.rs",
     "src/core/src/nodes.rs",
+    "src/core/src/nominal.rs",
     "src/core/src/program/bytecode/aggregates.rs",
     "src/core/src/program/bytecode/constants/composite.rs",
     "src/core/src/program/bytecode/constants/inline_type.rs",
@@ -297,6 +303,13 @@
     "src/core/src/program/symbol_table.rs",
     "src/core/src/reactive_transaction.rs",
     "src/core/src/resident_execution.rs",
+    "src/core/src/schema/encoding.rs",
+    "src/core/src/schema/mod.rs",
+    "src/core/src/schema/shape.rs",
+    "src/core/src/schema/table.rs",
+    "src/core/src/schema/validation.rs",
+    "src/core/src/semantic_error.rs",
+    "src/core/src/semantic_identity.rs",
     "src/core/src/state_journal/mod.rs",
     "src/core/src/stdlib.rs",
     "src/core/src/structures/enums.rs",
@@ -1018,6 +1031,46 @@
       "targets": [
         {
           "kinds": [
+            "test"
+          ],
+          "name": "canonical_schema_vectors",
+          "reachable_rust_files": [
+            "src/core/tests/canonical_schema_vectors.rs"
+          ],
+          "root": "src/core/tests/canonical_schema_vectors.rs"
+        },
+        {
+          "kinds": [
+            "test"
+          ],
+          "name": "dimension_contract",
+          "reachable_rust_files": [
+            "src/core/tests/dimension_contract.rs"
+          ],
+          "root": "src/core/tests/dimension_contract.rs"
+        },
+        {
+          "kinds": [
+            "test"
+          ],
+          "name": "kind_scheme_contract",
+          "reachable_rust_files": [
+            "src/core/tests/kind_scheme_contract.rs"
+          ],
+          "root": "src/core/tests/kind_scheme_contract.rs"
+        },
+        {
+          "kinds": [
+            "test"
+          ],
+          "name": "legacy_kind_adapter_contract",
+          "reachable_rust_files": [
+            "src/core/tests/legacy_kind_adapter_contract.rs"
+          ],
+          "root": "src/core/tests/legacy_kind_adapter_contract.rs"
+        },
+        {
+          "kinds": [
             "lib",
             "cfg-test"
           ],
@@ -1044,6 +1097,26 @@
             "src/core/src/state_journal/tests/support.rs"
           ],
           "root": "src/core/src/lib.rs"
+        },
+        {
+          "kinds": [
+            "test"
+          ],
+          "name": "schema_contract",
+          "reachable_rust_files": [
+            "src/core/tests/schema_contract.rs"
+          ],
+          "root": "src/core/tests/schema_contract.rs"
+        },
+        {
+          "kinds": [
+            "test"
+          ],
+          "name": "semantic_identity_contract",
+          "reachable_rust_files": [
+            "src/core/tests/semantic_identity_contract.rs"
+          ],
+          "root": "src/core/tests/semantic_identity_contract.rs"
         },
         {
           "kinds": [
@@ -2309,6 +2382,7 @@
     "src/cli/serve_options.rs",
     "src/core/benches/solve_result_overhead.rs",
     "src/core/benches/value_state_journal.rs",
+    "src/core/src/dimension.rs",
     "src/core/src/element.rs",
     "src/core/src/error.rs",
     "src/core/src/execution.rs",
@@ -2327,10 +2401,15 @@
     "src/core/src/function/tests/support.rs",
     "src/core/src/function/tests/transaction_state.rs",
     "src/core/src/kind.rs",
+    "src/core/src/kind_expr.rs",
+    "src/core/src/kind_scheme.rs",
+    "src/core/src/legacy_adapter/kind.rs",
+    "src/core/src/legacy_adapter/mod.rs",
     "src/core/src/lib.rs",
     "src/core/src/mika.rs",
     "src/core/src/module_manifest.rs",
     "src/core/src/nodes.rs",
+    "src/core/src/nominal.rs",
     "src/core/src/program/bytecode/aggregates.rs",
     "src/core/src/program/bytecode/constants/composite.rs",
     "src/core/src/program/bytecode/constants/inline_type.rs",
@@ -2359,6 +2438,13 @@
     "src/core/src/program/symbol_table.rs",
     "src/core/src/reactive_transaction.rs",
     "src/core/src/resident_execution.rs",
+    "src/core/src/schema/encoding.rs",
+    "src/core/src/schema/mod.rs",
+    "src/core/src/schema/shape.rs",
+    "src/core/src/schema/table.rs",
+    "src/core/src/schema/validation.rs",
+    "src/core/src/semantic_error.rs",
+    "src/core/src/semantic_identity.rs",
     "src/core/src/state_journal/mod.rs",
     "src/core/src/state_journal/tests/borrow_conflicts.rs",
     "src/core/src/state_journal/tests/collections.rs",
@@ -2384,6 +2470,12 @@
     "src/core/src/types/rational_numbers.rs",
     "src/core/src/value.rs",
     "src/core/src/value_snapshot.rs",
+    "src/core/tests/canonical_schema_vectors.rs",
+    "src/core/tests/dimension_contract.rs",
+    "src/core/tests/kind_scheme_contract.rs",
+    "src/core/tests/legacy_kind_adapter_contract.rs",
+    "src/core/tests/schema_contract.rs",
+    "src/core/tests/semantic_identity_contract.rs",
     "src/engine/benches/integrity_constraints.rs",
     "src/engine/benches/program_checkpoint.rs",
     "src/engine/benches/reactive_turn_rollback.rs",
@@ -16707,6 +16799,13 @@
     {
       "column": 9,
       "enum": "Kind",
+      "line": 50,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Any"
+    },
+    {
+      "column": 9,
+      "enum": "Kind",
       "line": 9,
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "variant": "Any"
@@ -16751,6 +16850,13 @@
       "enum": "Kind",
       "line": 46,
       "path": "src/core/src/kind.rs",
+      "variant": "Atom"
+    },
+    {
+      "column": 9,
+      "enum": "Kind",
+      "line": 56,
+      "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Atom"
     },
     {
@@ -16812,6 +16918,13 @@
     {
       "column": 9,
       "enum": "Kind",
+      "line": 52,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Empty"
+    },
+    {
+      "column": 9,
+      "enum": "Kind",
       "line": 11,
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "variant": "Empty"
@@ -16856,6 +16969,13 @@
       "enum": "Kind",
       "line": 47,
       "path": "src/core/src/kind.rs",
+      "variant": "Enum"
+    },
+    {
+      "column": 9,
+      "enum": "Kind",
+      "line": 64,
+      "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Enum"
     },
     {
@@ -16910,6 +17030,13 @@
     {
       "column": 9,
       "enum": "Kind",
+      "line": 54,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Id"
+    },
+    {
+      "column": 9,
+      "enum": "Kind",
       "line": 14,
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "variant": "Id"
@@ -16952,6 +17079,13 @@
     {
       "column": 9,
       "enum": "Kind",
+      "line": 55,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Index"
+    },
+    {
+      "column": 9,
+      "enum": "Kind",
       "line": 15,
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "variant": "Index"
@@ -16989,6 +17123,13 @@
       "enum": "Kind",
       "line": 39,
       "path": "src/core/src/kind.rs",
+      "variant": "Kind"
+    },
+    {
+      "column": 9,
+      "enum": "Kind",
+      "line": 179,
+      "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Kind"
     },
     {
@@ -17050,6 +17191,13 @@
     {
       "column": 9,
       "enum": "Kind",
+      "line": 156,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Map"
+    },
+    {
+      "column": 9,
+      "enum": "Kind",
       "line": 16,
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "variant": "Map"
@@ -17101,6 +17249,13 @@
       "enum": "Kind",
       "line": 55,
       "path": "src/core/src/kind.rs",
+      "variant": "Matrix"
+    },
+    {
+      "column": 9,
+      "enum": "Kind",
+      "line": 72,
+      "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Matrix"
     },
     {
@@ -17162,6 +17317,13 @@
     {
       "column": 9,
       "enum": "Kind",
+      "line": 51,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "None"
+    },
+    {
+      "column": 9,
+      "enum": "Kind",
       "line": 10,
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "variant": "None"
@@ -17206,6 +17368,13 @@
       "enum": "Kind",
       "line": 59,
       "path": "src/core/src/kind.rs",
+      "variant": "Option"
+    },
+    {
+      "column": 9,
+      "enum": "Kind",
+      "line": 90,
+      "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Option"
     },
     {
@@ -17267,6 +17436,13 @@
     {
       "column": 9,
       "enum": "Kind",
+      "line": 109,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Record"
+    },
+    {
+      "column": 9,
+      "enum": "Kind",
       "line": 25,
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "variant": "Record"
@@ -17323,6 +17499,13 @@
     {
       "column": 9,
       "enum": "Kind",
+      "line": 176,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Reference"
+    },
+    {
+      "column": 9,
+      "enum": "Kind",
       "line": 31,
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "variant": "Reference"
@@ -17367,6 +17550,13 @@
       "enum": "Kind",
       "line": 74,
       "path": "src/core/src/kind.rs",
+      "variant": "Scalar"
+    },
+    {
+      "column": 9,
+      "enum": "Kind",
+      "line": 53,
+      "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Scalar"
     },
     {
@@ -17423,6 +17613,13 @@
       "enum": "Kind",
       "line": 81,
       "path": "src/core/src/kind.rs",
+      "variant": "Set"
+    },
+    {
+      "column": 9,
+      "enum": "Kind",
+      "line": 137,
+      "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Set"
     },
     {
@@ -17491,6 +17688,13 @@
     {
       "column": 9,
       "enum": "Kind",
+      "line": 116,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Table"
+    },
+    {
+      "column": 9,
+      "enum": "Kind",
       "line": 37,
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "variant": "Table"
@@ -17542,6 +17746,13 @@
       "enum": "Kind",
       "line": 92,
       "path": "src/core/src/kind.rs",
+      "variant": "Tuple"
+    },
+    {
+      "column": 9,
+      "enum": "Kind",
+      "line": 95,
+      "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Tuple"
     },
     {
@@ -51348,6 +51559,20 @@
       "variant": "Any"
     },
     {
+      "column": 28,
+      "enum": "ValueKind",
+      "line": 234,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Any"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 472,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Any"
+    },
+    {
       "column": 22,
       "enum": "ValueKind",
       "line": 9,
@@ -51537,6 +51762,20 @@
       "variant": "Atom"
     },
     {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 294,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Atom"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 478,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Atom"
+    },
+    {
       "column": 33,
       "enum": "ValueKind",
       "line": 12,
@@ -51626,6 +51865,20 @@
       "line": 526,
       "path": "src/engine/src/patterns.rs",
       "variant": "Atom"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 231,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Bool"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 468,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Bool"
     },
     {
       "column": 18,
@@ -51766,6 +52019,20 @@
       "line": 466,
       "path": "src/engine/src/structures.rs",
       "variant": "Bool"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 228,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "C64"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 465,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "C64"
     },
     {
       "column": 17,
@@ -51926,6 +52193,20 @@
       "enum": "ValueKind",
       "line": 45,
       "path": "src/core/src/kind.rs",
+      "variant": "Empty"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 234,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Empty"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 471,
+      "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Empty"
     },
     {
@@ -52167,6 +52448,20 @@
       "variant": "Enum"
     },
     {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 257,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Enum"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 475,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Enum"
+    },
+    {
       "column": 33,
       "enum": "ValueKind",
       "line": 13,
@@ -52375,6 +52670,20 @@
       "line": 102,
       "path": "src/engine/src/statements/variable_define.rs",
       "variant": "Enum"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 226,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "F32"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 463,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "F32"
     },
     {
       "column": 17,
@@ -52732,6 +53041,20 @@
       "line": 443,
       "path": "src/engine/src/structures.rs",
       "variant": "F32"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 227,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "F64"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 464,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "F64"
     },
     {
       "column": 17,
@@ -53112,6 +53435,20 @@
       "variant": "F64"
     },
     {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 225,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "I128"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 462,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "I128"
+    },
+    {
       "column": 18,
       "enum": "ValueKind",
       "line": 66,
@@ -53390,6 +53727,20 @@
       "line": 429,
       "path": "src/engine/src/structures.rs",
       "variant": "I128"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 222,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "I16"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 459,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "I16"
     },
     {
       "column": 17,
@@ -53672,6 +54023,20 @@
       "variant": "I16"
     },
     {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 223,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "I32"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 460,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "I32"
+    },
+    {
       "column": 17,
       "enum": "ValueKind",
       "line": 64,
@@ -53952,6 +54317,20 @@
       "variant": "I32"
     },
     {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 224,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "I64"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 461,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "I64"
+    },
+    {
       "column": 17,
       "enum": "ValueKind",
       "line": 65,
@@ -54230,6 +54609,20 @@
       "line": 427,
       "path": "src/engine/src/structures.rs",
       "variant": "I64"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 221,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "I8"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 458,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "I8"
     },
     {
       "column": 16,
@@ -54519,6 +54912,20 @@
       "variant": "Id"
     },
     {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 232,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Id"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 469,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Id"
+    },
+    {
       "column": 21,
       "enum": "ValueKind",
       "line": 14,
@@ -54579,6 +54986,20 @@
       "enum": "ValueKind",
       "line": 49,
       "path": "src/core/src/kind.rs",
+      "variant": "Index"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 233,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Index"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 470,
+      "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Index"
     },
     {
@@ -54855,6 +55276,20 @@
       "variant": "Kind"
     },
     {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 361,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Kind"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 484,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Kind"
+    },
+    {
       "column": 30,
       "enum": "ValueKind",
       "line": 50,
@@ -54901,6 +55336,20 @@
       "enum": "ValueKind",
       "line": 53,
       "path": "src/core/src/kind.rs",
+      "variant": "Map"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 274,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Map"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 477,
+      "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Map"
     },
     {
@@ -55013,6 +55462,20 @@
       "enum": "ValueKind",
       "line": 57,
       "path": "src/core/src/kind.rs",
+      "variant": "Matrix"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 239,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Matrix"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 474,
+      "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Matrix"
     },
     {
@@ -55604,6 +56067,20 @@
       "variant": "None"
     },
     {
+      "column": 45,
+      "enum": "ValueKind",
+      "line": 234,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "None"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 473,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "None"
+    },
+    {
       "column": 23,
       "enum": "ValueKind",
       "line": 10,
@@ -55671,6 +56148,20 @@
       "enum": "ValueKind",
       "line": 61,
       "path": "src/core/src/kind.rs",
+      "variant": "Option"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 356,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Option"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 483,
+      "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Option"
     },
     {
@@ -56017,6 +56508,20 @@
       "variant": "Option"
     },
     {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 229,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "R64"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 466,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "R64"
+    },
+    {
       "column": 17,
       "enum": "ValueKind",
       "line": 70,
@@ -56140,6 +56645,20 @@
       "enum": "ValueKind",
       "line": 68,
       "path": "src/core/src/kind.rs",
+      "variant": "Record"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 267,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Record"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 476,
+      "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Record"
     },
     {
@@ -56273,6 +56792,20 @@
       "enum": "ValueKind",
       "line": 72,
       "path": "src/core/src/kind.rs",
+      "variant": "Reference"
+    },
+    {
+      "column": 63,
+      "enum": "ValueKind",
+      "line": 234,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Reference"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 481,
+      "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Reference"
     },
     {
@@ -56458,6 +56991,20 @@
       "variant": "Set"
     },
     {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 337,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Set"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 482,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Set"
+    },
+    {
       "column": 13,
       "enum": "ValueKind",
       "line": 35,
@@ -56568,6 +57115,20 @@
       "line": 59,
       "path": "src/engine/src/structures.rs",
       "variant": "Set"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 230,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "String"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 467,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "String"
     },
     {
       "column": 20,
@@ -56766,6 +57327,20 @@
       "variant": "Table"
     },
     {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 302,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Table"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 479,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Table"
+    },
+    {
       "column": 46,
       "enum": "ValueKind",
       "line": 37,
@@ -56955,6 +57530,20 @@
       "variant": "Tuple"
     },
     {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 323,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Tuple"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 480,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "Tuple"
+    },
+    {
       "column": 31,
       "enum": "ValueKind",
       "line": 44,
@@ -57093,6 +57682,20 @@
       "line": 91,
       "path": "src/engine/src/structures.rs",
       "variant": "Tuple"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 220,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "U128"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 457,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "U128"
     },
     {
       "column": 18,
@@ -57382,6 +57985,20 @@
       "variant": "U128"
     },
     {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 217,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "U16"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 454,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "U16"
+    },
+    {
       "column": 17,
       "enum": "ValueKind",
       "line": 58,
@@ -57667,6 +58284,20 @@
       "line": 434,
       "path": "src/engine/src/structures.rs",
       "variant": "U16"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 218,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "U32"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 455,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "U32"
     },
     {
       "column": 17,
@@ -57956,6 +58587,20 @@
       "variant": "U32"
     },
     {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 219,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "U64"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 456,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "U64"
+    },
+    {
       "column": 17,
       "enum": "ValueKind",
       "line": 60,
@@ -58241,6 +58886,20 @@
       "line": 438,
       "path": "src/engine/src/structures.rs",
       "variant": "U64"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 216,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "U8"
+    },
+    {
+      "column": 9,
+      "enum": "ValueKind",
+      "line": 453,
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "variant": "U8"
     },
     {
       "column": 16,
@@ -58535,7 +59194,7 @@
       "directory": ".",
       "manifest": "Cargo.toml",
       "name": "mech",
-      "rust_file_count": 859
+      "rust_file_count": 878
     },
     {
       "directory": "hosts/browser",
@@ -58601,7 +59260,7 @@
       "directory": "src/core",
       "manifest": "src/core/Cargo.toml",
       "name": "mech-core",
-      "rust_file_count": 77
+      "rust_file_count": 96
     },
     {
       "directory": "src/engine",

--- a/tests/architecture/value-system/current-inventory.json
+++ b/tests/architecture/value-system/current-inventory.json
@@ -1120,6 +1120,16 @@
         },
         {
           "kinds": [
+            "test"
+          ],
+          "name": "semantic_serde_contract",
+          "reachable_rust_files": [
+            "src/core/tests/semantic_serde_contract.rs"
+          ],
+          "root": "src/core/tests/semantic_serde_contract.rs"
+        },
+        {
+          "kinds": [
             "bench"
           ],
           "name": "solve_result_overhead",
@@ -2476,6 +2486,7 @@
     "src/core/tests/legacy_kind_adapter_contract.rs",
     "src/core/tests/schema_contract.rs",
     "src/core/tests/semantic_identity_contract.rs",
+    "src/core/tests/semantic_serde_contract.rs",
     "src/engine/benches/integrity_constraints.rs",
     "src/engine/benches/program_checkpoint.rs",
     "src/engine/benches/reactive_turn_rollback.rs",
@@ -16799,7 +16810,7 @@
     {
       "column": 9,
       "enum": "Kind",
-      "line": 50,
+      "line": 70,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Any"
     },
@@ -16855,7 +16866,7 @@
     {
       "column": 9,
       "enum": "Kind",
-      "line": 56,
+      "line": 76,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Atom"
     },
@@ -16918,7 +16929,7 @@
     {
       "column": 9,
       "enum": "Kind",
-      "line": 52,
+      "line": 72,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Empty"
     },
@@ -16974,7 +16985,7 @@
     {
       "column": 9,
       "enum": "Kind",
-      "line": 64,
+      "line": 84,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Enum"
     },
@@ -17030,7 +17041,7 @@
     {
       "column": 9,
       "enum": "Kind",
-      "line": 54,
+      "line": 74,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Id"
     },
@@ -17079,7 +17090,7 @@
     {
       "column": 9,
       "enum": "Kind",
-      "line": 55,
+      "line": 75,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Index"
     },
@@ -17128,7 +17139,7 @@
     {
       "column": 9,
       "enum": "Kind",
-      "line": 179,
+      "line": 199,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Kind"
     },
@@ -17191,7 +17202,7 @@
     {
       "column": 9,
       "enum": "Kind",
-      "line": 156,
+      "line": 176,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Map"
     },
@@ -17254,7 +17265,7 @@
     {
       "column": 9,
       "enum": "Kind",
-      "line": 72,
+      "line": 92,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Matrix"
     },
@@ -17317,7 +17328,7 @@
     {
       "column": 9,
       "enum": "Kind",
-      "line": 51,
+      "line": 71,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "None"
     },
@@ -17373,7 +17384,7 @@
     {
       "column": 9,
       "enum": "Kind",
-      "line": 90,
+      "line": 110,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Option"
     },
@@ -17436,7 +17447,7 @@
     {
       "column": 9,
       "enum": "Kind",
-      "line": 109,
+      "line": 129,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Record"
     },
@@ -17499,7 +17510,7 @@
     {
       "column": 9,
       "enum": "Kind",
-      "line": 176,
+      "line": 196,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Reference"
     },
@@ -17555,7 +17566,7 @@
     {
       "column": 9,
       "enum": "Kind",
-      "line": 53,
+      "line": 73,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Scalar"
     },
@@ -17618,7 +17629,7 @@
     {
       "column": 9,
       "enum": "Kind",
-      "line": 137,
+      "line": 157,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Set"
     },
@@ -17688,7 +17699,7 @@
     {
       "column": 9,
       "enum": "Kind",
-      "line": 116,
+      "line": 136,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Table"
     },
@@ -17751,7 +17762,7 @@
     {
       "column": 9,
       "enum": "Kind",
-      "line": 95,
+      "line": 115,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Tuple"
     },
@@ -51561,14 +51572,14 @@
     {
       "column": 28,
       "enum": "ValueKind",
-      "line": 234,
+      "line": 254,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Any"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 472,
+      "line": 492,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Any"
     },
@@ -51764,14 +51775,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 294,
+      "line": 314,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Atom"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 478,
+      "line": 498,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Atom"
     },
@@ -51869,14 +51880,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 231,
+      "line": 251,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Bool"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 468,
+      "line": 488,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Bool"
     },
@@ -52023,14 +52034,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 228,
+      "line": 248,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "C64"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 465,
+      "line": 485,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "C64"
     },
@@ -52198,14 +52209,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 234,
+      "line": 254,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Empty"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 471,
+      "line": 491,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Empty"
     },
@@ -52450,14 +52461,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 257,
+      "line": 277,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Enum"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 475,
+      "line": 495,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Enum"
     },
@@ -52674,14 +52685,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 226,
+      "line": 246,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "F32"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 463,
+      "line": 483,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "F32"
     },
@@ -53045,14 +53056,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 227,
+      "line": 247,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "F64"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 464,
+      "line": 484,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "F64"
     },
@@ -53437,14 +53448,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 225,
+      "line": 245,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "I128"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 462,
+      "line": 482,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "I128"
     },
@@ -53731,14 +53742,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 222,
+      "line": 242,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "I16"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 459,
+      "line": 479,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "I16"
     },
@@ -54025,14 +54036,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 223,
+      "line": 243,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "I32"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 460,
+      "line": 480,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "I32"
     },
@@ -54319,14 +54330,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 224,
+      "line": 244,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "I64"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 461,
+      "line": 481,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "I64"
     },
@@ -54613,14 +54624,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 221,
+      "line": 241,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "I8"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 458,
+      "line": 478,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "I8"
     },
@@ -54914,14 +54925,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 232,
+      "line": 252,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Id"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 469,
+      "line": 489,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Id"
     },
@@ -54991,14 +55002,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 233,
+      "line": 253,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Index"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 470,
+      "line": 490,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Index"
     },
@@ -55278,14 +55289,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 361,
+      "line": 381,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Kind"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 484,
+      "line": 504,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Kind"
     },
@@ -55341,14 +55352,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 274,
+      "line": 294,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Map"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 477,
+      "line": 497,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Map"
     },
@@ -55467,14 +55478,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 239,
+      "line": 259,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Matrix"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 474,
+      "line": 494,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Matrix"
     },
@@ -56069,14 +56080,14 @@
     {
       "column": 45,
       "enum": "ValueKind",
-      "line": 234,
+      "line": 254,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "None"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 473,
+      "line": 493,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "None"
     },
@@ -56153,14 +56164,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 356,
+      "line": 376,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Option"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 483,
+      "line": 503,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Option"
     },
@@ -56510,14 +56521,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 229,
+      "line": 249,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "R64"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 466,
+      "line": 486,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "R64"
     },
@@ -56650,14 +56661,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 267,
+      "line": 287,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Record"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 476,
+      "line": 496,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Record"
     },
@@ -56797,14 +56808,14 @@
     {
       "column": 63,
       "enum": "ValueKind",
-      "line": 234,
+      "line": 254,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Reference"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 481,
+      "line": 501,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Reference"
     },
@@ -56993,14 +57004,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 337,
+      "line": 357,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Set"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 482,
+      "line": 502,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Set"
     },
@@ -57119,14 +57130,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 230,
+      "line": 250,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "String"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 467,
+      "line": 487,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "String"
     },
@@ -57329,14 +57340,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 302,
+      "line": 322,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Table"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 479,
+      "line": 499,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Table"
     },
@@ -57532,14 +57543,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 323,
+      "line": 343,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Tuple"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 480,
+      "line": 500,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "Tuple"
     },
@@ -57686,14 +57697,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 220,
+      "line": 240,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "U128"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 457,
+      "line": 477,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "U128"
     },
@@ -57987,14 +57998,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 217,
+      "line": 237,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "U16"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 454,
+      "line": 474,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "U16"
     },
@@ -58288,14 +58299,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 218,
+      "line": 238,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "U32"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 455,
+      "line": 475,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "U32"
     },
@@ -58589,14 +58600,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 219,
+      "line": 239,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "U64"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 456,
+      "line": 476,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "U64"
     },
@@ -58890,14 +58901,14 @@
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 216,
+      "line": 236,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "U8"
     },
     {
       "column": 9,
       "enum": "ValueKind",
-      "line": 453,
+      "line": 473,
       "path": "src/core/src/legacy_adapter/kind.rs",
       "variant": "U8"
     },
@@ -59194,7 +59205,7 @@
       "directory": ".",
       "manifest": "Cargo.toml",
       "name": "mech",
-      "rust_file_count": 878
+      "rust_file_count": 879
     },
     {
       "directory": "hosts/browser",
@@ -59260,7 +59271,7 @@
       "directory": "src/core",
       "manifest": "src/core/Cargo.toml",
       "name": "mech-core",
-      "rust_file_count": 96
+      "rust_file_count": 97
     },
     {
       "directory": "src/engine",

--- a/tests/architecture/value-system/frozen-semantic-targets-v1.json
+++ b/tests/architecture/value-system/frozen-semantic-targets-v1.json
@@ -14,6 +14,18 @@
     },
     {
       "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 70
+        }
+      ],
+      "target": "kind-wildcard",
+      "variant": "Any"
+    },
+    {
+      "enum": "Kind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "sites": [
         {
@@ -75,6 +87,18 @@
         {
           "column": 13,
           "line": 46
+        }
+      ],
+      "target": "atom-kind-expression",
+      "variant": "Atom"
+    },
+    {
+      "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 76
         }
       ],
       "target": "atom-kind-expression",
@@ -154,6 +178,18 @@
     },
     {
       "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 72
+        }
+      ],
+      "target": "kind-hole",
+      "variant": "Empty"
+    },
+    {
+      "enum": "Kind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "sites": [
         {
@@ -222,6 +258,18 @@
     },
     {
       "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 84
+        }
+      ],
+      "target": "enum-kind-expression",
+      "variant": "Enum"
+    },
+    {
+      "enum": "Kind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "sites": [
         {
@@ -275,6 +323,18 @@
         {
           "column": 13,
           "line": 48
+        }
+      ],
+      "target": "id-kind-expression",
+      "variant": "Id"
+    },
+    {
+      "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 74
         }
       ],
       "target": "id-kind-expression",
@@ -338,6 +398,18 @@
     },
     {
       "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 75
+        }
+      ],
+      "target": "index-kind-expression",
+      "variant": "Index"
+    },
+    {
+      "enum": "Kind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "sites": [
         {
@@ -387,6 +459,18 @@
         {
           "column": 13,
           "line": 39
+        }
+      ],
+      "target": "type-of-kind-expression",
+      "variant": "Kind"
+    },
+    {
+      "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 199
         }
       ],
       "target": "type-of-kind-expression",
@@ -466,6 +550,18 @@
     },
     {
       "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 176
+        }
+      ],
+      "target": "map-kind-expression",
+      "variant": "Map"
+    },
+    {
+      "enum": "Kind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "sites": [
         {
@@ -531,6 +627,18 @@
         {
           "column": 13,
           "line": 55
+        }
+      ],
+      "target": "matrix-kind-expression",
+      "variant": "Matrix"
+    },
+    {
+      "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 92
         }
       ],
       "target": "matrix-kind-expression",
@@ -610,6 +718,18 @@
     },
     {
       "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 71
+        }
+      ],
+      "target": "kind-never",
+      "variant": "None"
+    },
+    {
+      "enum": "Kind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "sites": [
         {
@@ -671,6 +791,18 @@
         {
           "column": 13,
           "line": 59
+        }
+      ],
+      "target": "option-kind-expression",
+      "variant": "Option"
+    },
+    {
+      "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 110
         }
       ],
       "target": "option-kind-expression",
@@ -750,6 +882,18 @@
     },
     {
       "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 129
+        }
+      ],
+      "target": "record-kind-expression",
+      "variant": "Record"
+    },
+    {
+      "enum": "Kind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "sites": [
         {
@@ -822,6 +966,18 @@
     },
     {
       "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 196
+        }
+      ],
+      "target": "reference-binding-contract",
+      "variant": "Reference"
+    },
+    {
+      "enum": "Kind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "sites": [
         {
@@ -875,6 +1031,18 @@
         {
           "column": 13,
           "line": 74
+        }
+      ],
+      "target": "named-kind-expression",
+      "variant": "Scalar"
+    },
+    {
+      "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 73
         }
       ],
       "target": "named-kind-expression",
@@ -947,6 +1115,18 @@
         {
           "column": 13,
           "line": 81
+        }
+      ],
+      "target": "set-kind-expression",
+      "variant": "Set"
+    },
+    {
+      "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 157
         }
       ],
       "target": "set-kind-expression",
@@ -1030,6 +1210,18 @@
     },
     {
       "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 136
+        }
+      ],
+      "target": "table-kind-expression",
+      "variant": "Table"
+    },
+    {
+      "enum": "Kind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "sites": [
         {
@@ -1095,6 +1287,18 @@
         {
           "column": 13,
           "line": 92
+        }
+      ],
+      "target": "tuple-kind-expression",
+      "variant": "Tuple"
+    },
+    {
+      "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 115
         }
       ],
       "target": "tuple-kind-expression",
@@ -28970,6 +29174,22 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 28,
+          "line": 254
+        },
+        {
+          "column": 9,
+          "line": 492
+        }
+      ],
+      "target": "kind-wildcard",
+      "variant": "Any"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "sites": [
         {
@@ -29158,6 +29378,22 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 314
+        },
+        {
+          "column": 9,
+          "line": 498
+        }
+      ],
+      "target": "atom-schema",
+      "variant": "Atom"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "sites": [
         {
@@ -29263,6 +29499,22 @@
       ],
       "target": "atom-schema",
       "variant": "Atom"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 251
+        },
+        {
+          "column": 9,
+          "line": 488
+        }
+      ],
+      "target": "bool-schema",
+      "variant": "Bool"
     },
     {
       "enum": "ValueKind",
@@ -29439,6 +29691,22 @@
       ],
       "target": "bool-schema",
       "variant": "Bool"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 248
+        },
+        {
+          "column": 9,
+          "line": 485
+        }
+      ],
+      "target": "complex-schema",
+      "variant": "C64"
     },
     {
       "enum": "ValueKind",
@@ -29670,6 +29938,22 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 254
+        },
+        {
+          "column": 9,
+          "line": 491
+        }
+      ],
+      "target": "value-kind-hole",
+      "variant": "Empty"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "sites": [
         {
@@ -29887,6 +30171,22 @@
         {
           "column": 40,
           "line": 47
+        }
+      ],
+      "target": "enum-schema",
+      "variant": "Enum"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 277
+        },
+        {
+          "column": 9,
+          "line": 495
         }
       ],
       "target": "enum-schema",
@@ -30115,6 +30415,22 @@
       ],
       "target": "enum-schema",
       "variant": "Enum"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 246
+        },
+        {
+          "column": 9,
+          "line": 483
+        }
+      ],
+      "target": "floating-point-schema",
+      "variant": "F32"
     },
     {
       "enum": "ValueKind",
@@ -30407,6 +30723,22 @@
       ],
       "target": "floating-point-schema",
       "variant": "F32"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 247
+        },
+        {
+          "column": 9,
+          "line": 484
+        }
+      ],
+      "target": "floating-point-schema",
+      "variant": "F64"
     },
     {
       "enum": "ValueKind",
@@ -30730,6 +31062,22 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 245
+        },
+        {
+          "column": 9,
+          "line": 482
+        }
+      ],
+      "target": "signed-integer-schema",
+      "variant": "I128"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "sites": [
         {
@@ -30967,6 +31315,22 @@
       ],
       "target": "signed-integer-schema",
       "variant": "I128"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 242
+        },
+        {
+          "column": 9,
+          "line": 479
+        }
+      ],
+      "target": "signed-integer-schema",
+      "variant": "I16"
     },
     {
       "enum": "ValueKind",
@@ -31210,6 +31574,22 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 243
+        },
+        {
+          "column": 9,
+          "line": 480
+        }
+      ],
+      "target": "signed-integer-schema",
+      "variant": "I32"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "sites": [
         {
@@ -31450,6 +31830,22 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 244
+        },
+        {
+          "column": 9,
+          "line": 481
+        }
+      ],
+      "target": "signed-integer-schema",
+      "variant": "I64"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "sites": [
         {
@@ -31687,6 +32083,22 @@
       ],
       "target": "signed-integer-schema",
       "variant": "I64"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 241
+        },
+        {
+          "column": 9,
+          "line": 478
+        }
+      ],
+      "target": "signed-integer-schema",
+      "variant": "I8"
     },
     {
       "enum": "ValueKind",
@@ -31942,6 +32354,22 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 252
+        },
+        {
+          "column": 9,
+          "line": 489
+        }
+      ],
+      "target": "id-schema",
+      "variant": "Id"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "sites": [
         {
@@ -32019,6 +32447,22 @@
         {
           "column": 31,
           "line": 49
+        }
+      ],
+      "target": "index-schema",
+      "variant": "Index"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 253
+        },
+        {
+          "column": 9,
+          "line": 490
         }
       ],
       "target": "index-schema",
@@ -32238,6 +32682,22 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 381
+        },
+        {
+          "column": 9,
+          "line": 504
+        }
+      ],
+      "target": "reified-type-schema",
+      "variant": "Kind"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "sites": [
         {
@@ -32299,6 +32759,22 @@
         {
           "column": 20,
           "line": 53
+        }
+      ],
+      "target": "map-schema",
+      "variant": "Map"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 294
+        },
+        {
+          "column": 9,
+          "line": 497
         }
       ],
       "target": "map-schema",
@@ -32451,6 +32927,22 @@
         {
           "column": 20,
           "line": 57
+        }
+      ],
+      "target": "matrix-schema",
+      "variant": "Matrix"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 259
+        },
+        {
+          "column": 9,
+          "line": 494
         }
       ],
       "target": "matrix-schema",
@@ -32962,6 +33454,22 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 45,
+          "line": 254
+        },
+        {
+          "column": 9,
+          "line": 493
+        }
+      ],
+      "target": "kind-never",
+      "variant": "None"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "sites": [
         {
@@ -33043,6 +33551,22 @@
         {
           "column": 20,
           "line": 61
+        }
+      ],
+      "target": "option-schema",
+      "variant": "Option"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 376
+        },
+        {
+          "column": 9,
+          "line": 503
         }
       ],
       "target": "option-schema",
@@ -33342,6 +33866,22 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 249
+        },
+        {
+          "column": 9,
+          "line": 486
+        }
+      ],
+      "target": "rational-schema",
+      "variant": "R64"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "sites": [
         {
@@ -33503,6 +34043,22 @@
         {
           "column": 20,
           "line": 68
+        }
+      ],
+      "target": "record-schema",
+      "variant": "Record"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 287
+        },
+        {
+          "column": 9,
+          "line": 496
         }
       ],
       "target": "record-schema",
@@ -33683,6 +34239,22 @@
         {
           "column": 20,
           "line": 72
+        }
+      ],
+      "target": "reference-binding-contract",
+      "variant": "Reference"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 63,
+          "line": 254
+        },
+        {
+          "column": 9,
+          "line": 501
         }
       ],
       "target": "reference-binding-contract",
@@ -33890,6 +34462,22 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 357
+        },
+        {
+          "column": 9,
+          "line": 502
+        }
+      ],
+      "target": "set-schema",
+      "variant": "Set"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "sites": [
         {
@@ -34023,6 +34611,22 @@
       ],
       "target": "set-schema",
       "variant": "Set"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 250
+        },
+        {
+          "column": 9,
+          "line": 487
+        }
+      ],
+      "target": "string-schema",
+      "variant": "String"
     },
     {
       "enum": "ValueKind",
@@ -34274,6 +34878,22 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 322
+        },
+        {
+          "column": 9,
+          "line": 499
+        }
+      ],
+      "target": "table-schema",
+      "variant": "Table"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "sites": [
         {
@@ -34478,6 +35098,22 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 343
+        },
+        {
+          "column": 9,
+          "line": 500
+        }
+      ],
+      "target": "tuple-schema",
+      "variant": "Tuple"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "sites": [
         {
@@ -34659,6 +35295,22 @@
       ],
       "target": "tuple-schema",
       "variant": "Tuple"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 240
+        },
+        {
+          "column": 9,
+          "line": 477
+        }
+      ],
+      "target": "unsigned-integer-schema",
+      "variant": "U128"
     },
     {
       "enum": "ValueKind",
@@ -34914,6 +35566,22 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 237
+        },
+        {
+          "column": 9,
+          "line": 474
+        }
+      ],
+      "target": "unsigned-integer-schema",
+      "variant": "U16"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "sites": [
         {
@@ -35163,6 +35831,22 @@
       ],
       "target": "unsigned-integer-schema",
       "variant": "U16"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 238
+        },
+        {
+          "column": 9,
+          "line": 475
+        }
+      ],
+      "target": "unsigned-integer-schema",
+      "variant": "U32"
     },
     {
       "enum": "ValueKind",
@@ -35418,6 +36102,22 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 239
+        },
+        {
+          "column": 9,
+          "line": 476
+        }
+      ],
+      "target": "unsigned-integer-schema",
+      "variant": "U64"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "sites": [
         {
@@ -35667,6 +36367,22 @@
       ],
       "target": "unsigned-integer-schema",
       "variant": "U64"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "sites": [
+        {
+          "column": 9,
+          "line": 236
+        },
+        {
+          "column": 9,
+          "line": 473
+        }
+      ],
+      "target": "unsigned-integer-schema",
+      "variant": "U8"
     },
     {
       "enum": "ValueKind",

--- a/tests/architecture/value-system/gate-b-regression.json
+++ b/tests/architecture/value-system/gate-b-regression.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "reference_commit": "d5e41f6fd43c9d21c5858d80dab50e7ce64e9a10",
   "evidence_path": "benchmarks/runtime/gate-b/b2-resident-turn.json",
-  "evidence_commit": "bb3aa18d77cd8726fc6771b791ebd8cc7dea9fdd",
-  "evidence_sha256": "08b7c37f9976a1c6c1d182a4472576939655353ee9bf327f35a7cf14fe447230",
+  "evidence_commit": "501a40d9b1e634c62d5c8565aa2a14ff9aa13237",
+  "evidence_sha256": "12cc4c4940752fd864702ac3b0a80a2d60fde064442837b5f3beb0a36b1d0b87",
   "protected_paths": {
     "exact": [
       "Cargo.toml",

--- a/tests/architecture/value-system/migration-schema.json
+++ b/tests/architecture/value-system/migration-schema.json
@@ -105,7 +105,7 @@
       "additionalProperties": false,
       "properties": {
         "artifact_migrated": { "const": false },
-        "implemented": { "const": false },
+        "implemented": { "type": "boolean" },
         "inventoried": { "const": true },
         "legacy_removed": { "const": false },
         "ports_migrated": { "const": false },

--- a/tests/architecture/value-system/migration.json
+++ b/tests/architecture/value-system/migration.json
@@ -84,7 +84,7 @@
           "semantic_category": "schema",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -178,7 +178,7 @@
           "semantic_category": "schema",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -254,7 +254,7 @@
           "semantic_category": "schema",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -324,7 +324,7 @@
           "semantic_category": "schema",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -394,7 +394,7 @@
           "semantic_category": "schema",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -465,7 +465,7 @@
           "semantic_category": "schema",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -536,7 +536,7 @@
           "semantic_category": "schema",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -606,7 +606,7 @@
           "semantic_category": "schema",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -631,7 +631,7 @@
           "semantic_category": "kind-expression",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -701,7 +701,7 @@
           "semantic_category": "schema",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -726,7 +726,7 @@
           "semantic_category": "kind-expression",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -798,7 +798,7 @@
           "semantic_category": "schema",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -823,7 +823,7 @@
           "semantic_category": "kind-expression",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -895,7 +895,7 @@
           "semantic_category": "schema",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -920,7 +920,7 @@
           "semantic_category": "kind-expression",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -1056,7 +1056,7 @@
           "semantic_category": "schema",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -1081,7 +1081,7 @@
           "semantic_category": "kind-expression",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -1271,7 +1271,7 @@
           "semantic_category": "schema",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -1296,7 +1296,7 @@
           "semantic_category": "kind-expression",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -1368,7 +1368,7 @@
           "semantic_category": "schema",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -1393,7 +1393,7 @@
           "semantic_category": "kind-expression",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -1465,7 +1465,7 @@
           "semantic_category": "schema",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -1490,7 +1490,7 @@
           "semantic_category": "kind-expression",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -1562,7 +1562,7 @@
           "semantic_category": "schema",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -1587,7 +1587,7 @@
           "semantic_category": "kind-expression",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -1659,7 +1659,7 @@
           "semantic_category": "schema",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -1684,7 +1684,7 @@
           "semantic_category": "kind-expression",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -1871,7 +1871,7 @@
           "semantic_category": "schema",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -1896,7 +1896,7 @@
           "semantic_category": "kind-expression",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -2119,7 +2119,7 @@
           "semantic_category": "compiler-shape-hole",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -2169,7 +2169,7 @@
           "semantic_category": "kind-expression",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -2194,7 +2194,7 @@
           "semantic_category": "kind-expression",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -2241,7 +2241,7 @@
           "semantic_category": "kind-expression",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -2288,7 +2288,7 @@
           "semantic_category": "kind-expression",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -2329,7 +2329,7 @@
           "semantic_category": "schema",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -2354,7 +2354,7 @@
           "semantic_category": "kind-expression",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -2393,7 +2393,7 @@
           "semantic_category": "kind-expression",
           "status": {
             "artifact_migrated": false,
-            "implemented": false,
+            "implemented": true,
             "inventoried": true,
             "legacy_removed": false,
             "ports_migrated": false,
@@ -2417,6 +2417,21 @@
         {
           "column": 13,
           "line": 44
+        }
+      ],
+      "target": "kind-wildcard",
+      "variant": "Any"
+    },
+    {
+      "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 70
         }
       ],
       "target": "kind-wildcard",
@@ -2502,6 +2517,21 @@
         {
           "column": 13,
           "line": 46
+        }
+      ],
+      "target": "atom-kind-expression",
+      "variant": "Atom"
+    },
+    {
+      "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 76
         }
       ],
       "target": "atom-kind-expression",
@@ -2598,6 +2628,21 @@
     },
     {
       "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 72
+        }
+      ],
+      "target": "kind-hole",
+      "variant": "Empty"
+    },
+    {
+      "enum": "Kind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "roles": [
         "compiler-type-data",
@@ -2683,6 +2728,21 @@
     },
     {
       "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 84
+        }
+      ],
+      "target": "enum-kind-expression",
+      "variant": "Enum"
+    },
+    {
+      "enum": "Kind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "roles": [
         "compiler-type-data",
@@ -2750,6 +2810,21 @@
         {
           "column": 13,
           "line": 48
+        }
+      ],
+      "target": "id-kind-expression",
+      "variant": "Id"
+    },
+    {
+      "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 74
         }
       ],
       "target": "id-kind-expression",
@@ -2827,6 +2902,21 @@
     },
     {
       "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 75
+        }
+      ],
+      "target": "index-kind-expression",
+      "variant": "Index"
+    },
+    {
+      "enum": "Kind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "roles": [
         "compiler-type-data",
@@ -2890,6 +2980,21 @@
         {
           "column": 13,
           "line": 39
+        }
+      ],
+      "target": "type-of-kind-expression",
+      "variant": "Kind"
+    },
+    {
+      "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 199
         }
       ],
       "target": "type-of-kind-expression",
@@ -2986,6 +3091,21 @@
     },
     {
       "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 176
+        }
+      ],
+      "target": "map-kind-expression",
+      "variant": "Map"
+    },
+    {
+      "enum": "Kind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "roles": [
         "compiler-type-data",
@@ -3068,6 +3188,21 @@
         {
           "column": 13,
           "line": 55
+        }
+      ],
+      "target": "matrix-kind-expression",
+      "variant": "Matrix"
+    },
+    {
+      "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 92
         }
       ],
       "target": "matrix-kind-expression",
@@ -3164,6 +3299,21 @@
     },
     {
       "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 71
+        }
+      ],
+      "target": "kind-never",
+      "variant": "None"
+    },
+    {
+      "enum": "Kind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "roles": [
         "compiler-type-data",
@@ -3242,6 +3392,21 @@
         {
           "column": 13,
           "line": 59
+        }
+      ],
+      "target": "option-kind-expression",
+      "variant": "Option"
+    },
+    {
+      "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 110
         }
       ],
       "target": "option-kind-expression",
@@ -3338,6 +3503,21 @@
     },
     {
       "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 129
+        }
+      ],
+      "target": "record-kind-expression",
+      "variant": "Record"
+    },
+    {
+      "enum": "Kind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "roles": [
         "compiler-type-data",
@@ -3427,6 +3607,21 @@
     },
     {
       "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 196
+        }
+      ],
+      "target": "reference-binding-contract",
+      "variant": "Reference"
+    },
+    {
+      "enum": "Kind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "roles": [
         "binding-contract",
@@ -3494,6 +3689,21 @@
         {
           "column": 13,
           "line": 74
+        }
+      ],
+      "target": "named-kind-expression",
+      "variant": "Scalar"
+    },
+    {
+      "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 73
         }
       ],
       "target": "named-kind-expression",
@@ -3583,6 +3793,21 @@
         {
           "column": 13,
           "line": 81
+        }
+      ],
+      "target": "set-kind-expression",
+      "variant": "Set"
+    },
+    {
+      "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 157
         }
       ],
       "target": "set-kind-expression",
@@ -3683,6 +3908,21 @@
     },
     {
       "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 136
+        }
+      ],
+      "target": "table-kind-expression",
+      "variant": "Table"
+    },
+    {
+      "enum": "Kind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "roles": [
         "compiler-type-data",
@@ -3765,6 +4005,21 @@
         {
           "column": 13,
           "line": 92
+        }
+      ],
+      "target": "tuple-kind-expression",
+      "variant": "Tuple"
+    },
+    {
+      "enum": "Kind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 115
         }
       ],
       "target": "tuple-kind-expression",
@@ -5517,22 +5772,6 @@
       "enum": "Value",
       "path": "src/core/src/program/compiler/constants.rs",
       "roles": [
-        "generic-dispatch",
-        "serialization"
-      ],
-      "sites": [
-        {
-          "column": 9,
-          "line": 679
-        }
-      ],
-      "target": "generic-dispatch",
-      "variant": "Empty"
-    },
-    {
-      "enum": "Value",
-      "path": "src/core/src/program/compiler/constants.rs",
-      "roles": [
         "semantic-payload",
         "serialization"
       ],
@@ -5551,6 +5790,22 @@
         }
       ],
       "target": "option-absence",
+      "variant": "Empty"
+    },
+    {
+      "enum": "Value",
+      "path": "src/core/src/program/compiler/constants.rs",
+      "roles": [
+        "generic-dispatch",
+        "serialization"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 679
+        }
+      ],
+      "target": "generic-dispatch",
       "variant": "Empty"
     },
     {
@@ -5815,25 +6070,6 @@
       "enum": "Value",
       "path": "src/engine/src/interpreter/mod.rs",
       "roles": [
-        "semantic-payload"
-      ],
-      "sites": [
-        {
-          "column": 25,
-          "line": 2460
-        },
-        {
-          "column": 29,
-          "line": 2495
-        }
-      ],
-      "target": "option-absence",
-      "variant": "Empty"
-    },
-    {
-      "enum": "Value",
-      "path": "src/engine/src/interpreter/mod.rs",
-      "roles": [
         "mutable-storage"
       ],
       "sites": [
@@ -5847,6 +6083,25 @@
         }
       ],
       "target": "uninitialized-storage",
+      "variant": "Empty"
+    },
+    {
+      "enum": "Value",
+      "path": "src/engine/src/interpreter/mod.rs",
+      "roles": [
+        "semantic-payload"
+      ],
+      "sites": [
+        {
+          "column": 25,
+          "line": 2460
+        },
+        {
+          "column": 29,
+          "line": 2495
+        }
+      ],
+      "target": "option-absence",
       "variant": "Empty"
     },
     {
@@ -5937,22 +6192,6 @@
       "enum": "Value",
       "path": "src/engine/src/intrinsics/convert/mat_to_mat.rs",
       "roles": [
-        "generic-dispatch",
-        "machine-argument"
-      ],
-      "sites": [
-        {
-          "column": 15,
-          "line": 633
-        }
-      ],
-      "target": "generic-dispatch",
-      "variant": "Empty"
-    },
-    {
-      "enum": "Value",
-      "path": "src/engine/src/intrinsics/convert/mat_to_mat.rs",
-      "roles": [
         "machine-argument",
         "semantic-payload"
       ],
@@ -5967,6 +6206,22 @@
         }
       ],
       "target": "option-absence",
+      "variant": "Empty"
+    },
+    {
+      "enum": "Value",
+      "path": "src/engine/src/intrinsics/convert/mat_to_mat.rs",
+      "roles": [
+        "generic-dispatch",
+        "machine-argument"
+      ],
+      "sites": [
+        {
+          "column": 15,
+          "line": 633
+        }
+      ],
+      "target": "generic-dispatch",
       "variant": "Empty"
     },
     {
@@ -5993,6 +6248,22 @@
       "enum": "Value",
       "path": "src/engine/src/intrinsics/convert/scalar.rs",
       "roles": [
+        "compiler-type-data",
+        "machine-argument"
+      ],
+      "sites": [
+        {
+          "column": 53,
+          "line": 463
+        }
+      ],
+      "target": "source-empty-expression",
+      "variant": "Empty"
+    },
+    {
+      "enum": "Value",
+      "path": "src/engine/src/intrinsics/convert/scalar.rs",
+      "roles": [
         "machine-argument",
         "semantic-payload"
       ],
@@ -6007,22 +6278,6 @@
         }
       ],
       "target": "option-absence",
-      "variant": "Empty"
-    },
-    {
-      "enum": "Value",
-      "path": "src/engine/src/intrinsics/convert/scalar.rs",
-      "roles": [
-        "compiler-type-data",
-        "machine-argument"
-      ],
-      "sites": [
-        {
-          "column": 53,
-          "line": 463
-        }
-      ],
-      "target": "source-empty-expression",
       "variant": "Empty"
     },
     {
@@ -6121,21 +6376,6 @@
       "enum": "Value",
       "path": "src/engine/src/literals.rs",
       "roles": [
-        "compiler-type-data"
-      ],
-      "sites": [
-        {
-          "column": 5,
-          "line": 319
-        }
-      ],
-      "target": "source-empty-expression",
-      "variant": "Empty"
-    },
-    {
-      "enum": "Value",
-      "path": "src/engine/src/literals.rs",
-      "roles": [
         "compiler-shape-hole",
         "compiler-type-data"
       ],
@@ -6154,6 +6394,21 @@
         }
       ],
       "target": "unspecified-extent",
+      "variant": "Empty"
+    },
+    {
+      "enum": "Value",
+      "path": "src/engine/src/literals.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 5,
+          "line": 319
+        }
+      ],
+      "target": "source-empty-expression",
       "variant": "Empty"
     },
     {
@@ -6514,6 +6769,21 @@
       "enum": "Value",
       "path": "src/runtime/src/runtime/execution/module.rs",
       "roles": [
+        "mutable-storage"
+      ],
+      "sites": [
+        {
+          "column": 25,
+          "line": 387
+        }
+      ],
+      "target": "uninitialized-storage",
+      "variant": "Empty"
+    },
+    {
+      "enum": "Value",
+      "path": "src/runtime/src/runtime/execution/module.rs",
+      "roles": [
         "machine-output"
       ],
       "sites": [
@@ -6527,21 +6797,6 @@
         }
       ],
       "target": "execution-no-result",
-      "variant": "Empty"
-    },
-    {
-      "enum": "Value",
-      "path": "src/runtime/src/runtime/execution/module.rs",
-      "roles": [
-        "mutable-storage"
-      ],
-      "sites": [
-        {
-          "column": 25,
-          "line": 387
-        }
-      ],
-      "target": "uninitialized-storage",
       "variant": "Empty"
     },
     {
@@ -25612,21 +25867,6 @@
       "enum": "Value",
       "path": "src/engine/src/expressions/matches.rs",
       "roles": [
-        "generic-dispatch"
-      ],
-      "sites": [
-        {
-          "column": 9,
-          "line": 413
-        }
-      ],
-      "target": "legacy-matrix-value-adapter",
-      "variant": "MatrixValue"
-    },
-    {
-      "enum": "Value",
-      "path": "src/engine/src/expressions/matches.rs",
-      "roles": [
         "compiler-type-data"
       ],
       "sites": [
@@ -25636,6 +25876,21 @@
         }
       ],
       "target": "matrix-construction-ir",
+      "variant": "MatrixValue"
+    },
+    {
+      "enum": "Value",
+      "path": "src/engine/src/expressions/matches.rs",
+      "roles": [
+        "generic-dispatch"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 413
+        }
+      ],
+      "target": "legacy-matrix-value-adapter",
       "variant": "MatrixValue"
     },
     {
@@ -25837,21 +26092,6 @@
       ],
       "sites": [
         {
-          "column": 19,
-          "line": 726
-        }
-      ],
-      "target": "homogeneous-matrix-snapshot",
-      "variant": "MatrixValue"
-    },
-    {
-      "enum": "Value",
-      "path": "src/engine/src/structures.rs",
-      "roles": [
-        "generic-dispatch"
-      ],
-      "sites": [
-        {
           "column": 9,
           "line": 607
         },
@@ -25888,6 +26128,21 @@
         }
       ],
       "target": "matrix-construction-ir",
+      "variant": "MatrixValue"
+    },
+    {
+      "enum": "Value",
+      "path": "src/engine/src/structures.rs",
+      "roles": [
+        "generic-dispatch"
+      ],
+      "sites": [
+        {
+          "column": 19,
+          "line": 726
+        }
+      ],
+      "target": "homogeneous-matrix-snapshot",
       "variant": "MatrixValue"
     },
     {
@@ -35643,6 +35898,25 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 28,
+          "line": 254
+        },
+        {
+          "column": 9,
+          "line": 492
+        }
+      ],
+      "target": "kind-wildcard",
+      "variant": "Any"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "roles": [
         "compiler-type-data",
@@ -35868,6 +36142,25 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 314
+        },
+        {
+          "column": 9,
+          "line": 498
+        }
+      ],
+      "target": "atom-schema",
+      "variant": "Atom"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "roles": [
         "compiler-type-data",
@@ -35998,6 +36291,25 @@
       ],
       "target": "atom-schema",
       "variant": "Atom"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 251
+        },
+        {
+          "column": 9,
+          "line": 488
+        }
+      ],
+      "target": "bool-schema",
+      "variant": "Bool"
     },
     {
       "enum": "ValueKind",
@@ -36218,6 +36530,25 @@
       ],
       "target": "bool-schema",
       "variant": "Bool"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 248
+        },
+        {
+          "column": 9,
+          "line": 485
+        }
+      ],
+      "target": "complex-schema",
+      "variant": "C64"
     },
     {
       "enum": "ValueKind",
@@ -36507,6 +36838,25 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 254
+        },
+        {
+          "column": 9,
+          "line": 491
+        }
+      ],
+      "target": "value-kind-hole",
+      "variant": "Empty"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "roles": [
         "compiler-type-data",
@@ -36764,6 +37114,25 @@
         {
           "column": 40,
           "line": 47
+        }
+      ],
+      "target": "enum-schema",
+      "variant": "Enum"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 277
+        },
+        {
+          "column": 9,
+          "line": 495
         }
       ],
       "target": "enum-schema",
@@ -37037,6 +37406,25 @@
       ],
       "target": "enum-schema",
       "variant": "Enum"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 246
+        },
+        {
+          "column": 9,
+          "line": 483
+        }
+      ],
+      "target": "floating-point-schema",
+      "variant": "F32"
     },
     {
       "enum": "ValueKind",
@@ -37369,6 +37757,25 @@
       ],
       "target": "floating-point-schema",
       "variant": "F32"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 247
+        },
+        {
+          "column": 9,
+          "line": 484
+        }
+      ],
+      "target": "floating-point-schema",
+      "variant": "F64"
     },
     {
       "enum": "ValueKind",
@@ -37740,6 +38147,25 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 245
+        },
+        {
+          "column": 9,
+          "line": 482
+        }
+      ],
+      "target": "signed-integer-schema",
+      "variant": "I128"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "roles": [
         "compiler-type-data",
@@ -38013,6 +38439,25 @@
       ],
       "target": "signed-integer-schema",
       "variant": "I128"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 242
+        },
+        {
+          "column": 9,
+          "line": 479
+        }
+      ],
+      "target": "signed-integer-schema",
+      "variant": "I16"
     },
     {
       "enum": "ValueKind",
@@ -38292,6 +38737,25 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 243
+        },
+        {
+          "column": 9,
+          "line": 480
+        }
+      ],
+      "target": "signed-integer-schema",
+      "variant": "I32"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "roles": [
         "compiler-type-data",
@@ -38568,6 +39032,25 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 244
+        },
+        {
+          "column": 9,
+          "line": 481
+        }
+      ],
+      "target": "signed-integer-schema",
+      "variant": "I64"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "roles": [
         "compiler-type-data",
@@ -38841,6 +39324,25 @@
       ],
       "target": "signed-integer-schema",
       "variant": "I64"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 241
+        },
+        {
+          "column": 9,
+          "line": 478
+        }
+      ],
+      "target": "signed-integer-schema",
+      "variant": "I8"
     },
     {
       "enum": "ValueKind",
@@ -39135,6 +39637,25 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 252
+        },
+        {
+          "column": 9,
+          "line": 489
+        }
+      ],
+      "target": "id-schema",
+      "variant": "Id"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "roles": [
         "compiler-type-data",
@@ -39234,6 +39755,25 @@
         {
           "column": 31,
           "line": 49
+        }
+      ],
+      "target": "index-schema",
+      "variant": "Index"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 253
+        },
+        {
+          "column": 9,
+          "line": 490
         }
       ],
       "target": "index-schema",
@@ -39479,6 +40019,25 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 381
+        },
+        {
+          "column": 9,
+          "line": 504
+        }
+      ],
+      "target": "reified-type-schema",
+      "variant": "Kind"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "roles": [
         "compiler-type-data",
@@ -39562,6 +40121,25 @@
         {
           "column": 20,
           "line": 53
+        }
+      ],
+      "target": "map-schema",
+      "variant": "Map"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 294
+        },
+        {
+          "column": 9,
+          "line": 497
         }
       ],
       "target": "map-schema",
@@ -39754,6 +40332,25 @@
         {
           "column": 20,
           "line": 57
+        }
+      ],
+      "target": "matrix-schema",
+      "variant": "Matrix"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 259
+        },
+        {
+          "column": 9,
+          "line": 494
         }
       ],
       "target": "matrix-schema",
@@ -40340,6 +40937,25 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 45,
+          "line": 254
+        },
+        {
+          "column": 9,
+          "line": 493
+        }
+      ],
+      "target": "kind-never",
+      "variant": "None"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "roles": [
         "compiler-type-data",
@@ -40442,6 +41058,25 @@
         {
           "column": 20,
           "line": 61
+        }
+      ],
+      "target": "option-schema",
+      "variant": "Option"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 376
+        },
+        {
+          "column": 9,
+          "line": 503
         }
       ],
       "target": "option-schema",
@@ -40786,6 +41421,25 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 249
+        },
+        {
+          "column": 9,
+          "line": 486
+        }
+      ],
+      "target": "rational-schema",
+      "variant": "R64"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "roles": [
         "compiler-type-data",
@@ -40990,6 +41644,25 @@
         {
           "column": 20,
           "line": 68
+        }
+      ],
+      "target": "record-schema",
+      "variant": "Record"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 287
+        },
+        {
+          "column": 9,
+          "line": 496
         }
       ],
       "target": "record-schema",
@@ -41215,6 +41888,25 @@
         {
           "column": 20,
           "line": 72
+        }
+      ],
+      "target": "reference-binding-contract",
+      "variant": "Reference"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 63,
+          "line": 254
+        },
+        {
+          "column": 9,
+          "line": 501
         }
       ],
       "target": "reference-binding-contract",
@@ -41463,6 +42155,25 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 357
+        },
+        {
+          "column": 9,
+          "line": 502
+        }
+      ],
+      "target": "set-schema",
+      "variant": "Set"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "roles": [
         "compiler-type-data",
@@ -41628,6 +42339,25 @@
       ],
       "target": "set-schema",
       "variant": "Set"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 250
+        },
+        {
+          "column": 9,
+          "line": 487
+        }
+      ],
+      "target": "string-schema",
+      "variant": "String"
     },
     {
       "enum": "ValueKind",
@@ -41940,6 +42670,25 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 322
+        },
+        {
+          "column": 9,
+          "line": 499
+        }
+      ],
+      "target": "table-schema",
+      "variant": "Table"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "roles": [
         "compiler-type-data",
@@ -42187,6 +42936,25 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 343
+        },
+        {
+          "column": 9,
+          "line": 500
+        }
+      ],
+      "target": "tuple-schema",
+      "variant": "Tuple"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "roles": [
         "compiler-type-data",
@@ -42413,6 +43181,25 @@
       ],
       "target": "tuple-schema",
       "variant": "Tuple"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 240
+        },
+        {
+          "column": 9,
+          "line": 477
+        }
+      ],
+      "target": "unsigned-integer-schema",
+      "variant": "U128"
     },
     {
       "enum": "ValueKind",
@@ -42708,6 +43495,25 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 237
+        },
+        {
+          "column": 9,
+          "line": 474
+        }
+      ],
+      "target": "unsigned-integer-schema",
+      "variant": "U16"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "roles": [
         "compiler-type-data",
@@ -42997,6 +43803,25 @@
       ],
       "target": "unsigned-integer-schema",
       "variant": "U16"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 238
+        },
+        {
+          "column": 9,
+          "line": 475
+        }
+      ],
+      "target": "unsigned-integer-schema",
+      "variant": "U32"
     },
     {
       "enum": "ValueKind",
@@ -43292,6 +44117,25 @@
     },
     {
       "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 239
+        },
+        {
+          "column": 9,
+          "line": 476
+        }
+      ],
+      "target": "unsigned-integer-schema",
+      "variant": "U64"
+    },
+    {
+      "enum": "ValueKind",
       "path": "src/core/src/program/bytecode/constants/kind.rs",
       "roles": [
         "compiler-type-data",
@@ -43581,6 +44425,25 @@
       ],
       "target": "unsigned-integer-schema",
       "variant": "U64"
+    },
+    {
+      "enum": "ValueKind",
+      "path": "src/core/src/legacy_adapter/kind.rs",
+      "roles": [
+        "compiler-type-data"
+      ],
+      "sites": [
+        {
+          "column": 9,
+          "line": 236
+        },
+        {
+          "column": 9,
+          "line": 473
+        }
+      ],
+      "target": "unsigned-integer-schema",
+      "variant": "U8"
     },
     {
       "enum": "ValueKind",


### PR DESCRIPTION
## Stack

C0 base branch: `test/value-semantic-migration-contracts`  
C0 exact base SHA: `f89d369ddd356d31abce6d79de53fb0cc811a83d`  
C1 branch: `feat/core-semantic-foundations`  
C1 exact head SHA: `b52d369e93a1d26b27bef476329bc54cc9966a64`

## Purpose

Implement final semantic identities, dimensions, `KindExpr`, `KindScheme`, `Schema`, `ShapeInstance`, `SchemaKey`, `NominalKey`, `SchemaTable`, and explicit legacy adapters.

## Production routing

No compiler or runtime route changes. The current mutable `Value` remains authoritative.

## Validated construction boundary

- Open semantic syntax retains `Serialize + Deserialize`.
- Finalized `Schema`, `ShapeInstance`, `KindScheme`, `CanonicalNominalPath`, and `DimensionParameter` are `Serialize`-only and can be created only through validated APIs; derived, manual, qualified, renamed, and target-aliased `Deserialize` implementations are rejected, including for `SchemaHandle`.
- Semantic builders return structured errors for compile-time parameters and exhausted dimension/schema handles.
- Dimension expressions and parameter bounds normalize before parameter reachability is computed, so algebraically eliminated references do not survive in canonical identities.
- `SchemaHandle` is non-Serde, carries the inserted schema identity, and resolves through checked bounds/identity validation rather than unchecked indexing.
- `KindExpr` rejects duplicate record fields and table columns recursively through schemes, canonical closed-kind encoding, and legacy adapters.
- Shape instantiation checks the total product of separate matrix dimensions recursively.
- Legacy context output validates every declaration and returned dimension expression, including unused declarations.
- C1 enforcement resolves transitive aliases/wrappers, rejects standard interior-mutability dependencies, and structurally rejects wildcard, binding, attributed, parenthesized, and irrefutable or-pattern catch-all adapter arms.

## Identity model

- `ProgramRevision`: durable content-addressed program revision.
- `SchemaKey`: SHA-256 identity of canonical finalized schema bytes.
- `NominalKey`: SHA-256 identity of canonical atom/enum kind and path.
- `KindId`: deterministic kind-table identity.
- `KindParameterId`: dense quantified kind-parameter identity.
- `DimensionParameterId`: dense dimension-parameter identity.
- `SchemaId`: deterministic schema-table-local identity.
- `ReactiveInstanceId`: instance index plus checked generation.
- `CellSlotId`: stable cell slot within a reactive instance.
- `CellId`: reactive instance plus cell slot.
- `SlotIndex`: resident storage slot index.
- `InstanceEpoch`: checked resident publication epoch.
- `PlanGeneration` / `LayoutGeneration`: checked plan and layout generations.

## Canonical conformance

Positive schema vectors reproduced: 11 / 11  
Dimension vectors reproduced: 7 / 7  
Invalid schema vectors reproduced: 8 / 8  
SchemaKey vectors reproduced: 11 / 11  
NominalKey vectors reproduced: 1 / 1

## Legacy adapters

Kind variants covered: 17 / 17  
ValueKind variants covered: 32 / 32  
Wildcard, binding, or attributed catch-all arms: 0  
Ambiguous dimensions guessed: 0

The nonblocking adapter-error taxonomy cleanup is tracked separately in #737.

## Migration progress

C1-gated targets implemented: 37 / 37  
C2/C3/C4/D targets implemented: 0  
Legacy types removed: 0

## Resident compatibility

CellSlotId size: 4 bytes (`u32`)  
SlotIndex size: 4 bytes (`u32`)  
InstanceEpoch size: 8 bytes (`u64`)  
Steady-state allocations: 0 allocations / 0 bytes per turn  
Publication stores: 1 per accepted turn

## Gate B

Implementation commit measured: `501a40d9b1e634c62d5c8565aa2a14ff9aa13237`  
Evidence/report commit: `b52d369e93a1d26b27bef476329bc54cc9966a64`  
Report `evidence_commit`: `501a40d9b1e634c62d5c8565aa2a14ff9aa13237`  
Report SHA-256: `12cc4c4940752fd864702ac3b0a80a2d60fde064442837b5f3beb0a36b1d0b87`  
Raw-epoch ratio: `1.2113950645` (limit `1.25`)  
Legacy-gap closure: `0.9937288494` (minimum `0.80`)  
History ratios: `1k/0 = 1.0031794571`, `100k/0 = 1.0063871011`, high/low epoch `= 0.9979227382` (limits `1.05`)  
Primary denominator: `8249.2476654 ns/turn` (positive)  
Decision: `Pass`

All hard gates passed: correctness, executor tax, legacy-gap closure, zero allocation, no full clone, constant publication, history independence, tail stability, infallible post-publication append, and raw-epoch ratio.

## Commits

1. `d3a6520a04d4cc375c475ed1fea335abf62e3621` — `feat(core): add final semantic identities`
2. `d7313708973f2cc5dec92f2693452e91959cce10` — `feat(core): add dimensions and kind schemes`
3. `5ecb35161ac1bc8d9e81557a80e98cd8ef6892f6` — `feat(core): add canonical schemas and schema tables`
4. `6fefebafcbb071f008d9af45fd2d0444bd72813b` — `refactor(core): add explicit legacy kind adapters`
5. `501a40d9b1e634c62d5c8565aa2a14ff9aa13237` — `test(architecture): prove C1 semantic and resident contracts`
6. `b52d369e93a1d26b27bef476329bc54cc9966a64` — `bench(architecture): refresh Gate B evidence after C1`

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p mech-core --no-default-features`
- [x] `cargo check -p mech-core --no-default-features --features no_std`
- [x] `cargo test -p mech-core --all-features` — 285 unit tests plus all C1 integration contracts passed
- [x] focused resident engine tests — 5 passed
- [x] resident EKF contract tests — 4 passed
- [x] `cargo test -p mech-runtime --lib --no-default-features --features source_default` — 660 passed
- [x] current inventory and frozen legacy-baseline checks
- [x] `python3 scripts/check-value-system-contract.py` — passed in 307.5s with single-pass production-source analysis
- [x] `python3 scripts/check-value-execution-boundary.py`
- [x] exact-commit `python3 scripts/check-gate-b-contract.py --report ... --expected-commit ...`, including independent ancestry verification against the frozen B2 floor
- [x] generator/runner/Gate B/value-system checker suites — 253 passed
- [x] independent canonical-encoding vector reproduction
- [x] resident EKF benchmark target build
- [x] standard distribution contract, packaging, native-host catalog, and static-profile checks
- [x] controlled B2 benchmark on MacBook Air (Mac15,13), Apple M3, 8 cores, 16 GB
- [x] Static contracts retains every check with temporary 15-minute stabilization headroom
- [x] exactly six commits over the exact C0 base
- [x] clean worktree and `git diff --check`
