### PR TITLE
Add resident WebGPU particle host example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2087,6 +2087,7 @@ dependencies = [
  "mech-host-browser",
  "mech-host-cli",
  "mech-host-console",
+ "mech-host-gpu-particles",
  "mech-host-robot-arm",
  "mech-host-scene",
  "mech-host-time",
@@ -2243,6 +2244,16 @@ dependencies = [
  "mech-runtime",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "mech-host-gpu-particles"
+version = "0.3.5"
+dependencies = [
+ "js-sys",
+ "mech-core",
+ "mech-runtime",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2439,6 +2450,7 @@ dependencies = [
  "mech-engine",
  "mech-host-browser",
  "mech-host-console",
+ "mech-host-gpu-particles",
  "mech-host-scene",
  "mech-host-time",
  "mech-host-timer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ run = ["cli_core", "standard_source", "cli_host", "time_host_native", "timer_hos
 test = ["cli_core", "standard_source", "variable_define", "invariant_define", "symbol_table", "bool", "mech-runtime", "mech-runtime/default"]
 project = ["standard_source", "mech-runtime", "mech-runtime/default"]
 cli_host = ["mech-runtime", "mech-runtime/default", "dep:mech-host-cli", "mech-host-cli/provider"]
-web_host = ["mech-runtime", "mech-runtime/default", "mech-host-browser", "mech-host-browser/serde", "mech-host-browser/provider", "dep:mech-host-time", "dep:mech-host-timer", "dep:mech-host-console", "dep:mech-host-scene"]
+web_host = ["mech-runtime", "mech-runtime/default", "mech-host-browser", "mech-host-browser/serde", "mech-host-browser/provider", "dep:mech-host-time", "dep:mech-host-timer", "dep:mech-host-console", "dep:mech-host-scene", "dep:mech-host-gpu-particles"]
 bundle_web_core = ["project", "web_host", "formatter_core", "serde", "mech-runtime", "mech-runtime/default"]
 bundle_web = ["cli_core", "bundle_web_core"]
 serve = ["cli_core", "project", "web_host", "formatter_core", "mech-runtime", "mech-runtime/default", "ignore"]
@@ -358,6 +358,7 @@ mech-host-time = { version = "0.3.5", path = "hosts/time", default-features = fa
 mech-host-console = { version = "0.3.5", path = "hosts/console", default-features = false, optional = true }
 mech-host-timer = { version = "0.3.5", path = "hosts/timer", default-features = false, optional = true }
 mech-host-scene = { version = "0.3.5", path = "hosts/scene", default-features = false, optional = true }
+mech-host-gpu-particles = { version = "0.3.5", path = "hosts/gpu-particles", default-features = false, optional = true }
 mech-host-robot-arm = { version = "0.3.5", default-features = false, optional = true }
 ignore = { version = "0.4.24", optional = true }
 
@@ -404,6 +405,7 @@ members = [
   "hosts/time",
   "hosts/timer",
   "hosts/scene",
+  "hosts/gpu-particles",
   "tests/fixtures/native-live-host",
 ]
 
@@ -430,6 +432,7 @@ mech-host-time = { path = 'hosts/time'}
 mech-host-console = { path = 'hosts/console'}
 mech-host-timer = { path = 'hosts/timer'}
 mech-host-scene = { path = 'hosts/scene'}
+mech-host-gpu-particles = { path = 'hosts/gpu-particles'}
 #mech-utilities = { path = 'src/utilities' }
 mech-combinatorics = { path = 'machines/combinatorics' }
 mech-compare = { path = 'machines/compare' }

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,8 @@ Read about progress on our [blog](https://mech-lang.org/blog/), follow us on Twi
 
 - analog-clock - A maintained native/browser project using time, console, and scene hosts.
 - browser-dom-demo - A static browser bundle demonstrating browser DOM grants.
+- gpu-particles - A resident WebGPU particle simulation controlled by a Mech host.
+- n-body - A maintained native/browser orbital model using timer, console, and scene hosts.
 - transactional-integrity - An integrity-constraint declaration example.
 - aspirational - These programs don't yet work, but they will eventually once missing features are implemented.
 - working - These programs are functional and demonstrate features that are implemented so far.

--- a/examples/README.mec
+++ b/examples/README.mec
@@ -23,6 +23,8 @@ Browser project examples include:
 ```text
 examples/analog-clock/
 examples/browser-dom-demo/
+examples/gpu-particles/
+examples/n-body/
 ```
 
 Integrity-constraint declaration examples include:

--- a/examples/gpu-particles/README.md
+++ b/examples/gpu-particles/README.md
@@ -22,3 +22,19 @@ the configured `max-particles` capacity.
 The current example provides generation-level publication inside the GPU
 pipeline. It does not yet run a validation reduction that can reject a bad
 candidate generation and report that rejection to the Mech runtime.
+
+## Benchmark
+
+Add `?benchmark=all` to the served URL to run the resident benchmark at 100K,
+500K, 1M, and 2M particles. The page reports two measurements:
+
+- Compute only encodes many simulation steps, submits them together, waits for
+  the GPU queue to drain, and excludes command encoding from the timed region.
+- Compute and render measures one complete resident frame at a time, including
+  JavaScript orchestration, uniform upload, command encoding, compute,
+  rasterization, submission, and a queue drain.
+
+Use `?benchmark=compute` to skip rendering. Seeding, buffer allocation, pipeline
+creation, and two render warm-up frames are outside the measured regions. The
+per-frame queue drain is intentionally conservative; the interactive loop can
+keep work in flight and is also limited by the display refresh rate.

--- a/examples/gpu-particles/README.md
+++ b/examples/gpu-particles/README.md
@@ -1,0 +1,24 @@
+# GPU Particle Field
+
+This served example keeps a high-throughput particle simulation resident on the
+GPU. Mech commits one small control record through the `gpu-particles` host;
+particle buffers never cross the runtime boundary during steady-state updates.
+
+Build the browser package and serve the project:
+
+```sh
+bash scripts/build-mech-browser.sh
+./target/release/mech serve examples/gpu-particles
+```
+
+The browser must support WebGPU. The page reports a clear unavailable state
+when no compatible adapter can be created.
+
+The compute pass reads committed particle buffer A and writes candidate buffer
+B. The render pass consumes B in the same command submission, after which B
+becomes the next committed generation. The two buffers are allocated once at
+the configured `max-particles` capacity.
+
+The current example provides generation-level publication inside the GPU
+pipeline. It does not yet run a validation reduction that can reject a bad
+candidate generation and report that rejection to the Mech runtime.

--- a/examples/gpu-particles/README.mec
+++ b/examples/gpu-particles/README.mec
@@ -1,0 +1,14 @@
+GPU Particle Field
+===============================================================================
+
+This example sends one committed control record from Mech to a resident WebGPU
+particle pipeline. Particle arrays remain in persistent device buffers during
+steady-state execution.
+
+```sh
+bash scripts/build-mech-browser.sh
+./target/release/mech serve examples/gpu-particles
+```
+
+The browser must provide WebGPU. The compute and render passes share the same
+resident particle state; only control values cross the Mech host boundary.

--- a/examples/gpu-particles/index.html
+++ b/examples/gpu-particles/index.html
@@ -39,6 +39,11 @@
         <button type="button" class="command" id="reset-button">Reset</button>
       </div>
     </section>
+
+    <section class="benchmark-results" id="benchmark-results" hidden aria-live="polite">
+      <h2>Resident loop benchmark</h2>
+      <pre id="benchmark-output">Preparing benchmark</pre>
+    </section>
   </main>
 
   <script src="particle-gpu.js"></script>

--- a/examples/gpu-particles/index.html
+++ b/examples/gpu-particles/index.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Mech GPU Particle Field</title>
+  <link rel="stylesheet" href="particles.css" />
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <p class="eyebrow">Mech resident GPU runtime</p>
+        <h1>GPU Particle Field</h1>
+      </div>
+      <p class="status" id="gpu-status"><span aria-hidden="true"></span>Waiting for Mech</p>
+    </header>
+
+    <section class="simulation" aria-label="GPU particle simulation">
+      <canvas id="particle-canvas"></canvas>
+      <p class="canvas-message" id="canvas-message" role="status">Initializing</p>
+    </section>
+
+    <section class="telemetry" aria-label="Simulation telemetry">
+      <dl>
+        <div><dt>Particles</dt><dd id="particle-count">0</dd></div>
+        <div><dt>Frame rate</dt><dd id="frame-rate">0 Hz</dd></div>
+        <div><dt>Throughput</dt><dd id="throughput">0 M updates/s</dd></div>
+        <div><dt>State</dt><dd id="resident-state">0 MB resident</dd></div>
+      </dl>
+      <div class="controls" aria-label="Particle controls">
+        <div class="segments" role="group" aria-label="Particle count">
+          <button type="button" data-particle-count="100000">100K</button>
+          <button type="button" data-particle-count="500000">500K</button>
+          <button type="button" data-particle-count="1000000" aria-pressed="true">1M</button>
+          <button type="button" data-particle-count="2000000">2M</button>
+        </div>
+        <button type="button" class="command" id="pause-button">Pause</button>
+        <button type="button" class="command" id="reset-button">Reset</button>
+      </div>
+    </section>
+  </main>
+
+  <script src="particle-gpu.js"></script>
+  <script
+    type="module"
+    src="./_mech/project.js"
+    data-mech-project="."
+    data-mech-max-inputs="4"></script>
+</body>
+</html>

--- a/examples/gpu-particles/mech.mcfg
+++ b/examples/gpu-particles/mech.mcfg
@@ -1,0 +1,38 @@
+config := {
+  runtime: {
+    name: "gpu-particles"
+    limits: {
+      max-turn-duration-ms: 2000
+      max-in-memory-events: 128
+    }
+  }
+
+  serve: {
+    address: "127.0.0.1"
+    port: 8081
+    paths: ["particles.mec"]
+    shim: "index.html"
+  }
+
+  hosts: [
+    {
+      name: "particles"
+      provider: "gpu-particles"
+      settings: {
+        selector: "#particle-canvas"
+        max-particles: 2000000
+      }
+    }
+  ]
+
+  run: {
+    paths: ["particles.mec"]
+    grants: [
+      {
+        target: "particles/simulation"
+        operations: ["write"]
+        paths: ["control"]
+      }
+    ]
+  }
+}

--- a/examples/gpu-particles/particle-gpu.js
+++ b/examples/gpu-particles/particle-gpu.js
@@ -1,0 +1,438 @@
+(() => {
+  "use strict";
+
+  const simulations = new Map();
+
+  const computeShader = /* wgsl */ `
+struct Particle {
+  position: vec2f,
+  velocity: vec2f,
+}
+
+struct Params {
+  delta_time: f32,
+  time: f32,
+  particle_count: u32,
+  gravity: f32,
+  drag: f32,
+  point_size: f32,
+  pixel_x: f32,
+  pixel_y: f32,
+}
+
+@group(0) @binding(0) var<storage, read> source: array<Particle>;
+@group(0) @binding(1) var<storage, read_write> destination: array<Particle>;
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) id: vec3u) {
+  let index = id.x;
+  if (index >= params.particle_count) {
+    return;
+  }
+
+  var particle = source[index];
+  let center = -particle.position;
+  let radius = max(length(center), 0.025);
+  let radial = center / radius;
+  let tangent = vec2f(-radial.y, radial.x);
+  let pulse = sin(params.time * 0.37 + f32(index % 4096u) * 0.0017);
+  let acceleration = radial * (params.gravity / (0.16 + radius * radius))
+    + tangent * (0.09 + pulse * 0.018);
+  let damping = pow(params.drag, params.delta_time * 60.0);
+
+  particle.velocity = (particle.velocity + acceleration * params.delta_time) * damping;
+  particle.position = particle.position + particle.velocity * params.delta_time;
+
+  if (abs(particle.position.x) > 1.08) {
+    particle.position.x = clamp(particle.position.x, -1.08, 1.08);
+    particle.velocity.x = -particle.velocity.x * 0.72;
+  }
+  if (abs(particle.position.y) > 1.08) {
+    particle.position.y = clamp(particle.position.y, -1.08, 1.08);
+    particle.velocity.y = -particle.velocity.y * 0.72;
+  }
+
+  destination[index] = particle;
+}
+`;
+
+  const renderShader = /* wgsl */ `
+struct Particle {
+  position: vec2f,
+  velocity: vec2f,
+}
+
+struct Params {
+  delta_time: f32,
+  time: f32,
+  particle_count: u32,
+  gravity: f32,
+  drag: f32,
+  point_size: f32,
+  pixel_x: f32,
+  pixel_y: f32,
+}
+
+struct VertexOutput {
+  @builtin(position) position: vec4f,
+  @location(0) local: vec2f,
+  @location(1) color: vec3f,
+}
+
+@group(0) @binding(0) var<storage, read> particles: array<Particle>;
+@group(0) @binding(1) var<uniform> params: Params;
+
+const corners = array<vec2f, 6>(
+  vec2f(-1.0, -1.0), vec2f(1.0, -1.0), vec2f(-1.0, 1.0),
+  vec2f(-1.0, 1.0), vec2f(1.0, -1.0), vec2f(1.0, 1.0)
+);
+
+@vertex
+fn vertex_main(
+  @builtin(vertex_index) vertex_index: u32,
+  @builtin(instance_index) instance_index: u32,
+) -> VertexOutput {
+  let particle = particles[instance_index];
+  let local = corners[vertex_index];
+  let size = vec2f(params.pixel_x, params.pixel_y) * params.point_size;
+  let speed = clamp(length(particle.velocity) * 1.6, 0.0, 1.0);
+  let radius = clamp(length(particle.position), 0.0, 1.0);
+  let cold = vec3f(0.25, 0.82, 0.78);
+  let warm = vec3f(0.98, 0.47, 0.35);
+  let edge = vec3f(0.52, 0.62, 1.0);
+
+  var output: VertexOutput;
+  output.position = vec4f(particle.position + local * size, 0.0, 1.0);
+  output.local = local;
+  output.color = mix(mix(cold, warm, speed), edge, radius * 0.38);
+  return output;
+}
+
+@fragment
+fn fragment_main(input: VertexOutput) -> @location(0) vec4f {
+  let radius = length(input.local);
+  if (radius > 1.0) {
+    discard;
+  }
+  let alpha = (1.0 - smoothstep(0.52, 1.0, radius)) * 0.78;
+  return vec4f(input.color * alpha, alpha);
+}
+`;
+
+  class ParticleSimulation {
+    constructor(instance, selector, maxParticles) {
+      this.instance = instance;
+      this.selector = selector;
+      this.maxParticles = maxParticles;
+      this.canvas = document.querySelector(selector);
+      if (!(this.canvas instanceof HTMLCanvasElement)) {
+        throw new Error(`GPU particle selector ${selector} is not a canvas`);
+      }
+      this.status = document.querySelector("#gpu-status");
+      this.message = document.querySelector("#canvas-message");
+      this.control = null;
+      this.device = null;
+      this.activeBuffer = 0;
+      this.initializing = null;
+      this.running = false;
+      this.paused = false;
+      this.lastFrame = 0;
+      this.statsStart = 0;
+      this.statsFrames = 0;
+      this.frameHandle = 0;
+      this.generation = 0;
+      this.bindControls();
+    }
+
+    configure(control) {
+      this.control = this.validatedControl(control);
+      this.updateSelectedCount();
+      if (!this.initializing) {
+        this.initializing = this.initialize().catch((error) => this.fail(error));
+      } else if (this.device) {
+        this.seedParticles();
+      }
+    }
+
+    validatedControl(control) {
+      const particleCount = Math.min(
+        this.maxParticles,
+        Math.max(1, Math.trunc(Number(control.particleCount))),
+      );
+      return {
+        particleCount,
+        gravity: Number(control.gravity),
+        drag: Number(control.drag),
+        pointSize: Number(control.pointSize),
+        timeScale: Number(control.timeScale),
+      };
+    }
+
+    async initialize() {
+      this.setStatus("Requesting GPU", "");
+      if (!navigator.gpu) {
+        throw new Error("WebGPU is unavailable in this browser");
+      }
+      const adapter = await navigator.gpu.requestAdapter({ powerPreference: "high-performance" });
+      if (!adapter) {
+        throw new Error("No compatible WebGPU adapter was found");
+      }
+      this.device = await adapter.requestDevice();
+      this.context = this.canvas.getContext("webgpu");
+      if (!this.context) {
+        throw new Error("The canvas could not create a WebGPU context");
+      }
+      this.format = navigator.gpu.getPreferredCanvasFormat();
+      this.createPipelines();
+      this.createBuffers();
+      this.resize();
+      this.seedParticles();
+      this.running = true;
+      this.setStatus("GPU resident", "ready");
+      this.message.textContent = "";
+      this.lastFrame = performance.now();
+      this.statsStart = this.lastFrame;
+      this.frameHandle = requestAnimationFrame((time) => this.frame(time));
+    }
+
+    createPipelines() {
+      const computeModule = this.device.createShaderModule({ code: computeShader });
+      const renderModule = this.device.createShaderModule({ code: renderShader });
+      this.computePipeline = this.device.createComputePipeline({
+        layout: "auto",
+        compute: { module: computeModule, entryPoint: "main" },
+      });
+      this.renderPipeline = this.device.createRenderPipeline({
+        layout: "auto",
+        vertex: { module: renderModule, entryPoint: "vertex_main" },
+        fragment: {
+          module: renderModule,
+          entryPoint: "fragment_main",
+          targets: [{
+            format: this.format,
+            blend: {
+              color: { srcFactor: "one", dstFactor: "one", operation: "add" },
+              alpha: { srcFactor: "one", dstFactor: "one-minus-src-alpha", operation: "add" },
+            },
+          }],
+        },
+        primitive: { topology: "triangle-list" },
+      });
+    }
+
+    createBuffers() {
+      const stateBytes = this.maxParticles * 16;
+      this.particleBuffers = [0, 1].map(() => this.device.createBuffer({
+        size: stateBytes,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+      }));
+      this.uniformBuffer = this.device.createBuffer({
+        size: 32,
+        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+      });
+      this.computeBindGroups = [
+        this.computeBindGroup(0, 1),
+        this.computeBindGroup(1, 0),
+      ];
+      this.renderBindGroups = [0, 1].map((index) => this.device.createBindGroup({
+        layout: this.renderPipeline.getBindGroupLayout(0),
+        entries: [
+          { binding: 0, resource: { buffer: this.particleBuffers[index] } },
+          { binding: 1, resource: { buffer: this.uniformBuffer } },
+        ],
+      }));
+    }
+
+    computeBindGroup(source, destination) {
+      return this.device.createBindGroup({
+        layout: this.computePipeline.getBindGroupLayout(0),
+        entries: [
+          { binding: 0, resource: { buffer: this.particleBuffers[source] } },
+          { binding: 1, resource: { buffer: this.particleBuffers[destination] } },
+          { binding: 2, resource: { buffer: this.uniformBuffer } },
+        ],
+      });
+    }
+
+    seedParticles() {
+      if (!this.device || !this.control) {
+        return;
+      }
+      const count = this.control.particleCount;
+      const state = new Float32Array(count * 4);
+      let seed = 0x6d2b79f5;
+      const random = () => {
+        seed = Math.imul(seed ^ (seed >>> 15), seed | 1);
+        seed ^= seed + Math.imul(seed ^ (seed >>> 7), seed | 61);
+        return ((seed ^ (seed >>> 14)) >>> 0) / 4294967296;
+      };
+      for (let index = 0; index < count; index += 1) {
+        const angle = random() * Math.PI * 2;
+        const radius = Math.sqrt(random()) * 0.96 + 0.018;
+        const speed = Math.sqrt(Math.max(this.control.gravity, 0.02) / (0.42 + radius)) * 0.44;
+        const offset = index * 4;
+        state[offset] = Math.cos(angle) * radius;
+        state[offset + 1] = Math.sin(angle) * radius;
+        state[offset + 2] = -Math.sin(angle) * speed + (random() - 0.5) * 0.018;
+        state[offset + 3] = Math.cos(angle) * speed + (random() - 0.5) * 0.018;
+      }
+      this.device.queue.writeBuffer(this.particleBuffers[0], 0, state);
+      this.device.queue.writeBuffer(this.particleBuffers[1], 0, state);
+      this.activeBuffer = 0;
+      this.generation = 0;
+      this.updateTelemetry(0);
+    }
+
+    resize() {
+      const ratio = Math.min(window.devicePixelRatio || 1, 2);
+      const width = Math.max(1, Math.floor(this.canvas.clientWidth * ratio));
+      const height = Math.max(1, Math.floor(this.canvas.clientHeight * ratio));
+      if (this.canvas.width !== width || this.canvas.height !== height) {
+        this.canvas.width = width;
+        this.canvas.height = height;
+        this.context.configure({
+          device: this.device,
+          format: this.format,
+          alphaMode: "premultiplied",
+        });
+      }
+    }
+
+    writeUniforms(deltaSeconds, timeSeconds) {
+      const bytes = new ArrayBuffer(32);
+      const view = new DataView(bytes);
+      view.setFloat32(0, deltaSeconds, true);
+      view.setFloat32(4, timeSeconds, true);
+      view.setUint32(8, this.control.particleCount, true);
+      view.setFloat32(12, this.control.gravity, true);
+      view.setFloat32(16, this.control.drag, true);
+      view.setFloat32(20, this.control.pointSize, true);
+      view.setFloat32(24, 2 / this.canvas.width, true);
+      view.setFloat32(28, 2 / this.canvas.height, true);
+      this.device.queue.writeBuffer(this.uniformBuffer, 0, bytes);
+    }
+
+    frame(time) {
+      if (!this.running) {
+        return;
+      }
+      this.resize();
+      const elapsed = Math.min((time - this.lastFrame) / 1000, 0.05);
+      this.lastFrame = time;
+      const delta = this.paused ? 0 : elapsed * this.control.timeScale;
+      this.writeUniforms(delta, time / 1000);
+
+      const destination = 1 - this.activeBuffer;
+      const encoder = this.device.createCommandEncoder();
+      if (!this.paused) {
+        const compute = encoder.beginComputePass();
+        compute.setPipeline(this.computePipeline);
+        compute.setBindGroup(0, this.computeBindGroups[this.activeBuffer]);
+        compute.dispatchWorkgroups(Math.ceil(this.control.particleCount / 256));
+        compute.end();
+      }
+
+      const renderedBuffer = this.paused ? this.activeBuffer : destination;
+      const render = encoder.beginRenderPass({
+        colorAttachments: [{
+          view: this.context.getCurrentTexture().createView(),
+          clearValue: { r: 0.018, g: 0.026, b: 0.039, a: 1 },
+          loadOp: "clear",
+          storeOp: "store",
+        }],
+      });
+      render.setPipeline(this.renderPipeline);
+      render.setBindGroup(0, this.renderBindGroups[renderedBuffer]);
+      render.draw(6, this.control.particleCount);
+      render.end();
+      this.device.queue.submit([encoder.finish()]);
+
+      if (!this.paused) {
+        this.activeBuffer = destination;
+        this.generation += 1;
+      }
+      this.statsFrames += 1;
+      if (time - this.statsStart >= 500) {
+        const fps = (this.statsFrames * 1000) / (time - this.statsStart);
+        this.updateTelemetry(fps);
+        this.statsFrames = 0;
+        this.statsStart = time;
+      }
+      this.frameHandle = requestAnimationFrame((next) => this.frame(next));
+    }
+
+    updateTelemetry(fps) {
+      const count = this.control ? this.control.particleCount : 0;
+      this.setText("#particle-count", count.toLocaleString());
+      this.setText("#frame-rate", `${fps.toFixed(1)} Hz`);
+      this.setText("#throughput", `${(count * fps / 1_000_000).toFixed(1)} M updates/s`);
+      this.setText("#resident-state", `${(this.maxParticles * 32 / 1_048_576).toFixed(1)} MB resident`);
+    }
+
+    setText(selector, value) {
+      const element = document.querySelector(selector);
+      if (element) {
+        element.textContent = value;
+      }
+    }
+
+    setStatus(message, kind) {
+      if (!this.status) {
+        return;
+      }
+      this.status.className = `status ${kind}`.trim();
+      this.status.innerHTML = "<span aria-hidden=\"true\"></span>";
+      this.status.append(document.createTextNode(message));
+    }
+
+    fail(error) {
+      console.error("Mech GPU particle host failed", error);
+      this.running = false;
+      this.setStatus("GPU unavailable", "error");
+      this.message.textContent = error instanceof Error ? error.message : String(error);
+    }
+
+    updateSelectedCount() {
+      document.querySelectorAll("[data-particle-count]").forEach((button) => {
+        button.setAttribute(
+          "aria-pressed",
+          String(Number(button.dataset.particleCount) === this.control.particleCount),
+        );
+      });
+    }
+
+    bindControls() {
+      document.querySelectorAll("[data-particle-count]").forEach((button) => {
+        button.addEventListener("click", () => {
+          if (!this.control) {
+            return;
+          }
+          this.control.particleCount = Math.min(
+            this.maxParticles,
+            Number(button.dataset.particleCount),
+          );
+          this.updateSelectedCount();
+          this.seedParticles();
+        });
+      });
+      document.querySelector("#pause-button")?.addEventListener("click", (event) => {
+        this.paused = !this.paused;
+        event.currentTarget.textContent = this.paused ? "Resume" : "Pause";
+      });
+      document.querySelector("#reset-button")?.addEventListener("click", () => this.seedParticles());
+    }
+  }
+
+  globalThis.MechGpuParticles = Object.freeze({
+    configure(instance, selector, maxParticles, control) {
+      let simulation = simulations.get(instance);
+      if (!simulation) {
+        simulation = new ParticleSimulation(instance, selector, maxParticles);
+        simulations.set(instance, simulation);
+      }
+      simulation.configure(control);
+      return true;
+    },
+  });
+})();

--- a/examples/gpu-particles/particle-gpu.js
+++ b/examples/gpu-particles/particle-gpu.js
@@ -142,6 +142,8 @@ fn fragment_main(input: VertexOutput) -> @location(0) vec4f {
       this.statsFrames = 0;
       this.frameHandle = 0;
       this.generation = 0;
+      this.adapterInfo = {};
+      this.benchmarkScheduled = false;
       this.bindControls();
     }
 
@@ -178,6 +180,12 @@ fn fragment_main(input: VertexOutput) -> @location(0) vec4f {
       if (!adapter) {
         throw new Error("No compatible WebGPU adapter was found");
       }
+      this.adapterInfo = adapter.info ? {
+        vendor: adapter.info.vendor || "",
+        architecture: adapter.info.architecture || "",
+        device: adapter.info.device || "",
+        description: adapter.info.description || "",
+      } : {};
       this.device = await adapter.requestDevice();
       this.context = this.canvas.getContext("webgpu");
       if (!this.context) {
@@ -194,6 +202,28 @@ fn fragment_main(input: VertexOutput) -> @location(0) vec4f {
       this.lastFrame = performance.now();
       this.statsStart = this.lastFrame;
       this.frameHandle = requestAnimationFrame((time) => this.frame(time));
+    }
+
+    scheduleAutomaticBenchmark() {
+      const mode = new URLSearchParams(location.search).get("benchmark");
+      if (this.benchmarkScheduled || !mode) {
+        return;
+      }
+      this.benchmarkScheduled = true;
+      const output = document.querySelector("#benchmark-output");
+      const results = document.querySelector("#benchmark-results");
+      results.hidden = false;
+      this.initializing.then(async () => {
+        const benchmark = await this.benchmarkAll(mode, (message) => {
+          output.textContent = message;
+        });
+        output.textContent = this.formatBenchmark(benchmark);
+        output.dataset.json = JSON.stringify(benchmark);
+        document.title = "MECH_GPU_BENCHMARK_COMPLETE";
+      }).catch((error) => {
+        output.textContent = JSON.stringify({ error: String(error) }, null, 2);
+        document.title = "MECH_GPU_BENCHMARK_FAILED";
+      });
     }
 
     createPipelines() {
@@ -362,6 +392,174 @@ fn fragment_main(input: VertexOutput) -> @location(0) vec4f {
       this.frameHandle = requestAnimationFrame((next) => this.frame(next));
     }
 
+    stopFrameLoop() {
+      this.running = false;
+      cancelAnimationFrame(this.frameHandle);
+      this.frameHandle = 0;
+    }
+
+    async runComputeSteps(steps) {
+      this.writeUniforms(1 / 120, this.generation / 120);
+      const encoder = this.device.createCommandEncoder();
+      const compute = encoder.beginComputePass();
+      compute.setPipeline(this.computePipeline);
+      let active = this.activeBuffer;
+      for (let step = 0; step < steps; step += 1) {
+        compute.setBindGroup(0, this.computeBindGroups[active]);
+        compute.dispatchWorkgroups(Math.ceil(this.control.particleCount / 256));
+        active = 1 - active;
+      }
+      compute.end();
+      const started = performance.now();
+      this.device.queue.submit([encoder.finish()]);
+      await this.device.queue.onSubmittedWorkDone();
+      const elapsedMs = performance.now() - started;
+      this.activeBuffer = active;
+      this.generation += steps;
+      return elapsedMs;
+    }
+
+    percentile(values, fraction) {
+      const ordered = [...values].sort((left, right) => left - right);
+      const index = Math.min(ordered.length - 1, Math.floor(fraction * ordered.length));
+      return ordered[index];
+    }
+
+    async benchmarkCompute(particleCount) {
+      this.control.particleCount = particleCount;
+      this.seedParticles();
+      await this.device.queue.onSubmittedWorkDone();
+      const steps = particleCount <= 100_000 ? 256
+        : particleCount <= 500_000 ? 128
+          : particleCount <= 1_000_000 ? 64 : 32;
+      await this.runComputeSteps(Math.max(8, Math.floor(steps / 4)));
+      const samples = [];
+      for (let sample = 0; sample < 7; sample += 1) {
+        samples.push(await this.runComputeSteps(steps));
+      }
+      const totalMs = samples.reduce((sum, value) => sum + value, 0);
+      return {
+        particleCount,
+        stepsPerSample: steps,
+        samples: samples.length,
+        throughputMUpdatesPerSecond: Number(
+          ((particleCount * steps * samples.length) / totalMs / 1000).toFixed(2),
+        ),
+        sampleTimeMsP50: Number(this.percentile(samples, 0.5).toFixed(3)),
+        sampleTimeMsP95: Number(this.percentile(samples, 0.95).toFixed(3)),
+      };
+    }
+
+    async runRenderedFrame() {
+      const started = performance.now();
+      this.resize();
+      this.writeUniforms(1 / 120, this.generation / 120);
+      const destination = 1 - this.activeBuffer;
+      const encoder = this.device.createCommandEncoder();
+      const compute = encoder.beginComputePass();
+      compute.setPipeline(this.computePipeline);
+      compute.setBindGroup(0, this.computeBindGroups[this.activeBuffer]);
+      compute.dispatchWorkgroups(Math.ceil(this.control.particleCount / 256));
+      compute.end();
+      const render = encoder.beginRenderPass({
+        colorAttachments: [{
+          view: this.context.getCurrentTexture().createView(),
+          clearValue: { r: 0.018, g: 0.026, b: 0.039, a: 1 },
+          loadOp: "clear",
+          storeOp: "store",
+        }],
+      });
+      render.setPipeline(this.renderPipeline);
+      render.setBindGroup(0, this.renderBindGroups[destination]);
+      render.draw(6, this.control.particleCount);
+      render.end();
+      this.device.queue.submit([encoder.finish()]);
+      await this.device.queue.onSubmittedWorkDone();
+      this.activeBuffer = destination;
+      this.generation += 1;
+      return performance.now() - started;
+    }
+
+    async benchmarkRendered(particleCount) {
+      this.control.particleCount = particleCount;
+      this.seedParticles();
+      await this.device.queue.onSubmittedWorkDone();
+      await this.runRenderedFrame();
+      await this.runRenderedFrame();
+      const sampleCount = particleCount <= 100_000 ? 20
+        : particleCount <= 500_000 ? 12
+          : particleCount <= 1_000_000 ? 8 : 5;
+      const samples = [];
+      for (let sample = 0; sample < sampleCount; sample += 1) {
+        samples.push(await this.runRenderedFrame());
+      }
+      const totalMs = samples.reduce((sum, value) => sum + value, 0);
+      const fps = samples.length * 1000 / totalMs;
+      return {
+        particleCount,
+        frames: samples.length,
+        fps: Number(fps.toFixed(2)),
+        throughputMUpdatesPerSecond: Number((particleCount * fps / 1_000_000).toFixed(2)),
+        frameTimeMsP50: Number(this.percentile(samples, 0.5).toFixed(3)),
+        frameTimeMsP95: Number(this.percentile(samples, 0.95).toFixed(3)),
+        frameTimeMsP99: Number(this.percentile(samples, 0.99).toFixed(3)),
+      };
+    }
+
+    formatBenchmark(benchmark) {
+      const lines = [
+        benchmark.benchmark,
+        `${benchmark.adapter.description || benchmark.adapter.device || "WebGPU adapter"}`,
+        "",
+        "Compute only (queue-drained)",
+        "particles   M updates/s   p50 ms   p95 ms",
+      ];
+      for (const row of benchmark.computeOnly) {
+        lines.push(
+          `${String(row.particleCount).padStart(9)}   ${String(row.throughputMUpdatesPerSecond).padStart(11)}   ${String(row.sampleTimeMsP50).padStart(6)}   ${String(row.sampleTimeMsP95).padStart(6)}`,
+        );
+      }
+      if (benchmark.computeAndRender.length) {
+        lines.push("", "Compute + render (queue drained)", "particles      Hz   M updates/s   p50 ms   p95 ms   p99 ms");
+        for (const row of benchmark.computeAndRender) {
+          lines.push(
+            `${String(row.particleCount).padStart(9)}   ${String(row.fps).padStart(5)}   ${String(row.throughputMUpdatesPerSecond).padStart(11)}   ${String(row.frameTimeMsP50).padStart(6)}   ${String(row.frameTimeMsP95).padStart(6)}   ${String(row.frameTimeMsP99).padStart(6)}`,
+          );
+        }
+      }
+      return lines.join("\n");
+    }
+
+    async benchmarkAll(mode, progress) {
+      this.stopFrameLoop();
+      this.paused = false;
+      const counts = [100_000, 500_000, 1_000_000, 2_000_000];
+      const computeOnly = [];
+      const computeAndRender = [];
+      for (const count of counts) {
+        progress(`Compute-only benchmark: ${count.toLocaleString()} particles`);
+        computeOnly.push(await this.benchmarkCompute(count));
+      }
+      if (mode !== "compute") {
+        for (const count of counts) {
+          progress(`Compute + render benchmark: ${count.toLocaleString()} particles`);
+          computeAndRender.push(await this.benchmarkRendered(count));
+        }
+      }
+      return {
+        benchmark: "Mech resident WebGPU particle host",
+        measuredAt: new Date().toISOString(),
+        userAgent: navigator.userAgent,
+        adapter: this.adapterInfo,
+        methodology: {
+          computeOnly: "7 queue-drained samples after an untimed warm-up; command encoding excluded",
+          computeAndRender: "queue drained after every frame and 2 warm-up frames; includes JS orchestration, uniform upload, command encoding, compute, rendering, submission, and synchronization",
+        },
+        computeOnly,
+        computeAndRender,
+      };
+    }
+
     updateTelemetry(fps) {
       const count = this.control ? this.control.particleCount : 0;
       this.setText("#particle-count", count.toLocaleString());
@@ -432,6 +630,7 @@ fn fragment_main(input: VertexOutput) -> @location(0) vec4f {
         simulations.set(instance, simulation);
       }
       simulation.configure(control);
+      simulation.scheduleAutomaticBenchmark();
       return true;
     },
   });

--- a/examples/gpu-particles/particles.css
+++ b/examples/gpu-particles/particles.css
@@ -1,0 +1,254 @@
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #080b10;
+  color: #f2f5f7;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+  background: #080b10;
+}
+
+main {
+  width: min(1440px, 100%);
+  margin: 0 auto;
+  padding: 26px 32px 34px;
+}
+
+header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 22px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #8eb9d9;
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(32px, 5vw, 56px);
+  font-weight: 650;
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.status {
+  display: flex;
+  align-items: center;
+  flex: none;
+  gap: 10px;
+  margin: 0 0 4px;
+  color: #b9c6cf;
+  font-size: 14px;
+}
+
+.status span {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: #e6b655;
+  box-shadow: 0 0 14px rgba(230, 182, 85, 0.65);
+}
+
+.status.ready span {
+  background: #54d8ad;
+  box-shadow: 0 0 14px rgba(84, 216, 173, 0.65);
+}
+
+.status.error span {
+  background: #ef6c78;
+  box-shadow: 0 0 14px rgba(239, 108, 120, 0.55);
+}
+
+.simulation {
+  position: relative;
+  width: 100%;
+  height: min(72vh, 820px);
+  min-height: 420px;
+  overflow: hidden;
+  border: 1px solid #293341;
+  border-radius: 6px;
+  background: #070a0f;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.canvas-message {
+  position: absolute;
+  inset: 50% auto auto 50%;
+  margin: 0;
+  transform: translate(-50%, -50%);
+  color: #a9b8c5;
+  font-size: 14px;
+  pointer-events: none;
+}
+
+.canvas-message:empty {
+  display: none;
+}
+
+.telemetry {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 28px;
+  padding: 18px 2px 0;
+}
+
+dl {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(105px, 1fr));
+  flex: 1;
+  gap: 24px;
+  margin: 0;
+}
+
+dt {
+  margin-bottom: 4px;
+  color: #7f91a0;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+dd {
+  margin: 0;
+  color: #e9eef2;
+  font-variant-numeric: tabular-nums;
+  font-size: 16px;
+}
+
+.controls,
+.segments {
+  display: flex;
+  align-items: center;
+}
+
+.controls {
+  flex: none;
+  gap: 10px;
+}
+
+.segments {
+  overflow: hidden;
+  border: 1px solid #33404d;
+  border-radius: 6px;
+}
+
+button {
+  min-height: 36px;
+  border: 0;
+  color: #bdc9d2;
+  background: #111821;
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+button:hover {
+  color: #ffffff;
+  background: #19232e;
+}
+
+button:focus-visible {
+  outline: 2px solid #55b7e9;
+  outline-offset: 2px;
+}
+
+.segments button {
+  min-width: 52px;
+  padding: 0 11px;
+  border-right: 1px solid #33404d;
+}
+
+.segments button:last-child {
+  border-right: 0;
+}
+
+.segments button[aria-pressed="true"] {
+  color: #071016;
+  background: #65cbe9;
+}
+
+.command {
+  padding: 0 15px;
+  border: 1px solid #33404d;
+  border-radius: 6px;
+}
+
+@media (max-width: 900px) {
+  main {
+    padding: 20px 18px 28px;
+  }
+
+  .simulation {
+    height: 62vh;
+    min-height: 360px;
+  }
+
+  .telemetry {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  dl {
+    grid-template-columns: repeat(2, minmax(120px, 1fr));
+  }
+
+  .controls {
+    justify-content: space-between;
+  }
+}
+
+@media (max-width: 560px) {
+  header {
+    align-items: start;
+    flex-direction: column;
+    gap: 14px;
+  }
+
+  h1 {
+    font-size: 38px;
+  }
+
+  .simulation {
+    height: 56vh;
+    min-height: 330px;
+  }
+
+  .controls {
+    align-items: stretch;
+    flex-wrap: wrap;
+  }
+
+  .segments {
+    width: 100%;
+  }
+
+  .segments button {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .command {
+    flex: 1;
+  }
+}

--- a/examples/gpu-particles/particles.css
+++ b/examples/gpu-particles/particles.css
@@ -194,6 +194,27 @@ button:focus-visible {
   border-radius: 6px;
 }
 
+.benchmark-results {
+  margin-top: 22px;
+  padding-top: 20px;
+  border-top: 1px solid #293341;
+}
+
+.benchmark-results h2 {
+  margin: 0 0 12px;
+  font-size: 18px;
+  font-weight: 650;
+  letter-spacing: 0;
+}
+
+.benchmark-results pre {
+  overflow-x: auto;
+  margin: 0;
+  color: #c9d5dd;
+  font: 12px/1.55 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  white-space: pre-wrap;
+}
+
 @media (max-width: 900px) {
   main {
     padding: 20px 18px 28px;

--- a/examples/gpu-particles/particles.mec
+++ b/examples/gpu-particles/particles.mec
@@ -1,0 +1,17 @@
+@particles := gpu-particles://particles/simulation{:write(control)}
+
+particle-count := 1000000.0
+gravity := 0.34
+drag := 0.997
+point-size := 1.35
+time-scale := 1.0
+
+control := {
+  particle-count: particle-count
+  gravity: gravity
+  drag: drag
+  point-size: point-size
+  time-scale: time-scale
+}
+
+@particles/control <- control

--- a/hosts/gpu-particles/Cargo.toml
+++ b/hosts/gpu-particles/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "mech-host-gpu-particles"
+version = "0.3.5"
+authors = ["Corey Montella <corey@mech-lang.org>"]
+description = "Resident GPU particle-system host provider for Mech."
+documentation = "https://docs.mech-lang.org"
+homepage = "https://mech-lang.org"
+repository = "https://github.com/mech-lang/mech"
+license = "Apache-2.0"
+edition = "2024"
+rust-version = "1.92"
+
+[features]
+default = []
+browser = ["dep:js-sys", "dep:wasm-bindgen"]
+
+[dependencies]
+mech-core = { version = "0.3.5", default-features = false, features = ["f64", "record"] }
+mech-runtime = { version = "0.3.5", default-features = false, features = ["runtime", "f64"] }
+js-sys = { version = "0.3.82", optional = true }
+wasm-bindgen = { version = "0.2.105", optional = true }
+
+[dev-dependencies]
+mech-runtime = { version = "0.3.5", default-features = false, features = ["source"] }

--- a/hosts/gpu-particles/host.mcfg
+++ b/hosts/gpu-particles/host.mcfg
@@ -1,0 +1,12 @@
+config := {
+  host: {
+    provider: "gpu-particles"
+    contexts: [
+      {
+        name: "simulation"
+        base-uri: "gpu-particles://{instance}/simulation"
+        operations: ["write"]
+      }
+    ]
+  }
+}

--- a/hosts/gpu-particles/src/browser.rs
+++ b/hosts/gpu-particles/src/browser.rs
@@ -1,0 +1,113 @@
+use js_sys::{Object, Reflect};
+use mech_core::MResult;
+use wasm_bindgen::prelude::*;
+
+use crate::{
+    GpuParticleBackend, GpuParticleControl, GpuParticleHostFactory, GpuParticleHostSettings,
+    gpu_particle_error,
+};
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(
+        catch,
+        js_namespace = MechGpuParticles,
+        js_name = configure
+    )]
+    fn configure_gpu_particles(
+        instance: &str,
+        selector: &str,
+        max_particles: u32,
+        control: &JsValue,
+    ) -> Result<JsValue, JsValue>;
+}
+
+#[derive(Clone, Debug)]
+pub struct BrowserGpuParticleBackend {
+    instance: String,
+    settings: GpuParticleHostSettings,
+}
+
+impl BrowserGpuParticleBackend {
+    pub fn new(instance: impl Into<String>, settings: GpuParticleHostSettings) -> Self {
+        Self {
+            instance: instance.into(),
+            settings,
+        }
+    }
+}
+
+impl GpuParticleBackend for BrowserGpuParticleBackend {
+    fn configure(&mut self, control: GpuParticleControl) -> MResult<()> {
+        let value = Object::new();
+        set(&value, "particleCount", control.particle_count)?;
+        set(&value, "gravity", control.gravity)?;
+        set(&value, "drag", control.drag)?;
+        set(&value, "pointSize", control.point_size)?;
+        set(&value, "timeScale", control.time_scale)?;
+        configure_gpu_particles(
+            &self.instance,
+            &self.settings.selector,
+            self.settings.max_particles,
+            &value,
+        )
+        .map_err(|error| {
+            gpu_particle_error(
+                "BrowserGpuParticleBackend",
+                format!("browser GPU particle backend rejected control: {error:?}"),
+            )
+        })?;
+        Ok(())
+    }
+}
+
+fn set(value: &Object, name: &str, field: impl Into<JsValue>) -> MResult<()> {
+    Reflect::set(value, &JsValue::from_str(name), &field.into()).map_err(|error| {
+        gpu_particle_error(
+            "BrowserGpuParticleBackend",
+            format!("failed to encode gpu particle field `{name}`: {error:?}"),
+        )
+    })?;
+    Ok(())
+}
+
+#[derive(Debug)]
+pub struct BrowserGpuParticleHostFactory {
+    manifest: mech_runtime::HostManifestConfig,
+}
+
+impl BrowserGpuParticleHostFactory {
+    pub fn new() -> MResult<Self> {
+        Ok(Self {
+            manifest: crate::gpu_particle_host_manifest()?,
+        })
+    }
+}
+
+impl mech_runtime::RuntimeHostFactory for BrowserGpuParticleHostFactory {
+    fn provider_name(&self) -> &str {
+        "gpu-particles"
+    }
+
+    fn manifest(&self) -> &mech_runtime::HostManifestConfig {
+        &self.manifest
+    }
+
+    fn validate_settings(
+        &self,
+        _instance_name: &str,
+        settings: &mech_runtime::ConfigValue,
+    ) -> MResult<()> {
+        crate::gpu_particle_settings_from_config(settings).map(|_| ())
+    }
+
+    fn instantiate(
+        &self,
+        instance_name: &str,
+        settings: &mech_runtime::ConfigValue,
+    ) -> MResult<mech_runtime::RuntimeHostInstallation> {
+        let parsed = crate::gpu_particle_settings_from_config(settings)?;
+        GpuParticleHostFactory::with_backend(BrowserGpuParticleBackend::new(instance_name, parsed))?
+            .instantiate(instance_name, settings)
+    }
+}

--- a/hosts/gpu-particles/src/config.rs
+++ b/hosts/gpu-particles/src/config.rs
@@ -1,0 +1,117 @@
+use mech_core::MResult;
+use mech_runtime::ConfigValue;
+
+use crate::gpu_particle_error;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GpuParticleHostSettings {
+    pub selector: String,
+    pub max_particles: u32,
+}
+
+pub fn gpu_particle_settings_from_config(
+    settings: &ConfigValue,
+) -> MResult<GpuParticleHostSettings> {
+    let ConfigValue::Map(map) = settings else {
+        return Err(gpu_particle_error(
+            "GpuParticleHostConfig",
+            "gpu-particles host settings must be a map",
+        ));
+    };
+    let mut selector = None;
+    let mut max_particles = None;
+    for (key, value) in map {
+        match key.as_str() {
+            "selector" => {
+                let ConfigValue::String(raw) = value else {
+                    return Err(gpu_particle_error(
+                        "GpuParticleHostConfig",
+                        "gpu-particles selector must be a string",
+                    ));
+                };
+                if raw.trim().is_empty() {
+                    return Err(gpu_particle_error(
+                        "GpuParticleHostConfig",
+                        "gpu-particles selector must be non-empty",
+                    ));
+                }
+                selector = Some(raw.clone());
+            }
+            "max-particles" => {
+                let ConfigValue::Integer(raw) = value else {
+                    return Err(gpu_particle_error(
+                        "GpuParticleHostConfig",
+                        "gpu-particles max-particles must be an integer",
+                    ));
+                };
+                if !(1..=16_000_000).contains(raw) {
+                    return Err(gpu_particle_error(
+                        "GpuParticleHostConfig",
+                        "gpu-particles max-particles must be between 1 and 16000000",
+                    ));
+                }
+                max_particles = Some(*raw as u32);
+            }
+            other => {
+                return Err(gpu_particle_error(
+                    "GpuParticleHostConfig",
+                    format!("unknown gpu-particles host setting `{other}`"),
+                ));
+            }
+        }
+    }
+    Ok(GpuParticleHostSettings {
+        selector: selector.ok_or_else(|| {
+            gpu_particle_error(
+                "GpuParticleHostConfig",
+                "gpu-particles selector is required",
+            )
+        })?,
+        max_particles: max_particles.ok_or_else(|| {
+            gpu_particle_error(
+                "GpuParticleHostConfig",
+                "gpu-particles max-particles is required",
+            )
+        })?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    #[test]
+    fn parses_valid_settings() {
+        let settings = ConfigValue::Map(BTreeMap::from([
+            (
+                "selector".to_string(),
+                ConfigValue::String("#particles".to_string()),
+            ),
+            ("max-particles".to_string(), ConfigValue::Integer(1_000_000)),
+        ]));
+        assert_eq!(
+            gpu_particle_settings_from_config(&settings).unwrap(),
+            GpuParticleHostSettings {
+                selector: "#particles".to_string(),
+                max_particles: 1_000_000,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_unbounded_particle_counts() {
+        let settings = ConfigValue::Map(BTreeMap::from([
+            (
+                "selector".to_string(),
+                ConfigValue::String("#particles".to_string()),
+            ),
+            (
+                "max-particles".to_string(),
+                ConfigValue::Integer(16_000_001),
+            ),
+        ]));
+        assert!(gpu_particle_settings_from_config(&settings).is_err());
+    }
+}

--- a/hosts/gpu-particles/src/lib.rs
+++ b/hosts/gpu-particles/src/lib.rs
@@ -1,0 +1,46 @@
+#![forbid(unsafe_code)]
+
+#[cfg(feature = "browser")]
+mod browser;
+mod config;
+mod module;
+mod provider;
+mod schema;
+
+#[cfg(feature = "browser")]
+pub use browser::{BrowserGpuParticleBackend, BrowserGpuParticleHostFactory};
+pub use config::{GpuParticleHostSettings, gpu_particle_settings_from_config};
+pub use module::gpu_particle_host_manifest;
+pub use provider::{
+    GpuParticleBackend, GpuParticleHostFactory, GpuParticleResourceProvider,
+    RecordingGpuParticleBackend,
+};
+pub use schema::GpuParticleControl;
+
+use mech_core::{MechError, MechErrorKind};
+
+#[derive(Clone, Debug)]
+pub struct GpuParticleHostError {
+    pub name: &'static str,
+    pub message: String,
+}
+
+impl MechErrorKind for GpuParticleHostError {
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn message(&self) -> String {
+        self.message.clone()
+    }
+}
+
+pub(crate) fn gpu_particle_error(name: &'static str, message: impl Into<String>) -> MechError {
+    MechError::new(
+        GpuParticleHostError {
+            name,
+            message: message.into(),
+        },
+        None,
+    )
+}

--- a/hosts/gpu-particles/src/module.rs
+++ b/hosts/gpu-particles/src/module.rs
@@ -1,0 +1,28 @@
+pub fn gpu_particle_host_manifest() -> mech_core::MResult<mech_runtime::HostManifestConfig> {
+    Ok(mech_runtime::HostManifestConfig {
+        provider: "gpu-particles".to_string(),
+        contexts: vec![mech_runtime::HostContextManifest {
+            name: "simulation".to_string(),
+            base_uri_template: "gpu-particles://{instance}/simulation".to_string(),
+            operations: vec!["write".to_string()],
+        }],
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    const HOST_MCFG: &str = include_str!("../host.mcfg");
+
+    #[test]
+    fn direct_manifest_matches_documented_fixture() {
+        let parsed = mech_runtime::parse_config_document(
+            "hosts/gpu-particles/host.mcfg",
+            HOST_MCFG,
+            mech_runtime::ConfigProfileOptions::default(),
+        )
+        .unwrap()
+        .host
+        .unwrap();
+        assert_eq!(super::gpu_particle_host_manifest().unwrap(), parsed);
+    }
+}

--- a/hosts/gpu-particles/src/provider.rs
+++ b/hosts/gpu-particles/src/provider.rs
@@ -1,0 +1,233 @@
+use std::sync::{Arc, Mutex};
+
+use mech_core::{MResult, Value};
+use mech_runtime::{
+    ConfigValue, HostManifestConfig, PreparedRuntimeEffect, RuntimeAfterCommitEffect,
+    RuntimeEffectCost, RuntimeEffectMetadata, RuntimeEffectSource, RuntimeHostFactory,
+    RuntimeHostInstallation, RuntimeResourceProvider, RuntimeResourceReadRequest,
+    RuntimeResourceWriteIntent, RuntimeResourceWritePreflightRequest, RuntimeResourceWriteRequest,
+    materialize_host_manifest,
+};
+
+use crate::{
+    GpuParticleControl, GpuParticleHostSettings, gpu_particle_error, gpu_particle_host_manifest,
+    gpu_particle_settings_from_config,
+};
+
+pub trait GpuParticleBackend: Clone + std::fmt::Debug + 'static {
+    fn configure(&mut self, control: GpuParticleControl) -> MResult<()>;
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct RecordingGpuParticleBackend {
+    controls: Arc<Mutex<Vec<GpuParticleControl>>>,
+}
+
+impl RecordingGpuParticleBackend {
+    pub fn controls(&self) -> Vec<GpuParticleControl> {
+        self.controls.lock().unwrap().clone()
+    }
+}
+
+impl GpuParticleBackend for RecordingGpuParticleBackend {
+    fn configure(&mut self, control: GpuParticleControl) -> MResult<()> {
+        self.controls
+            .lock()
+            .map_err(|_| {
+                gpu_particle_error(
+                    "GpuParticleBackend",
+                    "gpu particle recording backend lock is poisoned",
+                )
+            })?
+            .push(control);
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct GpuParticleResourceProvider<B: GpuParticleBackend> {
+    instance: String,
+    max_particles: u32,
+    backend: Arc<Mutex<B>>,
+    last_accepted: Arc<Mutex<Option<GpuParticleControl>>>,
+}
+
+impl<B: GpuParticleBackend> GpuParticleResourceProvider<B> {
+    pub fn new(instance: impl Into<String>, max_particles: u32, backend: B) -> Self {
+        Self {
+            instance: instance.into(),
+            max_particles,
+            backend: Arc::new(Mutex::new(backend)),
+            last_accepted: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    fn base(&self) -> String {
+        format!("gpu-particles://{}/simulation", self.instance)
+    }
+}
+
+impl<B: GpuParticleBackend> RuntimeResourceProvider for GpuParticleResourceProvider<B> {
+    fn scheme(&self) -> &str {
+        "gpu-particles"
+    }
+
+    fn base_uris(&self) -> Vec<String> {
+        vec![self.base()]
+    }
+
+    fn read(&self, request: RuntimeResourceReadRequest) -> MResult<Value> {
+        Err(gpu_particle_error(
+            "GpuParticleResourceProvider",
+            format!("gpu particle resource `{}` is write-only", request.base_uri),
+        ))
+    }
+
+    fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
+        if request.base_uri != self.base() {
+            return Err(gpu_particle_error(
+                "GpuParticleResourceProvider",
+                format!("unsupported gpu particle resource `{}`", request.base_uri),
+            ));
+        }
+        if request.intent != RuntimeResourceWriteIntent::Send {
+            return Err(gpu_particle_error(
+                "GpuParticleResourceProvider",
+                "gpu particle controls accept send writes only; use <-",
+            ));
+        }
+        if request.path != "control" {
+            return Err(gpu_particle_error(
+                "GpuParticleResourceProvider",
+                "gpu particle simulation supports only the `control` path",
+            ));
+        }
+        Ok(())
+    }
+
+    fn plan_write(&self, request: RuntimeResourceWriteRequest) -> MResult<()> {
+        self.preflight_write(RuntimeResourceWritePreflightRequest {
+            base_uri: request.base_uri,
+            path: request.path,
+            context_name: request.context_name,
+            operation: request.operation,
+            intent: request.intent,
+        })?;
+        GpuParticleControl::from_value(&request.value, self.max_particles).map(|_| ())
+    }
+
+    fn prepare_write(
+        &self,
+        request: RuntimeResourceWriteRequest,
+    ) -> MResult<PreparedRuntimeEffect> {
+        self.preflight_write(RuntimeResourceWritePreflightRequest {
+            base_uri: request.base_uri.clone(),
+            path: request.path.clone(),
+            context_name: request.context_name.clone(),
+            operation: request.operation.clone(),
+            intent: request.intent,
+        })?;
+        let control = GpuParticleControl::from_value(&request.value, self.max_particles)?;
+        Ok(PreparedRuntimeEffect::AfterCommit(Box::new(
+            GpuParticleControlEffect {
+                backend: self.backend.clone(),
+                last_accepted: self.last_accepted.clone(),
+                control,
+                resource: request.base_uri,
+            },
+        )))
+    }
+}
+
+#[derive(Debug)]
+struct GpuParticleControlEffect<B: GpuParticleBackend> {
+    backend: Arc<Mutex<B>>,
+    last_accepted: Arc<Mutex<Option<GpuParticleControl>>>,
+    control: GpuParticleControl,
+    resource: String,
+}
+
+impl<B: GpuParticleBackend> RuntimeAfterCommitEffect for GpuParticleControlEffect<B> {
+    fn metadata(&self) -> RuntimeEffectMetadata {
+        RuntimeEffectMetadata::new(
+            RuntimeEffectSource::ResourceProvider {
+                scheme: "gpu-particles".to_string(),
+            },
+            "control",
+        )
+        .with_resource(self.resource.clone())
+        .with_cost(RuntimeEffectCost {
+            bytes: 20,
+            items: 1,
+        })
+    }
+
+    fn deliver(&mut self) -> MResult<()> {
+        let mut last_accepted = self.last_accepted.lock().map_err(|_| {
+            gpu_particle_error(
+                "GpuParticleResourceProvider",
+                "gpu particle acceptance lock is poisoned",
+            )
+        })?;
+        if last_accepted.as_ref() == Some(&self.control) {
+            return Ok(());
+        }
+        self.backend
+            .lock()
+            .map_err(|_| {
+                gpu_particle_error(
+                    "GpuParticleResourceProvider",
+                    "gpu particle backend lock is poisoned",
+                )
+            })?
+            .configure(self.control.clone())?;
+        *last_accepted = Some(self.control.clone());
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct GpuParticleHostFactory<B: GpuParticleBackend> {
+    backend: B,
+    manifest: HostManifestConfig,
+}
+
+impl<B: GpuParticleBackend> GpuParticleHostFactory<B> {
+    pub fn with_backend(backend: B) -> MResult<Self> {
+        Ok(Self {
+            backend,
+            manifest: gpu_particle_host_manifest()?,
+        })
+    }
+}
+
+impl<B: GpuParticleBackend> RuntimeHostFactory for GpuParticleHostFactory<B> {
+    fn provider_name(&self) -> &str {
+        "gpu-particles"
+    }
+
+    fn manifest(&self) -> &HostManifestConfig {
+        &self.manifest
+    }
+
+    fn validate_settings(&self, _instance_name: &str, settings: &ConfigValue) -> MResult<()> {
+        gpu_particle_settings_from_config(settings).map(|_| ())
+    }
+
+    fn instantiate(
+        &self,
+        instance_name: &str,
+        settings: &ConfigValue,
+    ) -> MResult<RuntimeHostInstallation> {
+        let settings: GpuParticleHostSettings = gpu_particle_settings_from_config(settings)?;
+        Ok(RuntimeHostInstallation {
+            interface: materialize_host_manifest(instance_name, &self.manifest)?,
+            resource_providers: vec![Box::new(GpuParticleResourceProvider::new(
+                instance_name,
+                settings.max_particles,
+                self.backend.clone(),
+            ))],
+            input_drivers: Vec::new(),
+        })
+    }
+}

--- a/hosts/gpu-particles/src/schema.rs
+++ b/hosts/gpu-particles/src/schema.rs
@@ -1,0 +1,104 @@
+use mech_core::{MResult, MechRecord, Value, hash_str};
+
+use crate::gpu_particle_error;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct GpuParticleControl {
+    pub particle_count: u32,
+    pub gravity: f32,
+    pub drag: f32,
+    pub point_size: f32,
+    pub time_scale: f32,
+}
+
+impl GpuParticleControl {
+    pub fn from_value(value: &Value, max_particles: u32) -> MResult<Self> {
+        if let Value::MutableReference(value) = value {
+            return Self::from_value(&value.borrow(), max_particles);
+        }
+        let Value::Record(record) = value else {
+            return Err(gpu_particle_error(
+                "GpuParticleControl",
+                "gpu particle control must be a record",
+            ));
+        };
+        let record = record.borrow();
+        let allowed = [
+            "particle-count",
+            "gravity",
+            "drag",
+            "point-size",
+            "time-scale",
+        ];
+        for (_, name) in &record.field_names {
+            if !allowed.contains(&name.as_str()) {
+                return Err(gpu_particle_error(
+                    "GpuParticleControl",
+                    format!("unknown gpu particle control field `{name}`"),
+                ));
+            }
+        }
+        let raw_count = number(&record, "particle-count")?;
+        if raw_count.fract() != 0.0 || raw_count < 1.0 || raw_count > f64::from(max_particles) {
+            return Err(gpu_particle_error(
+                "GpuParticleControl",
+                format!("particle-count must be an integer between 1 and {max_particles}"),
+            ));
+        }
+        let control = Self {
+            particle_count: raw_count as u32,
+            gravity: number(&record, "gravity")? as f32,
+            drag: number(&record, "drag")? as f32,
+            point_size: number(&record, "point-size")? as f32,
+            time_scale: number(&record, "time-scale")? as f32,
+        };
+        if !(-8.0..=8.0).contains(&control.gravity) {
+            return Err(gpu_particle_error(
+                "GpuParticleControl",
+                "gravity must be between -8 and 8",
+            ));
+        }
+        if !(0.8..=1.0).contains(&control.drag) {
+            return Err(gpu_particle_error(
+                "GpuParticleControl",
+                "drag must be between 0.8 and 1",
+            ));
+        }
+        if !(0.5..=8.0).contains(&control.point_size) {
+            return Err(gpu_particle_error(
+                "GpuParticleControl",
+                "point-size must be between 0.5 and 8",
+            ));
+        }
+        if !(0.0..=4.0).contains(&control.time_scale) {
+            return Err(gpu_particle_error(
+                "GpuParticleControl",
+                "time-scale must be between 0 and 4",
+            ));
+        }
+        Ok(control)
+    }
+}
+
+fn number(record: &MechRecord, field: &str) -> MResult<f64> {
+    let value = record.get(&hash_str(field)).ok_or_else(|| {
+        gpu_particle_error(
+            "GpuParticleControl",
+            format!("missing required gpu particle control field `{field}`"),
+        )
+    })?;
+    let value = value.as_f64().map_err(|_| {
+        gpu_particle_error(
+            "GpuParticleControl",
+            format!("gpu particle control field `{field}` must be numeric"),
+        )
+    })?;
+    let value = *value.borrow();
+    if !value.is_finite() {
+        return Err(gpu_particle_error(
+            "GpuParticleControl",
+            format!("gpu particle control field `{field}` must be finite"),
+        ));
+    }
+    Ok(value)
+}

--- a/hosts/gpu-particles/tests/provider.rs
+++ b/hosts/gpu-particles/tests/provider.rs
@@ -1,0 +1,100 @@
+use std::collections::BTreeMap;
+
+use mech_core::{MechRecord, Ref, Value};
+use mech_host_gpu_particles::{GpuParticleResourceProvider, RecordingGpuParticleBackend};
+use mech_runtime::{
+    ConfigValue, PreparedRuntimeEffect, RuntimeCapabilityOperation, RuntimeResourceProvider,
+    RuntimeResourceWriteIntent, RuntimeResourceWritePreflightRequest, RuntimeResourceWriteRequest,
+};
+
+fn number(value: f64) -> Value {
+    Value::F64(Ref::new(value))
+}
+
+fn control(particle_count: f64) -> Value {
+    Value::Record(Ref::new(MechRecord::new(vec![
+        ("particle-count", number(particle_count)),
+        ("gravity", number(0.34)),
+        ("drag", number(0.997)),
+        ("point-size", number(1.35)),
+        ("time-scale", number(1.0)),
+    ])))
+}
+
+fn request(value: Value) -> RuntimeResourceWriteRequest {
+    RuntimeResourceWriteRequest {
+        base_uri: "gpu-particles://particles/simulation".to_string(),
+        path: "control".to_string(),
+        context_name: "simulation".to_string(),
+        operation: RuntimeCapabilityOperation::Write,
+        intent: RuntimeResourceWriteIntent::Send,
+        value,
+    }
+}
+
+fn deliver(
+    provider: &dyn RuntimeResourceProvider,
+    request: RuntimeResourceWriteRequest,
+) -> mech_core::MResult<()> {
+    match provider.prepare_write(request)? {
+        PreparedRuntimeEffect::AfterCommit(mut effect) => effect.deliver(),
+        effect => panic!("expected after-commit effect, got {effect:?}"),
+    }
+}
+
+#[test]
+fn valid_control_is_delivered_after_commit() {
+    let backend = RecordingGpuParticleBackend::default();
+    let provider = GpuParticleResourceProvider::new("particles", 2_000_000, backend.clone());
+    deliver(&provider, request(control(1_000_000.0))).unwrap();
+    assert_eq!(backend.controls()[0].particle_count, 1_000_000);
+}
+
+#[test]
+fn identical_control_is_not_delivered_twice() {
+    let backend = RecordingGpuParticleBackend::default();
+    let provider = GpuParticleResourceProvider::new("particles", 2_000_000, backend.clone());
+    deliver(&provider, request(control(1_000_000.0))).unwrap();
+    deliver(&provider, request(control(1_000_000.0))).unwrap();
+    assert_eq!(backend.controls().len(), 1);
+}
+
+#[test]
+fn out_of_range_count_fails_before_delivery() {
+    let backend = RecordingGpuParticleBackend::default();
+    let provider = GpuParticleResourceProvider::new("particles", 2_000_000, backend.clone());
+    assert!(provider.plan_write(request(control(2_000_001.0))).is_err());
+    assert!(backend.controls().is_empty());
+}
+
+#[test]
+fn assignment_intent_is_rejected() {
+    let provider = GpuParticleResourceProvider::new(
+        "particles",
+        2_000_000,
+        RecordingGpuParticleBackend::default(),
+    );
+    assert!(
+        provider
+            .preflight_write(RuntimeResourceWritePreflightRequest {
+                base_uri: "gpu-particles://particles/simulation".to_string(),
+                path: "control".to_string(),
+                context_name: "simulation".to_string(),
+                operation: RuntimeCapabilityOperation::Write,
+                intent: RuntimeResourceWriteIntent::Assign,
+            })
+            .is_err()
+    );
+}
+
+#[test]
+fn example_settings_shape_is_valid() {
+    let settings = ConfigValue::Map(BTreeMap::from([
+        (
+            "selector".to_string(),
+            ConfigValue::String("#particle-canvas".to_string()),
+        ),
+        ("max-particles".to_string(), ConfigValue::Integer(2_000_000)),
+    ]));
+    assert!(mech_host_gpu_particles::gpu_particle_settings_from_config(&settings).is_ok());
+}

--- a/scripts/check-package-archives.py
+++ b/scripts/check-package-archives.py
@@ -28,6 +28,7 @@ PACKAGES = {
     "mech-combinatorics": ROOT / "machines/combinatorics/Cargo.toml",
     "mech-host-cli": ROOT / "hosts/cli/Cargo.toml",
     "mech-host-console": ROOT / "hosts/console/Cargo.toml",
+    "mech-host-gpu-particles": ROOT / "hosts/gpu-particles/Cargo.toml",
     "mech-host-time": ROOT / "hosts/time/Cargo.toml",
     "mech-host-timer": ROOT / "hosts/timer/Cargo.toml",
     "mech-host-scene": ROOT / "hosts/scene/Cargo.toml",
@@ -36,6 +37,7 @@ PACKAGES = {
 REQUIRED_RESOURCES = {
     "mech-host-cli": ("host.mcfg",),
     "mech-host-console": ("host.mcfg",),
+    "mech-host-gpu-particles": ("host.mcfg",),
     "mech-host-time": ("host.mcfg",),
     "mech-host-timer": ("host.mcfg",),
     "mech-host-scene": ("host.mcfg",),

--- a/src/wasm/Cargo.toml
+++ b/src/wasm/Cargo.toml
@@ -69,7 +69,7 @@ host_delegation_signing = ["host_delegation", "mech-runtime/host_delegation_sign
 # Served `/code/...` documents are encoded by a native formatter with Mika
 # nodes enabled. Keep that feature-gated Program schema identical in the
 # prebuilt browser package so serialized enum indices remain compatible.
-browser_project = ["source", "browser_project_runner", "sample_hold", "state_step", "served_project_authority", "browser_host_dom", "browser_host_time", "browser_host_timer", "browser_host_console", "browser_host_scene", "baselib", "mika", "statements_default", "compare_default", "logic_default", "subscript_default", "range_default", "math_default", "matrix_default", "f64", "bool", "string_default", "record", "tuple", "table", "atom", "enum", "variables"]
+browser_project = ["source", "browser_project_runner", "sample_hold", "state_step", "served_project_authority", "browser_host_dom", "browser_host_time", "browser_host_timer", "browser_host_console", "browser_host_scene", "browser_host_gpu_particles", "baselib", "mika", "statements_default", "compare_default", "logic_default", "subscript_default", "range_default", "math_default", "matrix_default", "f64", "bool", "string_default", "record", "tuple", "table", "atom", "enum", "variables"]
 browser_project_runner = ["source", "program", "pretty_print", "serde"]
 served_project_authority = ["host_delegation_signing"]
 browser_host_dom = ["dep:mech-host-browser", "mech-host-browser/provider", "mech-host-browser/serde"]
@@ -77,6 +77,7 @@ browser_host_time = ["dep:mech-host-time", "mech-host-time/browser"]
 browser_host_timer = ["dep:mech-host-timer", "mech-host-timer/browser"]
 browser_host_console = ["dep:mech-host-console", "mech-host-console/browser"]
 browser_host_scene = ["dep:mech-host-scene", "mech-host-scene/browser"]
+browser_host_gpu_particles = ["dep:mech-host-gpu-particles", "mech-host-gpu-particles/browser"]
 run_program = ["program"]
 inline_output_values = []
 codeblock_output_values = []
@@ -312,6 +313,7 @@ mech-host-time = { version = "0.3.5", path = "../../hosts/time", default-feature
 mech-host-console = { version = "0.3.5", path = "../../hosts/console", default-features = false, optional = true }
 mech-host-timer = { version = "0.3.5", path = "../../hosts/timer", default-features = false, optional = true }
 mech-host-scene = { version = "0.3.5", path = "../../hosts/scene", default-features = false, optional = true }
+mech-host-gpu-particles = { version = "0.3.5", path = "../../hosts/gpu-particles", default-features = false, optional = true }
 
 wasm-bindgen = "0.2.100"
 serde-wasm-bindgen = "0.6.5"

--- a/src/wasm/src/project.rs
+++ b/src/wasm/src/project.rs
@@ -16,6 +16,8 @@ use mech_host_browser::BrowserRuntimeInjectionConfig;
 use mech_host_browser::{BrowserHostDelegationEnvelope, verify_browser_host_delegation};
 #[cfg(feature = "browser_host_console")]
 use mech_host_console::BrowserConsoleHostFactory;
+#[cfg(feature = "browser_host_gpu_particles")]
+use mech_host_gpu_particles::BrowserGpuParticleHostFactory;
 #[cfg(feature = "browser_host_scene")]
 use mech_host_scene::{BrowserSceneHostFactory, BrowserSceneRegistry};
 #[cfg(feature = "browser_host_time")]
@@ -794,6 +796,14 @@ fn runtime_builder_with_factories(
             .host_factory(Box::new(scene_factory))
             .map_err(to_js_error)?;
     }
+    #[cfg(feature = "browser_host_gpu_particles")]
+    {
+        builder = builder
+            .host_factory(Box::new(
+                BrowserGpuParticleHostFactory::new().map_err(to_js_error)?,
+            ))
+            .map_err(to_js_error)?;
+    }
     Ok(builder)
 }
 
@@ -869,6 +879,8 @@ fn compiled_browser_providers() -> BTreeMap<&'static str, &'static str> {
     providers.insert("console", "browser_host_console");
     #[cfg(feature = "browser_host_scene")]
     providers.insert("scene", "browser_host_scene");
+    #[cfg(feature = "browser_host_gpu_particles")]
+    providers.insert("gpu-particles", "browser_host_gpu_particles");
     providers
 }
 
@@ -879,6 +891,7 @@ fn standard_browser_provider_feature(provider: &str) -> Option<&'static str> {
         "timer" => Some("browser_host_timer"),
         "console" => Some("browser_host_console"),
         "scene" => Some("browser_host_scene"),
+        "gpu-particles" => Some("browser_host_gpu_particles"),
         _ => None,
     }
 }

--- a/src/web_host.rs
+++ b/src/web_host.rs
@@ -46,6 +46,10 @@ fn standard_browser_runtime_provider_profile() -> MResult<BrowserRuntimeProvider
     profile.register(mech_host_scene::scene_host_manifest()?, |settings| {
         mech_host_scene::scene_settings_from_config(settings).map(|_| ())
     })?;
+    profile.register(
+        mech_host_gpu_particles::gpu_particle_host_manifest()?,
+        |settings| mech_host_gpu_particles::gpu_particle_settings_from_config(settings).map(|_| ()),
+    )?;
     Ok(profile)
 }
 


### PR DESCRIPTION
## What changed

- add a browser-only `gpu-particles` host with validated, capability-checked control writes delivered after commit
- keep particle state in two persistent WebGPU storage buffers and fuse simulation plus rendering into one command submission per frame
- add a served `examples/gpu-particles` project with 100K to 2M particle presets, pause/reset controls, and throughput telemetry
- register the provider in the browser runtime feature closure and browser authority profile
- add host schema, deduplication, planning, and package archive tests

## Why

This establishes a concrete GPU host boundary for Mech without passing particle arrays or individual matrix operations through the reactive runtime. Mech commits a small control record once; steady-state computation and rendering remain resident on the GPU.

The current prototype demonstrates generation-level ping-pong publication. It does not yet lower arbitrary Mech expressions to WGSL or report a failed GPU validation reduction back to the runtime.

## Validation

- `cargo test -p mech-host-gpu-particles`
- `cargo check -p mech-wasm --features browser_project --target wasm32-unknown-unknown`
- `bash scripts/build-mech-browser.sh`
- `cargo build --release --bin mech`
- `mech bundle-web examples/gpu-particles --out ... --wasm src/wasm/pkg`
- `cargo fmt --all -- --check`
- `git diff --check`
- JavaScript syntax checked with JavaScriptCore
- local server returned the injected `gpu-particles` authority and generated WASM glue imports `MechGpuParticles.configure`

Visual GPU execution was not screenshot-tested in this Codex task because no browser instance was connected.
