### PR TITLE
[PR-D5] refactor(runtime,products): close production legacy reachability

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -33,6 +33,63 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  migration-contracts:
+    name: Migration contract qualification
+    runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: 0
+      CARGO_PROFILE_TEST_DEBUG: "0"
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Install migration contract tools
+        run: |
+          rustup toolchain install nightly-2026-03-03 --profile minimal
+          if ! command -v rg >/dev/null 2>&1
+          then
+            sudo apt-get update
+            sudo apt-get install --yes ripgrep
+          fi
+      - name: Replay migration architecture evidence
+        run: |
+          python3 scripts/generate-value-system-inventory.py --check
+          python3 scripts/generate-value-system-inventory.py \
+            --git-ref d5e41f6fd43c9d21c5858d80dab50e7ce64e9a10 \
+            --check-legacy-baseline
+          python3 scripts/check-value-system-contract.py
+          python3 scripts/check-program-artifact-contract.py
+          python3 scripts/check-operation-contract.py
+          python3 scripts/check-resident-activation-contract.py
+          python3 scripts/generate-d1-contract.py --check
+          python3 scripts/check-d1-contract.py
+          python3 scripts/generate-d2-contract.py --check
+          python3 scripts/check-d2-contract.py
+          python3 scripts/generate-d3-contract.py --check
+          python3 scripts/check-d3-contract.py
+          python3 scripts/generate-d4-contract.py --check
+          python3 scripts/check-d4-contract.py
+          python3 scripts/check-gate-d-contract.py \
+            --report benchmarks/runtime/gate-d/d3-resident-external.json \
+            --expected-phase D3-resident-external
+          python3 -B -m unittest \
+            scripts/tests/test_generate_value_system_inventory.py \
+            scripts/tests/test_check_value_system_contract.py \
+            scripts/tests/test_check_program_artifact_contract.py \
+            scripts/tests/test_check_operation_contract.py \
+            scripts/tests/test_generate_resident_activation_contract.py \
+            scripts/tests/test_check_resident_activation_contract.py \
+            scripts/tests/test_generate_d1_contract.py \
+            scripts/tests/test_check_d1_contract.py \
+            scripts/tests/test_generate_d2_contract.py \
+            scripts/tests/test_check_d2_contract.py \
+            scripts/tests/test_generate_d3_contract.py \
+            scripts/tests/test_check_d3_contract.py \
+            scripts/tests/test_generate_d4_contract.py \
+            scripts/tests/test_check_d4_contract.py \
+            scripts/tests/test_run_gate_a_benchmarks.py \
+            scripts/tests/test_run_gate_b_benchmarks.py
+
   cargo-features:
     name: Cargo feature and example checks
     runs-on: ubuntu-latest
@@ -66,7 +123,7 @@ jobs:
 
           # The default CLI is the concrete standard compiler distribution.
           cargo build --bin mech
-          ./target/debug/mech test examples/working
+          ./target/debug/mech run tests/fixtures/standard-resident-scalar.mec
 
           # Prelude-only no-default feature checks.
           cargo check --no-default-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,46 +63,11 @@ jobs:
         run: |
           cargo +nightly-2026-03-03 fmt --all -- --check
           python3 -B -m unittest tests.ci.test_ci_impact
+          python3 scripts/check-production-resident-routing.py
           scripts/check-unsafe-boundaries.sh
           python3 scripts/check-runtime-factory-safety.py
           python3 scripts/check-value-execution-boundary.py
           python3 -B -m unittest scripts/tests/test_check_value_execution_boundary.py
-          python3 scripts/generate-value-system-inventory.py --check
-          python3 scripts/generate-value-system-inventory.py \
-            --git-ref d5e41f6fd43c9d21c5858d80dab50e7ce64e9a10 \
-            --check-legacy-baseline
-          python3 scripts/check-value-system-contract.py
-          python3 scripts/check-program-artifact-contract.py
-          python3 scripts/check-operation-contract.py
-          python3 scripts/check-resident-activation-contract.py
-          python3 scripts/generate-d1-contract.py --check
-          python3 scripts/check-d1-contract.py
-          python3 scripts/generate-d2-contract.py --check
-          python3 scripts/check-d2-contract.py
-          python3 scripts/generate-d3-contract.py --check
-          python3 scripts/check-d3-contract.py
-          python3 scripts/generate-d4-contract.py --check
-          python3 scripts/check-d4-contract.py
-          python3 scripts/check-gate-d-contract.py \
-            --report benchmarks/runtime/gate-d/d3-resident-external.json \
-            --expected-phase D3-resident-external
-          python3 -B -m unittest \
-            scripts/tests/test_generate_value_system_inventory.py \
-            scripts/tests/test_check_value_system_contract.py \
-            scripts/tests/test_check_program_artifact_contract.py \
-            scripts/tests/test_check_operation_contract.py \
-            scripts/tests/test_generate_resident_activation_contract.py \
-            scripts/tests/test_check_resident_activation_contract.py \
-            scripts/tests/test_generate_d1_contract.py \
-            scripts/tests/test_check_d1_contract.py \
-            scripts/tests/test_generate_d2_contract.py \
-            scripts/tests/test_check_d2_contract.py \
-            scripts/tests/test_generate_d3_contract.py \
-            scripts/tests/test_check_d3_contract.py \
-            scripts/tests/test_generate_d4_contract.py \
-            scripts/tests/test_check_d4_contract.py \
-            scripts/tests/test_run_gate_b_benchmarks.py
-          python3 -B -m unittest scripts/tests/test_run_gate_a_benchmarks.py
           python3 scripts/check-bytecode-v1-format.py
           cargo +nightly-2026-03-03 fetch --locked
           python3 -B scripts/check-distribution-contracts.py --profile standard
@@ -130,7 +95,7 @@ jobs:
           cargo +nightly-2026-03-03 fetch --locked
           cargo +nightly-2026-03-03 build --locked --bin mech
           target/debug/mech --version | grep '(standard)'
-          target/debug/mech test tests/fixtures/standard-dynamic-matrix.mec
+          target/debug/mech run tests/fixtures/standard-resident-scalar.mec
       - name: Exercise source to bytecode to generated native executable
         run: >-
           cargo +nightly-2026-03-03 test
@@ -141,18 +106,19 @@ jobs:
           --
           --exact
           --nocapture
-      - name: Exercise console hosting and multiple live timer updates
+      - name: Exercise resident timer observation and console effect delivery
         run: |
-          set +e
-          timeout --preserve-status --signal=INT 2s \
-            target/debug/mech run tests/fixtures/standard-live-timer \
+          target/debug/mech run tests/fixtures/standard-live-timer \
+            --max-live-turns 2 \
+            --runtime-info \
             > /tmp/mech-standard-live-timer.out 2>&1
-          status=$?
-          set -e
-          test "$status" -eq 0
           grep -E '^[0-9]+$' /tmp/mech-standard-live-timer.out > /tmp/mech-standard-live-values.out
           test "$(wc -l < /tmp/mech-standard-live-values.out)" -ge 2
           test "$(sort -u /tmp/mech-standard-live-values.out | wc -l)" -ge 2
+          grep -F '"route":"resident-external"' /tmp/mech-standard-live-timer.out
+          grep -F '"legacy_turns":0' /tmp/mech-standard-live-timer.out
+          grep -F '"resident_accepted_turns":2' /tmp/mech-standard-live-timer.out
+          grep -F '"resident_rejected_turns":0' /tmp/mech-standard-live-timer.out
 
   changed-owner-tests:
     name: Owner ${{ matrix.id }} (${{ matrix.owners }})
@@ -198,7 +164,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           target/debug/mech.exe --version | Select-String -SimpleMatch '(standard)'
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          target/debug/mech.exe test tests/fixtures/standard-dynamic-matrix.mec
+          target/debug/mech.exe run tests/fixtures/standard-resident-scalar.mec
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
   browser-canary:
@@ -229,11 +195,11 @@ jobs:
       - name: Build standard WASM and the standard server
         run: |
           bash scripts/build-mech-browser.sh
+          grep -q '^export class WasmDocument' src/wasm/pkg/mech_wasm.js
+          ! grep -q '^[[:space:]]*evaluate(source)' src/wasm/pkg/mech_wasm.js
           cargo build --locked --bin mech
-      - name: Verify a live SVG update without browser errors
-        run: |
-          MECH_BIN=target/debug/mech bash scripts/smoke-served-analog-clock-browser.sh
-          MECH_BIN=target/debug/mech bash scripts/smoke-served-resident-nbody-browser.sh
+      - name: Verify resident rendering without legacy turns or browser errors
+        run: MECH_BIN=target/debug/mech bash scripts/smoke-served-resident-nbody-browser.sh
       - name: Remove generated browser package
         if: always()
         run: rm -rf src/wasm/pkg

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ full_runtime = [
       "mech-engine/runtime",
       "mech-stdlib/full_runtime",
       "mech-runtime?/resident-routing",
+      "legacy-interpreter",
       ]
 full_source = [
       "full_runtime",
@@ -103,8 +104,8 @@ full-language = [
       "whos", "async", "trace",
       "mech-core/full", "mech-syntax/full",
       ]
-standard-cli = ["cli"]
-full-cli = ["cli"]
+standard-cli = ["cli-product"]
+full-cli = ["cli-product", "test", "repl", "legacy-interpreter"]
 standard-hosts = [
       "cli_host",
       "time_host_native", "timer_host_native", "console_host_native", "scene_host_native",
@@ -124,7 +125,9 @@ base = ["baselib", "pretty_print", "serde", "compiler", "program", "mika",
       "mech-core/base", "mech-engine/base", "mech-syntax/base",
       ]
 cli_core = []
-cli = ["cli_core", "build", "formatter", "serve", "bundle_web", "run", "test", "repl"]
+cli-product = ["cli_core", "build", "formatter", "serve", "bundle_web", "run"]
+cli = ["cli-product", "test", "repl", "legacy-interpreter"]
+legacy-interpreter = ["mech-runtime?/legacy-interpreter"]
 formatter_core = ["serde", "mech-syntax/formatter", "mech-syntax/mika", "mech-core/mika", "mech-syntax/variable_define", "mech-core/variable_define"]
 build = [
       "cli_core", "compiler",
@@ -132,9 +135,9 @@ build = [
       "mech-stdlib/native-plan",
       "mech-runtime", "mech-runtime/compiler", "mech-runtime/native-link", "mech-runtime/serde",
       ]
-repl = ["cli_core", "program"]
+repl = ["cli_core", "program", "legacy-interpreter"]
 run = ["cli_core", "project"]
-test = ["cli_core", "variable_define", "invariant_define", "symbol_table", "bool", "mech-runtime", "mech-runtime/invariant_define"]
+test = ["cli_core", "variable_define", "invariant_define", "symbol_table", "bool", "mech-runtime", "mech-runtime/invariant_define", "legacy-interpreter"]
 project = ["mech-runtime", "mech-runtime/source"]
 cli_host = ["mech-runtime", "dep:mech-terminal", "mech-terminal/provider"]
 web_host = ["mech-runtime", "mech-browser", "mech-browser/serde", "mech-browser/provider", "dep:mech-time", "dep:mech-timer", "dep:mech-console", "dep:mech-scene"]

--- a/docs/getting-started/repl.mec
+++ b/docs/getting-started/repl.mec
@@ -14,11 +14,16 @@ To start the REPL, run:
 mech
 ```
 
-You can load a script into the REPL by running with the `--repl` option:
+The REPL is available only in the full developer distribution. A targetless
+session may load scripts explicitly with `:load`:
 
 ```sh
-mech my_script.mec --repl
+mech --repl
+> :load my_script.mec
 ```
+
+Production targets cannot be combined with `--repl`; they are owned by the
+resident executor and cannot be mutated by the developer interpreter.
 
 Once inside, you can enter commands prefixed with `:`, otherwise the REPL will interpret the input as a Mech expression, evaluate it, and print the result with the associated type.
 

--- a/docs/guides/native-applications.mec
+++ b/docs/guides/native-applications.mec
@@ -1,8 +1,8 @@
 Native applications
 ===============================================================================
 
-`mech build` is the authoritative build command. It accepts one or more
-source roots, or exactly one official `.mecb` file.
+`mech build` is the authoritative build command. It accepts exactly one
+resident source root or exactly one official `.mecb` file.
 
 ~~~sh
 mech build app.mec --workspace-root . --out target/mech/app

--- a/docs/index.mec
+++ b/docs/index.mec
@@ -75,7 +75,7 @@ Mech Documentation
 
 - [`mech`](/reference/commands/mech.html)
 - [`mech run`](/reference/commands/run.html)
-- [`mech test`](/reference/commands/test.html)
+- [`mech test`](/reference/commands/test.html) (full distribution only)
 - [`mech serve`](/reference/commands/serve.html)
 - [`mech build`](/reference/commands/build.html)
 - [`mech format`](/reference/commands/format.html)

--- a/docs/mechdown/template-placeholders.mec
+++ b/docs/mechdown/template-placeholders.mec
@@ -45,7 +45,11 @@ These placeholders support browser-side Mech runtime integration.
 <div class="console-scroll mech-repl hidden" id="mech-output" data-mech-repl-mount aria-live="polite"></div>
 ```
 
-The shipped document controller attaches the browser REPL to `#mech-output`.
+The shipped standard document controller attaches a command-only console to
+`#mech-output`. It supports document commands such as `:help`, `:whos`,
+`:clear`, and `:step`; it does not expose ad-hoc source evaluation. A browser
+artifact explicitly built with the developer interpreter may additionally
+provide REPL evaluation.
 It is selected by the shim, so a standalone document does not need `mech.mcfg`
 or `project.js`.
 
@@ -56,7 +60,7 @@ browser controller with these slots:
 
 - `{{DOCUMENT_SCRIPT}}` — The embedded document-controller module. It creates a
   safe `WasmDocument`, starts document inputs, renders outputs, and attaches the
-  REPL when the shell includes the corresponding mount.
+  command console when the shell includes the corresponding mount.
 - `{{SOURCE_URL_KEY}}` — A server-supplied, percent-encoded source transport key.
   A formatted file leaves this value empty and the controller falls back to the
   embedded `{{CODE}}` payload.

--- a/docs/mechdown/template-placeholders.mec
+++ b/docs/mechdown/template-placeholders.mec
@@ -83,10 +83,10 @@ shared controller, or no runtime behavior at all.
 
 ### Reactive variable placeholders
 
-You can embed live interpreter variables directly in a template placeholder:
+You can embed live resident root variables directly in a template placeholder:
 
-- `{{VAR:x}}` — Reads variable `x` from the default interpreter.
-- `{{VAR:x@foo}}` — Reads variable `x` from interpreter `foo`.
+- `{{VAR:x}}` — Reads state-backed variable `x` from the resident document root.
 
 These bindings are reactive. If `x` changes in Mech, the rendered value in the
-document updates automatically.
+document updates automatically. Named legacy-interpreter placeholders are not
+part of the production document surface.

--- a/docs/reference/commands/build.mec
+++ b/docs/reference/commands/build.mec
@@ -3,6 +3,8 @@
 
 `mech build` produces a release native executable by default. Use `--emit` to
 request official bytecode v1, a native build plan, or a generated Cargo project.
+Every build accepts exactly one resident source root or one official `.mecb`
+file.
 
 1. Default native build
 -------------------------------------------------------------------------------

--- a/docs/reference/commands/index.mec
+++ b/docs/reference/commands/index.mec
@@ -6,13 +6,13 @@ This section documents the command-line tools and subcommands.
 1. Tools
 -------------------------------------------------------------------------------
 
-- [`mech`](mech.html) - runtime, REPL, test, serve, format, build, and bundle command.
+- [`mech`](mech.html) - runtime, serve, format, build, and bundle command, plus full-distribution developer tools.
 
 2. `mech` subcommands
 -------------------------------------------------------------------------------
 
 - [`mech run`](run.html)
-- [`mech test`](test.html)
+- [`mech test`](test.html) (full distribution only)
 - [`mech serve`](serve.html)
 - [`mech build`](build.html)
 - [`mech format`](format.html)

--- a/docs/reference/commands/mech.mec
+++ b/docs/reference/commands/mech.mec
@@ -1,14 +1,16 @@
 `mech`
 ===============================================================================
 
-`mech` is the main command-line tool for running, testing, serving, formatting, and bundling Mech projects.
+`mech` is the main command-line tool for running, serving, formatting, and
+bundling Mech projects. The full distribution also includes developer REPL and
+test commands; the standard production binary does not.
 
 1. Common usage
 -------------------------------------------------------------------------------
 
 ```sh
 mech run main.mec
-mech test .
+mech test . # full distribution only
 mech serve .
 mech format main.mec
 mech bundle-web examples/browser-dom-demo --out dist/browser-dom-demo

--- a/docs/reference/commands/run.mec
+++ b/docs/reference/commands/run.mec
@@ -8,8 +8,10 @@
 
 ```sh
 mech run main.mec
-mech run src/main.mec src/support.mec
 ```
+
+Production execution accepts exactly one resident program root. Use imports
+from that root instead of passing multiple source roots.
 
 2. Project directory
 -------------------------------------------------------------------------------

--- a/docs/reference/commands/test.mec
+++ b/docs/reference/commands/test.mec
@@ -3,6 +3,14 @@
 
 `mech test` runs source files and validates invariants.
 
+This command is developer tooling and is available only in the full
+distribution, not the standard production binary. Install a full release, or
+build it from source with:
+
+```sh
+cargo build --bin mech --no-default-features --features distribution-full
+```
+
 An invariant is a top-level binding whose name ends in `!` and whose expression evaluates to `bool`.
 
 ```mech

--- a/docs/reference/deployment/command-line.mec
+++ b/docs/reference/deployment/command-line.mec
@@ -1,12 +1,13 @@
 Command Line Deployment
 ===============================================================================
 
-Use command-line execution for local scripts, tests, and project runs.
+Use command-line execution for local scripts and project runs. Test execution
+is developer tooling available only in the full distribution.
 
 ```sh
 mech run main.mec
 mech run .
-mech test .
+mech test . # full distribution only
 ```
 
 Command-line deployment is the simplest path. It does not require a browser shim, wasm package, or static asset bundling.

--- a/docs/reference/index.mec
+++ b/docs/reference/index.mec
@@ -51,7 +51,7 @@ Concrete host provider behavior is documented in each host crate under `hosts/*/
 
 - [`mech`](/reference/commands/mech.html)
 - [`mech run`](/reference/commands/run.html)
-- [`mech test`](/reference/commands/test.html)
+- [`mech test`](/reference/commands/test.html) (full distribution only)
 - [`mech serve`](/reference/commands/serve.html)
 - [`mech build`](/reference/commands/build.html)
 - [`mech format`](/reference/commands/format.html)

--- a/docs/reference/validation.mec
+++ b/docs/reference/validation.mec
@@ -13,7 +13,10 @@ Rules:
 - Invariants are checked at runtime and must stay true.
 - Invariants are not valid on the right-hand side of other expressions.
 
-Use `mech test` to run and validate them:
+Use the full-distribution-only `mech test` command to run and validate them.
+Install a full release or build with `--features distribution-full`; the
+standard production binary intentionally omits the developer interpreter and
+test command.
 
 ```sh
 mech test .

--- a/hosts/browser/src/config.rs
+++ b/hosts/browser/src/config.rs
@@ -893,6 +893,7 @@ mod tests {
     use super::*;
     use crate::BrowserResourceKind;
     use mech_core::LegacyValue;
+    use mech_runtime::legacy_interpreter::LegacyInterpreterTestExt as _;
     use mech_runtime::{
         ConfigProfileOptions, RuntimeHostFactory, RuntimeHostInstallation, RuntimeResourceProvider,
         RuntimeResourceReadRequest, RuntimeResourceWriteIntent,

--- a/hosts/browser/src/config.rs
+++ b/hosts/browser/src/config.rs
@@ -99,6 +99,7 @@ impl BrowserRuntimeInjectionConfig {
         runtime_config: &RuntimeConfig,
         profile: &BrowserRuntimeProviderProfile,
     ) -> MResult<Self> {
+        runtime_config.validate_production_program_routing()?;
         for host in &document.hosts {
             if host.name == "browser" && host.provider != "browser" {
                 return Err(invalid_error(
@@ -281,6 +282,7 @@ impl BrowserHostConfig {
         document: &MechConfigDocument,
         runtime_config: &RuntimeConfig,
     ) -> MResult<Self> {
+        runtime_config.validate_production_program_routing()?;
         let browser = browser_config_from_hosts(document)?;
         Ok(Self {
             runtime: BrowserHostRuntimeConfig::from(runtime_config),
@@ -323,6 +325,7 @@ impl BrowserHostConfig {
             },
         };
         config.validate()?;
+        config.validate_production_program_routing()?;
         Ok(config)
     }
 
@@ -990,6 +993,23 @@ config := {
             BrowserDomProperty::parse_config_name("inner-html", None).unwrap(),
             BrowserDomProperty::InnerHtml
         );
+    }
+
+    #[test]
+    fn browser_product_authority_rejects_interpreter_routing() {
+        let document = config_document();
+        for routing in [
+            mech_runtime::ResidentRoutingPolicy::PreferResident,
+            mech_runtime::ResidentRoutingPolicy::LegacyOnly,
+        ] {
+            let mut runtime = RuntimeConfig::default();
+            runtime.program_routing.resident_routing = routing;
+            assert!(
+                BrowserRuntimeInjectionConfig::from_document_and_runtime(&document, &runtime)
+                    .is_err()
+            );
+            assert!(BrowserHostConfig::from_document_and_runtime(&document, &runtime).is_err());
+        }
     }
 
     #[test]

--- a/hosts/browser/src/delegation.rs
+++ b/hosts/browser/src/delegation.rs
@@ -179,11 +179,10 @@ pub fn encode_browser_runtime_injection_config(
 }
 
 fn encode_program_routing(out: &mut Vec<u8>, config: mech_runtime::ProgramRoutingConfig) {
-    let routing = match config.resident_routing {
-        mech_runtime::ResidentRoutingPolicy::PreferResident => 0,
-        mech_runtime::ResidentRoutingPolicy::RequireResident => 1,
-        mech_runtime::ResidentRoutingPolicy::LegacyOnly => 2,
-    };
+    // The pre-launch routing field remains in signed envelopes until E2/E3;
+    // the runtime enum owns its stable discriminants while products expose
+    // only the resident-required policy.
+    let routing = config.resident_routing as u64;
     let durability = match config.resident_durability {
         mech_runtime::ResidentDurabilityPolicy::Volatile => 0,
         mech_runtime::ResidentDurabilityPolicy::Retained => 1,

--- a/hosts/console/Cargo.toml
+++ b/hosts/console/Cargo.toml
@@ -23,4 +23,4 @@ web-sys = { version = "0.3.82", optional = true, features = ["console"] }
 
 [dev-dependencies]
 mech-engine = { version = "0.3.5", default-features = false }
-mech-runtime = { version = "0.3.5", default-features = false, features = ["source"] }
+mech-runtime = { version = "0.3.5", default-features = false, features = ["source", "legacy-interpreter"] }

--- a/hosts/console/src/provider.rs
+++ b/hosts/console/src/provider.rs
@@ -1,6 +1,10 @@
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 
-use mech_core::{LegacyValue, MResult, OperationContractDeclaration};
+use mech_core::{
+    AccessMode, DeliveryMode, EffectContract, EffectDeliveryPolicy, ExternalInteraction,
+    IdempotencyRequirement, InputPortLayout, InputPortPolicy, LegacyValue, MResult,
+    OperationContractDeclaration,
+};
 use mech_runtime::{
     ConfigValue, HostManifestConfig, PreparedRuntimeEffect, RuntimeAfterCommitEffect,
     RuntimeEffectCost, RuntimeEffectMetadata, RuntimeEffectSource, RuntimeHostFactory,
@@ -10,6 +14,22 @@ use mech_runtime::{
 };
 
 use crate::{console_error, console_host_manifest};
+
+static CONSOLE_EFFECT_CONTRACT: LazyLock<OperationContractDeclaration> =
+    LazyLock::new(|| OperationContractDeclaration {
+        inputs: InputPortLayout::Fixed(
+            vec![InputPortPolicy {
+                access: AccessMode::Read,
+                delivery: DeliveryMode::Signal,
+            }]
+            .into_boxed_slice(),
+        ),
+        outputs: Box::new([]),
+        interaction: ExternalInteraction::Effect(EffectContract {
+            delivery: EffectDeliveryPolicy::AtMostOnce,
+            idempotency: IdempotencyRequirement::NotRequired,
+        }),
+    });
 
 pub trait ConsoleBackend: std::fmt::Debug {
     fn write_line(&mut self, text: &str) -> MResult<()>;
@@ -90,8 +110,7 @@ impl<B: ConsoleBackend + 'static> RuntimeResourceProvider for ConsoleResourcePro
         &self,
         intent: RuntimeResourceWriteIntent,
     ) -> Option<&'static OperationContractDeclaration> {
-        (intent == RuntimeResourceWriteIntent::Send)
-            .then(mech_runtime::provider_defined_effect_contract)
+        (intent == RuntimeResourceWriteIntent::Send).then_some(&CONSOLE_EFFECT_CONTRACT)
     }
 
     fn equivalent_base_uri_groups(&self) -> Vec<Vec<String>> {

--- a/hosts/console/tests/provider.rs
+++ b/hosts/console/tests/provider.rs
@@ -231,3 +231,4 @@ fn run_resource_grant_does_not_cross_console_instances() {
     assert!(observed.lines().is_empty());
     assert_eq!(runtime.runtime_health(), RuntimeHealth::Healthy);
 }
+use mech_runtime::legacy_interpreter::LegacyInterpreterTestExt as _;

--- a/hosts/console/tests/provider.rs
+++ b/hosts/console/tests/provider.rs
@@ -1,7 +1,10 @@
 use std::sync::Arc;
 
 use mech_console::{ConsoleHostFactory, ConsoleResourceProvider, RecordingConsoleBackend};
-use mech_core::{FunctionCatalog, FunctionCatalogBuilder, LegacyValue};
+use mech_core::{
+    EffectContract, EffectDeliveryPolicy, ExternalInteraction, FunctionCatalog,
+    FunctionCatalogBuilder, IdempotencyRequirement, LegacyValue,
+};
 use mech_runtime::{
     ConfigValue, HostInstanceConfig, MechRuntime, PreparedRuntimeEffect, RunResourceGrantConfig,
     RuntimeBuilder, RuntimeCapabilityOperation, RuntimeEventKind, RuntimeHealth,
@@ -41,7 +44,7 @@ fn provider_writes_line_to_backend() {
 #[test]
 fn provider_rejects_unknown_path() {
     let backend = RecordingConsoleBackend::new();
-    let mut provider = ConsoleResourceProvider::new("console", backend);
+    let provider = ConsoleResourceProvider::new("console", backend);
     let err = provider
         .prepare_write(RuntimeResourceWriteRequest {
             base_uri: "console://console/output".to_string(),
@@ -67,6 +70,28 @@ fn factory_advertises_console_provider() {
         .unwrap();
     assert_eq!(installation.interface.provider, "console");
     assert_eq!(installation.resource_providers.len(), 1);
+}
+
+#[test]
+fn console_send_contract_is_at_most_once_without_idempotency() {
+    let provider = ConsoleResourceProvider::new("console", RecordingConsoleBackend::new());
+    let contract = provider
+        .semantic_write_contract(RuntimeResourceWriteIntent::Send)
+        .unwrap();
+
+    assert!(matches!(
+        &contract.interaction,
+        ExternalInteraction::Effect(EffectContract {
+            delivery: EffectDeliveryPolicy::AtMostOnce,
+            idempotency: IdempotencyRequirement::NotRequired,
+        })
+    ));
+    assert!(
+        provider
+            .semantic_write_contract(RuntimeResourceWriteIntent::Assign)
+            .is_none()
+    );
+    assert!(!provider.supports_resident_idempotency(RuntimeResourceWriteIntent::Send));
 }
 
 #[test]

--- a/include/document.js
+++ b/include/document.js
@@ -384,20 +384,12 @@ function outputAddress(element) {
   };
 }
 
-function resolveNamedInterpreter(name) {
-  const identifier = state.document.interpreterIdByName(name);
-  if (identifier === null || identifier === undefined) {
-    throw new Error(`named interpreter \`${name}\` was not found`);
-  }
-  return identifier.toString();
-}
-
 function prepareVarPlaceholders() {
   const root = state.root;
   if (!root) {
     return;
   }
-  const pattern = /\{\{VAR:([^@}\s]+)(?:@([^}\s]+))?\}\}/g;
+  const pattern = /\{\{VAR:([^@}\s]+)\}\}/g;
   const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
   const candidates = [];
   while (walker.nextNode()) {
@@ -420,15 +412,6 @@ function prepareVarPlaceholders() {
       const placeholder = document.createElement("span");
       placeholder.className = "mech-var-placeholder";
       placeholder.dataset.mechVarName = match[1];
-      try {
-        placeholder.dataset.mechInterpreterId = match[2]
-          ? resolveNamedInterpreter(match[2])
-          : "0";
-      } catch (error) {
-        placeholder.dataset.mechInterpreterError = errorMessage(error);
-        placeholder.textContent = "[unresolved Mech variable]";
-        appendError(error);
-      }
       fragment.append(placeholder);
       cursor = pattern.lastIndex;
     }
@@ -501,12 +484,9 @@ function renderValues() {
     }
   }
   for (const placeholder of state.root?.querySelectorAll(".mech-var-placeholder") || []) {
-    if (placeholder.dataset.mechInterpreterError) {
-      continue;
-    }
     try {
       const rendered = state.document.renderedSymbol(
-        BigInt(placeholder.dataset.mechInterpreterId || "0"),
+        0n,
         placeholder.dataset.mechVarName,
       );
       if (rendered !== null) {

--- a/include/document.js
+++ b/include/document.js
@@ -561,6 +561,10 @@ function appendConsoleError(error) {
   appendError(error);
 }
 
+function supportsInteractiveEvaluation() {
+  return typeof state.document?.evaluate === "function";
+}
+
 function appendHelp() {
   const target = transcript();
   if (!target) {
@@ -642,6 +646,11 @@ async function runConsoleCommand(source) {
     return;
   }
   if (!input.startsWith(":")) {
+    if (!supportsInteractiveEvaluation()) {
+      throw new Error(
+        "interactive source evaluation is unavailable in standard resident documents; use :help for document commands",
+      );
+    }
     const rendered = state.document.evaluate(source);
     appendRenderedResult(rendered);
     renderValues();
@@ -709,12 +718,20 @@ function attachConsole() {
   transcriptElement.setAttribute("aria-live", "polite");
   const inputRow = document.createElement("div");
   inputRow.className = "mech-repl-input-row";
+  const interactiveEvaluation = supportsInteractiveEvaluation();
   const prompt = document.createElement("span");
   prompt.className = "repl-prompt";
-  prompt.textContent = ">:";
+  prompt.textContent = interactiveEvaluation ? ">:" : ":";
   const input = document.createElement("textarea");
   input.className = "repl-input";
-  input.setAttribute("aria-label", "Mech REPL input");
+  input.dataset.mechInteractiveEvaluation = interactiveEvaluation ? "available" : "unavailable";
+  input.setAttribute(
+    "aria-label",
+    interactiveEvaluation ? "Mech developer REPL input" : "Mech document command input",
+  );
+  if (!interactiveEvaluation) {
+    input.placeholder = "Document commands only (:help)";
+  }
   input.addEventListener("keydown", (event) => {
     if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault();

--- a/scripts/check-production-resident-routing.py
+++ b/scripts/check-production-resident-routing.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Keep shipping Mech products on the resident-only execution boundary."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import sys
+
+
+ROOT = Path(__file__).resolve().parent.parent
+PRODUCT_ROOTS = (
+    Path("src/cli"),
+    Path("src/build/src"),
+    Path("src/wasm/src"),
+    Path("hosts/browser/src"),
+)
+PROHIBITED_ROUTE_REFERENCES = (
+    "ResidentRoutingPolicy::PreferResident",
+    "ResidentRoutingPolicy::LegacyOnly",
+    "RuntimeProgramRoute::Legacy",
+)
+OLD_EXECUTOR_CALL = re.compile(
+    r"\.(?:run_string(?:_with_context)?|run_source(?:_with_context)?|"
+    r"run_tree(?:_with_context)?|install_bytecode_with_context|"
+    r"evaluate_bytecode_once_with_context|resolve_and_run_root_module(?:_with_context|_report)?)\s*\("
+)
+TEST_MODULE = re.compile(
+    r"#\[cfg\([^\]]*\btest\b[^\]]*\)\]\s*(?:pub(?:\([^)]*\))?\s+)?mod\s+[A-Za-z0-9_]+\s*\{",
+    re.MULTILINE,
+)
+
+
+def rust_without_test_modules(source: str) -> str:
+    """Mask cfg(test) modules while retaining line numbers for diagnostics."""
+    chars = list(source)
+    search_from = 0
+    while match := TEST_MODULE.search(source, search_from):
+        brace = source.find("{", match.start(), match.end())
+        depth = 0
+        end = brace
+        in_string = False
+        escaped = False
+        for end in range(brace, len(source)):
+            char = source[end]
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == '"':
+                    in_string = False
+                continue
+            if char == '"':
+                in_string = True
+            elif char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    end += 1
+                    break
+        for index in range(match.start(), end):
+            if chars[index] != "\n":
+                chars[index] = " "
+        search_from = end
+    return "".join(chars)
+
+
+def product_sources() -> list[tuple[Path, str]]:
+    sources: list[tuple[Path, str]] = []
+    for relative_root in PRODUCT_ROOTS:
+        for path in sorted((ROOT / relative_root).rglob("*.rs")):
+            relative = path.relative_to(ROOT)
+            if "tests" in relative.parts:
+                continue
+            sources.append((relative, rust_without_test_modules(path.read_text(encoding="utf-8"))))
+    return sources
+
+
+def line_number(source: str, offset: int) -> int:
+    return source.count("\n", 0, offset) + 1
+
+
+def check_product_references() -> list[str]:
+    failures: list[str] = []
+    for path, source in product_sources():
+        for token in PROHIBITED_ROUTE_REFERENCES:
+            for match in re.finditer(re.escape(token), source):
+                failures.append(f"{path}:{line_number(source, match.start())}: prohibited {token}")
+
+        lines = source.splitlines()
+        for index, line in enumerate(lines):
+            for match in OLD_EXECUTOR_CALL.finditer(line):
+                # The temporary developer facade is explicit authority, not a
+                # direct old-executor call. Multi-line method chains need a
+                # small look-behind window.
+                context = "\n".join(lines[max(0, index - 4) : index + 1])
+                if ".legacy_interpreter()" in context:
+                    continue
+                failures.append(
+                    f"{path}:{index + 1}: direct old executor call {match.group(0).strip()}"
+                )
+    return failures
+
+
+def manifest_features(relative: str) -> dict[str, list[str]]:
+    manifest = (ROOT / relative).read_text(encoding="utf-8")
+    match = re.search(r"(?ms)^\[features\]\s*$\n(.*?)(?=^\[[^\n]+\]\s*$|\Z)", manifest)
+    if match is None:
+        return {}
+    features: dict[str, list[str]] = {}
+    name: str | None = None
+    value: list[str] = []
+    for line in match.group(1).splitlines():
+        if name is None:
+            assignment = re.match(r"^([A-Za-z0-9_-]+)\s*=\s*(.*)$", line)
+            if assignment is None:
+                continue
+            name = assignment.group(1)
+            remainder = assignment.group(2)
+        else:
+            remainder = line
+        value.extend(re.findall(r'"([^"]+)"', remainder))
+        if "]" in remainder:
+            features[name] = value
+            name = None
+            value = []
+    return features
+
+
+def feature_closure(features: dict[str, list[str]], root: str) -> set[str]:
+    if root not in features:
+        raise KeyError(root)
+    closure: set[str] = set()
+    pending = [root]
+    while pending:
+        feature = pending.pop()
+        if feature in closure:
+            continue
+        closure.add(feature)
+        for route in features.get(feature, []):
+            if route in features:
+                pending.append(route)
+    return closure
+
+
+def check_feature_boundaries() -> list[str]:
+    failures: list[str] = []
+    contracts = (
+        ("Cargo.toml", "distribution-standard", False),
+        ("Cargo.toml", "distribution-full", True),
+        ("src/runtime/Cargo.toml", "source_default", False),
+        ("src/runtime/Cargo.toml", "full_compiler", True),
+        ("src/wasm/Cargo.toml", "browser_project", False),
+        ("src/wasm/Cargo.toml", "full", True),
+    )
+    for manifest, root, expected in contracts:
+        features = manifest_features(manifest)
+        try:
+            closure = feature_closure(features, root)
+        except KeyError:
+            failures.append(f"{manifest}: missing feature {root}")
+            continue
+        actual = "legacy-interpreter" in closure
+        if actual != expected:
+            disposition = "include" if expected else "exclude"
+            failures.append(f"{manifest}: feature {root} must {disposition} legacy-interpreter")
+    return failures
+
+
+def check_required_product_seams() -> list[str]:
+    required = {
+        "src/cli/commands/run.rs": "load_production_source_program",
+        "src/build/src/project/render.rs": "load_production_bytecode_program",
+        "src/wasm/src/project.rs": "load_production_root_program",
+        "hosts/browser/src/config.rs": "validate_production_program_routing",
+    }
+    failures: list[str] = []
+    for relative, needle in required.items():
+        source = (ROOT / relative).read_text(encoding="utf-8")
+        if needle not in source:
+            failures.append(f"{relative}: missing resident production seam {needle}")
+    wasm_source = (ROOT / "src/wasm/src/project.rs").read_text(encoding="utf-8")
+    evaluate_boundary = re.compile(
+        r'#\[cfg\(feature = "legacy-interpreter"\)\]\s*pub fn evaluate\s*\('
+    )
+    if evaluate_boundary.search(wasm_source) is None:
+        failures.append(
+            "src/wasm/src/project.rs: WasmDocument.evaluate must exist only in legacy-interpreter builds"
+        )
+    if "pub(super) developer_runtime: MechRuntime" not in wasm_source or not re.search(
+        r"self\s*\.developer_runtime\s*\.legacy_interpreter\(\)\s*\.run_string\(",
+        wasm_source,
+    ):
+        failures.append(
+            "src/wasm/src/project.rs: developer evaluation must use a separate interpreter runtime"
+        )
+    controller_source = (ROOT / "include/document.js").read_text(encoding="utf-8")
+    if (
+        "interpreterIdByName" in wasm_source
+        or "interpreterIdByName" in controller_source
+        or "resolveNamedInterpreter" in controller_source
+    ):
+        failures.append(
+            "standard documents must not export, call, or carry named legacy document lookup"
+        )
+    for relative in (
+        "docs/mechdown/template-placeholders.mec",
+        "scripts/smoke-served-rich-document-browser.sh",
+    ):
+        source = (ROOT / relative).read_text(encoding="utf-8")
+        if re.search(r"\{\{VAR:[^}\n]*@[^}\n]*\}\}", source):
+            failures.append(
+                f"{relative}: named legacy placeholders must not be advertised or exercised"
+            )
+    build_source = (ROOT / "src/build/src/lib.rs").read_text(encoding="utf-8")
+    if 'runtime_features.insert("legacy-interpreter"' in build_source:
+        failures.append(
+            "src/build/src/lib.rs: production native plans must not select legacy-interpreter"
+        )
+    required_surface_contracts = {
+        "src/cli/commands/run.rs": (
+            "production inputs cannot be combined with a REPL",
+            "live_drain_limit(max_live_turns, completed_live_turns)",
+        ),
+        "src/cli/commands/build.rs": (
+            "Exactly one resident source root or one .mecb bytecode file",
+        ),
+        "src/build/src/project/render.rs": (
+            '\\"legacy_turns\\":{}',
+            "limit.saturating_sub(completed_live_turns)",
+        ),
+        "src/build/src/lib.rs": (
+            "validate_production_native_runtime_config(config)",
+            "NativeActorBootstrapUnsupported",
+        ),
+        "scripts/smoke-formatted-document-browser.sh": (
+            'submit(":whos answer")',
+        ),
+        "docs/getting-started/repl.mec": (
+            "Production targets cannot be combined with `--repl`",
+        ),
+        "docs/reference/commands/test.mec": (
+            "available only in the full",
+            "--features distribution-full",
+        ),
+        "docs/guides/native-applications.mec": (
+            "accepts exactly one",
+        ),
+    }
+    for relative, needles in required_surface_contracts.items():
+        source = (ROOT / relative).read_text(encoding="utf-8")
+        for needle in needles:
+            if needle not in source:
+                failures.append(f"{relative}: missing production surface contract {needle}")
+    return failures
+
+
+def main() -> int:
+    failures = (
+        check_product_references()
+        + check_feature_boundaries()
+        + check_required_product_seams()
+    )
+    if failures:
+        print("Production resident-routing contract failed:", file=sys.stderr)
+        print(*failures, sep="\n", file=sys.stderr)
+        return 1
+    print("Production resident-routing contract passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-shipped-document-shims.sh
+++ b/scripts/check-shipped-document-shims.sh
@@ -94,4 +94,12 @@ if grep -Ein -- '</script' include/document.js; then
   fail "include/document.js cannot be safely embedded inside a script element"
 fi
 
+for contract in \
+  'function supportsInteractiveEvaluation()' \
+  'typeof state.document?.evaluate === "function"' \
+  'interactive source evaluation is unavailable in standard resident documents' \
+  'Mech document command input'; do
+  require_literal include/document.js "$contract"
+done
+
 echo "shipped document shim contracts are present"

--- a/scripts/check-static-distribution-profiles.sh
+++ b/scripts/check-static-distribution-profiles.sh
@@ -138,6 +138,7 @@ check_full_machine_layers() {
 }
 
 check_static_boundary() {
+  python3 "$repository_root/scripts/check-production-resident-routing.py"
   python3 "$repository_root/scripts/check-rust-module-layout.py"
   python3 "$repository_root/scripts/check-source-catalog-entrypoints.py"
 

--- a/scripts/smoke-formatted-document-browser.sh
+++ b/scripts/smoke-formatted-document-browser.sh
@@ -29,11 +29,16 @@ work_dir="$(mktemp -d "$target_dir/formatted-document.XXXXXX")"
 server_pid=""
 
 cleanup() {
+  local status="$?"
   if [[ -n "$server_pid" ]]; then
     kill "$server_pid" 2>/dev/null || true
     wait "$server_pid" 2>/dev/null || true
   fi
-  rm -rf "$work_dir"
+  if [[ "$status" -ne 0 ]]; then
+    echo "Formatted document browser artifacts retained at: $work_dir" >&2
+  else
+    rm -rf "$work_dir"
+  fi
 }
 trap cleanup EXIT
 
@@ -58,8 +63,8 @@ cat > "$work_dir/project/main.mec" <<'MEC'
 +> ./vendor/percent.mec
 +> ./rate%.mec
 {included.mec}
-answer := café/value + extdep/value + package/value + support/value + percent/value + included-value + nested-included-value
-answer
+~answer := 0
+answer += café/value + extdep/value + package/value + support/value + percent/value + included-value + nested-included-value
 MEC
 cat > "$work_dir/project/café.mec" <<'MEC'
 value := 2
@@ -328,12 +333,12 @@ try:
         ):
             fail(f"could not submit browser REPL command: {command}")
 
-    exact_answer = "(() => { const values = [...document.querySelectorAll('.mech-repl-result-value')]; return values.at(-1)?.textContent.trim() === '58'; })()"
-    submit("answer")
+    exact_answer = "(() => { const tables = [...document.querySelectorAll('.mech-repl-symbols')]; return tables.at(-1)?.textContent.includes('answer') && tables.at(-1)?.textContent.includes('58'); })()"
+    submit(":whos answer")
     wait_for(exact_answer, "the imported source value")
     submit(":clear")
     wait_for("[...document.querySelectorAll('.mech-repl-info')].some(row => /Document reset/.test(row.textContent))", "the static document reset")
-    submit("answer")
+    submit(":whos answer")
     wait_for(exact_answer, "the imported source value after reset")
 finally:
     if websocket is not None:

--- a/scripts/smoke-served-resident-nbody-browser.sh
+++ b/scripts/smoke-served-resident-nbody-browser.sh
@@ -162,6 +162,7 @@ from pathlib import Path
 import signal
 import subprocess
 import sys
+import time
 
 chrome, page_url, profile, dom_file, chrome_log = sys.argv[1:]
 args = [
@@ -178,13 +179,26 @@ args = [
 ]
 with Path(dom_file).open("wb") as stdout, Path(chrome_log).open("wb") as stderr:
     process = subprocess.Popen(args, stdout=stdout, stderr=stderr, start_new_session=True)
-    try:
-        raise SystemExit(process.wait(timeout=35))
-    except subprocess.TimeoutExpired:
-        os.killpg(process.pid, signal.SIGKILL)
-        process.wait()
-        print("headless Chrome retained its process after emitting the D4 DOM proof", file=sys.stderr)
-        raise SystemExit(124)
+    deadline = time.monotonic() + 90
+    while True:
+        return_code = process.poll()
+        if return_code is not None:
+            raise SystemExit(return_code)
+        try:
+            proof_emitted = b'data-mech-done="true"' in Path(dom_file).read_bytes()
+        except OSError:
+            proof_emitted = False
+        if proof_emitted:
+            os.killpg(process.pid, signal.SIGKILL)
+            process.wait()
+            print("headless Chrome retained its process after emitting the D4 DOM proof", file=sys.stderr)
+            raise SystemExit(124)
+        if time.monotonic() >= deadline:
+            os.killpg(process.pid, signal.SIGKILL)
+            process.wait()
+            print("headless Chrome did not emit the D4 DOM proof within 90 seconds", file=sys.stderr)
+            raise SystemExit(124)
+        time.sleep(0.25)
 PY
 }
 

--- a/scripts/smoke-served-rich-document-browser.sh
+++ b/scripts/smoke-served-rich-document-browser.sh
@@ -544,7 +544,6 @@ def assert_desktop_contract():
     inlineOutput: [...document.querySelectorAll(".mech-inline-mech-code")]
       .some((element) => /42/.test(element.textContent) && element.getBoundingClientRect().height > 0),
     variableHydrated: Boolean(document.querySelector("#mech-smoke-var .mech-var-placeholder")?.textContent.trim()),
-    namedVariableHydrated: Boolean(document.querySelector("#mech-smoke-var-named .mech-var-placeholder")?.textContent.trim()),
     scrollWidth: document.documentElement.scrollWidth,
     viewportWidth: window.innerWidth,
     label: document.title,
@@ -561,7 +560,7 @@ def assert_desktop_contract():
         "navigationVisible", "titleVisible", "contentVisible", "consoleVisible",
         "consoleTabActive", "promptVisible", "inputVisible", "resizerVisible",
         "consoleToggleVisible", "fullscreenVisible", "citationsVisible", "footnotesVisible", "blockOutput",
-        "inlineOutput", "variableHydrated", "namedVariableHydrated",
+        "inlineOutput", "variableHydrated",
     ):
         if not desktop[name]:
             fail(f"desktop rich-document contract failed for {name}: {desktop!r}")
@@ -690,21 +689,41 @@ def submit(command):
 
 
 def assert_console_contract():
+    command_only = evaluate_json("""
+(() => {
+  const input = document.querySelector('.repl-input');
+  if (!input) return null;
+  return {
+    capability: input.dataset.mechInteractiveEvaluation,
+    label: input.getAttribute('aria-label'),
+    placeholder: input.getAttribute('placeholder'),
+  };
+})()
+""")
+    if command_only != {
+        "capability": "unavailable",
+        "label": "Mech document command input",
+        "placeholder": "Document commands only (:help)",
+    }:
+        fail(f"the standard document console advertised developer evaluation: {command_only!r}")
+
     if label == "configured":
         # This value is deliberately distinct from the mutable `answer`
         # fixture. It proves the configured page resolved its sibling module
         # while the document bootstrap independently proves that its granted
         # live clock host can be validated and installed.
-        submit("configured-answer")
+        submit(":whos configured-answer")
         wait_for(
-            "(() => { const values = [...document.querySelectorAll('.mech-repl-result-value')]; "
-            "return values.at(-1)?.textContent.trim() === '41'; })()",
+            "[...document.querySelectorAll('.mech-repl-symbols')].some((table) => "
+            "/configured-answer/.test(table.textContent) && /41/.test(table.textContent))",
             "the configured document's imported value",
         )
     submit("answer + 1")
     wait_for(
-        "[...document.querySelectorAll('.mech-repl-result')].some((row) => /42/.test(row.textContent))",
-        "the result of `answer + 1` in the document console",
+        "[...document.querySelectorAll('.mech-repl-error')].some((row) => "
+        "/interactive source evaluation is unavailable/.test(row.textContent)) && "
+        "document.querySelectorAll('.mech-repl-result').length === 0",
+        "the standard console rejecting developer source evaluation",
     )
     submit(":whos answer")
     wait_for(
@@ -713,22 +732,11 @@ def assert_console_contract():
     )
     submit(":help")
     wait_for("Boolean(document.querySelector('.mech-repl-help'))", "the browser console help table")
-    submit("answer = 7")
-    wait_for(
-        "/7/.test(document.querySelector('#mech-smoke-var')?.textContent || '')",
-        "the updated browser variable before :clear",
-    )
     submit(":clear")
     wait_for(
         "[...document.querySelectorAll('.mech-repl-info')].some((row) => /Document reset/.test(row.textContent)) && "
         "/41/.test(document.querySelector('#mech-smoke-var')?.textContent || '')",
         "the reset browser document state",
-    )
-    submit("answer :=")
-    wait_for(
-        "document.querySelectorAll('.mech-repl-error').length > 0 && "
-        "document.querySelector('#mech-document-errors')?.textContent.trim().length > 0",
-        "a browser console error for invalid Mech source",
     )
     evaluate("document.querySelector('#output-tab')?.click()")
     wait_for(
@@ -960,7 +968,7 @@ try:
     # Keep real variable placeholders in the DOM before the controller starts.
     # Shipped templates intentionally do not hard-code a document's symbols, so
     # this uses browser automation instead of test-only production behavior to
-    # verify both root and named-interpreter placeholder contracts.
+    # verify the resident root-variable placeholder contract.
     devtools.call(
         "Page.addScriptToEvaluateOnNewDocument",
         {"source": """
@@ -975,12 +983,6 @@ try:
       const marker = document.createElement('span');
       marker.id = 'mech-smoke-var';
       marker.textContent = '{{VAR:answer}}';
-      root.append(marker);
-    }
-    if (!document.getElementById('mech-smoke-var-named')) {
-      const marker = document.createElement('span');
-      marker.id = 'mech-smoke-var-named';
-      marker.textContent = '{{VAR:foo-value@foo}}';
       root.append(marker);
     }
     if (!document.getElementById('mech-smoke-unrelated-controls')) {
@@ -1030,11 +1032,6 @@ try:
     wait_for(
         "Boolean(document.querySelector('#mech-smoke-var .mech-var-placeholder')?.textContent.trim())",
         "hydration of {{VAR:answer}}",
-        timeout=15,
-    )
-    wait_for(
-        "Boolean(document.querySelector('#mech-smoke-var-named .mech-var-placeholder')?.textContent.trim())",
-        "hydration of {{VAR:foo-value@foo}}",
         timeout=15,
     )
     assert_desktop_contract()

--- a/src/build/Cargo.toml
+++ b/src/build/Cargo.toml
@@ -36,7 +36,7 @@ toml_edit = "0.23"
 
 [dev-dependencies]
 mech-native-live-host-fixture = { version = "0.3.5", path = "../../tests/fixtures/native-live-host" }
-mech-runtime = { version = "0.3.5", default-features = false, features = ["compiler_default"] }
+mech-runtime = { version = "0.3.5", default-features = false, features = ["compiler_default", "legacy-interpreter"] }
 mech-stdlib = { version = "0.3.5", default-features = false, features = ["native-plan", "full_compiler"] }
 tempfile = "3"
 

--- a/src/build/src/error/mod.rs
+++ b/src/build/src/error/mod.rs
@@ -94,6 +94,7 @@ pub enum NativeBuildErrorKind {
     },
     NativeActorBootstrapMissing,
     NativeActorBootstrapUnused,
+    NativeActorBootstrapUnsupported,
     NativeActorLiveApplicationUnsupported,
     NativeResourceOwnerAmbiguous {
         target: String,
@@ -204,6 +205,7 @@ impl MechErrorKind for NativeBuildErrorKind {
             }
             Self::NativeActorBootstrapMissing => "NativeActorBootstrapMissing",
             Self::NativeActorBootstrapUnused => "NativeActorBootstrapUnused",
+            Self::NativeActorBootstrapUnsupported => "NativeActorBootstrapUnsupported",
             Self::NativeActorLiveApplicationUnsupported => "NativeActorLiveApplicationUnsupported",
             Self::NativeResourceOwnerAmbiguous { .. } => "NativeResourceOwnerAmbiguous",
             Self::NativeTargetUnsupported { .. } => "NativeTargetUnsupported",
@@ -278,6 +280,10 @@ impl MechErrorKind for NativeBuildErrorKind {
             }
             Self::NativeActorBootstrapUnused => {
                 "an actor bootstrap was configured for an application with no actor-turn requirements"
+                    .to_owned()
+            }
+            Self::NativeActorBootstrapUnsupported => {
+                "actor bootstrap is not part of the production resident program contract"
                     .to_owned()
             }
             Self::NativeActorLiveApplicationUnsupported => {

--- a/src/build/src/lib.rs
+++ b/src/build/src/lib.rs
@@ -109,6 +109,9 @@ impl NativeApplicationBuilder {
             runtime_features.insert("runtime".to_owned());
             runtime_features.insert("string".to_owned());
             runtime_features.insert("resident-routing".to_owned());
+            if requirements.actor_bootstrap.is_some() {
+                runtime_features.insert("legacy-interpreter".to_owned());
+            }
             // Hosted execution owns the transaction boundary, so it must
             // enable the validation hook whenever the bytecode carries an
             // integrity-constraint marker. Engine-only applications enforce

--- a/src/build/src/lib.rs
+++ b/src/build/src/lib.rs
@@ -50,6 +50,9 @@ impl NativeApplicationBuilder {
         if let Some(target) = request.target.as_deref() {
             plan::validate_target(target)?;
         }
+        if let Some(config) = request.runtime_config.as_ref() {
+            config.runtime.validate_production_program_routing()?;
+        }
 
         let program = ParsedProgram::from_bytes(&request.bytecode)?;
         plan::validate_target_index_constants(&program, request.target.as_deref())?;

--- a/src/build/src/lib.rs
+++ b/src/build/src/lib.rs
@@ -51,7 +51,7 @@ impl NativeApplicationBuilder {
             plan::validate_target(target)?;
         }
         if let Some(config) = request.runtime_config.as_ref() {
-            config.runtime.validate_production_program_routing()?;
+            validate_production_native_runtime_config(config)?;
         }
 
         let program = ParsedProgram::from_bytes(&request.bytecode)?;
@@ -109,9 +109,6 @@ impl NativeApplicationBuilder {
             runtime_features.insert("runtime".to_owned());
             runtime_features.insert("string".to_owned());
             runtime_features.insert("resident-routing".to_owned());
-            if requirements.actor_bootstrap.is_some() {
-                runtime_features.insert("legacy-interpreter".to_owned());
-            }
             // Hosted execution owns the transaction boundary, so it must
             // enable the validation hook whenever the bytecode carries an
             // integrity-constraint marker. Engine-only applications enforce
@@ -360,6 +357,19 @@ impl NativeApplicationBuilder {
             request.offline,
         )
     }
+}
+
+pub(crate) fn validate_production_native_runtime_config(
+    config: &NativeRuntimeConfig,
+) -> MResult<()> {
+    config.runtime.validate_production_program_routing()?;
+    if config.actor_bootstrap.is_some() {
+        return Err(error::native_build_error(
+            error::NativeBuildErrorKind::NativeActorBootstrapUnsupported,
+            None,
+        ));
+    }
+    Ok(())
 }
 
 #[derive(Clone, Debug)]

--- a/src/build/src/project/render.rs
+++ b/src/build/src/project/render.rs
@@ -199,6 +199,9 @@ fn validate_runtime_config_implications(
             run_grants: Vec::new(),
             actor_bootstrap: None,
         });
+    normalized_config
+        .runtime
+        .validate_production_program_routing()?;
     if normalized_config.runtime != plan.runtime_config {
         return project_invalid("request runtime settings do not match the normalized build plan");
     }
@@ -496,21 +499,17 @@ fn runtime_info_json(runtime: &mech_runtime::MechRuntime) -> String {
     let info = runtime.program_execution_info();
     let route = match info.route {
         mech_runtime::RuntimeProgramRoute::None => "none",
-        mech_runtime::RuntimeProgramRoute::Legacy => "legacy",
         mech_runtime::RuntimeProgramRoute::ResidentPure => "resident-pure",
         mech_runtime::RuntimeProgramRoute::ResidentExternal => "resident-external",
+        _ => "invalid-production-route",
     };
-    let policy = match info.policy {
-        mech_runtime::ResidentRoutingPolicy::PreferResident => "prefer-resident",
-        mech_runtime::ResidentRoutingPolicy::RequireResident => "require-resident",
-        mech_runtime::ResidentRoutingPolicy::LegacyOnly => "legacy-only",
-    };
+    let policy = "require-resident";
     let revision = info.program_revision.map(|revision| {
         format!("\"{}\"", revision.as_bytes().iter().map(|byte| format!("{byte:02x}")).collect::<String>())
     }).unwrap_or_else(|| "null".to_string());
     let plan = info.plan_generation.map(|value| value.get().saturating_add(1).to_string()).unwrap_or_else(|| "null".to_string());
     let layout = info.layout_generation.map(|value| value.get().saturating_add(1).to_string()).unwrap_or_else(|| "null".to_string());
-    format!("{{\"route\":\"{route}\",\"routing_policy\":\"{policy}\",\"program_revision\":{revision},\"plan_generation\":{plan},\"layout_generation\":{layout},\"requirements\":{},\"observations\":{},\"effects\":{},\"resident_accepted_turns\":{},\"resident_rejected_turns\":{},\"coalesced_host_packets\":{},\"ignored_host_packets\":{},\"legacy_turns\":{}}}", info.requirement_count, info.observation_count, info.effect_count, info.resident_accepted_turns, info.resident_rejected_turns, info.coalesced_host_packets, info.ignored_host_packets, info.legacy_turns)
+    format!("{{\"route\":\"{route}\",\"routing_policy\":\"{policy}\",\"program_revision\":{revision},\"plan_generation\":{plan},\"layout_generation\":{layout},\"requirements\":{},\"observations\":{},\"effects\":{},\"legacy_turns\":{},\"resident_accepted_turns\":{},\"resident_rejected_turns\":{},\"coalesced_host_packets\":{},\"ignored_host_packets\":{}}}", info.requirement_count, info.observation_count, info.effect_count, info.legacy_turns, info.resident_accepted_turns, info.resident_rejected_turns, info.coalesced_host_packets, info.ignored_host_packets)
 }
 
 fn run(arguments: GeneratedArguments) -> (MResult<()>, Vec<MechError>) {
@@ -525,13 +524,10 @@ fn run(arguments: GeneratedArguments) -> (MResult<()>, Vec<MechError>) {
     let runtime_constructed = true;
     let mut drivers_started = false;
     let primary = (|| -> MResult<()> {
-        let execution = runtime.config().program_routing.clone();
-        let outcome = runtime.load_bytecode_program(
+        let durability = runtime.config().program_routing.resident_durability;
+        let outcome = runtime.load_production_bytecode_program(
             PROGRAM,
-            mech_runtime::RuntimeProgramLoadOptions {
-                routing: execution.resident_routing,
-                durability: execution.resident_durability,
-            },
+            durability,
         )?;
         let value = outcome.initial_value;
 
@@ -560,7 +556,11 @@ fn run(arguments: GeneratedArguments) -> (MResult<()>, Vec<MechError>) {
             if arguments.max_live_turns.is_some_and(|limit| completed_live_turns >= limit) {
                 break;
             }
-            let outcomes = runtime.drain_host_inputs(64)?;
+            let drain_limit = arguments.max_live_turns
+                .map(|limit| limit.saturating_sub(completed_live_turns))
+                .unwrap_or(64)
+                .min(64);
+            let outcomes = runtime.drain_host_inputs(drain_limit)?;
             completed_live_turns = completed_live_turns.saturating_add(
                 outcomes.iter().filter(|outcome| {
                     outcome.turn.is_some() || outcome.resident_turn.is_some()
@@ -660,21 +660,17 @@ fn runtime_info_json(runtime: &mech_runtime::MechRuntime) -> String {
     let info = runtime.program_execution_info();
     let route = match info.route {
         mech_runtime::RuntimeProgramRoute::None => "none",
-        mech_runtime::RuntimeProgramRoute::Legacy => "legacy",
         mech_runtime::RuntimeProgramRoute::ResidentPure => "resident-pure",
         mech_runtime::RuntimeProgramRoute::ResidentExternal => "resident-external",
+        _ => "invalid-production-route",
     };
-    let policy = match info.policy {
-        mech_runtime::ResidentRoutingPolicy::PreferResident => "prefer-resident",
-        mech_runtime::ResidentRoutingPolicy::RequireResident => "require-resident",
-        mech_runtime::ResidentRoutingPolicy::LegacyOnly => "legacy-only",
-    };
+    let policy = "require-resident";
     let revision = info.program_revision.map(|revision| {
         format!("\"{}\"", revision.as_bytes().iter().map(|byte| format!("{byte:02x}")).collect::<String>())
     }).unwrap_or_else(|| "null".to_string());
     let plan = info.plan_generation.map(|value| value.get().saturating_add(1).to_string()).unwrap_or_else(|| "null".to_string());
     let layout = info.layout_generation.map(|value| value.get().saturating_add(1).to_string()).unwrap_or_else(|| "null".to_string());
-    format!("{{\"route\":\"{route}\",\"routing_policy\":\"{policy}\",\"program_revision\":{revision},\"plan_generation\":{plan},\"layout_generation\":{layout},\"requirements\":{},\"observations\":{},\"effects\":{},\"resident_accepted_turns\":{},\"resident_rejected_turns\":{},\"coalesced_host_packets\":{},\"ignored_host_packets\":{},\"legacy_turns\":{}}}", info.requirement_count, info.observation_count, info.effect_count, info.resident_accepted_turns, info.resident_rejected_turns, info.coalesced_host_packets, info.ignored_host_packets, info.legacy_turns)
+    format!("{{\"route\":\"{route}\",\"routing_policy\":\"{policy}\",\"program_revision\":{revision},\"plan_generation\":{plan},\"layout_generation\":{layout},\"requirements\":{},\"observations\":{},\"effects\":{},\"legacy_turns\":{},\"resident_accepted_turns\":{},\"resident_rejected_turns\":{},\"coalesced_host_packets\":{},\"ignored_host_packets\":{}}}", info.requirement_count, info.observation_count, info.effect_count, info.legacy_turns, info.resident_accepted_turns, info.resident_rejected_turns, info.coalesced_host_packets, info.ignored_host_packets)
 }
 
 fn run(arguments: GeneratedArguments) -> (MResult<()>, Vec<MechError>) {
@@ -688,13 +684,10 @@ fn run(arguments: GeneratedArguments) -> (MResult<()>, Vec<MechError>) {
     };
     let runtime_constructed = true;
     let primary = (|| -> MResult<()> {
-        let execution = runtime.config().program_routing.clone();
-        let outcome = runtime.load_bytecode_program(
+        let durability = runtime.config().program_routing.resident_durability;
+        let outcome = runtime.load_production_bytecode_program(
             PROGRAM,
-            mech_runtime::RuntimeProgramLoadOptions {
-                routing: execution.resident_routing,
-                durability: execution.resident_durability,
-            },
+            durability,
         )?;
         let value = outcome.initial_value;
 
@@ -766,7 +759,7 @@ fn render_hosted_main_source_for_plan(plan: &NativeBuildPlan) -> String {
         "actor-turn plans must carry an actor bootstrap"
     );
 
-    let resident_install = "        let execution = runtime.config().program_routing.clone();\n        let outcome = runtime.load_bytecode_program(\n            PROGRAM,\n            mech_runtime::RuntimeProgramLoadOptions {\n                routing: execution.resident_routing,\n                durability: execution.resident_durability,\n            },\n        )?;\n        let value = outcome.initial_value;";
+    let resident_install = "        let durability = runtime.config().program_routing.resident_durability;\n        let outcome = runtime.load_production_bytecode_program(\n            PROGRAM,\n            durability,\n        )?;\n        let value = outcome.initial_value;";
     let ordinary_install = if source.contains(resident_install) {
         resident_install
     } else {
@@ -1070,14 +1063,13 @@ pub fn render_generated_native_project(
 }
 
 fn render_runtime_config(config: &RuntimeConfig) -> String {
+    config
+        .validate_production_program_routing()
+        .expect("native production plan must require resident execution");
     format!(
         "RuntimeConfig {{\n        name: {}.to_string(),\n        program_routing: ProgramRoutingConfig {{\n            resident_routing: ResidentRoutingPolicy::{},\n            resident_durability: ResidentDurabilityPolicy::{},\n        }},\n        limits: RuntimeLimits {{\n            max_steps_per_turn: {},\n            max_turn_duration_ms: {},\n            max_memory_bytes: {},\n            max_tasks: {},\n            max_actors: {},\n            max_actor_mailbox_len: {},\n            max_source_bytes: {},\n            max_in_memory_events: {},\n        }},\n        diagnostics: DiagnosticsConfig {{\n            trace_enabled: {},\n            profile_enabled: {},\n            debug_enabled: {},\n            log_level: LogLevel::{},\n        }},\n    }}",
         rust_string_literal(&config.name),
-        match config.program_routing.resident_routing {
-            mech_runtime::ResidentRoutingPolicy::PreferResident => "PreferResident",
-            mech_runtime::ResidentRoutingPolicy::RequireResident => "RequireResident",
-            mech_runtime::ResidentRoutingPolicy::LegacyOnly => "LegacyOnly",
-        },
+        "RequireResident",
         match config.program_routing.resident_durability {
             mech_runtime::ResidentDurabilityPolicy::Volatile => "Volatile",
             mech_runtime::ResidentDurabilityPolicy::Retained => "Retained",
@@ -1498,6 +1490,7 @@ mod tests {
                 )
             );
             assert!(source.contains("std::process::exit(2)"));
+            assert!(source.contains("\\\"legacy_turns\\\":{}"));
         }
     }
 
@@ -1519,7 +1512,8 @@ mod tests {
         let live_source = render_hosted_main_source(true);
         assert!(live_source.contains("AtomicBool"));
         assert!(live_source.contains("Ordering::SeqCst"));
-        assert!(live_source.contains("runtime.drain_host_inputs(64)?"));
+        assert!(live_source.contains("limit.saturating_sub(completed_live_turns)"));
+        assert!(live_source.contains("runtime.drain_host_inputs(drain_limit)?"));
         assert!(live_source.contains("Duration::from_millis(10)"));
         assert!(live_source.contains("runtime.stop_input_drivers()"));
         assert!(live_source.contains("runtime.shutdown()"));

--- a/src/build/src/project/render.rs
+++ b/src/build/src/project/render.rs
@@ -760,17 +760,12 @@ fn render_hosted_main_source_for_plan(plan: &NativeBuildPlan) -> String {
     );
 
     let resident_install = "        let durability = runtime.config().program_routing.resident_durability;\n        let outcome = runtime.load_production_bytecode_program(\n            PROGRAM,\n            durability,\n        )?;\n        let value = outcome.initial_value;";
-    let ordinary_install = if source.contains(resident_install) {
-        resident_install
-    } else {
-        "        let mut context = runtime.runtime_context()?;\n        let value = runtime.install_bytecode_with_context(&mut context, PROGRAM)?;"
-    };
     assert!(
-        source.contains(ordinary_install),
+        source.contains(resident_install),
         "hosted main template must retain the program-install seam"
     );
     source = source.replace(
-        ordinary_install,
+        resident_install,
         "        let value = install_actor_bytecode(&mut runtime)?;",
     );
     let seam = "fn parse_arguments() -> Result<GeneratedArguments, ()> {";
@@ -861,7 +856,9 @@ fn install_actor_bytecode(
         runtime
             .next_actor_turn_with_context(&mut context, actor)?
             .ok_or_else(|| actor_error("generated actor turn was not available"))?;
-        runtime.install_bytecode_with_context(&mut context, PROGRAM)
+        runtime
+            .legacy_interpreter()
+            .install_bytecode_with_context(&mut context, PROGRAM)
     }})();
 
     match evaluation {{

--- a/src/build/src/project/render.rs
+++ b/src/build/src/project/render.rs
@@ -199,9 +199,7 @@ fn validate_runtime_config_implications(
             run_grants: Vec::new(),
             actor_bootstrap: None,
         });
-    normalized_config
-        .runtime
-        .validate_production_program_routing()?;
+    crate::validate_production_native_runtime_config(&normalized_config)?;
     if normalized_config.runtime != plan.runtime_config {
         return project_invalid("request runtime settings do not match the normalized build plan");
     }
@@ -1351,7 +1349,7 @@ mod tests {
     }
 
     #[test]
-    fn actor_main_bootstraps_message_state_capabilities_and_transaction() {
+    fn actor_bootstrap_template_is_quarantined_from_production_rendering() {
         let mut plan = base_plan(NativeApplicationKind::Hosted);
         plan.application_requirements = [
             "actor/message/kind",
@@ -1396,19 +1394,12 @@ mod tests {
             hosts: Vec::new(),
             run_grants: Vec::new(),
         };
-        let runtime = render_runtime_source(&plan, Some(&config)).unwrap();
-        for expected in [
-            "render-test-actor",
-            "render-test-message",
-            "render-test-payload",
-            "render-test-state",
-        ] {
-            assert!(runtime.contains(expected));
-        }
+        let error = render_runtime_source(&plan, Some(&config)).unwrap_err();
+        assert_eq!(error.kind_name(), "NativeActorBootstrapUnsupported");
     }
 
     #[test]
-    fn distinct_actor_bootstraps_change_generated_runtime_identity() {
+    fn distinct_actor_bootstraps_remain_unrenderable_production_plans() {
         let mut alpha = base_plan(NativeApplicationKind::Hosted);
         alpha.application_requirements = vec![PlannedApplicationRequirement::HostFunction {
             name: "actor/message/kind".into(),
@@ -1443,11 +1434,10 @@ mod tests {
             hosts: Vec::new(),
             run_grants: Vec::new(),
         };
-        let alpha_source = render_runtime_source(&alpha, Some(&alpha_config)).unwrap();
-        let beta_source = render_runtime_source(&beta, Some(&beta_config)).unwrap();
-        assert_ne!(alpha_source, beta_source);
-        assert!(alpha_source.contains("actor:alpha"));
-        assert!(beta_source.contains("actor:beta"));
+        for (plan, config) in [(&alpha, &alpha_config), (&beta, &beta_config)] {
+            let error = render_runtime_source(plan, Some(config)).unwrap_err();
+            assert_eq!(error.kind_name(), "NativeActorBootstrapUnsupported");
+        }
         assert_ne!(
             compute_plan_sha256(&alpha).unwrap(),
             compute_plan_sha256(&beta).unwrap()

--- a/src/build/tests/native_output_seed_arities.rs
+++ b/src/build/tests/native_output_seed_arities.rs
@@ -111,3 +111,4 @@ fn poisoned_output_seeds_are_recomputed_for_every_runtime_arity() {
         assert_eq!(result.stdout.unwrap().trim(), expected, "{name}");
     }
 }
+use mech_runtime::legacy_interpreter::LegacyInterpreterTestExt as _;

--- a/src/build/tests/planning.rs
+++ b/src/build/tests/planning.rs
@@ -6,8 +6,8 @@ use std::{
 };
 
 use mech_build::{
-    NativeApplicationBuilder, NativeApplicationKind, NativeBuildEnvironment, NativeBuildProfile,
-    NativeBuildRequest, NativeDependencySource, NativeEmit, NativeHostCatalog,
+    NativeActorBootstrap, NativeApplicationBuilder, NativeApplicationKind, NativeBuildEnvironment,
+    NativeBuildProfile, NativeBuildRequest, NativeDependencySource, NativeEmit, NativeHostCatalog,
     NativeHostFunctionContext, NativeHostFunctionLinkage, NativeRuntimeConfig, WorkspacePackage,
     fingerprint_workspace,
 };
@@ -328,6 +328,27 @@ fn host_free_plan_accepts_scalar_runtime_config_as_plan_identity() {
     let plan = builder.plan(&request).unwrap();
     assert_eq!(plan.application_kind, NativeApplicationKind::Hosted);
     assert_eq!(plan.runtime_config, runtime);
+}
+
+#[test]
+fn production_builder_rejects_actor_bootstrap_before_planning() {
+    let builder = NativeApplicationBuilder::new(environment(empty_catalog()));
+    let mut request = request(LITERAL_F64);
+    request.runtime_config = Some(NativeRuntimeConfig {
+        runtime: RuntimeConfig::default(),
+        actor_bootstrap: Some(NativeActorBootstrap {
+            subject: "actor:test".to_owned(),
+            message_kind: "test".to_owned(),
+            message_payload: "payload".to_owned(),
+            initial_state: None,
+        }),
+        hosts: Vec::new(),
+        run_grants: Vec::new(),
+    });
+
+    let error = builder.plan(&request).unwrap_err();
+    assert_eq!(error.kind_name(), "NativeActorBootstrapUnsupported");
+    assert!(error.display_message().contains("actor bootstrap"));
 }
 
 #[test]

--- a/src/build/tests/standard_host_source_planning.rs
+++ b/src/build/tests/standard_host_source_planning.rs
@@ -370,3 +370,4 @@ fn every_trusted_actor_function_plans_source_to_bytecode() {
         );
     }
 }
+use mech_runtime::legacy_interpreter::LegacyInterpreterTestExt as _;

--- a/src/build/tests/support/generated_cases.rs
+++ b/src/build/tests/support/generated_cases.rs
@@ -304,3 +304,4 @@ fn host_configuration(
         _ => panic!("unsupported generated host provider {provider}"),
     }
 }
+use mech_runtime::legacy_interpreter::LegacyInterpreterTestExt as _;

--- a/src/cli/app/mod.rs
+++ b/src/cli/app/mod.rs
@@ -77,7 +77,7 @@ pub(crate) fn build_cli() -> Command {
         Arg::new("repl")
             .short('r')
             .long("repl")
-            .help("Start REPL")
+            .help("Start the targetless full-developer REPL")
             .action(ArgAction::SetTrue),
     );
 

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -4,16 +4,13 @@ use std::path::{Path, PathBuf};
 
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use mech_build::{
-    NativeActorBootstrap, NativeApplicationBuilder, NativeBuildEnvironment, NativeBuildProfile,
-    NativeBuildRequest, NativeDependencySource, NativeEmit, NativeRuntimeConfig,
+    NativeApplicationBuilder, NativeBuildEnvironment, NativeBuildProfile, NativeBuildRequest,
+    NativeDependencySource, NativeEmit, NativeRuntimeConfig,
 };
 use mech_core::*;
 use mech_runtime::{HostInstanceConfig, RunResourceGrantConfig, RuntimeConfig, SourceRequest};
 
-use crate::cli::module_execution::{
-    execute_planning_source_module_roots, module_runtime_config,
-    prepare_planning_source_module_runtime,
-};
+use crate::cli::module_execution::{module_runtime_config, prepare_planning_source_module_runtime};
 use crate::cli::outcome::{CliOutcome, RootFlags};
 use crate::source_discovery::{DedupePolicy, DiscoveryOptions, MissingPathPolicy, collect_sources};
 
@@ -59,7 +56,7 @@ pub(crate) fn command() -> Command {
         .about("Build a Mech program as a native application, bytecode, plan, or Cargo project.")
         .arg(
             Arg::new("mech_build_file_paths")
-                .help("One or more source roots, or exactly one .mecb bytecode file")
+                .help("Exactly one resident source root or one .mecb bytecode file")
                 .required(false)
                 .action(ArgAction::Append),
         )
@@ -233,10 +230,27 @@ pub(crate) fn run(options: BuildOptions) -> MResult<CliOutcome> {
         let bytecode = fs::read(&path)?;
         ParsedProgram::from_bytes(&bytecode)?;
         let config = load_build_config(&options, Some(&path))?;
+        validate_production_build_config(config.as_ref(), &binary_name)?;
         (bytecode, config)
     } else {
         let loaded_config = load_build_config(&options, None)?;
+        validate_production_build_config(loaded_config.as_ref(), &binary_name)?;
         let source_roots = discover_source_roots(&options.paths)?;
+        if source_roots.len() != 1 {
+            let class = if source_roots.len() > 1 {
+                mech_runtime::ResidentRouteFailureClass::MultipleRootsUnsupported
+            } else {
+                mech_runtime::ResidentRouteFailureClass::SemanticUnsupported
+            };
+            return Err(MechError::new(
+                mech_runtime::ResidentRouteFailure {
+                    class,
+                    reason: "production builds require exactly one resident source root"
+                        .to_string(),
+                },
+                None,
+            ));
+        }
         let configured_hosts = configured_hosts(loaded_config.as_ref());
         let run_grants = configured_run_grants(loaded_config.as_ref());
         let mut planner_config = module_runtime_config(
@@ -250,49 +264,16 @@ pub(crate) fn run(options: BuildOptions) -> MResult<CliOutcome> {
             planner_config =
                 crate::apply_runtime_config_patch(planner_config, &config.document.runtime)?;
         }
-        let actor = loaded_config
-            .as_ref()
-            .and_then(|config| config.document.build.as_ref())
-            .and_then(|build| build.actor.as_ref());
-        let routing = planner_config.program_routing.resident_routing;
-        let bytecode = if routing != mech_runtime::ResidentRoutingPolicy::LegacyOnly
-            && source_roots.len() == 1
-        {
-            let (mut runtime, roots) = prepare_planning_source_module_runtime(
-                planner_config.clone(),
-                &configured_hosts,
-                &run_grants,
-                actor,
-                &source_roots,
-            )?;
-            let request = SourceRequest::from_filesystem_path(&roots[0])?;
-            match runtime.compile_root_program_bytecode(request) {
-                Ok(bytecode) => bytecode,
-                Err(error)
-                    if routing == mech_runtime::ResidentRoutingPolicy::PreferResident
-                        && mech_runtime::resident_fallback_eligible(&error) =>
-                {
-                    let mut runtime = execute_planning_source_module_roots(
-                        planner_config,
-                        &configured_hosts,
-                        &run_grants,
-                        actor,
-                        &source_roots,
-                    )?;
-                    runtime.compile_program_bytecode()?
-                }
-                Err(error) => return Err(error),
-            }
-        } else {
-            let mut runtime = execute_planning_source_module_roots(
-                planner_config,
-                &configured_hosts,
-                &run_grants,
-                actor,
-                &source_roots,
-            )?;
-            runtime.compile_program_bytecode()?
-        };
+        planner_config.validate_production_program_routing()?;
+        let (mut runtime, roots) = prepare_planning_source_module_runtime(
+            planner_config,
+            &configured_hosts,
+            &run_grants,
+            None,
+            &source_roots,
+        )?;
+        let request = SourceRequest::from_filesystem_path(&roots[0])?;
+        let bytecode = runtime.compile_root_program_bytecode(request)?;
         (bytecode, loaded_config)
     };
 
@@ -566,6 +547,35 @@ fn configured_run_grants(config: Option<&crate::LoadedMechConfig>) -> Vec<RunRes
         .unwrap_or_default()
 }
 
+fn validate_production_build_config(
+    config: Option<&crate::LoadedMechConfig>,
+    binary_name: &str,
+) -> MResult<()> {
+    let runtime = match config {
+        Some(config) => crate::apply_runtime_config_patch(
+            RuntimeConfig::new(binary_name),
+            &config.document.runtime,
+        )?,
+        None => RuntimeConfig::new(binary_name),
+    };
+    runtime.validate_production_program_routing()?;
+    if config
+        .and_then(|config| config.document.build.as_ref())
+        .and_then(|build| build.actor.as_ref())
+        .is_some()
+    {
+        return Err(MechError::new(
+            mech_runtime::ResidentRouteFailure {
+                class: mech_runtime::ResidentRouteFailureClass::SemanticUnsupported,
+                reason: "actor bootstrap is not part of the production resident program contract"
+                    .to_string(),
+            },
+            None,
+        ));
+    }
+    Ok(())
+}
+
 fn native_runtime_config(
     config: Option<&crate::LoadedMechConfig>,
     binary_name: &str,
@@ -590,6 +600,7 @@ fn native_runtime_config(
         RuntimeConfig::new(binary_name),
         &config.document.runtime,
     )?;
+    runtime.validate_production_program_routing()?;
     let (hosts, run_grants) = if needs_resource_config {
         (
             configured_hosts(Some(config)),
@@ -602,17 +613,7 @@ fn native_runtime_config(
         runtime,
         hosts,
         run_grants,
-        actor_bootstrap: config
-            .document
-            .build
-            .as_ref()
-            .and_then(|build| build.actor.as_ref())
-            .map(|actor| NativeActorBootstrap {
-                subject: actor.subject.clone(),
-                message_kind: actor.message_kind.clone(),
-                message_payload: actor.message_payload.clone(),
-                initial_state: actor.initial_state.clone(),
-            }),
+        actor_bootstrap: None,
     }))
 }
 

--- a/src/cli/commands/repl/tests/runtime_live.rs
+++ b/src/cli/commands/repl/tests/runtime_live.rs
@@ -217,6 +217,7 @@ fn runtime_with_driver_and_resolver(
 
 fn bind_live_input(runtime: &mut MechRuntime) {
     runtime
+        .legacy_interpreter()
         .run_string(
             "@pulse := replinput://clock/ticks{:read(value)}\n\
              output := @pulse/value\n",

--- a/src/cli/commands/run.rs
+++ b/src/cli/commands/run.rs
@@ -12,18 +12,13 @@ use mech_runtime::{FS_LIST, FS_READ, MECH_TOOL_SUBJECT};
 use crate::cli::capabilities;
 use crate::cli::config;
 use crate::cli::outcome::CliOutcome;
-use crate::cli::run::{
-    RunInputMode, cli_module_options, new_cli_runtime_with_source_resolver,
-    run_cli_root_module_with_events, run_cli_source_code_with_events, run_cli_source_with_events,
-};
+use crate::cli::run::{RunInputMode, cli_module_options, new_cli_runtime_with_source_resolver};
 use crate::cli::runtime_plan::RunExecutionPlan;
 use crate::source_discovery::{
     DedupePolicy, DiscoveryOptions, MissingPathPolicy, SkipReason, SourceDiscoveryEvent,
     collect_sources_with_events,
 };
-use mech_runtime::{
-    RuntimeEvent, RuntimeEventKind, RuntimeValueSnapshot, SourceKind, SourceRequest,
-};
+use mech_runtime::{RuntimeValueSnapshot, SourceKind, SourceRequest};
 
 #[derive(Debug, Clone)]
 struct CliRunError {
@@ -67,16 +62,6 @@ pub(crate) fn command() -> Command {
       .long("trace")
       .help("Print trace output for state-machine arms and function calls")
       .action(ArgAction::SetTrue))
-    .arg(Arg::new("resident")
-      .long("resident")
-      .help("Require production resident execution")
-      .conflicts_with("legacy")
-      .action(ArgAction::SetTrue))
-    .arg(Arg::new("legacy")
-      .long("legacy")
-      .help("Use the legacy executor without resident planning")
-      .conflicts_with("resident")
-      .action(ArgAction::SetTrue))
     .arg(Arg::new("runtime-info")
       .long("runtime-info")
       .help("Print final production routing diagnostics as JSON")
@@ -92,7 +77,7 @@ pub(crate) fn command() -> Command {
         Arg::new("repl")
             .short('r')
             .long("repl")
-            .help("Enter a runtime-backed REPL after running the selected inputs")
+            .help("Developer-only REPL flag; production inputs cannot be combined with a REPL")
             .action(ArgAction::SetTrue),
     );
     command
@@ -234,18 +219,13 @@ fn render_config_event(event: &config::ConfigLoadEvent) {
     }
 }
 
-fn enforce_required_resident_target_shape(
-    routing: mech_runtime::ResidentRoutingPolicy,
-    targets: &[PathBuf],
-) -> MResult<()> {
-    if routing != mech_runtime::ResidentRoutingPolicy::RequireResident {
-        return Ok(());
-    }
+fn enforce_production_resident_target_shape(targets: &[PathBuf]) -> MResult<()> {
     if targets.len() > 1 {
         return Err(MechError::new(
             mech_runtime::ResidentRouteFailure {
                 class: mech_runtime::ResidentRouteFailureClass::MultipleRootsUnsupported,
-                reason: "multiple independent roots cannot be resident-routed in D4".to_string(),
+                reason: "production execution accepts exactly one resident program root"
+                    .to_string(),
             },
             None,
         ));
@@ -254,8 +234,7 @@ fn enforce_required_resident_target_shape(
         return Err(MechError::new(
             mech_runtime::ResidentRouteFailure {
                 class: mech_runtime::ResidentRouteFailureClass::SemanticUnsupported,
-                reason: "required resident execution needs exactly one .mec or .mecb root"
-                    .to_string(),
+                reason: "production execution requires exactly one .mec or .mecb root".to_string(),
             },
             None,
         ));
@@ -271,15 +250,17 @@ fn print_value(value: &RuntimeValueSnapshot) {
     println!("{:#?}", value);
 }
 
-fn print_run_runtime_events(events: &[RuntimeEvent]) {
-    for event in events {
-        if let RuntimeEventKind::ProgramProfiled { duration_ns, .. } = &event.kind {
-            println!("Cycle Time: {:.3}ms", *duration_ns as f64 / 1_000_000.0);
-        }
-    }
-}
-
 fn execute_plan(plan: RunExecutionPlan) -> MResult<CliOutcome> {
+    if plan.repl_requested && !plan.missing_run_options {
+        return Err(MechError::new(
+            mech_runtime::ResidentRouteFailure {
+                class: mech_runtime::ResidentRouteFailureClass::ReplUnsupported,
+                reason: "interactive REPL mutation cannot be combined with a resident production target; start the full developer REPL without a target instead".to_string(),
+            },
+            None,
+        ));
+    }
+
     render_config_event(&plan.config_event);
     render_capability_events(&plan.filesystem_access.events);
     let mut runtime = new_cli_runtime_with_source_resolver(
@@ -291,33 +272,27 @@ fn execute_plan(plan: RunExecutionPlan) -> MResult<CliOutcome> {
             .with_capabilities(plan.filesystem_access.kernel.clone(), MECH_TOOL_SUBJECT),
     )?;
 
-    let load_options = mech_runtime::RuntimeProgramLoadOptions {
-        routing: plan.resident_routing,
-        durability: plan.resident_durability,
-    };
-
-    if (plan.repl_requested || plan.missing_run_options)
-        && plan.resident_routing == mech_runtime::ResidentRoutingPolicy::RequireResident
-    {
+    if plan.missing_run_options {
+        #[cfg(feature = "repl")]
+        return Ok(CliOutcome::EnterRepl(
+            crate::cli::commands::repl::ReplStartup {
+                runtime: Some(runtime),
+            },
+        ));
+        #[cfg(not(feature = "repl"))]
         return Err(MechError::new(
             mech_runtime::ResidentRouteFailure {
                 class: mech_runtime::ResidentRouteFailureClass::ReplUnsupported,
-                reason: "resident REPL mutation is not supported in D4".to_string(),
+                reason: "the production run command requires a resident program; interactive mutation is available only in the full developer distribution".to_string(),
             },
             None,
         ));
     }
 
     let result: MResult<RuntimeValueSnapshot> = match &plan.input_mode {
-        RunInputMode::InlineSource(source) if !plan.repl_requested => runtime
-            .load_source_program(source.trim(), load_options)
+        RunInputMode::InlineSource(source) => runtime
+            .load_production_source_program(source.trim(), plan.resident_durability)
             .map(|outcome| outcome.initial_value),
-        RunInputMode::InlineSource(source) => {
-            run_cli_source_with_events(&mut runtime, source.trim()).map(|(value, events)| {
-                print_run_runtime_events(&events);
-                value
-            })
-        }
         _ => {
             if plan.run_paths.is_empty() {
                 Ok(RuntimeValueSnapshot::empty())
@@ -330,87 +305,28 @@ fn execute_plan(plan: RunExecutionPlan) -> MResult<CliOutcome> {
                         &fs_kernel,
                     )?);
                 }
-                enforce_required_resident_target_shape(plan.resident_routing, &targets)?;
-                if targets.len() == 1
-                    && SourceKind::from_path(&targets[0]).is_executable_mech()
-                    && !plan.repl_requested
-                {
-                    let canonical_target = targets[0].canonicalize().map_err(|error| {
-                        MechError::new(
-                            CliRunError {
-                                operation: "canonicalize_run_target".to_string(),
-                                reason: format!("{}: {}", targets[0].display(), error),
-                            },
-                            None,
-                        )
-                    })?;
-                    runtime
-                        .load_root_program(
-                            SourceRequest::from_filesystem_path(&canonical_target)?,
-                            cli_module_options(),
-                            load_options,
-                        )
-                        .map(|outcome| outcome.initial_value)
-                } else {
-                    let legacy_turns = targets.len() as u64;
-                    let mut last = RuntimeValueSnapshot::empty();
-                    for target in targets {
-                        let (value, events) = if SourceKind::from_path(&target) == SourceKind::Mech
-                        {
-                            let canonical_target = target.canonicalize().map_err(|error| {
-                                MechError::new(
-                                    CliRunError {
-                                        operation: "canonicalize_run_target".to_string(),
-                                        reason: format!("{}: {}", target.display(), error),
-                                    },
-                                    None,
-                                )
-                            })?;
-                            run_cli_root_module_with_events(
-                                &mut runtime,
-                                SourceRequest::from_filesystem_path(&canonical_target)?,
-                                cli_module_options(),
-                            )?
-                        } else {
-                            let src = mech_runtime::read_runtime_source_file_with_capabilities(
-                                &target,
-                                Some(&fs_kernel),
-                                Some(MECH_TOOL_SUBJECT),
-                            )?;
-                            run_cli_source_code_with_events(&mut runtime, &src)?
-                        };
-                        print_run_runtime_events(&events);
-                        last = value;
-                    }
-                    runtime
-                        .record_legacy_program_route(plan.resident_routing, legacy_turns.max(1))?;
-                    Ok(last)
-                }
+                enforce_production_resident_target_shape(&targets)?;
+                let canonical_target = targets[0].canonicalize().map_err(|error| {
+                    MechError::new(
+                        CliRunError {
+                            operation: "canonicalize_run_target".to_string(),
+                            reason: format!("{}: {}", targets[0].display(), error),
+                        },
+                        None,
+                    )
+                })?;
+                runtime
+                    .load_production_root_program(
+                        SourceRequest::from_filesystem_path(&canonical_target)?,
+                        cli_module_options(),
+                        plan.resident_durability,
+                    )
+                    .map(|outcome| outcome.initial_value)
             }
         }
     };
 
-    let repl_flag = plan.repl_requested || plan.missing_run_options;
     match result {
-        Ok(value) if repl_flag => {
-            if runtime.program_route() == mech_runtime::RuntimeProgramRoute::None {
-                runtime.record_legacy_program_route(plan.resident_routing, 1)?;
-            }
-            #[cfg(all(feature = "run", feature = "repl"))]
-            {
-                let _ = value;
-                return Ok(CliOutcome::EnterRepl(
-                    crate::cli::commands::repl::ReplStartup {
-                        runtime: Some(runtime),
-                    },
-                ));
-            }
-            #[cfg(not(feature = "repl"))]
-            {
-                print_value(&value);
-                return Ok(CliOutcome::exit(0));
-            }
-        }
         Ok(value) => {
             if should_run_live(&runtime)? {
                 run_live_runtime(&mut runtime, plan.max_live_turns)?;
@@ -467,7 +383,6 @@ fn run_live_loop(
     stop: &AtomicBool,
     max_live_turns: Option<usize>,
 ) -> MResult<()> {
-    const MAX_DRAIN_PER_TURN: usize = 64;
     const IDLE_SLEEP: Duration = Duration::from_millis(10);
 
     let mut completed_live_turns = 0usize;
@@ -479,11 +394,20 @@ fn run_live_loop(
             std::thread::sleep(IDLE_SLEEP);
             continue;
         }
-        let outcomes = runtime.drain_host_inputs(MAX_DRAIN_PER_TURN)?;
+        let drain_limit = live_drain_limit(max_live_turns, completed_live_turns);
+        let outcomes = runtime.drain_host_inputs(drain_limit)?;
         completed_live_turns =
             completed_live_turns.saturating_add(successful_live_turn_count(&outcomes));
     }
     Ok(())
+}
+
+fn live_drain_limit(max_live_turns: Option<usize>, completed_live_turns: usize) -> usize {
+    const MAX_DRAIN_PER_TURN: usize = 64;
+    max_live_turns
+        .map(|limit| limit.saturating_sub(completed_live_turns))
+        .unwrap_or(MAX_DRAIN_PER_TURN)
+        .min(MAX_DRAIN_PER_TURN)
 }
 
 fn successful_live_turn_count(outcomes: &[mech_runtime::RuntimeHostInputOutcome]) -> usize {
@@ -497,14 +421,9 @@ fn runtime_info_json(runtime: &mech_runtime::MechRuntime) -> serde_json::Value {
     let info = runtime.program_execution_info();
     let route = match info.route {
         mech_runtime::RuntimeProgramRoute::None => "none",
-        mech_runtime::RuntimeProgramRoute::Legacy => "legacy",
         mech_runtime::RuntimeProgramRoute::ResidentPure => "resident-pure",
         mech_runtime::RuntimeProgramRoute::ResidentExternal => "resident-external",
-    };
-    let routing_policy = match info.policy {
-        mech_runtime::ResidentRoutingPolicy::PreferResident => "prefer-resident",
-        mech_runtime::ResidentRoutingPolicy::RequireResident => "require-resident",
-        mech_runtime::ResidentRoutingPolicy::LegacyOnly => "legacy-only",
+        _ => "invalid-production-route",
     };
     let revision = info.program_revision.map(|revision| {
         revision
@@ -515,18 +434,18 @@ fn runtime_info_json(runtime: &mech_runtime::MechRuntime) -> serde_json::Value {
     });
     serde_json::json!({
         "route": route,
-        "routing_policy": routing_policy,
+        "routing_policy": "require-resident",
         "program_revision": revision,
         "plan_generation": info.plan_generation.map(|generation| generation.get().saturating_add(1)),
         "layout_generation": info.layout_generation.map(|generation| generation.get().saturating_add(1)),
         "requirements": info.requirement_count,
         "observations": info.observation_count,
         "effects": info.effect_count,
+        "legacy_turns": info.legacy_turns,
         "resident_accepted_turns": info.resident_accepted_turns,
         "resident_rejected_turns": info.resident_rejected_turns,
         "coalesced_host_packets": info.coalesced_host_packets,
         "ignored_host_packets": info.ignored_host_packets,
-        "legacy_turns": info.legacy_turns,
     })
 }
 
@@ -541,13 +460,22 @@ mod command_outcome_tests {
     }
 
     #[test]
+    fn production_run_command_exposes_no_executor_selection_flags() {
+        for flag in ["--resident", "--legacy"] {
+            let error = command()
+                .try_get_matches_from(["run", flag, "program.mec"])
+                .expect_err("shipping run command must not expose executor selection");
+            assert_eq!(error.kind(), clap::error::ErrorKind::UnknownArgument);
+        }
+    }
+
+    #[test]
     fn require_resident_rejects_empty_and_legacy_only_target_shapes() {
-        let routing = mech_runtime::ResidentRoutingPolicy::RequireResident;
-        let empty = enforce_required_resident_target_shape(routing, &[]).unwrap_err();
+        let empty = enforce_production_resident_target_shape(&[]).unwrap_err();
         assert_eq!(empty.kind_name(), "ResidentRouteFailure");
 
         let document = [PathBuf::from("program.mdoc")];
-        let legacy_only = enforce_required_resident_target_shape(routing, &document).unwrap_err();
+        let legacy_only = enforce_production_resident_target_shape(&document).unwrap_err();
         let failure = legacy_only
             .kind_as::<mech_runtime::ResidentRouteFailure>()
             .unwrap();
@@ -559,19 +487,12 @@ mod command_outcome_tests {
 
     #[test]
     fn require_resident_accepts_one_source_or_bytecode_root_only() {
-        let routing = mech_runtime::ResidentRoutingPolicy::RequireResident;
-        assert!(
-            enforce_required_resident_target_shape(routing, &[PathBuf::from("program.mec")])
-                .is_ok()
-        );
-        assert!(
-            enforce_required_resident_target_shape(routing, &[PathBuf::from("program.mecb")])
-                .is_ok()
-        );
-        let multiple = enforce_required_resident_target_shape(
-            routing,
-            &[PathBuf::from("a.mec"), PathBuf::from("b.mec")],
-        )
+        assert!(enforce_production_resident_target_shape(&[PathBuf::from("program.mec")]).is_ok());
+        assert!(enforce_production_resident_target_shape(&[PathBuf::from("program.mecb")]).is_ok());
+        let multiple = enforce_production_resident_target_shape(&[
+            PathBuf::from("a.mec"),
+            PathBuf::from("b.mec"),
+        ])
         .unwrap_err();
         assert_eq!(
             multiple
@@ -601,6 +522,15 @@ mod command_outcome_tests {
             },
         ];
         assert_eq!(successful_live_turn_count(&outcomes), 1);
+    }
+
+    #[test]
+    fn live_drain_limit_never_exceeds_the_remaining_turn_budget() {
+        assert_eq!(live_drain_limit(Some(2), 0), 2);
+        assert_eq!(live_drain_limit(Some(2), 1), 1);
+        assert_eq!(live_drain_limit(Some(2), 2), 0);
+        assert_eq!(live_drain_limit(Some(100), 0), 64);
+        assert_eq!(live_drain_limit(None, 9), 64);
     }
 
     #[cfg(target_os = "linux")]
@@ -660,7 +590,6 @@ mod command_outcome_tests {
             time: false,
             repl: false,
             rounds_per_step: None,
-            resident_routing_override: None,
             runtime_info: false,
             max_live_turns: None,
             loaded_config: None,

--- a/src/cli/module_execution.rs
+++ b/src/cli/module_execution.rs
@@ -144,6 +144,7 @@ fn resolver_roots(canonical_roots: &[PathBuf]) -> MResult<Vec<PathBuf>> {
     Ok(roots)
 }
 
+#[cfg(feature = "legacy-interpreter")]
 pub(crate) fn execute_source_module_roots(
     config: RuntimeConfig,
     roots: &[PathBuf],
@@ -154,30 +155,6 @@ pub(crate) fn execute_source_module_roots(
 /// Compile trusted local roots in plan mode for the build command. This shares
 /// the resolver and module execution path with source commands, but installs
 /// only effect-free planning hosts and never starts input drivers.
-#[cfg(feature = "build")]
-pub(crate) fn execute_planning_source_module_roots(
-    config: RuntimeConfig,
-    configured_hosts: &[HostInstanceConfig],
-    run_grants: &[RunResourceGrantConfig],
-    actor_bootstrap: Option<&ActorBootstrapConfig>,
-    roots: &[PathBuf],
-) -> MResult<MechRuntime> {
-    let (mut runtime, canonical_roots) = prepare_planning_source_module_runtime(
-        config,
-        configured_hosts,
-        run_grants,
-        actor_bootstrap,
-        roots,
-    )?;
-    for root in canonical_roots {
-        runtime.resolve_and_run_root_module(
-            SourceRequest::from_filesystem_path(&root)?,
-            module_build_options(),
-        )?;
-    }
-    Ok(runtime)
-}
-
 #[cfg(feature = "build")]
 pub(crate) fn prepare_planning_source_module_runtime(
     config: RuntimeConfig,
@@ -295,6 +272,7 @@ pub(crate) fn execute_source_module_roots_with_report(
     })
 }
 
+#[cfg(feature = "legacy-interpreter")]
 fn execute_source_module_roots_internal(
     config: RuntimeConfig,
     roots: &[PathBuf],
@@ -307,12 +285,15 @@ fn execute_source_module_roots_internal(
         let request = SourceRequest::from_filesystem_path(&root)?;
         #[cfg(feature = "test")]
         {
-            let report =
-                runtime.resolve_and_run_root_module_report(request, module_build_options())?;
+            let report = runtime
+                .legacy_interpreter()
+                .resolve_and_run_root_module_report(request, module_build_options())?;
             integrity_evaluations.extend(report.integrity.evaluations);
         }
         #[cfg(not(feature = "test"))]
-        runtime.resolve_and_run_root_module(request, module_build_options())?;
+        runtime
+            .legacy_interpreter()
+            .resolve_and_run_root_module(request, module_build_options())?;
     }
     Ok(SourceModuleExecutionInternal {
         runtime,
@@ -338,7 +319,7 @@ fn source_module_runtime_builder(
     Ok((builder, canonical_roots))
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "legacy-interpreter"))]
 mod tests {
     use super::*;
     use mech_runtime::RuntimeValueSnapshot;
@@ -406,47 +387,6 @@ mod tests {
             },
             other => panic!("expected string value, got {other:?}"),
         }
-    }
-
-    #[cfg(feature = "build")]
-    #[test]
-    fn actor_source_planning_tracks_state_put_before_later_reads() {
-        let root = temp_root("actor-state-sequence");
-        let source = root.join("main.mec");
-        std::fs::write(
-            &source,
-            "updated := actor/state/put(\"created\")\nstate := actor/state/get()\nidentifier := actor/state/id()\nidentifier\n",
-        )
-        .unwrap();
-        let bootstrap = ActorBootstrapConfig {
-            subject: "actor:planning".to_owned(),
-            message_kind: "test".to_owned(),
-            message_payload: String::new(),
-            initial_state: None,
-        };
-
-        let runtime =
-            execute_planning_source_module_roots(config(), &[], &[], Some(&bootstrap), &[source])
-                .unwrap();
-
-        assert_string(runtime.root_symbol_value("state").unwrap(), "created");
-        match runtime
-            .root_symbol_value("identifier")
-            .unwrap()
-            .into_value()
-        {
-            LegacyValue::String(value) => {
-                assert!(value.borrow().starts_with("planning-state-put-"))
-            }
-            LegacyValue::MutableReference(value) => match &*value.borrow() {
-                LegacyValue::String(value) => {
-                    assert!(value.borrow().starts_with("planning-state-put-"))
-                }
-                other => panic!("expected string value, got {other:?}"),
-            },
-            other => panic!("expected string value, got {other:?}"),
-        }
-        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/src/cli/run/mod.rs
+++ b/src/cli/run/mod.rs
@@ -564,21 +564,27 @@ pub fn effective_run_runtime_config(
     Ok(config)
 }
 
+#[cfg(feature = "legacy-interpreter")]
 pub fn run_cli_source_with_events(
     runtime: &mut MechRuntime,
     source: &str,
 ) -> MResult<(RuntimeValueSnapshot, Vec<RuntimeEvent>)> {
     let mut context = runtime.runtime_context()?;
-    let result = runtime.run_string_with_context(&mut context, source)?;
+    let result = runtime
+        .legacy_interpreter()
+        .run_string_with_context(&mut context, source)?;
     Ok((result, context.events().to_vec()))
 }
 
+#[cfg(feature = "legacy-interpreter")]
 pub fn run_cli_source_code_with_events(
     runtime: &mut MechRuntime,
     source: &MechSourceCode,
 ) -> MResult<(RuntimeValueSnapshot, Vec<RuntimeEvent>)> {
     let mut context = runtime.runtime_context()?;
-    let result = runtime.run_source_with_context(&mut context, source)?;
+    let result = runtime
+        .legacy_interpreter()
+        .run_source_with_context(&mut context, source)?;
     Ok((result, context.events().to_vec()))
 }
 
@@ -586,21 +592,25 @@ pub fn cli_module_options() -> ModuleBuildOptions<'static> {
     ModuleBuildOptions::new(env!("CARGO_PKG_VERSION"), "v0.3", "native", &[], &[])
 }
 
+#[cfg(feature = "legacy-interpreter")]
 pub fn run_cli_root_module_with_events(
     runtime: &mut MechRuntime,
     request: SourceRequest,
     options: ModuleBuildOptions<'_>,
 ) -> MResult<(RuntimeValueSnapshot, Vec<RuntimeEvent>)> {
     let mut context = runtime.runtime_context()?;
-    let result =
-        runtime.resolve_and_run_root_module_with_context(&mut context, request, options)?;
+    let result = runtime
+        .legacy_interpreter()
+        .resolve_and_run_root_module_with_context(&mut context, request, options)?;
     Ok((result, context.events().to_vec()))
 }
 
+#[cfg(feature = "legacy-interpreter")]
 pub fn run_cli_source(runtime: &mut MechRuntime, source: &str) -> MResult<RuntimeValueSnapshot> {
     run_cli_source_with_events(runtime, source).map(|(value, _)| value)
 }
 
+#[cfg(feature = "legacy-interpreter")]
 pub fn run_cli_source_code(
     runtime: &mut MechRuntime,
     source: &MechSourceCode,
@@ -677,7 +687,7 @@ pub fn cli_host_capability_selection(
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "legacy-interpreter"))]
 mod tests {
     use super::*;
     use mech_runtime::{ConfigProfileOptions, parse_config_document};
@@ -769,6 +779,7 @@ mod tests {
         .unwrap();
 
         runtime
+            .legacy_interpreter()
             .run_string("+> @out := cli/stdout\n@out/line <- \"ok\"\n")
             .unwrap();
     }
@@ -801,6 +812,7 @@ mod tests {
         .unwrap();
 
         runtime
+            .legacy_interpreter()
             .run_string("+> @out := term/stdout\n@out/line <- \"ok\"\n")
             .unwrap();
     }
@@ -868,20 +880,24 @@ mod tests {
         .unwrap();
 
         runtime
+            .legacy_interpreter()
             .run_string("+> @out := cli/stdout\n@out/line <- \"ok\"\n")
             .unwrap();
         assert!(
             runtime
+                .legacy_interpreter()
                 .run_string("+> @env := cli/env\nx := @env/HOME\n")
                 .is_err()
         );
         assert!(
             runtime
+                .legacy_interpreter()
                 .run_string("+> @err := cli/stderr\n@err/line <- \"bad\"\n")
                 .is_err()
         );
         assert!(
             runtime
+                .legacy_interpreter()
                 .run_string("+> @out := cli/stdout\n@out/text <- \"bad\"\n")
                 .is_err()
         );
@@ -918,19 +934,22 @@ mod tests {
         .unwrap();
 
         runtime
+            .legacy_interpreter()
             .run_string("+> @out := cli/stdout\n@out/line <- \"ok\"\n")
             .unwrap();
         runtime
+            .legacy_interpreter()
             .run_string("+> @err := cli/stderr\n@err/line <- \"ok\"\n")
             .unwrap();
         assert!(
             runtime
+                .legacy_interpreter()
                 .run_string("+> @env := cli/env\nx := @env/HOME\n")
                 .is_err()
         );
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "legacy-interpreter"))]
 #[path = "tests/resource_aliases.rs"]
 mod resource_alias_tests;

--- a/src/cli/run/tests/resource_aliases.rs
+++ b/src/cli/run/tests/resource_aliases.rs
@@ -117,6 +117,7 @@ fn run_resource_grant_authorizes_cli_stdout_legacy_alias() {
     runtime.begin_transaction(&mut context).unwrap();
 
     runtime
+        .legacy_interpreter()
         .run_string_with_context(
             &mut context,
             "@out := cli://stdout{:write(line)}\n@out/line <- \"legacy alias\"\n",
@@ -138,6 +139,7 @@ fn run_resource_grant_authorizes_cli_stdout_legacy_alias() {
     );
 
     let error = runtime
+        .legacy_interpreter()
         .run_string("@out-text := cli://stdout{:write(text)}\n@out-text/text <- \"denied\"\n")
         .unwrap_err();
     let error_kind = error.kind_name();
@@ -168,6 +170,7 @@ fn run_resource_grant_authorizes_cli_env_legacy_alias() {
     );
 
     let result = runtime
+        .legacy_interpreter()
         .run_string("@env := cli://env{:read(HOME)}\nhome := @env/HOME\nhome\n")
         .unwrap();
 
@@ -287,6 +290,7 @@ fn run_resource_grant_authorizes_browser_dom_legacy_alias() {
         .unwrap();
 
     runtime
+        .legacy_interpreter()
         .run_string(
             "@dom := browser://dom{:write(body/header/title)}\n\
              @dom/body/header/title = \"legacy browser\"\n",
@@ -313,6 +317,7 @@ fn run_resource_grant_does_not_cross_cli_instances() {
     );
 
     let error = runtime
+        .legacy_interpreter()
         .run_string("@out := cli://stdout{:write(line)}\n@out/line <- \"must fail\"\n")
         .unwrap_err();
     let error_kind = error.kind_name();

--- a/src/cli/run_options.rs
+++ b/src/cli/run_options.rs
@@ -15,7 +15,6 @@ pub(crate) struct RunCliArgs {
     pub time: bool,
     pub repl: bool,
     pub rounds_per_step: Option<usize>,
-    pub resident_routing_override: Option<mech_runtime::ResidentRoutingPolicy>,
     pub runtime_info: bool,
     pub max_live_turns: Option<usize>,
     pub cli_capability_selection: host_grants::CliHostCapabilitySelection,
@@ -49,15 +48,6 @@ impl RunCliArgs {
             rounds_per_step: run_matches
                 .and_then(|matches| matches.get_one::<usize>("rounds-per-step").copied())
                 .or(root.rounds_per_step),
-            resident_routing_override: run_matches.and_then(|matches| {
-                if matches.get_flag("resident") {
-                    Some(mech_runtime::ResidentRoutingPolicy::RequireResident)
-                } else if matches.get_flag("legacy") {
-                    Some(mech_runtime::ResidentRoutingPolicy::LegacyOnly)
-                } else {
-                    None
-                }
-            }),
             runtime_info: run_matches
                 .map(|matches| matches.get_flag("runtime-info"))
                 .unwrap_or(false),
@@ -76,7 +66,6 @@ pub(crate) struct PreparedRunOptions {
     pub time: bool,
     pub repl: bool,
     pub rounds_per_step: Option<usize>,
-    pub resident_routing_override: Option<mech_runtime::ResidentRoutingPolicy>,
     pub runtime_info: bool,
     pub max_live_turns: Option<usize>,
     pub loaded_config: Option<crate::LoadedMechConfig>,
@@ -106,7 +95,6 @@ pub(crate) fn prepare_run_options(
         time: args.time,
         repl: args.repl,
         rounds_per_step: args.rounds_per_step,
-        resident_routing_override: args.resident_routing_override,
         runtime_info: args.runtime_info,
         max_live_turns: args.max_live_turns,
         loaded_config,

--- a/src/cli/runtime_plan.rs
+++ b/src/cli/runtime_plan.rs
@@ -57,15 +57,17 @@ pub(crate) fn build_run_execution_plan(options: PreparedRunOptions) -> MResult<R
         RunInputMode::Paths(paths) => paths.clone(),
         RunInputMode::Empty | RunInputMode::InlineSource(_) => Vec::new(),
     };
-    let effective_options = if matches!(input_mode, RunInputMode::InlineSource(_)) {
-        None
-    } else {
-        crate::cli::run_options::effective_run_options(
-            run_paths,
-            loaded_config.as_ref(),
-            explicit_run_command,
-        )?
-    };
+    let targetless_repl = options.repl && matches!(input_mode, RunInputMode::Empty);
+    let effective_options =
+        if matches!(input_mode, RunInputMode::InlineSource(_)) || targetless_repl {
+            None
+        } else {
+            crate::cli::run_options::effective_run_options(
+                run_paths,
+                loaded_config.as_ref(),
+                explicit_run_command,
+            )?
+        };
     let missing_run_options =
         effective_options.is_none() && !matches!(input_mode, RunInputMode::InlineSource(_));
     let run_paths = effective_options

--- a/src/cli/runtime_plan.rs
+++ b/src/cli/runtime_plan.rs
@@ -12,7 +12,6 @@ pub(crate) struct RunExecutionPlan {
     pub run_paths: Vec<String>,
     pub repl_requested: bool,
     pub missing_run_options: bool,
-    pub resident_routing: mech_runtime::ResidentRoutingPolicy,
     pub resident_durability: mech_runtime::ResidentDurabilityPolicy,
     pub runtime_info: bool,
     pub max_live_turns: Option<usize>,
@@ -28,7 +27,7 @@ pub(crate) fn build_run_execution_plan(options: PreparedRunOptions) -> MResult<R
     let uuid = generate_uuid();
     let input_mode = options.input_mode;
     let loaded_config = options.loaded_config;
-    let mut runtime_config = effective_run_runtime_config(
+    let runtime_config = effective_run_runtime_config(
         loaded_config.as_ref(),
         format!("program-{}", uuid),
         options.debug,
@@ -36,12 +35,6 @@ pub(crate) fn build_run_execution_plan(options: PreparedRunOptions) -> MResult<R
         options.time,
         options.rounds_per_step,
     )?;
-    if let Some(routing) = options.resident_routing_override {
-        runtime_config.program_routing.resident_routing = routing;
-    }
-    let resident_routing = runtime_config.program_routing.resident_routing;
-    let resident_durability = runtime_config.program_routing.resident_durability;
-
     let cli_grants = host_grants::effective_cli_host_grants(
         loaded_config.as_ref(),
         options.cli_capability_selection,
@@ -79,6 +72,15 @@ pub(crate) fn build_run_execution_plan(options: PreparedRunOptions) -> MResult<R
         .map(|options| options.paths)
         .unwrap_or_default();
 
+    // A targetless invocation belongs to the explicitly enabled developer
+    // REPL, not to the production program-loading boundary. Production
+    // routing policy becomes authoritative only when there is a program to
+    // load.
+    if !missing_run_options {
+        runtime_config.validate_production_program_routing()?;
+    }
+    let resident_durability = runtime_config.program_routing.resident_durability;
+
     filesystem_access.kernel = filesystem_access.authority.kernel().clone();
 
     Ok(RunExecutionPlan {
@@ -87,7 +89,6 @@ pub(crate) fn build_run_execution_plan(options: PreparedRunOptions) -> MResult<R
         run_paths,
         repl_requested: options.repl,
         missing_run_options,
-        resident_routing,
         resident_durability,
         runtime_info: options.runtime_info,
         max_live_turns: options.max_live_turns,
@@ -172,7 +173,6 @@ mod tests {
             time: false,
             repl: false,
             rounds_per_step: None,
-            resident_routing_override: None,
             runtime_info: false,
             max_live_turns: None,
             loaded_config: None,
@@ -205,7 +205,6 @@ mod tests {
             time: false,
             repl: false,
             rounds_per_step: None,
-            resident_routing_override: None,
             runtime_info: false,
             max_live_turns: None,
             loaded_config: None,

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -501,11 +501,13 @@ impl MechRepl {
                 for source_path in paths {
                     let request = runtime_repl_load_request(&source_path)?;
                     let (runtime, context) = self.runtime_with_next_turn_context()?;
-                    result = runtime.resolve_and_run_root_module_with_context(
-                        context,
-                        request,
-                        crate::cli::run::cli_module_options(),
-                    )?;
+                    result = runtime
+                        .legacy_interpreter()
+                        .resolve_and_run_root_module_with_context(
+                            context,
+                            request,
+                            crate::cli::run::cli_module_options(),
+                        )?;
                 }
                 Ok(format!("\n{}\n{}\n", result.kind(), result))
             }
@@ -514,7 +516,9 @@ impl MechRepl {
                 for (_, source) in code {
                     let source = source.to_string();
                     let (runtime, context) = self.runtime_with_next_turn_context()?;
-                    result = runtime.run_string_with_context(context, &source)?;
+                    result = runtime
+                        .legacy_interpreter()
+                        .run_string_with_context(context, &source)?;
                 }
                 let kind_formatted = format!("{}", result.kind()).ansi_color(218);
                 Ok(format!("\n{}\n{}\n", kind_formatted, result))

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -23,6 +23,7 @@ runtime_bench_gate_b = ["compiler", "mech-engine/resident-artifact"]
 resident-external = ["runtime", "mech-engine/resident-artifact"]
 resident-routing = ["resident-external"]
 resident-routing-source = ["resident-routing", "compiler"]
+legacy-interpreter = ["runtime", "source"]
 runtime_bench_gate_d = ["runtime_bench_gate_b", "runtime_default"]
 runtime_bench_gate_d3 = ["resident-external", "runtime_bench_gate_d"]
 native-link = ["runtime", "string"]
@@ -70,9 +71,9 @@ source_default = [
   "watcher",
 ]
 compiler_default = ["source_default", "compiler"]
-full_runtime = ["runtime_default"]
-full_source = ["source_default"]
-full_compiler = ["compiler_default"]
+full_runtime = ["runtime_default", "legacy-interpreter"]
+full_source = ["source_default", "legacy-interpreter"]
+full_compiler = ["compiler_default", "legacy-interpreter"]
 default = []
 base = ["compiler_default", "mech-core/base", "mech-engine/base"]
 
@@ -251,17 +252,17 @@ required-features = ["source_default"]
 [[example]]
 name = "arbitrary_rust_host_function"
 path = "examples/arbitrary_rust_host_function.rs"
-required-features = ["source_default"]
+required-features = ["source_default", "legacy-interpreter"]
 
 [[example]]
 name = "arbitrary_rust_host_functions2"
 path = "examples/arbitrary_rust_host_functions2.rs"
-required-features = ["source_default"]
+required-features = ["source_default", "legacy-interpreter"]
 
 [[example]]
 name = "basic_runtime"
 path = "examples/basic_runtime.rs"
-required-features = ["source_default"]
+required-features = ["source_default", "legacy-interpreter"]
 
 [[example]]
 name = "dep_cycle"
@@ -276,7 +277,7 @@ required-features = ["source_default"]
 [[example]]
 name = "host_value_roundtrip"
 path = "examples/host_value_roundtrip.rs"
-required-features = ["source_default"]
+required-features = ["source_default", "legacy-interpreter"]
 
 [[example]]
 name = "runtime_dep_src"
@@ -321,7 +322,22 @@ required-features = ["source_default"]
 [[test]]
 name = "module_smoke"
 path = "tests/module_smoke.rs"
-required-features = ["source_default"]
+required-features = ["source_default", "legacy-interpreter"]
+
+[[test]]
+name = "generic_host"
+path = "tests/generic_host.rs"
+required-features = ["source_default", "legacy-interpreter"]
+
+[[test]]
+name = "native_live_resource"
+path = "tests/native_live_resource.rs"
+required-features = ["source_default", "legacy-interpreter"]
+
+[[test]]
+name = "sealed_snapshots"
+path = "tests/sealed_snapshots.rs"
+required-features = ["source_default", "legacy-interpreter"]
 
 [[test]]
 name = "recording_bench_facade"
@@ -336,17 +352,17 @@ required-features = ["source_default"]
 [[bench]]
 name = "program_transaction"
 harness = false
-required-features = ["source_default"]
+required-features = ["source_default", "legacy-interpreter"]
 
 [[bench]]
 name = "reactive_transaction"
 harness = false
-required-features = ["source_default"]
+required-features = ["source_default", "legacy-interpreter"]
 
 [[bench]]
 name = "history_scaling"
 harness = false
-required-features = ["source_default", "runtime_bench_probes"]
+required-features = ["source_default", "runtime_bench_probes", "legacy-interpreter"]
 
 [[bench]]
 name = "recording_primitives"
@@ -356,4 +372,4 @@ required-features = ["runtime_default", "runtime_bench_probes"]
 [[bench]]
 name = "resident_ekf"
 harness = false
-required-features = ["source_default", "runtime_bench_gate_b"]
+required-features = ["source_default", "runtime_bench_gate_b", "legacy-interpreter"]

--- a/src/runtime/benches/program_transaction.rs
+++ b/src/runtime/benches/program_transaction.rs
@@ -1,5 +1,6 @@
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use mech_core::{LegacyValue, MResult, MechSourceCode, MechTuple, Ref};
+use mech_runtime::legacy_interpreter::LegacyInterpreterTestExt as _;
 use mech_runtime::{
     BasicCapability, BasicOperation, BasicResource, BasicSubject, CapabilityId, CapabilityRequest,
     HostCall, InMemoryDocsProvider, InMemorySourceResolver, MechRuntime, ModuleBuildOptions,

--- a/src/runtime/benches/reactive_transaction.rs
+++ b/src/runtime/benches/reactive_transaction.rs
@@ -2,6 +2,7 @@ use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use mech_core::{GenericError, LegacyValue, MResult, MechError, Ref, hash_str};
 use mech_engine::Interpreter;
 use mech_engine::{MechProgram, MechProgramConfig, ProgramInputId, ProgramInputUpdate};
+use mech_runtime::legacy_interpreter::LegacyInterpreterTestExt as _;
 use mech_runtime::{
     BasicCapability, BasicOperation, BasicResource, BasicSubject, CapabilityId,
     DeterministicHostFunction, HostArgumentValue, MechRuntime, ObjectRecord,

--- a/src/runtime/benches/support/gate_b/legacy_atomic.rs
+++ b/src/runtime/benches/support/gate_b/legacy_atomic.rs
@@ -1,6 +1,8 @@
 use std::collections::VecDeque;
 use std::sync::Arc;
 
+use mech_runtime::legacy_interpreter::LegacyInterpreterTestExt as _;
+
 use mech_core::structures::Matrix as MechMatrix;
 #[cfg(feature = "compiler")]
 use mech_core::{BytecodeCompilerContext, MechFunctionCompiler, Register};

--- a/src/runtime/benches/support/history.rs
+++ b/src/runtime/benches/support/history.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use mech_runtime::legacy_interpreter::LegacyInterpreterTestExt as _;
+
 use mech_core::{GenericError, LegacyValue, MResult, MechError, Ref};
 use mech_runtime::{
     ActorId, ActorRecord, BasicCapability, BasicOperation, BasicResource, BasicSubject,

--- a/src/runtime/examples/arbitrary_rust_host_function.rs
+++ b/src/runtime/examples/arbitrary_rust_host_function.rs
@@ -1,6 +1,8 @@
 use std::fmt::Display;
 use std::sync::Arc;
 
+use mech_runtime::legacy_interpreter::LegacyInterpreterTestExt as _;
+
 use mech_core::{LegacyValue, MResult, Ref};
 
 use mech_runtime::{

--- a/src/runtime/examples/arbitrary_rust_host_functions2.rs
+++ b/src/runtime/examples/arbitrary_rust_host_functions2.rs
@@ -1,6 +1,8 @@
 use std::fmt::Display;
 use std::sync::Arc;
 
+use mech_runtime::legacy_interpreter::LegacyInterpreterTestExt as _;
+
 use mech_core::{LegacyValue, MResult};
 
 use mech_runtime::{

--- a/src/runtime/examples/basic_runtime.rs
+++ b/src/runtime/examples/basic_runtime.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use mech_runtime::legacy_interpreter::LegacyInterpreterTestExt as _;
+
 use mech_core::{LegacyValue, MResult};
 use mech_runtime::{
     BasicCapability, BasicCapabilityKernel, BasicOperation, BasicResource, BasicSubject,

--- a/src/runtime/examples/host_value_roundtrip.rs
+++ b/src/runtime/examples/host_value_roundtrip.rs
@@ -1,6 +1,8 @@
 use std::fmt::Display;
 use std::sync::Arc;
 
+use mech_runtime::legacy_interpreter::LegacyInterpreterTestExt as _;
+
 use mech_core::{LegacyValue, MResult};
 
 use mech_runtime::{

--- a/src/runtime/src/config/mod.rs
+++ b/src/runtime/src/config/mod.rs
@@ -86,6 +86,23 @@ impl RuntimeConfig {
         Ok(())
     }
 
+    /// Validate the execution policy accepted by shipping products.
+    ///
+    /// Developer-only legacy facades may still carry the other policy values,
+    /// but a production entry point must never select or fall back to them.
+    pub fn validate_production_program_routing(&self) -> MResult<()> {
+        if self.program_routing.resident_routing != ResidentRoutingPolicy::RequireResident {
+            return Err(MechError::new(
+                InvalidRuntimeConfigValue {
+                    field: "runtime.program-routing.resident-routing",
+                    reason: "production products require `require-resident` routing".to_string(),
+                },
+                None,
+            ));
+        }
+        Ok(())
+    }
+
     pub fn apply_patch(mut self, patch: &crate::RuntimeConfigPatch) -> MResult<Self> {
         if let Some(name) = &patch.name {
             self.name = name.clone();
@@ -382,6 +399,22 @@ mod tests {
     fn default_config_is_valid() {
         let config = RuntimeConfig::default();
         assert!(config.validate().is_ok());
+        assert!(config.validate_production_program_routing().is_ok());
+    }
+
+    #[test]
+    fn production_routing_rejects_interpreter_selection() {
+        for routing in [
+            ResidentRoutingPolicy::PreferResident,
+            ResidentRoutingPolicy::LegacyOnly,
+        ] {
+            let mut config = RuntimeConfig::default();
+            config.program_routing.resident_routing = routing;
+            let error = config
+                .validate_production_program_routing()
+                .expect_err("shipping products must reject interpreter routing");
+            assert_eq!(error.kind_name(), "InvalidRuntimeConfigValue");
+        }
     }
 
     #[test]

--- a/src/runtime/src/config/mod.rs
+++ b/src/runtime/src/config/mod.rs
@@ -160,8 +160,8 @@ impl RuntimeConfig {
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum ResidentRoutingPolicy {
-    #[default]
     PreferResident,
+    #[default]
     RequireResident,
     LegacyOnly,
 }

--- a/src/runtime/src/config/mod.rs
+++ b/src/runtime/src/config/mod.rs
@@ -175,12 +175,13 @@ impl RuntimeConfig {
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[repr(u8)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum ResidentRoutingPolicy {
-    PreferResident,
+    PreferResident = 0,
     #[default]
-    RequireResident,
-    LegacyOnly,
+    RequireResident = 1,
+    LegacyOnly = 2,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/runtime/src/legacy_interpreter.rs
+++ b/src/runtime/src/legacy_interpreter.rs
@@ -1,0 +1,220 @@
+//! Temporary developer-only access to the pre-resident interpreter.
+//!
+//! Shipping products must use the production resident loaders instead. This
+//! facade exists only to keep migration tests and full-development tools
+//! usable until E1 removes the old executor.
+
+use mech_core::{MResult, MechSourceCode, Program};
+
+use crate::{MechRuntime, ModuleBuildOptions, RuntimeContext, RuntimeValueSnapshot, SourceRequest};
+
+/// Explicit, temporary authority to execute through the legacy interpreter.
+pub struct LegacyInterpreter<'runtime> {
+    runtime: &'runtime mut MechRuntime,
+}
+
+impl MechRuntime {
+    /// Enter the temporary developer-only interpreter facade.
+    pub fn legacy_interpreter(&mut self) -> LegacyInterpreter<'_> {
+        LegacyInterpreter { runtime: self }
+    }
+}
+
+impl LegacyInterpreter<'_> {
+    pub fn run_string(&mut self, source: &str) -> MResult<RuntimeValueSnapshot> {
+        self.runtime.run_string(source)
+    }
+
+    pub fn run_string_with_context(
+        &mut self,
+        context: &mut RuntimeContext,
+        source: &str,
+    ) -> MResult<RuntimeValueSnapshot> {
+        self.runtime.run_string_with_context(context, source)
+    }
+
+    pub fn run_source_with_context(
+        &mut self,
+        context: &mut RuntimeContext,
+        source: &MechSourceCode,
+    ) -> MResult<RuntimeValueSnapshot> {
+        self.runtime.run_source_with_context(context, source)
+    }
+
+    pub fn run_tree(&mut self, tree: &Program) -> MResult<RuntimeValueSnapshot> {
+        self.runtime.run_tree(tree)
+    }
+
+    pub fn run_tree_with_context(
+        &mut self,
+        context: &mut RuntimeContext,
+        tree: &Program,
+    ) -> MResult<RuntimeValueSnapshot> {
+        self.runtime.run_tree_with_context(context, tree)
+    }
+
+    pub fn resolve_and_run_root_module(
+        &mut self,
+        request: impl Into<SourceRequest>,
+        options: ModuleBuildOptions<'_>,
+    ) -> MResult<RuntimeValueSnapshot> {
+        self.runtime.resolve_and_run_root_module(request, options)
+    }
+
+    pub fn resolve_and_run_root_module_with_context(
+        &mut self,
+        context: &mut RuntimeContext,
+        request: impl Into<SourceRequest>,
+        options: ModuleBuildOptions<'_>,
+    ) -> MResult<RuntimeValueSnapshot> {
+        self.runtime
+            .resolve_and_run_root_module_with_context(context, request, options)
+    }
+
+    #[cfg(feature = "invariant_define")]
+    pub fn resolve_and_run_root_module_report(
+        &mut self,
+        request: impl Into<SourceRequest>,
+        options: ModuleBuildOptions<'_>,
+    ) -> MResult<crate::RuntimeRootModuleExecutionReport> {
+        self.runtime
+            .resolve_and_run_root_module_report(request, options)
+    }
+
+    pub fn install_bytecode_with_context(
+        &mut self,
+        context: &mut RuntimeContext,
+        bytecode: &[u8],
+    ) -> MResult<RuntimeValueSnapshot> {
+        self.runtime
+            .install_bytecode_with_context(context, bytecode)
+    }
+}
+
+/// Compatibility syntax for migration-only tests, examples, and benchmarks.
+///
+/// New developer tools must use [`MechRuntime::legacy_interpreter`] visibly.
+#[doc(hidden)]
+pub trait LegacyInterpreterTestExt {
+    fn run_string(&mut self, source: &str) -> MResult<RuntimeValueSnapshot>;
+    fn run_string_with_context(
+        &mut self,
+        context: &mut RuntimeContext,
+        source: &str,
+    ) -> MResult<RuntimeValueSnapshot>;
+    fn run_source_with_context(
+        &mut self,
+        context: &mut RuntimeContext,
+        source: &MechSourceCode,
+    ) -> MResult<RuntimeValueSnapshot>;
+    fn run_source(&mut self, source: &MechSourceCode) -> MResult<RuntimeValueSnapshot>;
+    fn run_tree(&mut self, tree: &Program) -> MResult<RuntimeValueSnapshot>;
+    fn run_tree_with_context(
+        &mut self,
+        context: &mut RuntimeContext,
+        tree: &Program,
+    ) -> MResult<RuntimeValueSnapshot>;
+    fn resolve_and_run_root_module(
+        &mut self,
+        request: impl Into<SourceRequest>,
+        options: ModuleBuildOptions<'_>,
+    ) -> MResult<RuntimeValueSnapshot>;
+    fn resolve_and_run_root_module_with_context(
+        &mut self,
+        context: &mut RuntimeContext,
+        request: impl Into<SourceRequest>,
+        options: ModuleBuildOptions<'_>,
+    ) -> MResult<RuntimeValueSnapshot>;
+    #[cfg(feature = "invariant_define")]
+    fn resolve_and_run_root_module_report(
+        &mut self,
+        request: impl Into<SourceRequest>,
+        options: ModuleBuildOptions<'_>,
+    ) -> MResult<crate::RuntimeRootModuleExecutionReport>;
+    fn install_bytecode_with_context(
+        &mut self,
+        context: &mut RuntimeContext,
+        bytecode: &[u8],
+    ) -> MResult<RuntimeValueSnapshot>;
+}
+
+impl LegacyInterpreterTestExt for MechRuntime {
+    fn run_string(&mut self, source: &str) -> MResult<RuntimeValueSnapshot> {
+        self.legacy_interpreter().run_string(source)
+    }
+
+    fn run_string_with_context(
+        &mut self,
+        context: &mut RuntimeContext,
+        source: &str,
+    ) -> MResult<RuntimeValueSnapshot> {
+        self.legacy_interpreter()
+            .run_string_with_context(context, source)
+    }
+
+    fn run_source_with_context(
+        &mut self,
+        context: &mut RuntimeContext,
+        source: &MechSourceCode,
+    ) -> MResult<RuntimeValueSnapshot> {
+        self.legacy_interpreter()
+            .run_source_with_context(context, source)
+    }
+
+    fn run_source(&mut self, source: &MechSourceCode) -> MResult<RuntimeValueSnapshot> {
+        let mut context = self.runtime_context()?;
+        self.legacy_interpreter()
+            .run_source_with_context(&mut context, source)
+    }
+
+    fn run_tree(&mut self, tree: &Program) -> MResult<RuntimeValueSnapshot> {
+        self.legacy_interpreter().run_tree(tree)
+    }
+
+    fn run_tree_with_context(
+        &mut self,
+        context: &mut RuntimeContext,
+        tree: &Program,
+    ) -> MResult<RuntimeValueSnapshot> {
+        self.legacy_interpreter()
+            .run_tree_with_context(context, tree)
+    }
+
+    fn resolve_and_run_root_module(
+        &mut self,
+        request: impl Into<SourceRequest>,
+        options: ModuleBuildOptions<'_>,
+    ) -> MResult<RuntimeValueSnapshot> {
+        self.legacy_interpreter()
+            .resolve_and_run_root_module(request, options)
+    }
+
+    fn resolve_and_run_root_module_with_context(
+        &mut self,
+        context: &mut RuntimeContext,
+        request: impl Into<SourceRequest>,
+        options: ModuleBuildOptions<'_>,
+    ) -> MResult<RuntimeValueSnapshot> {
+        self.legacy_interpreter()
+            .resolve_and_run_root_module_with_context(context, request, options)
+    }
+
+    #[cfg(feature = "invariant_define")]
+    fn resolve_and_run_root_module_report(
+        &mut self,
+        request: impl Into<SourceRequest>,
+        options: ModuleBuildOptions<'_>,
+    ) -> MResult<crate::RuntimeRootModuleExecutionReport> {
+        self.legacy_interpreter()
+            .resolve_and_run_root_module_report(request, options)
+    }
+
+    fn install_bytecode_with_context(
+        &mut self,
+        context: &mut RuntimeContext,
+        bytecode: &[u8],
+    ) -> MResult<RuntimeValueSnapshot> {
+        self.legacy_interpreter()
+            .install_bytecode_with_context(context, bytecode)
+    }
+}

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -9,6 +9,8 @@ pub mod id;
 pub mod input;
 #[cfg(feature = "runtime")]
 mod ledger;
+#[cfg(feature = "legacy-interpreter")]
+pub mod legacy_interpreter;
 pub mod operation;
 #[cfg(feature = "runtime")]
 mod outbox;

--- a/src/runtime/src/runtime/execution/bytecode.rs
+++ b/src/runtime/src/runtime/execution/bytecode.rs
@@ -9,7 +9,7 @@ use std::time::Instant;
 use web_time::Instant;
 
 impl MechRuntime {
-    pub fn evaluate_bytecode_once_with_context(
+    pub(crate) fn evaluate_bytecode_once_with_context(
         &mut self,
         context: &mut RuntimeContext,
         bytecode: &[u8],
@@ -151,7 +151,7 @@ impl MechRuntime {
     ///     .install_bytecode_with_context(&mut context, b"not-bytecode")
     ///     .is_err());
     /// ```
-    pub fn install_bytecode_with_context(
+    pub(crate) fn install_bytecode_with_context(
         &mut self,
         context: &mut RuntimeContext,
         bytecode: &[u8],

--- a/src/runtime/src/runtime/execution/source.rs
+++ b/src/runtime/src/runtime/execution/source.rs
@@ -106,12 +106,12 @@ impl MechRuntime {
         Ok(result)
     }
 
-    pub fn run_string(&mut self, source: &str) -> MResult<RuntimeValueSnapshot> {
+    pub(crate) fn run_string(&mut self, source: &str) -> MResult<RuntimeValueSnapshot> {
         let mut context = self.runtime_context()?;
         self.run_string_with_context(&mut context, source)
     }
 
-    pub fn run_string_with_context(
+    pub(crate) fn run_string_with_context(
         &mut self,
         context: &mut RuntimeContext,
         source: &str,
@@ -231,7 +231,7 @@ impl MechRuntime {
         result
     }
 
-    pub fn run_source_with_context(
+    pub(crate) fn run_source_with_context(
         &mut self,
         context: &mut RuntimeContext,
         source: &MechSourceCode,
@@ -241,7 +241,7 @@ impl MechRuntime {
         })
     }
 
-    pub fn run_source(&mut self, source: &MechSourceCode) -> MResult<RuntimeValueSnapshot> {
+    pub(crate) fn run_source(&mut self, source: &MechSourceCode) -> MResult<RuntimeValueSnapshot> {
         let mut context = self.runtime_context()?;
         self.run_source_with_context(&mut context, source)
     }
@@ -315,12 +315,12 @@ impl MechRuntime {
         }
     }
 
-    pub fn run_tree(&mut self, tree: &mech_core::Program) -> MResult<RuntimeValueSnapshot> {
+    pub(crate) fn run_tree(&mut self, tree: &mech_core::Program) -> MResult<RuntimeValueSnapshot> {
         let mut context = self.runtime_context()?;
         self.run_tree_with_context(&mut context, tree)
     }
 
-    pub fn run_tree_with_context(
+    pub(crate) fn run_tree_with_context(
         &mut self,
         context: &mut RuntimeContext,
         tree: &mech_core::Program,

--- a/src/runtime/src/runtime/module/mod.rs
+++ b/src/runtime/src/runtime/module/mod.rs
@@ -646,7 +646,7 @@ impl MechRuntime {
         )
     }
 
-    pub fn resolve_and_run_root_module(
+    pub(crate) fn resolve_and_run_root_module(
         &mut self,
         request: impl Into<SourceRequest>,
         options: ModuleBuildOptions<'_>,
@@ -656,7 +656,7 @@ impl MechRuntime {
         self.resolve_and_run_root_module_with_context(&mut context, request, options)
     }
 
-    pub fn resolve_and_run_root_module_with_context(
+    pub(crate) fn resolve_and_run_root_module_with_context(
         &mut self,
         context: &mut RuntimeContext,
         request: impl Into<SourceRequest>,
@@ -667,7 +667,7 @@ impl MechRuntime {
     }
 
     #[cfg(feature = "invariant_define")]
-    pub fn resolve_and_run_root_module_report(
+    pub(crate) fn resolve_and_run_root_module_report(
         &mut self,
         request: impl Into<SourceRequest>,
         options: ModuleBuildOptions<'_>,
@@ -678,7 +678,7 @@ impl MechRuntime {
     }
 
     #[cfg(feature = "invariant_define")]
-    pub fn resolve_and_run_root_module_report_with_context(
+    pub(crate) fn resolve_and_run_root_module_report_with_context(
         &mut self,
         context: &mut RuntimeContext,
         request: impl Into<SourceRequest>,

--- a/src/runtime/src/runtime/resident_program/artifact_tests.rs
+++ b/src/runtime/src/runtime/resident_program/artifact_tests.rs
@@ -2,9 +2,9 @@ use super::{RuntimeProgramLoadOptions, RuntimeProgramRoute};
 use crate::{ResidentDurabilityPolicy, ResidentRoutingPolicy, RuntimeBuilder};
 
 #[test]
-fn artifact_load_options_default_to_prefer_resident_and_volatile() {
+fn artifact_load_options_default_to_required_resident_and_volatile() {
     let options = RuntimeProgramLoadOptions::default();
-    assert_eq!(options.routing, ResidentRoutingPolicy::PreferResident);
+    assert_eq!(options.routing, ResidentRoutingPolicy::RequireResident);
     assert_eq!(options.durability, ResidentDurabilityPolicy::Volatile);
 }
 

--- a/src/runtime/src/runtime/resident_program/load.rs
+++ b/src/runtime/src/runtime/resident_program/load.rs
@@ -40,6 +40,76 @@ use super::{
 
 impl MechRuntime {
     #[cfg(feature = "resident-routing-source")]
+    pub fn load_production_source_program(
+        &mut self,
+        source: &str,
+        durability: crate::ResidentDurabilityPolicy,
+    ) -> MResult<RuntimeProgramLoadOutcome> {
+        self.enforce_source_byte_limit(u64::try_from(source.len()).unwrap_or(u64::MAX))?;
+        self.load_production_with(durability, |runtime| {
+            Ok(Arc::new(
+                runtime.plan_source_product(source)?.into_parts().0,
+            ))
+        })
+    }
+
+    #[cfg(feature = "resident-routing-source")]
+    pub fn load_production_root_program(
+        &mut self,
+        request: SourceRequest,
+        module_options: ModuleBuildOptions<'_>,
+        durability: crate::ResidentDurabilityPolicy,
+    ) -> MResult<RuntimeProgramLoadOutcome> {
+        self.load_production_with(durability, |runtime| {
+            let resolved = runtime.resolve_source(request.clone())?.ok_or_else(|| {
+                route_failure(
+                    ResidentRouteFailureClass::InvalidArtifact,
+                    format!("root source `{}` was not found", request.specifier),
+                )
+            })?;
+            match &resolved.source {
+                MechSourceCode::String(source) => {
+                    runtime.enforce_source_byte_limit(
+                        u64::try_from(source.len()).unwrap_or(u64::MAX),
+                    )?;
+                    Ok(Arc::new(
+                        runtime
+                            .plan_root_source_product(request.clone(), module_options)?
+                            .into_parts()
+                            .0,
+                    ))
+                }
+                MechSourceCode::Tree(_) => Ok(Arc::new(
+                    runtime
+                        .plan_root_source_product(request.clone(), module_options)?
+                        .into_parts()
+                        .0,
+                )),
+                MechSourceCode::ByteCode(bytecode) => {
+                    runtime.enforce_source_byte_limit(
+                        u64::try_from(bytecode.len()).unwrap_or(u64::MAX),
+                    )?;
+                    runtime.decode_artifact(bytecode)
+                }
+                _ => Err(route_failure(
+                    ResidentRouteFailureClass::SemanticUnsupported,
+                    "root source kind is not resident-routable",
+                )),
+            }
+        })
+    }
+
+    #[cfg(feature = "resident-routing")]
+    pub fn load_production_bytecode_program(
+        &mut self,
+        bytecode: &[u8],
+        durability: crate::ResidentDurabilityPolicy,
+    ) -> MResult<RuntimeProgramLoadOutcome> {
+        self.enforce_source_byte_limit(u64::try_from(bytecode.len()).unwrap_or(u64::MAX))?;
+        self.load_production_with(durability, |runtime| runtime.decode_artifact(bytecode))
+    }
+
+    #[cfg(feature = "resident-routing-source")]
     pub fn load_source_program(
         &mut self,
         source: &str,
@@ -119,6 +189,26 @@ impl MechRuntime {
                 runtime.evaluate_bytecode_once_with_context(&mut context, bytecode)
             },
         )
+    }
+
+    fn load_production_with<Resident>(
+        &mut self,
+        durability: crate::ResidentDurabilityPolicy,
+        resident: Resident,
+    ) -> MResult<RuntimeProgramLoadOutcome>
+    where
+        Resident: FnOnce(&mut Self) -> MResult<Arc<ProgramArtifact>>,
+    {
+        self.ensure_program_slot_available()?;
+        super::ensure_supported_durability(durability)?;
+        let options = RuntimeProgramLoadOptions::production(durability);
+        let result =
+            resident(self).and_then(|artifact| self.install_resident_artifact(artifact, options));
+        if result.is_err() {
+            debug_assert!(matches!(self.active_program, ActiveProgramExecution::None));
+            self.program_execution_info = RuntimeProgramExecutionInfo::default();
+        }
+        result
     }
 
     fn load_with_selection<Resident, Legacy>(

--- a/src/runtime/src/runtime/resident_program/load.rs
+++ b/src/runtime/src/runtime/resident_program/load.rs
@@ -109,7 +109,10 @@ impl MechRuntime {
         self.load_production_with(durability, |runtime| runtime.decode_artifact(bytecode))
     }
 
-    #[cfg(feature = "resident-routing-source")]
+    #[cfg(all(
+        feature = "resident-routing-source",
+        any(test, feature = "legacy-interpreter")
+    ))]
     pub fn load_source_program(
         &mut self,
         source: &str,
@@ -127,7 +130,10 @@ impl MechRuntime {
         )
     }
 
-    #[cfg(feature = "resident-routing-source")]
+    #[cfg(all(
+        feature = "resident-routing-source",
+        any(test, feature = "legacy-interpreter")
+    ))]
     pub fn load_root_program(
         &mut self,
         request: SourceRequest,
@@ -174,7 +180,10 @@ impl MechRuntime {
         )
     }
 
-    #[cfg(feature = "resident-routing")]
+    #[cfg(all(
+        feature = "resident-routing",
+        any(test, feature = "legacy-interpreter")
+    ))]
     pub fn load_bytecode_program(
         &mut self,
         bytecode: &[u8],
@@ -211,6 +220,7 @@ impl MechRuntime {
         result
     }
 
+    #[cfg(any(test, feature = "legacy-interpreter"))]
     fn load_with_selection<Resident, Legacy>(
         &mut self,
         options: RuntimeProgramLoadOptions,
@@ -535,6 +545,7 @@ impl MechRuntime {
         Ok(())
     }
 
+    #[cfg(any(test, feature = "legacy-interpreter"))]
     fn install_legacy_outcome(
         &mut self,
         value: RuntimeValueSnapshot,

--- a/src/runtime/src/runtime/resident_program/route.rs
+++ b/src/runtime/src/runtime/resident_program/route.rs
@@ -184,6 +184,7 @@ pub(crate) fn unsupported_route(reason: impl Into<String>) -> mech_core::MechErr
 /// Returns whether a resident-routing failure may safely select the legacy
 /// executor under [`ResidentRoutingPolicy::PreferResident`]. Authority,
 /// provider, bytecode, activation, and internal failures are never eligible.
+#[cfg(any(test, feature = "legacy-interpreter"))]
 pub fn resident_fallback_eligible(error: &MechError) -> bool {
     error
         .kind_as::<ResidentRouteFailure>()
@@ -252,6 +253,7 @@ impl MechRuntime {
         self.program_execution_info.clone()
     }
 
+    #[cfg(any(test, feature = "legacy-interpreter"))]
     pub fn record_legacy_program_route(
         &mut self,
         policy: crate::ResidentRoutingPolicy,

--- a/src/runtime/src/runtime/resident_program/route.rs
+++ b/src/runtime/src/runtime/resident_program/route.rs
@@ -41,7 +41,7 @@ impl Default for RuntimeProgramExecutionInfo {
     fn default() -> Self {
         Self {
             route: RuntimeProgramRoute::None,
-            policy: ResidentRoutingPolicy::PreferResident,
+            policy: ResidentRoutingPolicy::RequireResident,
             program_revision: None,
             plan_generation: None,
             layout_generation: None,
@@ -65,9 +65,20 @@ pub struct RuntimeProgramLoadOptions {
 
 impl Default for RuntimeProgramLoadOptions {
     fn default() -> Self {
+        Self::production(ResidentDurabilityPolicy::Volatile)
+    }
+}
+
+impl RuntimeProgramLoadOptions {
+    /// The one shipping program-loading policy.
+    ///
+    /// Production callers choose durability only. Execution-engine selection
+    /// remains available solely to the temporary legacy-interpreter facade
+    /// and migration tests until E1 removes it.
+    pub const fn production(durability: ResidentDurabilityPolicy) -> Self {
         Self {
-            routing: ResidentRoutingPolicy::PreferResident,
-            durability: ResidentDurabilityPolicy::Volatile,
+            routing: ResidentRoutingPolicy::RequireResident,
+            durability,
         }
     }
 }

--- a/src/runtime/src/runtime/resident_program/tests.rs
+++ b/src/runtime/src/runtime/resident_program/tests.rs
@@ -566,11 +566,11 @@ fn unactivated_external_runtime(driver_count: usize) -> crate::MechRuntime {
 }
 
 #[test]
-fn load_options_default_to_prefer_resident_and_volatile() {
+fn load_options_default_to_required_resident_and_volatile() {
     let options = RuntimeProgramLoadOptions::default();
     assert_eq!(
         options.routing,
-        crate::ResidentRoutingPolicy::PreferResident
+        crate::ResidentRoutingPolicy::RequireResident
     );
     assert_eq!(
         options.durability,
@@ -837,7 +837,13 @@ fn unsupported_source_falls_back_only_when_policy_allows_it() {
     let unsupported = r#"message := "resident strings are deliberately unsupported""#;
     let mut preferred = runtime();
     let outcome = preferred
-        .load_source_program(unsupported, RuntimeProgramLoadOptions::default())
+        .load_source_program(
+            unsupported,
+            RuntimeProgramLoadOptions {
+                routing: crate::ResidentRoutingPolicy::PreferResident,
+                ..RuntimeProgramLoadOptions::default()
+            },
+        )
         .unwrap();
     assert_eq!(outcome.route, RuntimeProgramRoute::Legacy);
     assert_eq!(outcome.info.legacy_turns, 1);
@@ -854,6 +860,53 @@ fn unsupported_source_falls_back_only_when_policy_allows_it() {
         .unwrap_err();
     assert_eq!(error.kind_name(), "ResidentRouteFailure");
     assert!(error.kind_message().starts_with("SemanticUnsupported:"));
+}
+
+#[test]
+fn production_source_and_bytecode_load_residently_without_engine_selection() {
+    let mut source_runtime = runtime();
+    let source = source_runtime
+        .load_production_source_program(PURE_SOURCE, crate::ResidentDurabilityPolicy::Volatile)
+        .unwrap();
+    assert_eq!(source.route, RuntimeProgramRoute::ResidentPure);
+    assert_eq!(
+        source.info.policy,
+        crate::ResidentRoutingPolicy::RequireResident
+    );
+    assert_eq!(source.info.legacy_turns, 0);
+
+    let ActiveProgramExecution::ResidentPure(execution) = &source_runtime.active_program else {
+        unreachable!()
+    };
+    let bytecode = encode_program_artifact_bytecode_v1(&execution.artifact).unwrap();
+    let mut bytecode_runtime = runtime();
+    let decoded = bytecode_runtime
+        .load_production_bytecode_program(&bytecode, crate::ResidentDurabilityPolicy::Volatile)
+        .unwrap();
+    assert_eq!(decoded.route, RuntimeProgramRoute::ResidentPure);
+    assert_eq!(
+        decoded.info.policy,
+        crate::ResidentRoutingPolicy::RequireResident
+    );
+    assert_eq!(decoded.info.legacy_turns, 0);
+}
+
+#[test]
+fn production_unsupported_semantics_fail_without_installing_legacy() {
+    let mut runtime = runtime();
+    let error = runtime
+        .load_production_source_program(
+            r#"message := "resident strings are deliberately unsupported""#,
+            crate::ResidentDurabilityPolicy::Volatile,
+        )
+        .unwrap_err();
+    let failure = error.kind_as::<ResidentRouteFailure>().unwrap();
+    assert_eq!(
+        failure.class,
+        ResidentRouteFailureClass::SemanticUnsupported
+    );
+    assert_eq!(runtime.program_route(), RuntimeProgramRoute::None);
+    assert_eq!(runtime.program_execution_info().legacy_turns, 0);
 }
 
 #[test]

--- a/src/runtime/tests/generic_host.rs
+++ b/src/runtime/tests/generic_host.rs
@@ -3,6 +3,7 @@
 use std::sync::{Arc, Mutex};
 
 use mech_core::{FunctionCatalogBuilder, LegacyValue, MResult, MechError, MechErrorKind, Ref};
+use mech_runtime::legacy_interpreter::LegacyInterpreterTestExt as _;
 use mech_runtime::*;
 
 fn runtime_builder_with_intrinsics() -> RuntimeBuilder {

--- a/src/runtime/tests/module_smoke.rs
+++ b/src/runtime/tests/module_smoke.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
+use mech_runtime::legacy_interpreter::LegacyInterpreterTestExt as _;
+
 #[cfg(feature = "compiler")]
 use mech_core::{BytecodeCompilerContext, MechFunctionCompiler, Register};
 use mech_core::{

--- a/src/runtime/tests/native_live_resource.rs
+++ b/src/runtime/tests/native_live_resource.rs
@@ -9,6 +9,8 @@ use std::{
     },
 };
 
+use mech_runtime::legacy_interpreter::LegacyInterpreterTestExt as _;
+
 use mech_core::{
     ApplicationRequirement, BytecodeInstruction, FunctionArgs, FunctionCatalog,
     FunctionCatalogBuilder, FunctionRuntimeType, LegacyValue, MResult, MechError, MechErrorKind,

--- a/src/runtime/tests/sealed_snapshots.rs
+++ b/src/runtime/tests/sealed_snapshots.rs
@@ -4,6 +4,8 @@
 use std::cell::RefCell;
 use std::sync::Arc;
 
+use mech_runtime::legacy_interpreter::LegacyInterpreterTestExt as _;
+
 #[cfg(feature = "compiler")]
 use mech_core::Ref;
 use mech_core::{FunctionCatalogBuilder, LegacyValue};

--- a/src/wasm/Cargo.toml
+++ b/src/wasm/Cargo.toml
@@ -23,7 +23,7 @@ crate-type = ["cdylib", "rlib"]
 [features]
 
 default = []
-full = ["base",
+full = ["base", "legacy-interpreter",
       "u8", "u16", "u32", "u64", "u128",
       "i8", "i16", "i32", "i64", "i128",
       "f32", "f64", "c64", "r64",
@@ -60,6 +60,7 @@ source = ["runtime", "mech-engine/source", "mech-runtime/source", "mech-stdlib/s
 compiler = ["source", "mech-core/compiler", "mech-engine/compiler", "mech-syntax/compiler", "mech-runtime/compiler", "mech-stdlib/compiler"]
 resident-routing = ["mech-runtime/resident-routing"]
 resident-routing-source = ["resident-routing", "compiler", "mech-runtime/resident-routing-source"]
+legacy-interpreter = ["source", "mech-runtime/legacy-interpreter"]
 program = ["mech-core/program", "mech-engine/program", "mech-syntax/program", "mech-runtime/program"]
 pretty_print = ["mech-core/pretty_print", "mech-syntax/pretty_print", "mech-runtime/pretty_print"]
 formatter = ["mech-syntax/formatter"]
@@ -328,6 +329,7 @@ gloo-net = {version = "0.6.0", features = ["http"]}
 wasm-bindgen-futures = "0.4.50"
 
 [dev-dependencies]
+mech-runtime = { path = "../runtime", default-features = false, features = ["legacy-interpreter"] }
 serde_json = "1"
 wasm-bindgen-test = "0.3.50"
 

--- a/src/wasm/src/project.rs
+++ b/src/wasm/src/project.rs
@@ -19,9 +19,8 @@ use mech_core::{MechError, MechErrorKind, MechSourceCode};
 use mech_runtime::{
     ConfigProfileOptions, InMemorySourceResolver, MechConfigDocument, MechRuntime,
     ModuleBuildOptions, ResidentRouteFailure, ResidentRouteFailureClass, ResolvedSource,
-    RuntimeBuilder, RuntimeProgramExecutionInfo, RuntimeProgramLoadOptions, RuntimeProgramRoute,
-    SourceKind, SourceRequest, SourceResolutionEntry, parse_config_document,
-    validate_source_resolution_entries,
+    RuntimeBuilder, RuntimeProgramExecutionInfo, RuntimeProgramRoute, SourceKind, SourceRequest,
+    SourceResolutionEntry, parse_config_document, validate_source_resolution_entries,
 };
 #[cfg(feature = "served_project_authority")]
 use mech_runtime::{
@@ -367,340 +366,363 @@ struct ServedDocumentBootstrap {
     authority: BrowserRuntimeInjectionConfig,
 }
 
-#[wasm_bindgen]
-pub struct WasmDocument {
-    project: WasmProject,
-    bootstrap: WasmDocumentBootstrap,
-}
+mod document {
+    use super::*;
 
-#[wasm_bindgen]
-impl WasmDocument {
-    #[wasm_bindgen(js_name = fromEncoded)]
-    pub fn from_encoded(encoded: &str) -> Result<WasmDocument, JsValue> {
-        let tree = decode_document_tree(encoded)?;
-        #[cfg(feature = "browser_host_scene")]
-        let scenes = BrowserSceneRegistry::new();
-        let mut runtime = runtime_builder_with_factories(
-            #[cfg(feature = "browser_host_scene")]
-            scenes.clone(),
-        )?
-        .build()
-        .map_err(to_js_error)?;
-        runtime.run_tree(&tree).map_err(to_js_error)?;
-        Ok(Self {
-            project: WasmProject::from_runtime(
-                runtime,
-                #[cfg(feature = "browser_host_scene")]
-                scenes,
-            ),
-            bootstrap: WasmDocumentBootstrap::Detached,
-        })
+    #[wasm_bindgen]
+    pub struct WasmDocument {
+        pub(super) project: WasmProject,
+        bootstrap: WasmDocumentBootstrap,
     }
 
-    /// Builds a formatted source document with a resolver rooted at its
-    /// logical source specifier. This keeps relative imports available without
-    /// requiring a configured project.
-    #[wasm_bindgen(js_name = fromEncodedWithSources)]
-    pub fn from_encoded_with_sources(
-        encoded: &str,
+    fn load_resident_document_root(
+        runtime: &mut MechRuntime,
         root_specifier: &str,
-        sources: JsValue,
-    ) -> Result<WasmDocument, JsValue> {
-        let tree = decode_document_tree(encoded)?;
-        let source_map = source_map_from_js(sources)?;
-        Self::from_tree_with_sources(tree, root_specifier, source_map, Vec::new())
-    }
-
-    #[wasm_bindgen(js_name = fromEncodedWithBundle)]
-    pub fn from_encoded_with_bundle(
-        encoded: &str,
-        root_specifier: &str,
-        sources: JsValue,
-        resolutions: JsValue,
-    ) -> Result<WasmDocument, JsValue> {
-        let tree = decode_document_tree(encoded)?;
-        let source_map = source_map_from_js(sources)?;
-        let resolutions = document_resolutions_from_js(resolutions, &source_map)?;
-        Self::from_tree_with_sources(tree, root_specifier, source_map, resolutions)
-    }
-
-    fn from_tree_with_sources(
-        tree: mech_core::nodes::Program,
-        root_specifier: &str,
-        source_map: HashMap<String, String>,
-        resolutions: Vec<SourceResolutionEntry>,
-    ) -> Result<WasmDocument, JsValue> {
-        let bootstrap = SourceBackedDocumentBootstrap {
-            root_specifier: root_specifier.to_string(),
-            source_map,
-            resolutions,
-        };
-        #[cfg(feature = "browser_host_scene")]
-        let scenes = BrowserSceneRegistry::new();
-        let source_resolver = document_source_resolver(tree, &bootstrap)?;
-        let mut runtime = runtime_builder_with_factories(
-            #[cfg(feature = "browser_host_scene")]
-            scenes.clone(),
-        )?
-        .source_resolver(source_resolver)
-        .build()
-        .map_err(to_js_error)?;
+    ) -> Result<(), JsValue> {
+        let durability = runtime.config().program_routing.resident_durability;
         runtime
-            .resolve_and_run_root_module(
-                SourceRequest::new(&bootstrap.root_specifier),
+            .load_production_root_program(
+                SourceRequest::new(root_specifier),
                 browser_module_options(),
+                durability,
             )
-            .map_err(to_js_error)?;
-
-        Ok(Self {
-            project: WasmProject::from_runtime(
-                runtime,
-                #[cfg(feature = "browser_host_scene")]
-                scenes,
-            ),
-            bootstrap: WasmDocumentBootstrap::SourceBacked(bootstrap),
-        })
+            .map(|_| ())
+            .map_err(to_js_error)
     }
 
-    /// Builds a formatted source document with the configured project's
-    /// server-projected host authority and complete source resolver.
-    #[cfg(feature = "served_project_authority")]
-    #[wasm_bindgen(js_name = fromServedEncoded)]
-    pub fn from_served_encoded(
-        encoded: &str,
-        root_specifier: &str,
-        config_source: &str,
-        sources: JsValue,
-    ) -> Result<WasmDocument, JsValue> {
-        let tree = decode_document_tree(encoded)?;
-        let document = parse_project_config(config_source)?;
-        let source_map = source_map_from_js(sources)?;
-        let authority = served_browser_authority()?;
-        Self::from_served_tree(
-            tree,
-            root_specifier,
-            document,
-            config_source,
-            source_map,
-            Vec::new(),
-            authority,
-        )
-    }
-
-    /// Builds a served document with the resolver's authoritative dependency
-    /// edges. This keeps browser resolution identical to the native workspace
-    /// for extension, index, alias, and other resolver-specific matches.
-    #[cfg(feature = "served_project_authority")]
-    #[wasm_bindgen(js_name = fromServedEncodedWithBundle)]
-    pub fn from_served_encoded_with_bundle(
-        encoded: &str,
-        root_specifier: &str,
-        config_source: &str,
-        sources: JsValue,
-        resolutions: JsValue,
-    ) -> Result<WasmDocument, JsValue> {
-        let tree = decode_document_tree(encoded)?;
-        let document = parse_project_config(config_source)?;
-        let source_map = source_map_from_js(sources)?;
-        let resolutions = document_resolutions_from_js(resolutions, &source_map)?;
-        let authority = served_browser_authority()?;
-        Self::from_served_tree(
-            tree,
-            root_specifier,
-            document,
-            config_source,
-            source_map,
-            resolutions,
-            authority,
-        )
-    }
-
-    #[cfg(feature = "served_project_authority")]
-    fn from_served_tree(
-        tree: mech_core::nodes::Program,
-        root_specifier: &str,
-        document: MechConfigDocument,
-        config_source: &str,
-        source_map: HashMap<String, String>,
-        resolutions: Vec<SourceResolutionEntry>,
-        authority: BrowserRuntimeInjectionConfig,
-    ) -> Result<WasmDocument, JsValue> {
-        let source = SourceBackedDocumentBootstrap {
-            root_specifier: root_specifier.to_string(),
-            source_map,
-            resolutions,
-        };
-        validate_served_authority(&document, &authority).map_err(to_js_error)?;
-        validate_compiled_host_providers_for_hosts(&document.hosts).map_err(to_js_error)?;
-        #[cfg(feature = "browser_host_scene")]
-        let scenes = BrowserSceneRegistry::new();
-        let source_resolver = document_source_resolver(tree, &source)?;
-        let mut runtime = build_runtime_from_authority(
-            &document,
-            &authority,
-            source_resolver,
+    #[wasm_bindgen]
+    impl WasmDocument {
+        #[wasm_bindgen(js_name = fromEncoded)]
+        pub fn from_encoded(encoded: &str) -> Result<WasmDocument, JsValue> {
+            let tree = decode_document_tree(encoded)?;
+            let source = SourceBackedDocumentBootstrap {
+                root_specifier: "document.mec".to_string(),
+                source_map: HashMap::from([("document.mec".to_string(), String::new())]),
+                resolutions: Vec::new(),
+            };
             #[cfg(feature = "browser_host_scene")]
-            scenes.clone(),
-        )?;
-        runtime
-            .resolve_and_run_root_module(
-                SourceRequest::new(&source.root_specifier),
-                browser_module_options(),
-            )
-            .map_err(to_js_error)?;
-
-        Ok(Self {
-            project: WasmProject::from_runtime(
-                runtime,
+            let scenes = BrowserSceneRegistry::new();
+            let mut runtime = runtime_builder_with_factories(
                 #[cfg(feature = "browser_host_scene")]
-                scenes,
-            ),
-            bootstrap: WasmDocumentBootstrap::Served(ServedDocumentBootstrap {
-                source,
-                config_source: config_source.to_string(),
+                scenes.clone(),
+            )?
+            .source_resolver(document_source_resolver(tree, &source)?)
+            .build()
+            .map_err(to_js_error)?;
+            load_resident_document_root(&mut runtime, &source.root_specifier)?;
+            Ok(Self {
+                project: WasmProject::from_runtime(
+                    runtime,
+                    #[cfg(feature = "browser_host_scene")]
+                    scenes,
+                ),
+                bootstrap: WasmDocumentBootstrap::Detached,
+            })
+        }
+
+        /// Builds a formatted source document with a resolver rooted at its
+        /// logical source specifier. This keeps relative imports available without
+        /// requiring a configured project.
+        #[wasm_bindgen(js_name = fromEncodedWithSources)]
+        pub fn from_encoded_with_sources(
+            encoded: &str,
+            root_specifier: &str,
+            sources: JsValue,
+        ) -> Result<WasmDocument, JsValue> {
+            let tree = decode_document_tree(encoded)?;
+            let source_map = source_map_from_js(sources)?;
+            Self::from_tree_with_sources(tree, root_specifier, source_map, Vec::new())
+        }
+
+        #[wasm_bindgen(js_name = fromEncodedWithBundle)]
+        pub fn from_encoded_with_bundle(
+            encoded: &str,
+            root_specifier: &str,
+            sources: JsValue,
+            resolutions: JsValue,
+        ) -> Result<WasmDocument, JsValue> {
+            let tree = decode_document_tree(encoded)?;
+            let source_map = source_map_from_js(sources)?;
+            let resolutions = document_resolutions_from_js(resolutions, &source_map)?;
+            Self::from_tree_with_sources(tree, root_specifier, source_map, resolutions)
+        }
+
+        pub(super) fn from_tree_with_sources(
+            tree: mech_core::nodes::Program,
+            root_specifier: &str,
+            source_map: HashMap<String, String>,
+            resolutions: Vec<SourceResolutionEntry>,
+        ) -> Result<WasmDocument, JsValue> {
+            let bootstrap = SourceBackedDocumentBootstrap {
+                root_specifier: root_specifier.to_string(),
+                source_map,
+                resolutions,
+            };
+            #[cfg(feature = "browser_host_scene")]
+            let scenes = BrowserSceneRegistry::new();
+            let source_resolver = document_source_resolver(tree, &bootstrap)?;
+            let mut runtime = runtime_builder_with_factories(
+                #[cfg(feature = "browser_host_scene")]
+                scenes.clone(),
+            )?
+            .source_resolver(source_resolver)
+            .build()
+            .map_err(to_js_error)?;
+            load_resident_document_root(&mut runtime, &bootstrap.root_specifier)?;
+
+            Ok(Self {
+                project: WasmProject::from_runtime(
+                    runtime,
+                    #[cfg(feature = "browser_host_scene")]
+                    scenes,
+                ),
+                bootstrap: WasmDocumentBootstrap::SourceBacked(bootstrap),
+            })
+        }
+
+        /// Builds a formatted source document with the configured project's
+        /// server-projected host authority and complete source resolver.
+        #[cfg(feature = "served_project_authority")]
+        #[wasm_bindgen(js_name = fromServedEncoded)]
+        pub fn from_served_encoded(
+            encoded: &str,
+            root_specifier: &str,
+            config_source: &str,
+            sources: JsValue,
+        ) -> Result<WasmDocument, JsValue> {
+            let tree = decode_document_tree(encoded)?;
+            let document = parse_project_config(config_source)?;
+            let source_map = source_map_from_js(sources)?;
+            let authority = served_browser_authority()?;
+            Self::from_served_tree(
+                tree,
+                root_specifier,
+                document,
+                config_source,
+                source_map,
+                Vec::new(),
                 authority,
-            }),
-        })
-    }
-
-    #[wasm_bindgen(js_name = rootInterpreterId)]
-    pub fn root_interpreter_id(&self) -> u64 {
-        self.project.root_interpreter_id()
-    }
-
-    #[wasm_bindgen(js_name = renderedOutput)]
-    pub fn rendered_output(&self, interpreter_id: u64, output_id: u64) -> Result<JsValue, JsValue> {
-        self.project.rendered_output(interpreter_id, output_id)
-    }
-
-    #[wasm_bindgen(js_name = renderedSymbol)]
-    pub fn rendered_symbol(&self, interpreter_id: u64, name: &str) -> Result<JsValue, JsValue> {
-        self.project.rendered_symbol(interpreter_id, name)
-    }
-
-    #[wasm_bindgen(js_name = reset)]
-    pub fn reset(&mut self, encoded: &str) -> Result<(), JsValue> {
-        // Construct before touching the live project. A malformed replacement
-        // must leave the current document usable.
-        let replacement = match &self.bootstrap {
-            WasmDocumentBootstrap::Detached => Self::from_encoded(encoded)?,
-            WasmDocumentBootstrap::SourceBacked(bootstrap) => Self::from_tree_with_sources(
-                decode_document_tree(encoded)?,
-                &bootstrap.root_specifier,
-                bootstrap.source_map.clone(),
-                bootstrap.resolutions.clone(),
-            )?,
-            #[cfg(feature = "served_project_authority")]
-            WasmDocumentBootstrap::Served(bootstrap) => {
-                let tree = decode_document_tree(encoded)?;
-                let document = parse_project_config(&bootstrap.config_source)?;
-                Self::from_served_tree(
-                    tree,
-                    &bootstrap.source.root_specifier,
-                    document,
-                    &bootstrap.config_source,
-                    bootstrap.source.source_map.clone(),
-                    bootstrap.source.resolutions.clone(),
-                    bootstrap.authority.clone(),
-                )?
-            }
-        };
-        let was_started = self.project.started && !self.project.stopped;
-
-        self.project.stop()?;
-        self.project = replacement.project;
-        self.bootstrap = replacement.bootstrap;
-        if was_started {
-            self.project.start()?;
+            )
         }
-        Ok(())
-    }
 
-    #[wasm_bindgen(js_name = step)]
-    pub fn step(&mut self, count: u64) -> Result<(), JsValue> {
-        if count == 0 {
-            return Err(js_error("count must be greater than zero"));
+        /// Builds a served document with the resolver's authoritative dependency
+        /// edges. This keeps browser resolution identical to the native workspace
+        /// for extension, index, alias, and other resolver-specific matches.
+        #[cfg(feature = "served_project_authority")]
+        #[wasm_bindgen(js_name = fromServedEncodedWithBundle)]
+        pub fn from_served_encoded_with_bundle(
+            encoded: &str,
+            root_specifier: &str,
+            config_source: &str,
+            sources: JsValue,
+            resolutions: JsValue,
+        ) -> Result<WasmDocument, JsValue> {
+            let tree = decode_document_tree(encoded)?;
+            let document = parse_project_config(config_source)?;
+            let source_map = source_map_from_js(sources)?;
+            let resolutions = document_resolutions_from_js(resolutions, &source_map)?;
+            let authority = served_browser_authority()?;
+            Self::from_served_tree(
+                tree,
+                root_specifier,
+                document,
+                config_source,
+                source_map,
+                resolutions,
+                authority,
+            )
         }
-        #[cfg(feature = "functions")]
-        {
-            for _ in 0..count {
-                self.project
-                    .runtime
-                    .step_active_program()
-                    .map_err(to_js_error)?;
+
+        #[cfg(feature = "served_project_authority")]
+        fn from_served_tree(
+            tree: mech_core::nodes::Program,
+            root_specifier: &str,
+            document: MechConfigDocument,
+            config_source: &str,
+            source_map: HashMap<String, String>,
+            resolutions: Vec<SourceResolutionEntry>,
+            authority: BrowserRuntimeInjectionConfig,
+        ) -> Result<WasmDocument, JsValue> {
+            let source = SourceBackedDocumentBootstrap {
+                root_specifier: root_specifier.to_string(),
+                source_map,
+                resolutions,
+            };
+            validate_served_authority(&document, &authority).map_err(to_js_error)?;
+            validate_compiled_host_providers_for_hosts(&document.hosts).map_err(to_js_error)?;
+            #[cfg(feature = "browser_host_scene")]
+            let scenes = BrowserSceneRegistry::new();
+            let source_resolver = document_source_resolver(tree, &source)?;
+            let mut runtime = build_runtime_from_authority(
+                &document,
+                &authority,
+                source_resolver,
+                #[cfg(feature = "browser_host_scene")]
+                scenes.clone(),
+            )?;
+            load_resident_document_root(&mut runtime, &source.root_specifier)?;
+
+            Ok(Self {
+                project: WasmProject::from_runtime(
+                    runtime,
+                    #[cfg(feature = "browser_host_scene")]
+                    scenes,
+                ),
+                bootstrap: WasmDocumentBootstrap::Served(ServedDocumentBootstrap {
+                    source,
+                    config_source: config_source.to_string(),
+                    authority,
+                }),
+            })
+        }
+
+        #[wasm_bindgen(js_name = rootInterpreterId)]
+        pub fn root_interpreter_id(&self) -> u64 {
+            self.project.root_interpreter_id()
+        }
+
+        #[wasm_bindgen(js_name = renderedOutput)]
+        pub fn rendered_output(
+            &self,
+            interpreter_id: u64,
+            output_id: u64,
+        ) -> Result<JsValue, JsValue> {
+            self.project.rendered_output(interpreter_id, output_id)
+        }
+
+        #[wasm_bindgen(js_name = renderedSymbol)]
+        pub fn rendered_symbol(&self, interpreter_id: u64, name: &str) -> Result<JsValue, JsValue> {
+            self.project.rendered_symbol(interpreter_id, name)
+        }
+
+        #[wasm_bindgen(js_name = reset)]
+        pub fn reset(&mut self, encoded: &str) -> Result<(), JsValue> {
+            // Construct before touching the live project. A malformed replacement
+            // must leave the current document usable.
+            let replacement = match &self.bootstrap {
+                WasmDocumentBootstrap::Detached => Self::from_encoded(encoded)?,
+                WasmDocumentBootstrap::SourceBacked(bootstrap) => Self::from_tree_with_sources(
+                    decode_document_tree(encoded)?,
+                    &bootstrap.root_specifier,
+                    bootstrap.source_map.clone(),
+                    bootstrap.resolutions.clone(),
+                )?,
+                #[cfg(feature = "served_project_authority")]
+                WasmDocumentBootstrap::Served(bootstrap) => {
+                    let tree = decode_document_tree(encoded)?;
+                    let document = parse_project_config(&bootstrap.config_source)?;
+                    Self::from_served_tree(
+                        tree,
+                        &bootstrap.source.root_specifier,
+                        document,
+                        &bootstrap.config_source,
+                        bootstrap.source.source_map.clone(),
+                        bootstrap.source.resolutions.clone(),
+                        bootstrap.authority.clone(),
+                    )?
+                }
+            };
+            let was_started = self.project.started && !self.project.stopped;
+
+            self.project.stop()?;
+            self.project = replacement.project;
+            self.bootstrap = replacement.bootstrap;
+            if was_started {
+                self.project.start()?;
             }
             Ok(())
         }
-        #[cfg(not(feature = "functions"))]
-        {
-            let _ = count;
-            Err(js_error(
-                "this WASM artifact was built without reactive step support",
-            ))
-        }
-    }
 
-    #[wasm_bindgen(js_name = renderedSymbols)]
-    pub fn rendered_symbols(&self, names: JsValue) -> Result<JsValue, JsValue> {
-        let names = rendered_symbol_names_from_js(names)?;
-        let values = match names {
-            Some(names) => {
-                let names = names.iter().map(String::as_str).collect::<Vec<_>>();
-                self.project
-                    .runtime
-                    .root_symbol_values(&names)
-                    .map_err(to_js_error)?
+        #[wasm_bindgen(js_name = step)]
+        pub fn step(&mut self, count: u64) -> Result<(), JsValue> {
+            if count == 0 {
+                return Err(js_error("count must be greater than zero"));
             }
-            None => self
+            #[cfg(feature = "functions")]
+            {
+                for _ in 0..count {
+                    self.project
+                        .runtime
+                        .step_active_program()
+                        .map_err(to_js_error)?;
+                }
+                Ok(())
+            }
+            #[cfg(not(feature = "functions"))]
+            {
+                let _ = count;
+                Err(js_error(
+                    "this WASM artifact was built without reactive step support",
+                ))
+            }
+        }
+
+        #[wasm_bindgen(js_name = renderedSymbols)]
+        pub fn rendered_symbols(&self, names: JsValue) -> Result<JsValue, JsValue> {
+            let names = rendered_symbol_names_from_js(names)?;
+            let values = match names {
+                Some(names) => {
+                    let names = names.iter().map(String::as_str).collect::<Vec<_>>();
+                    self.project
+                        .runtime
+                        .root_symbol_values(&names)
+                        .map_err(to_js_error)?
+                }
+                None => self
+                    .project
+                    .runtime
+                    .root_symbol_values_all()
+                    .map_err(to_js_error)?,
+            };
+            let rows = Array::new();
+            for (name, value) in values {
+                rows.push(&rendered_symbol_row(&name, value)?);
+            }
+            Ok(rows.into())
+        }
+
+        #[wasm_bindgen(js_name = interpreterIdByName)]
+        pub fn interpreter_id_by_name(&self, name: &str) -> Result<JsValue, JsValue> {
+            self.project
+                .runtime
+                .interpreter_id_by_name(name)
+                .map_err(to_js_error)
+                .map(|id| {
+                    id.map(|id| js_sys::BigInt::from(id).into())
+                        .unwrap_or(JsValue::NULL)
+                })
+        }
+
+        #[cfg(feature = "legacy-interpreter")]
+        pub fn evaluate(&mut self, source: &str) -> Result<JsValue, JsValue> {
+            let rendered = self
                 .project
                 .runtime
-                .root_symbol_values_all()
-                .map_err(to_js_error)?,
-        };
-        let rows = Array::new();
-        for (name, value) in values {
-            rows.push(&rendered_symbol_row(&name, value)?);
+                .legacy_interpreter()
+                .run_string(source)
+                .map_err(to_js_error)
+                .and_then(rendered_value)?;
+            if self.project.started && !self.project.stopped {
+                self.project.refresh_relevant_input_drivers()?;
+            }
+            Ok(rendered)
         }
-        Ok(rows.into())
-    }
 
-    #[wasm_bindgen(js_name = interpreterIdByName)]
-    pub fn interpreter_id_by_name(&self, name: &str) -> Result<JsValue, JsValue> {
-        self.project
-            .runtime
-            .interpreter_id_by_name(name)
-            .map_err(to_js_error)
-            .map(|id| {
-                id.map(|id| js_sys::BigInt::from(id).into())
-                    .unwrap_or(JsValue::NULL)
-            })
-    }
-
-    pub fn evaluate(&mut self, source: &str) -> Result<JsValue, JsValue> {
-        let rendered = self
-            .project
-            .runtime
-            .run_string(source)
-            .map_err(to_js_error)
-            .and_then(rendered_value)?;
-        if self.project.started && !self.project.stopped {
-            self.project.refresh_relevant_input_drivers()?;
+        pub fn start(&mut self) -> Result<(), JsValue> {
+            self.project.start()
         }
-        Ok(rendered)
-    }
 
-    pub fn start(&mut self) -> Result<(), JsValue> {
-        self.project.start()
-    }
+        pub fn frame(&mut self, max_inputs: usize) -> Result<JsValue, JsValue> {
+            self.project.frame(max_inputs)
+        }
 
-    pub fn frame(&mut self, max_inputs: usize) -> Result<JsValue, JsValue> {
-        self.project.frame(max_inputs)
-    }
-
-    pub fn stop(&mut self) -> Result<(), JsValue> {
-        self.project.stop()
+        pub fn stop(&mut self) -> Result<(), JsValue> {
+            self.project.stop()
+        }
     }
 }
+
+pub use document::WasmDocument;
 
 #[cfg(feature = "served_project_authority")]
 fn bundle_roots_from_js(value: JsValue) -> Result<Vec<String>, JsValue> {
@@ -846,15 +868,17 @@ fn build_runtime(
     source_resolver: InMemorySourceResolver,
     #[cfg(feature = "browser_host_scene")] scenes: BrowserSceneRegistry,
 ) -> Result<MechRuntime, JsValue> {
+    let runtime_config = mech_runtime::RuntimeConfig::default()
+        .apply_patch(&document.runtime)
+        .map_err(to_js_error)?;
+    runtime_config
+        .validate_production_program_routing()
+        .map_err(to_js_error)?;
     let mut builder = runtime_builder_with_factories(
         #[cfg(feature = "browser_host_scene")]
         scenes,
     )?
-    .config(
-        mech_runtime::RuntimeConfig::default()
-            .apply_patch(&document.runtime)
-            .map_err(to_js_error)?,
-    )
+    .config(runtime_config)
     .source_resolver(source_resolver);
     for host in &document.hosts {
         builder = builder.host_instance(host.clone());
@@ -873,13 +897,17 @@ fn build_runtime_from_authority(
     source_resolver: InMemorySourceResolver,
     #[cfg(feature = "browser_host_scene")] scenes: BrowserSceneRegistry,
 ) -> Result<MechRuntime, JsValue> {
+    let runtime_config = authority.into_runtime_config().map_err(to_js_error)?;
+    runtime_config
+        .validate_production_program_routing()
+        .map_err(to_js_error)?;
     let mut builder = runtime_builder_with_factories(
         #[cfg(feature = "browser_host_scene")]
         scenes,
     )?
     // The served authority already contains the project patch that the server
     // verified and signed. Keep that runtime environment authoritative here.
-    .config(authority.into_runtime_config().map_err(to_js_error)?)
+    .config(runtime_config)
     .source_resolver(source_resolver);
     for required in &document.hosts {
         if let Some(host) = authority
@@ -1327,44 +1355,30 @@ fn run_source_roots<'a>(
         .into_iter()
         .map(str::to_owned)
         .collect::<Vec<String>>();
-    let options = RuntimeProgramLoadOptions {
-        routing: runtime.config().program_routing.resident_routing,
-        durability: runtime.config().program_routing.resident_durability,
-    };
-    if roots.len() == 1 {
-        runtime.load_root_program(
-            SourceRequest::new(roots[0].clone()),
-            browser_module_options(),
-            options,
-        )?;
-        return Ok(());
-    }
-    if options.routing == mech_runtime::ResidentRoutingPolicy::RequireResident {
+    if roots.len() != 1 {
         return Err(MechError::new(
             ResidentRouteFailure {
                 class: ResidentRouteFailureClass::MultipleRootsUnsupported,
-                reason: "multiple independent browser roots cannot be resident-routed in D4"
-                    .to_string(),
+                reason: "browser products require exactly one resident program root".to_string(),
             },
             None,
         ));
     }
-    for key in &roots {
-        runtime.resolve_and_run_root_module(
-            SourceRequest::new(key.clone()),
-            browser_module_options(),
-        )?;
-    }
-    runtime.record_legacy_program_route(options.routing, roots.len() as u64)?;
+    let durability = runtime.config().program_routing.resident_durability;
+    runtime.load_production_root_program(
+        SourceRequest::new(roots[0].clone()),
+        browser_module_options(),
+        durability,
+    )?;
     Ok(())
 }
 
 fn runtime_route_name(route: RuntimeProgramRoute) -> &'static str {
     match route {
         RuntimeProgramRoute::None => "none",
-        RuntimeProgramRoute::Legacy => "legacy",
         RuntimeProgramRoute::ResidentPure => "resident-pure",
         RuntimeProgramRoute::ResidentExternal => "resident-external",
+        _ => "invalid-production-route",
     }
 }
 
@@ -1377,14 +1391,9 @@ fn runtime_info_value(info: &RuntimeProgramExecutionInfo) -> Result<JsValue, JsV
             .map(|byte| format!("{byte:02x}"))
             .collect::<String>()
     });
-    let routing_policy = match info.policy {
-        mech_runtime::ResidentRoutingPolicy::PreferResident => "prefer-resident",
-        mech_runtime::ResidentRoutingPolicy::RequireResident => "require-resident",
-        mech_runtime::ResidentRoutingPolicy::LegacyOnly => "legacy-only",
-    };
     for (key, value) in [
         ("route", JsValue::from_str(runtime_route_name(info.route))),
-        ("routing_policy", JsValue::from_str(routing_policy)),
+        ("routing_policy", JsValue::from_str("require-resident")),
         (
             "program_revision",
             revision.map_or(JsValue::NULL, |value| JsValue::from_str(&value)),
@@ -1418,6 +1427,7 @@ fn runtime_info_value(info: &RuntimeProgramExecutionInfo) -> Result<JsValue, JsV
             "resident_rejected_turns",
             JsValue::from_f64(info.resident_rejected_turns as f64),
         ),
+        ("legacy_turns", JsValue::from_f64(info.legacy_turns as f64)),
         (
             "coalesced_host_packets",
             JsValue::from_f64(info.coalesced_host_packets as f64),
@@ -1426,7 +1436,6 @@ fn runtime_info_value(info: &RuntimeProgramExecutionInfo) -> Result<JsValue, JsV
             "ignored_host_packets",
             JsValue::from_f64(info.ignored_host_packets as f64),
         ),
-        ("legacy_turns", JsValue::from_f64(info.legacy_turns as f64)),
     ] {
         Reflect::set(&out, &JsValue::from_str(key), &value)?;
     }
@@ -1537,6 +1546,7 @@ fn to_js_error(error: MechError) -> JsValue {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mech_runtime::legacy_interpreter::LegacyInterpreterTestExt as _;
 
     const CONFIG: &str = r#"config := {
   hosts: []
@@ -1584,8 +1594,21 @@ mod tests {
         assert!(required_path_strings(config).is_err());
     }
 
+    fn assert_production_route_failed_closed(
+        runtime: &MechRuntime,
+        error: &MechError,
+        expected: ResidentRouteFailureClass,
+    ) {
+        let failure = error
+            .kind_as::<ResidentRouteFailure>()
+            .expect("production project failure must retain its resident route class");
+        assert_eq!(failure.class, expected);
+        assert_eq!(runtime.program_route(), RuntimeProgramRoute::None);
+        assert_eq!(runtime.program_execution_info().legacy_turns, 0);
+    }
+
     #[test]
-    fn from_sources_executes_paths_in_order() {
+    fn multiple_project_roots_fail_closed_without_legacy_execution() {
         let document =
             parse_config_document("test.mcfg", CONFIG, ConfigProfileOptions::default()).unwrap();
         let mut sources = HashMap::new();
@@ -1595,7 +1618,12 @@ mod tests {
             .source_resolver(project_source_resolver(&sources).unwrap())
             .build()
             .unwrap();
-        run_project_sources(&mut runtime, &document).unwrap();
+        let error = run_project_sources(&mut runtime, &document).unwrap_err();
+        assert_production_route_failed_closed(
+            &runtime,
+            &error,
+            ResidentRouteFailureClass::MultipleRootsUnsupported,
+        );
     }
 
     fn project_document(paths: &[&str]) -> MechConfigDocument {
@@ -1613,7 +1641,7 @@ mod tests {
     }
 
     #[test]
-    fn browser_project_profile_supports_string_concatenation() {
+    fn unsupported_string_concatenation_fails_closed_without_legacy_execution() {
         let document = project_document(&["demo.mec"]);
 
         let mut sources = HashMap::new();
@@ -1627,7 +1655,12 @@ mod tests {
             .build()
             .unwrap();
 
-        run_project_sources(&mut runtime, &document).unwrap();
+        let error = run_project_sources(&mut runtime, &document).unwrap_err();
+        assert_production_route_failed_closed(
+            &runtime,
+            &error,
+            ResidentRouteFailureClass::SemanticUnsupported,
+        );
     }
 
     #[test]
@@ -1641,6 +1674,34 @@ mod tests {
         runtime.run_tree(&decoded).unwrap();
 
         assert_f64(runtime.root_symbol_value("answer").unwrap(), 42.0);
+    }
+
+    #[test]
+    fn encoded_document_controller_loads_residently_without_legacy_execution() {
+        let tree = mech_syntax::parser::parse("~answer := 0\nanswer += 42\nanswer").unwrap();
+        let encoded = mech_core::nodes::compress_and_encode(&tree).unwrap();
+        let document = WasmDocument::from_encoded(&encoded).unwrap();
+
+        assert_f64(
+            document
+                .project
+                .runtime
+                .root_symbol_value("answer")
+                .unwrap(),
+            42.0,
+        );
+        assert_eq!(
+            document.project.runtime.program_route(),
+            RuntimeProgramRoute::ResidentPure,
+        );
+        assert_eq!(
+            document
+                .project
+                .runtime
+                .program_execution_info()
+                .legacy_turns,
+            0,
+        );
     }
 
     #[test]
@@ -1696,7 +1757,7 @@ mod tests {
     }
 
     #[test]
-    fn project_sources_resolve_sibling_and_parent_modules() {
+    fn multiple_module_roots_fail_closed_before_legacy_resolution() {
         let document = project_document(&["app/main.mec", "nested/main.mec"]);
         let sources = HashMap::from([
             (
@@ -1721,15 +1782,17 @@ mod tests {
             .build()
             .unwrap();
 
-        run_project_sources(&mut runtime, &document).unwrap();
-
-        assert_f64(runtime.root_symbol_value("answer").unwrap(), 42.0);
-        assert_f64(runtime.root_symbol_value("parent-answer").unwrap(), 42.0);
+        let error = run_project_sources(&mut runtime, &document).unwrap_err();
+        assert_production_route_failed_closed(
+            &runtime,
+            &error,
+            ResidentRouteFailureClass::MultipleRootsUnsupported,
+        );
     }
 
     #[test]
     fn source_backed_document_resolves_relative_imports_from_its_root_specifier() {
-        let source = "The imported answer is {math/value + 1}.\n\n+> ./math.mec\nanswer := math/value + 1\nanswer\n";
+        let source = "+> ./math.mec\n~answer := 0\nanswer += math/value + 1\nanswer\n";
         let tree = mech_syntax::parser::parse(source).unwrap();
         let source_map = HashMap::from([
             ("docs/main.mec".to_string(), source.to_string()),
@@ -1751,23 +1814,11 @@ mod tests {
                 .unwrap(),
             42.0,
         );
-        assert_f64(
-            document
-                .project
-                .runtime
-                .output_value_for_interpreter(
-                    document.project.runtime.root_interpreter_id(),
-                    mech_core::hash_str("inline-eval:0:0"),
-                )
-                .unwrap()
-                .expect("formatted source root must retain inline output"),
-            42.0,
-        );
     }
 
     #[test]
     fn source_backed_document_preserves_explicit_resolution_edges_across_reset() {
-        let source = "+> ./math.mec\nanswer := math/value + 1\nanswer\n";
+        let source = "+> ./math.mec\n~answer := 0\nanswer += math/value + 1\nanswer\n";
         let tree = mech_syntax::parser::parse(source).unwrap();
         let encoded = mech_core::nodes::compress_and_encode(&tree).unwrap();
         let source_map = HashMap::from([
@@ -1831,7 +1882,7 @@ mod tests {
     }
 
     #[test]
-    fn project_sources_only_execute_configured_roots() {
+    fn configured_multiple_roots_fail_closed_without_reading_unused_sources() {
         let document = project_document(&["first.mec", "second.mec"]);
         let sources = HashMap::from([
             ("first.mec".to_string(), "marker := 1\n".to_string()),
@@ -1849,9 +1900,12 @@ mod tests {
             .build()
             .unwrap();
 
-        run_project_sources(&mut runtime, &document).unwrap();
-
-        assert_f64(runtime.root_symbol_value("answer").unwrap(), 2.0);
+        let error = run_project_sources(&mut runtime, &document).unwrap_err();
+        assert_production_route_failed_closed(
+            &runtime,
+            &error,
+            ResidentRouteFailureClass::MultipleRootsUnsupported,
+        );
     }
 
     #[cfg(feature = "served_project_authority")]
@@ -1999,7 +2053,7 @@ mod tests {
     }
 
     #[test]
-    fn generic_table_project_source_runs_through_runtime_loader() {
+    fn unsupported_generic_table_project_fails_closed_without_legacy_execution() {
         let document = parse_config_document(
             "generic-table.mcfg",
             r#"config := { hosts: [] run: { paths: ["generic-table.mec"] grants: [] } }"#,
@@ -2019,7 +2073,12 @@ rows := |id<string> x<f64>|
             .source_resolver(project_source_resolver(&sources).unwrap())
             .build()
             .unwrap();
-        run_project_sources(&mut runtime, &document).unwrap();
+        let error = run_project_sources(&mut runtime, &document).unwrap_err();
+        assert_production_route_failed_closed(
+            &runtime,
+            &error,
+            ResidentRouteFailureClass::SemanticUnsupported,
+        );
     }
 
     #[cfg(all(feature = "browser_host_timer", feature = "browser_host_scene"))]
@@ -2096,28 +2155,8 @@ rows := |id<string> x<f64>|
     }
 
     #[cfg(all(feature = "browser_host_timer", feature = "browser_host_scene"))]
-    fn fixture_timer_packet(tick: u64, delta_seconds: f64) -> mech_runtime::RuntimeHostInput {
-        mech_runtime::RuntimeHostInput::new(vec![
-            mech_runtime::RuntimeHostInputUpdate {
-                source: mech_runtime::RuntimeHostInputSource::new("timer://tick/tick", "tick")
-                    .unwrap(),
-                value: mech_runtime::RuntimeHostInputValue::F64(tick as f64),
-            },
-            mech_runtime::RuntimeHostInputUpdate {
-                source: mech_runtime::RuntimeHostInputSource::new(
-                    "timer://tick/tick",
-                    "delta-seconds",
-                )
-                .unwrap(),
-                value: mech_runtime::RuntimeHostInputValue::F64(delta_seconds),
-            },
-        ])
-        .unwrap()
-    }
-
-    #[cfg(all(feature = "browser_host_timer", feature = "browser_host_scene"))]
     #[test]
-    fn generic_timer_table_scene_fixture_executes_with_timer_and_scene_hosts() {
+    fn unsupported_timer_table_scene_fails_before_effects_or_legacy_execution() {
         let document = generic_fixture_document();
         let source_paths = required_path_strings(include_str!(
             "../tests/fixtures/generic-timer-table-scene/mech.mcfg"
@@ -2142,43 +2181,13 @@ rows := |id<string> x<f64>|
             builder = builder.run_resource_grant(grant.clone());
         }
         let mut runtime = builder.build().unwrap();
-        run_project_sources(&mut runtime, &document).unwrap();
-
-        let initial_scene = scene_backend.latest().unwrap();
-        assert_eq!(initial_scene.circles.len(), 2);
-        assert_eq!(initial_scene.lines.len(), 3);
-        let initial_x = initial_scene.circles[0].x;
-
-        runtime.start_input_drivers().unwrap();
-        runtime
-            .ingress()
-            .submit(fixture_timer_packet(1, 0.25))
-            .unwrap();
-        assert_eq!(runtime.pending_host_input_count().unwrap(), 1);
-        let outcomes = runtime.drain_host_inputs(1).unwrap();
-        assert_eq!(outcomes.len(), 1);
-        assert_eq!(runtime.pending_host_input_count().unwrap(), 0);
-
-        let updated_scene = scene_backend.latest().unwrap();
-        assert!(updated_scene.circles[0].x > initial_x);
-        assert!((updated_scene.circles[0].x - 20.25).abs() < 0.000001);
-        assert_eq!(updated_scene.circles.len(), 2);
-        assert_eq!(updated_scene.lines.len(), 3);
-        assert!(scene_backend.generation() >= 2);
-
-        for tick in 2..12 {
-            runtime
-                .ingress()
-                .submit(fixture_timer_packet(tick, 0.25))
-                .unwrap();
-        }
-        assert_eq!(runtime.pending_host_input_count().unwrap(), 10);
-        let drained = runtime.drain_host_inputs(3).unwrap();
-        assert_eq!(drained.len(), 3);
-        assert_eq!(runtime.pending_host_input_count().unwrap(), 7);
-        runtime.stop_input_drivers().unwrap();
-        runtime.shutdown().unwrap();
-        runtime.shutdown().unwrap();
+        let error = run_project_sources(&mut runtime, &document).unwrap_err();
+        assert_production_route_failed_closed(
+            &runtime,
+            &error,
+            ResidentRouteFailureClass::SemanticUnsupported,
+        );
+        assert_eq!(scene_backend.generation(), 0);
     }
 
     #[test]
@@ -2480,6 +2489,7 @@ mod browser_tests {
         }
     }
 
+    #[cfg(feature = "legacy-interpreter")]
     fn document_with_manual_input_driver() -> (WasmDocument, Rc<RefCell<DocumentInputDriverState>>)
     {
         let state = Rc::new(RefCell::new(DocumentInputDriverState::default()));
@@ -2650,6 +2660,7 @@ mod browser_tests {
         );
     }
 
+    #[cfg(feature = "legacy-interpreter")]
     #[wasm_bindgen_test]
     fn wasm_document_evaluate_returns_rendered_value() {
         let encoded = encoded_document("answer := 41 + 1\nanswer");
@@ -2665,6 +2676,7 @@ mod browser_tests {
         );
     }
 
+    #[cfg(feature = "legacy-interpreter")]
     #[wasm_bindgen_test]
     fn wasm_document_evaluate_refreshes_mutable_root_symbol() {
         let encoded = encoded_document("~answer := 41\nanswer");
@@ -2682,6 +2694,7 @@ mod browser_tests {
         );
     }
 
+    #[cfg(feature = "legacy-interpreter")]
     #[wasm_bindgen_test]
     fn wasm_document_evaluate_starts_newly_relevant_input_driver() {
         let (mut document, state) = document_with_manual_input_driver();
@@ -2719,6 +2732,7 @@ mod browser_tests {
         assert_eq!(state.borrow().stops, 1);
     }
 
+    #[cfg(feature = "legacy-interpreter")]
     #[wasm_bindgen_test]
     fn wasm_document_failed_evaluation_does_not_start_driver() {
         let (mut document, state) = document_with_manual_input_driver();
@@ -2734,19 +2748,17 @@ mod browser_tests {
     fn wasm_document_reset_restores_initial_program() {
         let initial = encoded_document("answer := 1\nanswer");
         let mut document = WasmDocument::from_encoded(&initial).unwrap();
-        document.evaluate("temporary := 9\ntemporary").unwrap();
-        assert!(!document.rendered_symbol(0, "temporary").unwrap().is_null());
+        let replacement = encoded_document("answer := 7\nanswer");
 
-        document.reset(&initial).unwrap();
+        document.reset(&replacement).unwrap();
 
-        assert!(document.rendered_symbol(0, "temporary").unwrap().is_null());
         let answer = document.rendered_symbol(0, "answer").unwrap();
         assert_eq!(
             Reflect::get(&answer, &JsValue::from_str("inlineHtml"))
                 .unwrap()
                 .as_string()
                 .as_deref(),
-            Some("1"),
+            Some("7"),
         );
     }
 

--- a/src/wasm/src/project.rs
+++ b/src/wasm/src/project.rs
@@ -372,6 +372,11 @@ mod document {
     #[wasm_bindgen]
     pub struct WasmDocument {
         pub(super) project: WasmProject,
+        #[cfg(feature = "legacy-interpreter")]
+        // The full/developer console owns an interpreter runtime that is
+        // deliberately disjoint from the resident document owner. Ad-hoc
+        // evaluation can neither mutate nor select execution for the product.
+        pub(super) developer_runtime: MechRuntime,
         bootstrap: WasmDocumentBootstrap,
     }
 
@@ -385,6 +390,21 @@ mod document {
                 SourceRequest::new(root_specifier),
                 browser_module_options(),
                 durability,
+            )
+            .map(|_| ())
+            .map_err(to_js_error)
+    }
+
+    #[cfg(feature = "legacy-interpreter")]
+    fn load_developer_document_root(
+        runtime: &mut MechRuntime,
+        root_specifier: &str,
+    ) -> Result<(), JsValue> {
+        runtime
+            .legacy_interpreter()
+            .resolve_and_run_root_module(
+                SourceRequest::new(root_specifier),
+                browser_module_options(),
             )
             .map(|_| ())
             .map_err(to_js_error)
@@ -406,16 +426,32 @@ mod document {
                 #[cfg(feature = "browser_host_scene")]
                 scenes.clone(),
             )?
-            .source_resolver(document_source_resolver(tree, &source)?)
+            .source_resolver(document_source_resolver(tree.clone(), &source)?)
             .build()
             .map_err(to_js_error)?;
             load_resident_document_root(&mut runtime, &source.root_specifier)?;
+            #[cfg(feature = "legacy-interpreter")]
+            let mut developer_runtime = {
+                #[cfg(feature = "browser_host_scene")]
+                let developer_scenes = BrowserSceneRegistry::new();
+                runtime_builder_with_factories(
+                    #[cfg(feature = "browser_host_scene")]
+                    developer_scenes,
+                )?
+                .source_resolver(document_source_resolver(tree.clone(), &source)?)
+                .build()
+                .map_err(to_js_error)?
+            };
+            #[cfg(feature = "legacy-interpreter")]
+            load_developer_document_root(&mut developer_runtime, &source.root_specifier)?;
             Ok(Self {
                 project: WasmProject::from_runtime(
                     runtime,
                     #[cfg(feature = "browser_host_scene")]
                     scenes,
                 ),
+                #[cfg(feature = "legacy-interpreter")]
+                developer_runtime,
                 bootstrap: WasmDocumentBootstrap::Detached,
             })
         }
@@ -460,7 +496,7 @@ mod document {
             };
             #[cfg(feature = "browser_host_scene")]
             let scenes = BrowserSceneRegistry::new();
-            let source_resolver = document_source_resolver(tree, &bootstrap)?;
+            let source_resolver = document_source_resolver(tree.clone(), &bootstrap)?;
             let mut runtime = runtime_builder_with_factories(
                 #[cfg(feature = "browser_host_scene")]
                 scenes.clone(),
@@ -469,6 +505,20 @@ mod document {
             .build()
             .map_err(to_js_error)?;
             load_resident_document_root(&mut runtime, &bootstrap.root_specifier)?;
+            #[cfg(feature = "legacy-interpreter")]
+            let mut developer_runtime = {
+                #[cfg(feature = "browser_host_scene")]
+                let developer_scenes = BrowserSceneRegistry::new();
+                runtime_builder_with_factories(
+                    #[cfg(feature = "browser_host_scene")]
+                    developer_scenes,
+                )?
+                .source_resolver(document_source_resolver(tree, &bootstrap)?)
+                .build()
+                .map_err(to_js_error)?
+            };
+            #[cfg(feature = "legacy-interpreter")]
+            load_developer_document_root(&mut developer_runtime, &bootstrap.root_specifier)?;
 
             Ok(Self {
                 project: WasmProject::from_runtime(
@@ -476,6 +526,8 @@ mod document {
                     #[cfg(feature = "browser_host_scene")]
                     scenes,
                 ),
+                #[cfg(feature = "legacy-interpreter")]
+                developer_runtime,
                 bootstrap: WasmDocumentBootstrap::SourceBacked(bootstrap),
             })
         }
@@ -552,7 +604,7 @@ mod document {
             validate_compiled_host_providers_for_hosts(&document.hosts).map_err(to_js_error)?;
             #[cfg(feature = "browser_host_scene")]
             let scenes = BrowserSceneRegistry::new();
-            let source_resolver = document_source_resolver(tree, &source)?;
+            let source_resolver = document_source_resolver(tree.clone(), &source)?;
             let mut runtime = build_runtime_from_authority(
                 &document,
                 &authority,
@@ -561,6 +613,21 @@ mod document {
                 scenes.clone(),
             )?;
             load_resident_document_root(&mut runtime, &source.root_specifier)?;
+            #[cfg(feature = "legacy-interpreter")]
+            let mut developer_runtime = {
+                #[cfg(feature = "browser_host_scene")]
+                let developer_scenes = BrowserSceneRegistry::new();
+                let developer_resolver = document_source_resolver(tree, &source)?;
+                build_runtime_from_authority(
+                    &document,
+                    &authority,
+                    developer_resolver,
+                    #[cfg(feature = "browser_host_scene")]
+                    developer_scenes,
+                )?
+            };
+            #[cfg(feature = "legacy-interpreter")]
+            load_developer_document_root(&mut developer_runtime, &source.root_specifier)?;
 
             Ok(Self {
                 project: WasmProject::from_runtime(
@@ -568,6 +635,8 @@ mod document {
                     #[cfg(feature = "browser_host_scene")]
                     scenes,
                 ),
+                #[cfg(feature = "legacy-interpreter")]
+                developer_runtime,
                 bootstrap: WasmDocumentBootstrap::Served(ServedDocumentBootstrap {
                     source,
                     config_source: config_source.to_string(),
@@ -625,7 +694,13 @@ mod document {
             let was_started = self.project.started && !self.project.stopped;
 
             self.project.stop()?;
+            #[cfg(feature = "legacy-interpreter")]
+            self.developer_runtime.shutdown().map_err(to_js_error)?;
             self.project = replacement.project;
+            #[cfg(feature = "legacy-interpreter")]
+            {
+                self.developer_runtime = replacement.developer_runtime;
+            }
             self.bootstrap = replacement.bootstrap;
             if was_started {
                 self.project.start()?;
@@ -681,30 +756,16 @@ mod document {
             Ok(rows.into())
         }
 
-        #[wasm_bindgen(js_name = interpreterIdByName)]
-        pub fn interpreter_id_by_name(&self, name: &str) -> Result<JsValue, JsValue> {
-            self.project
-                .runtime
-                .interpreter_id_by_name(name)
-                .map_err(to_js_error)
-                .map(|id| {
-                    id.map(|id| js_sys::BigInt::from(id).into())
-                        .unwrap_or(JsValue::NULL)
-                })
-        }
-
+        /// Evaluates developer-console source in an isolated interpreter.
+        /// The resident document remains the sole product execution owner.
         #[cfg(feature = "legacy-interpreter")]
         pub fn evaluate(&mut self, source: &str) -> Result<JsValue, JsValue> {
             let rendered = self
-                .project
-                .runtime
+                .developer_runtime
                 .legacy_interpreter()
                 .run_string(source)
                 .map_err(to_js_error)
                 .and_then(rendered_value)?;
-            if self.project.started && !self.project.stopped {
-                self.project.refresh_relevant_input_drivers()?;
-            }
             Ok(rendered)
         }
 
@@ -717,7 +778,13 @@ mod document {
         }
 
         pub fn stop(&mut self) -> Result<(), JsValue> {
-            self.project.stop()
+            let was_stopped = self.project.stopped;
+            self.project.stop()?;
+            #[cfg(feature = "legacy-interpreter")]
+            if !was_stopped {
+                self.developer_runtime.shutdown().map_err(to_js_error)?;
+            }
+            Ok(())
         }
     }
 }
@@ -2262,8 +2329,6 @@ rows := |id<string> x<f64>|
 mod browser_tests {
     use super::*;
     use js_sys::{Array, Object};
-    use std::cell::RefCell;
-    use std::rc::Rc;
     use wasm_bindgen_test::*;
 
     wasm_bindgen_test_configure!(run_in_browser);
@@ -2271,6 +2336,16 @@ mod browser_tests {
     fn encoded_document(source: &str) -> String {
         let tree = mech_syntax::parser::parse(source).unwrap();
         mech_core::nodes::compress_and_encode(&tree).unwrap()
+    }
+
+    fn assert_resident_rejection<T>(result: Result<T, JsValue>, expected: &str) {
+        let error = match result {
+            Ok(_) => panic!("expected resident production admission to reject the program"),
+            Err(error) => error,
+        };
+        let message = error.as_string().unwrap_or_else(|| format!("{error:?}"));
+        assert!(message.contains("ResidentRouteFailure"), "{message}");
+        assert!(message.contains(expected), "{message}");
     }
 
     #[cfg(feature = "served_project_authority")]
@@ -2305,7 +2380,7 @@ mod browser_tests {
 
     #[cfg(feature = "served_project_authority")]
     fn served_document_source() -> &'static str {
-        "+> ./math.mec\n@clock := time://clock/clock{:read(second)}\nconfigured-answer := math/value\n~answer := 41\nanswer\n"
+        "+> ./math.mec\n~configured-answer := 0\nconfigured-answer += math/value\nconfigured-answer\n"
     }
 
     #[cfg(feature = "served_project_authority")]
@@ -2346,179 +2421,6 @@ mod browser_tests {
                 .as_deref(),
             Some("41"),
         );
-    }
-
-    const DOCUMENT_TEST_INPUT_BASE_URI: &str = "test://clock/ticks";
-
-    #[derive(Debug, Default)]
-    struct DocumentInputDriverState {
-        starts: usize,
-        stops: usize,
-        live: bool,
-        ingress: Option<mech_runtime::RuntimeIngress>,
-    }
-
-    #[derive(Clone, Debug)]
-    struct DocumentInputDriver {
-        state: Rc<RefCell<DocumentInputDriverState>>,
-    }
-
-    impl mech_runtime::RuntimeHostInputDriver for DocumentInputDriver {
-        fn drives(&self, source: &mech_runtime::RuntimeHostInputSource) -> bool {
-            source.base_uri() == DOCUMENT_TEST_INPUT_BASE_URI && source.path() == "value"
-        }
-
-        fn attach(&mut self, ingress: mech_runtime::RuntimeIngress) -> mech_core::MResult<()> {
-            self.state.borrow_mut().ingress = Some(ingress);
-            Ok(())
-        }
-
-        fn start(&mut self) -> mech_core::MResult<()> {
-            let mut state = self.state.borrow_mut();
-            state.starts += 1;
-            state.live = true;
-            Ok(())
-        }
-
-        fn stop(&mut self) -> mech_core::MResult<()> {
-            let mut state = self.state.borrow_mut();
-            state.stops += 1;
-            state.live = false;
-            Ok(())
-        }
-
-        fn is_live(&self) -> bool {
-            self.state.borrow().live
-        }
-    }
-
-    #[derive(Debug)]
-    struct DocumentInputProvider;
-
-    impl mech_runtime::RuntimeResourceProvider for DocumentInputProvider {
-        fn scheme(&self) -> &str {
-            "test"
-        }
-
-        fn base_uris(&self) -> Vec<String> {
-            vec![DOCUMENT_TEST_INPUT_BASE_URI.to_string()]
-        }
-
-        fn read(
-            &self,
-            request: mech_runtime::RuntimeResourceReadRequest,
-        ) -> mech_core::MResult<mech_core::LegacyValue> {
-            if request.base_uri == DOCUMENT_TEST_INPUT_BASE_URI && request.path == "value" {
-                return Ok(mech_core::LegacyValue::F64(mech_core::Ref::new(0.0)));
-            }
-            Err(MechError::new(
-                ProjectError {
-                    message: "missing document test resource".to_string(),
-                },
-                None,
-            ))
-        }
-
-        fn plan_read(
-            &self,
-            request: mech_runtime::RuntimeResourceReadRequest,
-        ) -> mech_core::MResult<mech_core::LegacyValue> {
-            if request.base_uri == DOCUMENT_TEST_INPUT_BASE_URI && request.path == "value" {
-                return Ok(mech_core::LegacyValue::F64(mech_core::Ref::new(0.0)));
-            }
-            Err(MechError::new(
-                ProjectError {
-                    message: "missing document test planning resource".to_string(),
-                },
-                None,
-            ))
-        }
-    }
-
-    #[derive(Debug)]
-    struct DocumentInputHostFactory {
-        manifest: mech_runtime::HostManifestConfig,
-        state: Rc<RefCell<DocumentInputDriverState>>,
-    }
-
-    impl DocumentInputHostFactory {
-        fn new(state: Rc<RefCell<DocumentInputDriverState>>) -> Self {
-            Self {
-                manifest: mech_runtime::HostManifestConfig {
-                    provider: "document-test-input".to_string(),
-                    contexts: vec![mech_runtime::HostContextManifest {
-                        name: "ticks".to_string(),
-                        base_uri_template: "test://{instance}/ticks".to_string(),
-                        operations: vec!["read".to_string()],
-                    }],
-                },
-                state,
-            }
-        }
-    }
-
-    impl mech_runtime::RuntimeHostFactory for DocumentInputHostFactory {
-        fn provider_name(&self) -> &str {
-            "document-test-input"
-        }
-
-        fn manifest(&self) -> &mech_runtime::HostManifestConfig {
-            &self.manifest
-        }
-
-        fn validate_settings(
-            &self,
-            _instance_name: &str,
-            _settings: &mech_runtime::ConfigValue,
-        ) -> mech_core::MResult<()> {
-            Ok(())
-        }
-
-        fn instantiate(
-            &self,
-            _instance_name: &str,
-            _settings: &mech_runtime::ConfigValue,
-        ) -> mech_core::MResult<mech_runtime::RuntimeHostInstallation> {
-            Ok(mech_runtime::RuntimeHostInstallation {
-                interface: mech_runtime::materialize_host_manifest("clock", &self.manifest)?,
-                resource_providers: vec![Box::new(DocumentInputProvider)],
-                input_drivers: vec![Box::new(DocumentInputDriver {
-                    state: self.state.clone(),
-                })],
-            })
-        }
-    }
-
-    #[cfg(feature = "legacy-interpreter")]
-    fn document_with_manual_input_driver() -> (WasmDocument, Rc<RefCell<DocumentInputDriverState>>)
-    {
-        let state = Rc::new(RefCell::new(DocumentInputDriverState::default()));
-        let runtime = browser_runtime_builder()
-            .host_factory(Box::new(DocumentInputHostFactory::new(state.clone())))
-            .unwrap()
-            .host_instance(mech_runtime::HostInstanceConfig {
-                name: "clock".to_string(),
-                provider: "document-test-input".to_string(),
-                settings: mech_runtime::ConfigValue::Map(Default::default()),
-            })
-            .run_resource_grant(mech_runtime::RunResourceGrantConfig {
-                target: "clock/ticks".to_string(),
-                operations: vec!["read".to_string()],
-                paths: vec!["value".to_string()],
-            })
-            .build()
-            .unwrap();
-        (
-            WasmDocument {
-                project: WasmProject::from_runtime(
-                    runtime,
-                    #[cfg(feature = "browser_host_scene")]
-                    BrowserSceneRegistry::new(),
-                ),
-                bootstrap: WasmDocumentBootstrap::Detached,
-            },
-            state,
-        )
     }
 
     #[wasm_bindgen_test]
@@ -2613,7 +2515,7 @@ mod browser_tests {
         Reflect::set(
             &sources,
             &JsValue::from_str("main.mec"),
-            &JsValue::from_str("x := 1"),
+            &JsValue::from_str("~x := 0\nx += 1\nx"),
         )
         .unwrap();
         let mut project = WasmProject::from_sources(config, sources.into()).unwrap();
@@ -2625,7 +2527,7 @@ mod browser_tests {
 
     #[wasm_bindgen_test]
     fn encoded_document_executes_and_exposes_detached_render_queries() {
-        let tree = mech_syntax::parser::parse("answer := 41 + 1\nanswer").unwrap();
+        let tree = mech_syntax::parser::parse("~answer := 0\nanswer += 42\nanswer").unwrap();
         let encoded = mech_core::nodes::compress_and_encode(&tree).unwrap();
         let mut document = WasmDocument::from_encoded(&encoded).unwrap();
         let rendered = document.rendered_symbol(0, "answer").unwrap();
@@ -2644,26 +2546,16 @@ mod browser_tests {
     }
 
     #[wasm_bindgen_test]
-    fn encoded_document_uses_the_formatter_root_namespace_for_inline_output() {
+    fn encoded_inline_document_is_excluded_from_the_resident_browser_product() {
         let encoded =
             encoded_document("The document evaluates {answer + 1} inline.\n\nanswer := 41");
-        let document = WasmDocument::from_encoded(&encoded).unwrap();
-        let output_id = mech_core::hash_str("inline-eval:0:0");
-        let rendered = document.rendered_output(0, output_id).unwrap();
-
-        assert_eq!(
-            Reflect::get(&rendered, &JsValue::from_str("inlineHtml"))
-                .unwrap()
-                .as_string()
-                .as_deref(),
-            Some("42"),
-        );
+        assert_resident_rejection(WasmDocument::from_encoded(&encoded), "SemanticUnsupported");
     }
 
     #[cfg(feature = "legacy-interpreter")]
     #[wasm_bindgen_test]
     fn wasm_document_evaluate_returns_rendered_value() {
-        let encoded = encoded_document("answer := 41 + 1\nanswer");
+        let encoded = encoded_document("~answer := 0\nanswer += 42\nanswer");
         let mut document = WasmDocument::from_encoded(&encoded).unwrap();
 
         let rendered = document.evaluate("answer + 1").unwrap();
@@ -2678,77 +2570,91 @@ mod browser_tests {
 
     #[cfg(feature = "legacy-interpreter")]
     #[wasm_bindgen_test]
-    fn wasm_document_evaluate_refreshes_mutable_root_symbol() {
-        let encoded = encoded_document("~answer := 41\nanswer");
+    fn wasm_document_evaluate_isolated_from_resident_root_symbol() {
+        let encoded = encoded_document("~answer := 0\nanswer += 41\nanswer");
         let mut document = WasmDocument::from_encoded(&encoded).unwrap();
 
         document.evaluate("answer = 7").unwrap();
 
+        let developer_answer = document.evaluate("answer").unwrap();
+        assert_eq!(
+            Reflect::get(&developer_answer, &JsValue::from_str("inlineHtml"))
+                .unwrap()
+                .as_string()
+                .as_deref(),
+            Some("7"),
+        );
         let answer = document.rendered_symbol(0, "answer").unwrap();
         assert_eq!(
             Reflect::get(&answer, &JsValue::from_str("inlineHtml"))
                 .unwrap()
                 .as_string()
                 .as_deref(),
-            Some("7"),
+            Some("41"),
         );
     }
 
     #[cfg(feature = "legacy-interpreter")]
     #[wasm_bindgen_test]
-    fn wasm_document_evaluate_starts_newly_relevant_input_driver() {
-        let (mut document, state) = document_with_manual_input_driver();
-        document.start().unwrap();
-        assert_eq!(state.borrow().starts, 0);
+    fn wasm_document_evaluate_never_enters_legacy_on_resident_owner() {
+        let encoded = encoded_document("~answer := 0\nanswer += 42\nanswer");
+        let mut document = WasmDocument::from_encoded(&encoded).unwrap();
 
-        document
-            .evaluate("@tick := test://clock/ticks{:read(value)}\ncurrent := @tick/value\ncurrent")
-            .unwrap();
-        assert_eq!(state.borrow().starts, 1);
-
-        document
-            .project
-            .runtime
-            .ingress()
-            .submit(mech_runtime::RuntimeHostInput::single(
-                mech_runtime::RuntimeHostInputSource::new(DOCUMENT_TEST_INPUT_BASE_URI, "value")
-                    .unwrap(),
-                mech_runtime::RuntimeHostInputValue::F64(7.0),
-            ))
-            .unwrap();
-        document.frame(1).unwrap();
-        let current = document.rendered_symbol(0, "current").unwrap();
         assert_eq!(
-            Reflect::get(&current, &JsValue::from_str("inlineHtml"))
+            document
+                .project
+                .runtime
+                .program_execution_info()
+                .legacy_turns,
+            0
+        );
+        document.evaluate("answer + 1").unwrap();
+        assert_eq!(
+            document
+                .project
+                .runtime
+                .program_execution_info()
+                .legacy_turns,
+            0
+        );
+        assert!(
+            document
+                .developer_runtime
+                .program_execution_info()
+                .legacy_turns
+                > 0
+        );
+    }
+
+    #[cfg(feature = "legacy-interpreter")]
+    #[wasm_bindgen_test]
+    fn wasm_document_failed_evaluation_leaves_resident_owner_untouched() {
+        let encoded = encoded_document("~answer := 0\nanswer += 42\nanswer");
+        let mut document = WasmDocument::from_encoded(&encoded).unwrap();
+        assert!(document.evaluate("missing-document-symbol").is_err());
+        assert_eq!(
+            document
+                .project
+                .runtime
+                .program_execution_info()
+                .legacy_turns,
+            0
+        );
+        let answer = document.rendered_symbol(0, "answer").unwrap();
+        assert_eq!(
+            Reflect::get(&answer, &JsValue::from_str("inlineHtml"))
                 .unwrap()
                 .as_string()
                 .as_deref(),
-            Some("7"),
+            Some("42"),
         );
-
-        document.evaluate("unrelated := 1\nunrelated").unwrap();
-        assert_eq!(state.borrow().starts, 1);
-        document.stop().unwrap();
-        assert_eq!(state.borrow().stops, 1);
-    }
-
-    #[cfg(feature = "legacy-interpreter")]
-    #[wasm_bindgen_test]
-    fn wasm_document_failed_evaluation_does_not_start_driver() {
-        let (mut document, state) = document_with_manual_input_driver();
-        document.start().unwrap();
-
-        assert!(document.evaluate("missing-document-symbol").is_err());
-        assert_eq!(state.borrow().starts, 0);
-        document.stop().unwrap();
-        assert_eq!(state.borrow().stops, 1);
     }
 
     #[wasm_bindgen_test]
     fn wasm_document_reset_restores_initial_program() {
-        let initial = encoded_document("answer := 1\nanswer");
+        let initial = encoded_document("~answer := 0\nanswer += 1\nanswer");
         let mut document = WasmDocument::from_encoded(&initial).unwrap();
-        let replacement = encoded_document("answer := 7\nanswer");
+        let replacement = encoded_document("~answer := 0\nanswer += 7\nanswer");
 
         document.reset(&replacement).unwrap();
 
@@ -2764,15 +2670,15 @@ mod browser_tests {
 
     #[wasm_bindgen_test]
     fn wasm_document_step_rejects_zero() {
-        let encoded = encoded_document("answer := 1\nanswer");
+        let encoded = encoded_document("~answer := 0\nanswer += 1\nanswer");
         let mut document = WasmDocument::from_encoded(&encoded).unwrap();
         assert!(document.step(0).is_err());
     }
 
     #[wasm_bindgen_test]
     fn wasm_document_rendered_symbols_returns_detached_rows() {
-        let initial = encoded_document("answer := 42\nanswer");
-        let replacement = encoded_document("answer := 7\nanswer");
+        let initial = encoded_document("~answer := 0\nanswer += 42\nanswer");
+        let replacement = encoded_document("~answer := 0\nanswer += 7\nanswer");
         let mut document = WasmDocument::from_encoded(&initial).unwrap();
         let requested = Array::new();
         requested.push(&JsValue::from_str("answer"));
@@ -2806,25 +2712,7 @@ mod browser_tests {
     }
 
     #[wasm_bindgen_test]
-    fn wasm_document_named_interpreter_lookup_is_stable() {
-        let encoded = encoded_document("~~~mech:foo\nanswer := 7\n~~~");
-        let document = WasmDocument::from_encoded(&encoded).unwrap();
-        let id = document.interpreter_id_by_name("foo").unwrap();
-        assert!(id.is_bigint());
-        assert_eq!(
-            id,
-            JsValue::from(js_sys::BigInt::from(mech_core::hash_str("foo"))),
-        );
-        assert!(
-            document
-                .interpreter_id_by_name("missing")
-                .unwrap()
-                .is_null()
-        );
-    }
-
-    #[wasm_bindgen_test]
-    fn encoded_fizzbuzz_document_uses_native_formatter_output_key() {
+    fn encoded_fizzbuzz_document_is_excluded_from_the_resident_browser_product() {
         let tree =
             mech_syntax::parser::parse(include_str!("../../../examples/working/fizzbuzz.mec"))
                 .unwrap();
@@ -2850,11 +2738,7 @@ mod browser_tests {
         );
 
         let encoded = mech_core::nodes::compress_and_encode(&tree).unwrap();
-        let document = WasmDocument::from_encoded(&encoded).unwrap();
-        assert!(
-            !document.rendered_output(0, output_id).unwrap().is_null(),
-            "the formatted FizzBuzz output must remain renderable in WASM",
-        );
+        assert_resident_rejection(WasmDocument::from_encoded(&encoded), "InvalidArtifact");
     }
 
     #[wasm_bindgen_test]
@@ -2864,12 +2748,7 @@ mod browser_tests {
         Reflect::set(
             &sources,
             &JsValue::from_str("generic-table.mec"),
-            &JsValue::from_str(
-                r#"delta := 0.25
-rows := |id<string> x<f64>|
-  | "row-a" 1 + delta |
-  | "row-b" 2 + delta |"#,
-            ),
+            &JsValue::from_str("~x := 0\nx += 1\nx"),
         )
         .unwrap();
         let mut project = WasmProject::from_sources(config, sources.into()).unwrap();
@@ -2883,7 +2762,7 @@ rows := |id<string> x<f64>|
         Reflect::set(
             &sources,
             &JsValue::from_str("main.mec"),
-            &JsValue::from_str("x := 1"),
+            &JsValue::from_str("~x := 0\nx += 1\nx"),
         )
         .unwrap();
         let project = WasmProject::from_sources(config, sources.into()).unwrap();
@@ -2897,7 +2776,7 @@ rows := |id<string> x<f64>|
         Reflect::set(
             &sources,
             &JsValue::from_str("main.mec"),
-            &JsValue::from_str("x := 1"),
+            &JsValue::from_str("~x := 0\nx += 1\nx"),
         )
         .unwrap();
         let mut project = WasmProject::from_sources(config, sources.into()).unwrap();
@@ -2918,7 +2797,7 @@ rows := |id<string> x<f64>|
     }
 
     #[wasm_bindgen_test]
-    fn generic_project_with_timer_table_and_scene_renders_fixture() {
+    fn generic_timer_table_scene_is_excluded_from_the_resident_browser_product() {
         let window = web_sys::window().unwrap();
         let document = window.document().unwrap();
         let canvas = document.create_element("canvas").unwrap();
@@ -2935,16 +2814,10 @@ rows := |id<string> x<f64>|
             )),
         )
         .unwrap();
-        let mut project = WasmProject::from_sources(config, sources.into()).unwrap();
-        project.start().unwrap();
-        let result = project.frame(1).unwrap();
-        assert_eq!(
-            Reflect::get(&result, &JsValue::from_str("rendered"))
-                .unwrap()
-                .as_f64(),
-            Some(1.0)
+        assert_resident_rejection(
+            WasmProject::from_sources(config, sources.into()),
+            "SemanticUnsupported",
         );
-        project.stop().unwrap();
         canvas.remove();
     }
 }

--- a/src/wasm/tests/function_system_source_contract.rs
+++ b/src/wasm/tests/function_system_source_contract.rs
@@ -1,7 +1,9 @@
 use std::collections::BTreeSet;
 
 use mech_core::{LegacyValue, OperationId, RuntimeFunctionId};
-use mech_runtime::{RuntimeBuilder, RuntimeValueSnapshot};
+use mech_runtime::{
+    RuntimeBuilder, RuntimeValueSnapshot, legacy_interpreter::LegacyInterpreterTestExt as _,
+};
 use mech_stdlib::source_catalog;
 use mech_wasm as _;
 use serde::Deserialize;

--- a/tests/architecture/distributions/full.json
+++ b/tests/architecture/distributions/full.json
@@ -177,7 +177,7 @@
     "bundle_web",
     "bundle_web_core",
     "c64",
-    "cli",
+    "cli-product",
     "cli_core",
     "cli_host",
     "compiler",
@@ -207,6 +207,7 @@
     "invariant_define",
     "kind_annotation",
     "kind_define",
+    "legacy-interpreter",
     "logical_indexing",
     "map",
     "matrix",
@@ -262,6 +263,6 @@
     "whos"
   ],
   "source_specializer_count": 119,
-  "surface_digest": "fd5c9dea90ecb148d7cf0aa64b814ede236b283de74cf93403c392cad805046d",
+  "surface_digest": "8c2ccef84a194d129714908fbb7b2ddf2e1b8fbcc3e456f198c0ed95771237b5",
   "surface_digest_algorithm": "sha256-canonical-selected-cargo-surface-v1"
 }

--- a/tests/architecture/distributions/standard.json
+++ b/tests/architecture/distributions/standard.json
@@ -118,7 +118,7 @@
     "build",
     "bundle_web",
     "bundle_web_core",
-    "cli",
+    "cli-product",
     "cli_core",
     "cli_host",
     "compiler",
@@ -152,7 +152,6 @@
     "program",
     "project",
     "record",
-    "repl",
     "row_vectord",
     "run",
     "scene_host_browser",
@@ -178,7 +177,6 @@
     "swizzle",
     "symbol_table",
     "table",
-    "test",
     "time_host_browser",
     "time_host_native",
     "timer_host_browser",
@@ -193,6 +191,6 @@
     "whos"
   ],
   "source_specializer_count": 69,
-  "surface_digest": "9c87fb07539576ef9925c4a7aa3176bcb90fde0f4c380be35de41a56b8291e98",
+  "surface_digest": "bc4fcc3d364aca2580d2b43ae1ed7c0c83a877bb1b5eb1eb2905e08c4f22dfbf",
   "surface_digest_algorithm": "sha256-canonical-selected-cargo-surface-v1"
 }

--- a/tests/fixtures/standard-live-timer/live.mec
+++ b/tests/fixtures/standard-live-timer/live.mec
@@ -3,4 +3,3 @@
 
 tick := @timer/tick
 @out/line <- tick
-tick

--- a/tests/fixtures/standard-resident-scalar.mec
+++ b/tests/fixtures/standard-resident-scalar.mec
@@ -1,0 +1,3 @@
+~state := 0.0
+state += 1.0
+output := state

--- a/tests/mech_cli_host.rs
+++ b/tests/mech_cli_host.rs
@@ -106,7 +106,14 @@ fn mech_run_subcommand_loads_cli_host_provider() {
 #[test]
 fn mech_run_uses_config_run_paths() {
     let root = temp_root("config-run");
-    write_cli_host_source(&root);
+    std::fs::write(
+        root.join("cli_host.mec"),
+        r#"~state := 0.0
+state += 424242.0
+output := state
+"#,
+    )
+    .unwrap();
     std::fs::write(
         root.join("mech.mcfg"),
         r#"config := {
@@ -121,11 +128,10 @@ fn mech_run_uses_config_run_paths() {
     let output = std::process::Command::new(env!("CARGO_BIN_EXE_mech"))
         .arg("run")
         .current_dir(&root)
-        .env("MECH_CLI_HOST_TEST", "mech-config-run-ok")
         .output()
         .unwrap();
 
-    assert_success_contains(output, "mech-config-run-ok");
+    assert_success_contains(output, "424242");
 }
 
 #[cfg(all(feature = "run", feature = "cli_host"))]
@@ -164,6 +170,11 @@ fn bare_mech_with_run_paths_enters_repl_without_running_config_paths() {
     std::fs::write(
         root.join("mech.mcfg"),
         r#"config := {
+  runtime: {
+    program-routing: {
+      resident-routing: "prefer-resident"
+    }
+  }
   run: {
     paths: ["cli_host.mec"]
   }
@@ -177,7 +188,7 @@ fn bare_mech_with_run_paths_enters_repl_without_running_config_paths() {
 
     assert!(
         output.status.success(),
-        "bare mech REPL should exit cleanly:
+        "targetless developer REPL should ignore production routing validation:
 {combined}"
     );
     assert!(
@@ -189,7 +200,36 @@ fn bare_mech_with_run_paths_enters_repl_without_running_config_paths() {
 
 #[cfg(all(feature = "run", feature = "cli_host", feature = "repl"))]
 #[test]
-fn repl_after_file_execution_preserves_loaded_program_state() {
+fn run_subcommand_without_target_enters_developer_repl() {
+    let root = temp_root("run-subcommand-config-repl");
+    write_cli_host_source(&root);
+    std::fs::write(
+        root.join("mech.mcfg"),
+        r#"config := {
+  run: {
+    paths: ["cli_host.mec"]
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    let output = run_mech_with_stdin(&root, &["run", "--repl"], ":quit\n");
+    let combined = combined_output(&output);
+
+    assert!(
+        output.status.success(),
+        "targetless run-level developer REPL failed:\n{combined}"
+    );
+    assert!(
+        !combined.contains("ResidentRouteFailure") && !combined.contains("no run inputs supplied"),
+        "run-level REPL was treated as a production run:\n{combined}"
+    );
+}
+
+#[cfg(all(feature = "run", feature = "cli_host", feature = "repl"))]
+#[test]
+fn repl_with_file_target_is_rejected_before_production_loading() {
     let root = temp_root("repl-startup-state");
     std::fs::write(root.join("startup.mec"), "x := 42\n").unwrap();
 
@@ -197,20 +237,20 @@ fn repl_after_file_execution_preserves_loaded_program_state() {
     let combined = combined_output(&output);
 
     assert!(
-        output.status.success(),
-        "REPL command failed:
-{combined}"
+        !output.status.success(),
+        "target-backed REPL unexpectedly succeeded:\n{combined}"
     );
     assert!(
-        combined.contains("42"),
-        "REPL did not see definition loaded from startup file:
+        combined.contains("ReplUnsupported")
+            && combined.contains("cannot be combined with a resident production target"),
+        "target-backed REPL did not fail at the typed resident boundary:
 {combined}"
     );
 }
 
 #[cfg(all(feature = "run", feature = "cli_host", feature = "repl"))]
 #[test]
-fn run_project_repl_retains_runtime_host_behavior() {
+fn run_project_repl_is_rejected_before_runtime_host_effects() {
     let root = temp_root("runtime-backed-repl");
     let project = root.join("project");
     std::fs::create_dir_all(&project).unwrap();
@@ -244,23 +284,19 @@ startup := "pre-repl-runtime-host-ok"
     let combined = combined_output(&output);
 
     assert!(
-        output.status.success(),
-        "runtime-backed project REPL should exit cleanly:
+        !output.status.success(),
+        "runtime-backed project REPL unexpectedly succeeded:\n{combined}"
+    );
+    assert!(
+        combined.contains("ReplUnsupported")
+            && combined.contains("cannot be combined with a resident production target"),
+        "runtime-backed project REPL did not fail at the typed resident boundary:
 {combined}"
     );
     assert!(
-        combined.contains("pre-repl-runtime-host-ok"),
-        "the project host read/write did not run before entering the REPL:
-{combined}"
-    );
-    assert!(
-        combined.matches("pre-repl-runtime-host-ok").count() >= 2,
-        "the startup symbol was not retained in the runtime-backed REPL:
-{combined}"
-    );
-    assert!(
-        combined.contains("repl-runtime-host-ok"),
-        "the retained runtime did not execute a later REPL host write:
+        !combined.contains("pre-repl-runtime-host-ok")
+            && !combined.contains("repl-runtime-host-ok"),
+        "the rejected resident target executed host effects before failing:
 {combined}"
     );
 }


### PR DESCRIPTION
## Stack

- Base: `feat/production-resident-routing` (PR-D4)
- Head: `codex/d5-production-resident-only`
- This is a stacked draft PR. Do not retarget or merge it independently of D4.

## Summary

- defines fail-closed resident-only production source, root, and bytecode loading
- routes shipping CLI, native build, WASM, and browser products through those production loaders with no executor selector or legacy fallback
- isolates the legacy interpreter behind an explicit full/developer feature boundary
- enforces production legacy unreachability with a fast static contract in CI

## Validation

- focused production routing and no-fallback runtime tests
- standard CLI command contract tests
- generated native scalar application
- standard and full distribution checks and frozen projections
- distribution packaging, native host catalog, and complete static-contract tail
- WASM/browser-project compile
- real served n-body browser smoke: 60 accepted resident turns, 0 legacy turns, stable orbit, no console or page errors
- formatting and diff checks
