### PR TITLE
feat(ekf): execute 1,000 resident filters on WebGPU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,10 +240,21 @@ jobs:
               raise SystemExit("scalar and WebGPU checkpoints used different completed turns")
           if len(cpu["output"]) != 15 or len(wgpu["output"]) != 15:
               raise SystemExit("the EKF checkpoint must contain state, covariance, and prediction")
-          errors = [abs(left - right) for left, right in zip(cpu["output"], wgpu["output"])]
-          if not all(math.isfinite(error) for error in errors) or max(errors) > 1e-5:
+          relative_tolerance = 1e-5
+          absolute_tolerance = 1e-7
+          comparisons = []
+          for index, (left, right) in enumerate(zip(cpu["output"], wgpu["output"])):
+              error = abs(left - right)
+              tolerance = absolute_tolerance + relative_tolerance * max(abs(left), abs(right))
+              comparisons.append((index, left, right, error, tolerance))
+          failures = [comparison for comparison in comparisons
+                      if not math.isfinite(comparison[3]) or comparison[3] > comparison[4]]
+          if failures:
+              index, left, right, error, tolerance = max(failures, key=lambda item: item[3] / item[4])
               raise SystemExit(
-                  f"WebGPU EKF checkpoint diverged from scalar oracle; max component error={max(errors)}"
+                  "WebGPU EKF checkpoint diverged from scalar oracle at "
+                  f"component {index}: cpu={left}, wgpu={right}, "
+                  f"error={error}, tolerance={tolerance}"
               )
           print("EKF_WEBGPU_PARITY", json.dumps({"cpu": cpu, "wgpu": wgpu}, sort_keys=True))
           PY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,17 @@ jobs:
             bash scripts/smoke-served-resident-ekf-browser.sh
           MECH_BIN=target/debug/mech \
             MECH_EKF_COMPUTE_BACKEND=cpu-scalar \
+            MECH_EKF_CONTINUITY_EDIT=false \
+            MECH_EKF_RESULT_FILE=/tmp/ekf-cpu-no-edit.json \
+            bash scripts/smoke-served-resident-ekf-browser.sh
+          MECH_BIN=target/debug/mech \
+            MECH_EKF_COMPUTE_BACKEND=cpu-scalar \
             MECH_EKF_RESULT_FILE=/tmp/ekf-cpu.json \
+            bash scripts/smoke-served-resident-ekf-browser.sh
+          MECH_BIN=target/debug/mech \
+            MECH_EKF_COMPUTE_BACKEND=wgpu \
+            MECH_EKF_CONTINUITY_EDIT=false \
+            MECH_EKF_RESULT_FILE=/tmp/ekf-wgpu-no-edit.json \
             bash scripts/smoke-served-resident-ekf-browser.sh
           MECH_BIN=target/debug/mech \
             MECH_EKF_COMPUTE_BACKEND=wgpu \
@@ -245,31 +255,49 @@ jobs:
 
           with open("/tmp/ekf-cpu-single.json") as source:
               cpu_single = json.load(source)
+          with open("/tmp/ekf-cpu-no-edit.json") as source:
+              cpu_no_edit = json.load(source)
           with open("/tmp/ekf-cpu.json") as source:
               cpu = json.load(source)
           with open("/tmp/ekf-wgpu.json") as source:
               wgpu = json.load(source)
+          with open("/tmp/ekf-wgpu-no-edit.json") as source:
+              wgpu_no_edit = json.load(source)
           # Each smoke independently proves that its asynchronous live robot
-          # remains bounded and trackable. The numeric cross-backend oracle is
-          # the first completed filter turn after the compatible REPL edit:
-          # unlike a later display frame, it is anchored to compute progress.
-          if cpu_single["backend"] != "cpu-scalar" or cpu["backend"] != "cpu-scalar":
-              raise SystemExit("scalar EKF checkpoint reported a non-scalar backend")
+          # remains bounded and trackable. The continuity oracle is the first
+          # completed filter turn after the edit boundary and is compared to
+          # an independent no-edit run on the same backend; unlike a later
+          # display frame, it is anchored to compute progress.
+          if (
+              cpu_single["backend"] != "cpu-scalar"
+              or cpu_no_edit["backend"] != "cpu-scalar"
+              or cpu["backend"] != "cpu-scalar"
+              or wgpu_no_edit["backend"] != "wgpu"
+              or wgpu["backend"] != "wgpu"
+          ):
+              raise SystemExit("an EKF checkpoint reported the wrong compute backend")
           if cpu["updates"] != wgpu["updates"]:
               raise SystemExit("scalar and WebGPU checkpoints used different completed turns")
           if len(cpu["output"]) != 15 or len(wgpu["output"]) != 15:
               raise SystemExit("the EKF checkpoint must contain state, covariance, and prediction")
-          if len(cpu["continuity_output"]) != 15 or len(wgpu["continuity_output"]) != 15:
+          if any(len(result["continuity_output"]) != 15 for result in (
+              cpu_single, cpu_no_edit, cpu, wgpu_no_edit, wgpu,
+          )):
               raise SystemExit("the EKF continuity checkpoint must contain one complete lane")
           relative_tolerance = 5e-5
           absolute_tolerance = 1e-6
           continuity_failures = []
           continuity_oracles = (
-              ("CPU-1", cpu_single["continuity_output"]),
-              ("WebGPU-1000", wgpu["continuity_output"]),
+              ("CPU-1000 edited", cpu_no_edit["continuity_output"], cpu["continuity_output"]),
+              ("CPU-1", cpu_no_edit["continuity_output"], cpu_single["continuity_output"]),
+              (
+                  "WebGPU-1000 edited",
+                  wgpu_no_edit["continuity_output"],
+                  wgpu["continuity_output"],
+              ),
           )
-          for label, observed in continuity_oracles:
-              for index, (left, right) in enumerate(zip(cpu["continuity_output"], observed)):
+          for label, reference, observed in continuity_oracles:
+              for index, (left, right) in enumerate(zip(reference, observed)):
                   error = abs(left - right)
                   tolerance = absolute_tolerance + relative_tolerance * max(abs(left), abs(right))
                   if not math.isfinite(error) or error > tolerance:
@@ -282,10 +310,30 @@ jobs:
               )
               raise SystemExit(
                   f"{label} EKF restarted or diverged after compatible REPL replacement at "
-                  f"component {index}: cpu1000={left}, observed={right}, "
+                  f"component {index}: no_edit={left}, observed={right}, "
                   f"error={error}, tolerance={tolerance}"
               )
-          print("EKF_WEBGPU_PARITY", json.dumps({"cpu": cpu, "wgpu": wgpu}, sort_keys=True))
+          # Backend parity is a separate numerical property from same-backend
+          # no-edit/edit continuity. Shader and scalar evaluation order can
+          # differ slightly while representing the same f32 trajectory.
+          parity_relative_tolerance = relative_tolerance
+          for index, (left, right) in enumerate(zip(
+              cpu_no_edit["continuity_output"],
+              wgpu_no_edit["continuity_output"],
+          )):
+              error = abs(left - right)
+              tolerance = absolute_tolerance + parity_relative_tolerance * max(abs(left), abs(right))
+              if not math.isfinite(error) or error > tolerance:
+                  raise SystemExit(
+                      f"CPU/WebGPU turn-121 parity failed at component {index}: "
+                      f"cpu={left}, wgpu={right}, error={error}, tolerance={tolerance}"
+                  )
+          print("EKF_WEBGPU_PARITY", json.dumps({
+              "cpu_no_edit": cpu_no_edit,
+              "cpu": cpu,
+              "wgpu_no_edit": wgpu_no_edit,
+              "wgpu": wgpu,
+          }, sort_keys=True))
           PY
       - name: Remove generated browser package
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,7 @@ jobs:
         run: >-
           MECH_BIN=target/debug/mech
           python3 scripts/smoke-gpu-particles-browser.py
-          --backend gpu --particle-count 16384
+          --backend gpu --particle-count 16384 --software-adapter
       - name: Verify scalar and WebGPU EKF rendering against one numeric oracle
         run: |
           MECH_BIN=target/debug/mech \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,10 +219,11 @@ jobs:
           grep -q '^export class WasmDocument' src/wasm/pkg/mech_wasm.js
           grep -q '^export class WasmMixedComputeProject' src/wasm/pkg/mech_wasm.js
           cargo build --locked --bin mech --features compute_backends_native
-      - name: Verify million-particle report-only WebGPU execution
+      - name: Verify report-only particle WebGPU execution
         run: >-
           MECH_BIN=target/debug/mech
-          python3 scripts/smoke-gpu-particles-browser.py --backend gpu
+          python3 scripts/smoke-gpu-particles-browser.py
+          --backend gpu --particle-count 16384
       - name: Verify scalar and WebGPU EKF rendering against one numeric oracle
         run: |
           MECH_BIN=target/debug/mech \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,42 +249,40 @@ jobs:
               cpu = json.load(source)
           with open("/tmp/ekf-wgpu.json") as source:
               wgpu = json.load(source)
-          # Each smoke run independently verifies its rendered tracking error.
-          # That DOM measurement is diagnostic presentation state and can be
-          # observed on an adjacent animation frame. Filter-count invariance is
-          # the compute checkpoint: the same completed turn and first-lane
-          # numeric output must be bit-for-bit identical.
-          scalar_checkpoint_fields = ("updates", "output")
-          scalar_differences = {
-              field: (cpu_single[field], cpu[field])
-              for field in scalar_checkpoint_fields
-              if cpu_single[field] != cpu[field]
-          }
+          # Each smoke independently proves that its asynchronous live robot
+          # remains bounded and trackable. The numeric cross-backend oracle is
+          # the first completed filter turn after the compatible REPL edit:
+          # unlike a later display frame, it is anchored to compute progress.
           if cpu_single["backend"] != "cpu-scalar" or cpu["backend"] != "cpu-scalar":
               raise SystemExit("scalar EKF checkpoint reported a non-scalar backend")
-          if scalar_differences:
-              raise SystemExit(
-                  "served scalar EKF compute checkpoint depends on the independent "
-                  f"filter count: {scalar_differences}"
-              )
           if cpu["updates"] != wgpu["updates"]:
               raise SystemExit("scalar and WebGPU checkpoints used different completed turns")
           if len(cpu["output"]) != 15 or len(wgpu["output"]) != 15:
               raise SystemExit("the EKF checkpoint must contain state, covariance, and prediction")
-          relative_tolerance = 1e-5
-          absolute_tolerance = 1e-7
-          comparisons = []
-          for index, (left, right) in enumerate(zip(cpu["output"], wgpu["output"])):
-              error = abs(left - right)
-              tolerance = absolute_tolerance + relative_tolerance * max(abs(left), abs(right))
-              comparisons.append((index, left, right, error, tolerance))
-          failures = [comparison for comparison in comparisons
-                      if not math.isfinite(comparison[3]) or comparison[3] > comparison[4]]
-          if failures:
-              index, left, right, error, tolerance = max(failures, key=lambda item: item[3] / item[4])
+          if len(cpu["continuity_output"]) != 15 or len(wgpu["continuity_output"]) != 15:
+              raise SystemExit("the EKF continuity checkpoint must contain one complete lane")
+          relative_tolerance = 5e-5
+          absolute_tolerance = 1e-6
+          continuity_failures = []
+          continuity_oracles = (
+              ("CPU-1", cpu_single["continuity_output"]),
+              ("WebGPU-1000", wgpu["continuity_output"]),
+          )
+          for label, observed in continuity_oracles:
+              for index, (left, right) in enumerate(zip(cpu["continuity_output"], observed)):
+                  error = abs(left - right)
+                  tolerance = absolute_tolerance + relative_tolerance * max(abs(left), abs(right))
+                  if not math.isfinite(error) or error > tolerance:
+                      continuity_failures.append(
+                          (label, index, left, right, error, tolerance)
+                      )
+          if continuity_failures:
+              label, index, left, right, error, tolerance = max(
+                  continuity_failures, key=lambda item: item[4] / item[5]
+              )
               raise SystemExit(
-                  "WebGPU EKF checkpoint diverged from scalar oracle at "
-                  f"component {index}: cpu={left}, wgpu={right}, "
+                  f"{label} EKF restarted or diverged after compatible REPL replacement at "
+                  f"component {index}: cpu1000={left}, observed={right}, "
                   f"error={error}, tolerance={tolerance}"
               )
           print("EKF_WEBGPU_PARITY", json.dumps({"cpu": cpu, "wgpu": wgpu}, sort_keys=True))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
     needs: impact
     if: needs.impact.outputs.browser_canary_required == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 20
     env:
       CARGO_TERM_COLOR: always
       CARGO_INCREMENTAL: 0
@@ -212,6 +212,12 @@ jobs:
             --lib
       - name: Verify resident rendering without browser errors
         run: MECH_BIN=target/debug/mech bash scripts/smoke-served-resident-nbody-browser.sh
+      - name: Build mixed compute WASM and refresh the server
+        run: |
+          bash scripts/build-mech-gpu-browser.sh
+          grep -q '^export class WasmDocument' src/wasm/pkg/mech_wasm.js
+          grep -q '^export class WasmMixedComputeProject' src/wasm/pkg/mech_wasm.js
+          cargo build --locked --bin mech --features compute_backends_native
       - name: Verify resident EKF rendering without browser errors
         run: MECH_BIN=target/debug/mech bash scripts/smoke-served-resident-ekf-browser.sh
       - name: Remove generated browser package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,10 +214,15 @@ jobs:
         run: MECH_BIN=target/debug/mech bash scripts/smoke-served-resident-nbody-browser.sh
       - name: Build mixed compute WASM and refresh the server
         run: |
+          node scripts/test-browser-compute-lifecycle.mjs
           bash scripts/build-mech-gpu-browser.sh
           grep -q '^export class WasmDocument' src/wasm/pkg/mech_wasm.js
           grep -q '^export class WasmMixedComputeProject' src/wasm/pkg/mech_wasm.js
           cargo build --locked --bin mech --features compute_backends_native
+      - name: Verify million-particle report-only WebGPU execution
+        run: >-
+          MECH_BIN=target/debug/mech
+          python3 scripts/smoke-gpu-particles-browser.py --backend gpu
       - name: Verify scalar and WebGPU EKF rendering against one numeric oracle
         run: |
           MECH_BIN=target/debug/mech \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
     needs: impact
     if: needs.impact.outputs.browser_canary_required == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     env:
       CARGO_TERM_COLOR: always
       CARGO_INCREMENTAL: 0
@@ -218,8 +218,39 @@ jobs:
           grep -q '^export class WasmDocument' src/wasm/pkg/mech_wasm.js
           grep -q '^export class WasmMixedComputeProject' src/wasm/pkg/mech_wasm.js
           cargo build --locked --bin mech --features compute_backends_native
-      - name: Verify resident EKF rendering without browser errors
-        run: MECH_BIN=target/debug/mech bash scripts/smoke-served-resident-ekf-browser.sh
+      - name: Verify scalar and WebGPU EKF rendering against one numeric oracle
+        run: |
+          MECH_BIN=target/debug/mech \
+            MECH_EKF_COMPUTE_BACKEND=cpu-scalar \
+            MECH_EKF_RESULT_FILE=/tmp/ekf-cpu.json \
+            bash scripts/smoke-served-resident-ekf-browser.sh
+          MECH_BIN=target/debug/mech \
+            MECH_EKF_COMPUTE_BACKEND=wgpu \
+            MECH_EKF_RESULT_FILE=/tmp/ekf-wgpu.json \
+            bash scripts/smoke-served-resident-ekf-browser.sh
+          python3 - <<'PY'
+          import json
+          import math
+
+          with open("/tmp/ekf-cpu.json") as source:
+              cpu = json.load(source)
+          with open("/tmp/ekf-wgpu.json") as source:
+              wgpu = json.load(source)
+          # The asynchronous bridge can observe the first completed-lap frame
+          # a few resident packets later than the synchronous scalar backend.
+          # Compare both at that physical checkpoint with bounds tighter than
+          # one robot radius rather than coupling the proof to frame timing.
+          truth_error = math.dist(cpu["truth"], wgpu["truth"])
+          if truth_error > 2.0:
+              raise SystemExit(f"WebGPU truth checkpoint diverged from scalar oracle by {truth_error} pixels")
+          estimate_error = math.dist(cpu["estimate"], wgpu["estimate"])
+          if estimate_error > 6.0:
+              raise SystemExit(f"WebGPU estimate diverged from scalar oracle by {estimate_error} pixels")
+          covariance_error = abs(cpu["covariance_extent"] - wgpu["covariance_extent"])
+          if covariance_error > 0.1:
+              raise SystemExit(f"WebGPU covariance diverged from scalar oracle by {covariance_error} pixels")
+          print("EKF_WEBGPU_PARITY", json.dumps({"cpu": cpu, "wgpu": wgpu}, sort_keys=True))
+          PY
       - name: Remove generated browser package
         if: always()
         run: rm -rf src/wasm/pkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,11 @@ jobs:
         run: |
           MECH_BIN=target/debug/mech \
             MECH_EKF_COMPUTE_BACKEND=cpu-scalar \
+            MECH_EKF_FILTER_COUNT=1 \
+            MECH_EKF_RESULT_FILE=/tmp/ekf-cpu-single.json \
+            bash scripts/smoke-served-resident-ekf-browser.sh
+          MECH_BIN=target/debug/mech \
+            MECH_EKF_COMPUTE_BACKEND=cpu-scalar \
             MECH_EKF_RESULT_FILE=/tmp/ekf-cpu.json \
             bash scripts/smoke-served-resident-ekf-browser.sh
           MECH_BIN=target/debug/mech \
@@ -232,10 +237,16 @@ jobs:
           import json
           import math
 
+          with open("/tmp/ekf-cpu-single.json") as source:
+              cpu_single = json.load(source)
           with open("/tmp/ekf-cpu.json") as source:
               cpu = json.load(source)
           with open("/tmp/ekf-wgpu.json") as source:
               wgpu = json.load(source)
+          if cpu_single != cpu:
+              raise SystemExit(
+                  "served scalar EKF checkpoint depends on the independent filter count"
+              )
           if cpu["updates"] != wgpu["updates"]:
               raise SystemExit("scalar and WebGPU checkpoints used different completed turns")
           if len(cpu["output"]) != 15 or len(wgpu["output"]) != 15:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,9 +243,23 @@ jobs:
               cpu = json.load(source)
           with open("/tmp/ekf-wgpu.json") as source:
               wgpu = json.load(source)
-          if cpu_single != cpu:
+          # Each smoke run independently verifies its rendered tracking error.
+          # That DOM measurement is diagnostic presentation state and can be
+          # observed on an adjacent animation frame. Filter-count invariance is
+          # the compute checkpoint: the same completed turn and first-lane
+          # numeric output must be bit-for-bit identical.
+          scalar_checkpoint_fields = ("updates", "output")
+          scalar_differences = {
+              field: (cpu_single[field], cpu[field])
+              for field in scalar_checkpoint_fields
+              if cpu_single[field] != cpu[field]
+          }
+          if cpu_single["backend"] != "cpu-scalar" or cpu["backend"] != "cpu-scalar":
+              raise SystemExit("scalar EKF checkpoint reported a non-scalar backend")
+          if scalar_differences:
               raise SystemExit(
-                  "served scalar EKF checkpoint depends on the independent filter count"
+                  "served scalar EKF compute checkpoint depends on the independent "
+                  f"filter count: {scalar_differences}"
               )
           if cpu["updates"] != wgpu["updates"]:
               raise SystemExit("scalar and WebGPU checkpoints used different completed turns")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,19 +236,15 @@ jobs:
               cpu = json.load(source)
           with open("/tmp/ekf-wgpu.json") as source:
               wgpu = json.load(source)
-          # The asynchronous bridge can observe the first completed-lap frame
-          # a few resident packets later than the synchronous scalar backend.
-          # Compare both at that physical checkpoint with bounds tighter than
-          # one robot radius rather than coupling the proof to frame timing.
-          truth_error = math.dist(cpu["truth"], wgpu["truth"])
-          if truth_error > 2.0:
-              raise SystemExit(f"WebGPU truth checkpoint diverged from scalar oracle by {truth_error} pixels")
-          estimate_error = math.dist(cpu["estimate"], wgpu["estimate"])
-          if estimate_error > 6.0:
-              raise SystemExit(f"WebGPU estimate diverged from scalar oracle by {estimate_error} pixels")
-          covariance_error = abs(cpu["covariance_extent"] - wgpu["covariance_extent"])
-          if covariance_error > 0.1:
-              raise SystemExit(f"WebGPU covariance diverged from scalar oracle by {covariance_error} pixels")
+          if cpu["updates"] != wgpu["updates"]:
+              raise SystemExit("scalar and WebGPU checkpoints used different completed turns")
+          if len(cpu["output"]) != 15 or len(wgpu["output"]) != 15:
+              raise SystemExit("the EKF checkpoint must contain state, covariance, and prediction")
+          errors = [abs(left - right) for left, right in zip(cpu["output"], wgpu["output"])]
+          if not all(math.isfinite(error) for error in errors) or max(errors) > 1e-5:
+              raise SystemExit(
+                  f"WebGPU EKF checkpoint diverged from scalar oracle; max component error={max(errors)}"
+              )
           print("EKF_WEBGPU_PARITY", json.dumps({"cpu": cpu, "wgpu": wgpu}, sort_keys=True))
           PY
       - name: Remove generated browser package

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2835,6 +2835,7 @@ dependencies = [
  "js-sys",
  "mech-core",
  "mech-runtime",
+ "mech-stdlib",
  "serde",
  "serde_json",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2736,6 +2736,8 @@ dependencies = [
  "mech-stdlib",
  "mech-syntax",
  "pollster",
+ "serde",
+ "serde_json",
  "web-time",
  "wgpu",
  "wide",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2738,6 +2738,7 @@ dependencies = [
  "pollster",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "web-time",
  "wgpu",
  "wide",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,7 @@ compute_backends_native = [
       "mech-runtime/f32", "mech-runtime/f64", "mech-runtime/string", "mech-runtime/matrixd",
       "f32", "row_vectord", "matrixd", "kind_annotation", "convert", "matrix_horzcat", "range_inclusive",
       "math_add", "math_sub", "math_mul", "math_div", "math_mod", "math_sin", "math_cos",
+      "math_ceil",
       "mech-stdlib/native-plan",
       ]
 base = ["baselib", "pretty_print", "serde", "compiler", "program", "mika",
@@ -246,6 +247,7 @@ math_sub_assign = ["mech-stdlib/math_sub_assign"]
 math_mul_assign = ["mech-stdlib/math_mul_assign"]
 math_div_assign = ["mech-stdlib/math_div_assign"]
 math_sqrt = ["mech-stdlib/math_sqrt"]
+math_ceil = ["mech-stdlib/math_ceil"]
 math_acos = ["mech-stdlib/math_acos"]
 math_acosh = ["mech-stdlib/math_acosh"]
 math_acot = ["mech-stdlib/math_acot"]

--- a/build.rs
+++ b/build.rs
@@ -33,6 +33,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo::rustc-check-cfg=cfg(has_file_js)");
     println!("cargo::rerun-if-changed=include/project.js");
     println!("cargo::rerun-if-changed=include/document.js");
+    println!("cargo::rerun-if-changed=include/browser-compute.js");
     println!("cargo::rerun-if-changed=include/index.html");
     println!("cargo::rerun-if-changed=include/style.css");
     println!("cargo::rerun-if-changed=include/mech-source.css");

--- a/examples/ekf/localization.mec
+++ b/examples/ekf/localization.mec
@@ -28,9 +28,13 @@ robot and contracts after the next camera reacquires it.
 
 @clock := timer://clock/tick{:read(tick)}
 @scene := scene://localization/frame{:write(replace)}
+@filters := compute://filters/kernel{:read(sample/result.0), :write(input/control), :write(input/camera), :write(input/measurement), :write(turn)}
 
   π := 3.141592654
-  turn-pulse := @clock/tick * 0.0 + 1.0
+  ~last-clock-tick := 0.0
+  clock-delta := @clock/tick - last-clock-tick
+  clock-delta-positive := (clock-delta + (clock-delta ^ 2) ^ 0.5) / 2.0
+  turn-pulse := clock-delta-positive - (clock-delta-positive - 1.0 + ((clock-delta-positive - 1.0) ^ 2) ^ 0.5) / 2.0
   Δt := turn-pulse * 0.05
   cruise-speed := 1.15
   turn-rate-limit := 1.75
@@ -45,6 +49,8 @@ robot and contracts after the next camera reacquires it.
               9.0 1.0
               9.0 9.0
               1.0 9.0]
+
+  last-clock-tick = @clock/tick
 
 
 2. Square-Drive State Machine
@@ -86,7 +92,8 @@ reduction make the corners smooth without position clamps.
   lap-ticks := 4.0 * side-ticks
   ~drive-phase-index := 1.0
   drive-phase := drive-phases[1,drive-phase-index]
-  next-drive-phase-index := (drive-phase-index % lap-ticks) + turn-pulse
+  advanced-drive-phase-index := (drive-phase-index % lap-ticks) + 1.0
+  next-drive-phase-index := drive-phase-index + turn-pulse * (advanced-drive-phase-index - drive-phase-index)
   phase-progress := ((drive-phase-index - 1.0) % side-ticks) / side-ticks
   path-parameter := drive-phase + phase-progress
   lookahead-parameter := (path-parameter + 0.15) % 4.0
@@ -104,7 +111,7 @@ reduction make the corners smooth without position clamps.
   ~truth := [2.5
              2.5
              0.0]
-  simulation-time := @clock/tick * Δt
+  simulation-time := @clock/tick * 0.05
   target-heading := math/atan2(target-y - truth[2], target-x - truth[1])
   heading-error-raw := target-heading - truth[3]
   heading-error := math/atan2(math/sin(heading-error-raw), math/cos(heading-error-raw))
@@ -218,60 +225,152 @@ The matrix equations below are the complete filter. The motion model predicts
 once per control interval, then the scheduled range-and-bearing observation may
 correct the state if that camera is in range. Covariance uses the numerically
 stable Joseph form and is symmetrized before becoming the next resident state.
+The ordinary arrays here define 1,000 independent lanes. Lane zero receives the
+exact displayed measurement; the remaining lanes receive deterministic sensor
+perturbations so the work is a real filter ensemble rather than 1,000 copies of
+one arithmetic result. Only lane zero is sampled back for the scene.
 
-  identity-3 := [1.0 0.0 0.0
-                 0.0 1.0 0.0
-                 0.0 0.0 1.0]
-  process-covariance := [0.08 0.0
-                         0.0 0.018]
-  measurement-covariance := [0.0225 0.0
-                             0.0 0.0004]
-  ~estimate := [2.9
-                2.15
-                0.16]
-  ~covariance := [0.45 0.0 0.0
-                  0.0 0.45 0.0
-                  0.0 0.0 0.08]
+  filter-count := 1000.0
+  filter-index := 1.0..=filter-count
+  filter-phase := 2.0 * 3.141592654 * (filter-index - 1.0) / filter-count
+  lane-dt-base := Δt
+  lane-speed-base := commanded-speed
+  lane-omega-base := commanded-omega
+  lane-camera-x-base := active-camera[1]
+  lane-camera-y-base := active-camera[2]
+  lane-range-base := observation[1]
+  lane-bearing-base := observation[2]
+  lane-visibility-base := active-camera-visibility
+  lane-zero := filter-index * 0.0
+  lane-dt := lane-zero + lane-dt-base
+  lane-speed := lane-zero + lane-speed-base * (1.0 + 0.002 * math/sin(filter-phase * 3.0))
+  lane-omega := lane-zero + lane-omega-base * (1.0 + 0.002 * math/sin(filter-phase * 5.0))
+  lane-camera-x := lane-zero + lane-camera-x-base
+  lane-camera-y := lane-zero + lane-camera-y-base
+  lane-range := lane-zero + lane-range-base + 0.012 * math/sin(filter-phase * 7.0)
+  lane-bearing := lane-zero + lane-bearing-base + 0.0015 * math/sin(filter-phase * 11.0)
+  lane-visibility := lane-zero + lane-visibility-base
+  lane-control := [lane-dt' lane-speed' lane-omega']
+  lane-camera := [lane-camera-x' lane-camera-y']
+  lane-measurement := [lane-range' lane-bearing' lane-visibility']
 
-  estimate-mid-heading := estimate[3] + commanded-omega * Δt / 2.0
-  estimate-mid-cos := math/cos(estimate-mid-heading)
-  estimate-mid-sin := math/sin(estimate-mid-heading)
-  motion-jacobian := [1.0 0.0 -commanded-speed * estimate-mid-sin * Δt
-                      0.0 1.0  commanded-speed * estimate-mid-cos * Δt
-                      0.0 0.0 1.0]
-  control-jacobian := [estimate-mid-cos * Δt -commanded-speed * estimate-mid-sin * Δt ^ 2 / 2.0
-                       estimate-mid-sin * Δt  commanded-speed * estimate-mid-cos * Δt ^ 2 / 2.0
-                       0.0                      Δt]
-  predicted-estimate := estimate + [commanded-speed * estimate-mid-cos * Δt
-                                    commanded-speed * estimate-mid-sin * Δt
-                                    commanded-omega * Δt]
+  @filters/input/control <- lane-control
+  @filters/input/camera <- lane-camera
+  @filters/input/measurement <- lane-measurement
+  @filters/turn <- @clock/tick
+
+  filter-sample := @filters/sample/result.0
+  corrected-estimate := [filter-sample[1]
+                         filter-sample[2]
+                         filter-sample[3]]
+  corrected-covariance := [filter-sample[4] filter-sample[7] filter-sample[10]
+                           filter-sample[5] filter-sample[8] filter-sample[11]
+                           filter-sample[6] filter-sample[9] filter-sample[12]]
+  predicted-estimate := [filter-sample[13]
+                         filter-sample[14]
+                         filter-sample[15]]
+
+
+ekf-batch @compute
+-------------------------------------------------------------------------------
+
+  control := [0.05<f32>; 1f32; 0f32]
+  camera := [1f32; 1f32]
+  measurement := [1f32; 0f32; 0f32]
+  dt := control[1,1]
+  linear-velocity := control[2,1]
+  angular-velocity := control[3,1]
+  visibility := measurement[3,1]
+
+  identity-3 := [1f32 0f32 0f32
+                 0f32 1f32 0f32
+                 0f32 0f32 1f32]
+  process-covariance := [0.08<f32> 0f32
+                         0f32 0.018<f32>]
+  measurement-covariance := [0.0225<f32> 0f32
+                             0f32 0.0004<f32>]
+  ~filter-state := [2.9<f32>
+                    2.15<f32>
+                    0.16<f32>
+                    0.45<f32>
+                    0f32
+                    0f32
+                    0f32
+                    0.45<f32>
+                    0f32
+                    0f32
+                    0f32
+                    0.08<f32>
+                    2.9<f32>
+                    2.15<f32>
+                    0.16<f32>]
+  state := [filter-state[1,1]
+            filter-state[2,1]
+            filter-state[3,1]]
+  covariance := [filter-state[4,1] filter-state[7,1] filter-state[10,1]
+                 filter-state[5,1] filter-state[8,1] filter-state[11,1]
+                 filter-state[6,1] filter-state[9,1] filter-state[12,1]]
+
+  mid-heading := state[3,1] + angular-velocity * dt / 2f32
+  mid-cos := math/cos(mid-heading)
+  mid-sin := math/sin(mid-heading)
+  motion-jacobian := [1f32 0f32 -linear-velocity * mid-sin * dt
+                      0f32 1f32  linear-velocity * mid-cos * dt
+                      0f32 0f32 1f32]
+  control-jacobian := [mid-cos * dt -linear-velocity * mid-sin * dt * dt / 2f32
+                       mid-sin * dt  linear-velocity * mid-cos * dt * dt / 2f32
+                       0f32          dt]
+  predicted-state := state + [linear-velocity * mid-cos * dt
+                              linear-velocity * mid-sin * dt
+                              angular-velocity * dt]
   predicted-covariance := motion-jacobian ** covariance ** motion-jacobian' + control-jacobian ** process-covariance ** control-jacobian'
 
-  predicted-dx := active-camera[1] - predicted-estimate[1]
-  predicted-dy := active-camera[2] - predicted-estimate[2]
-  predicted-q := predicted-dx ^ 2 + predicted-dy ^ 2
-  predicted-range := predicted-q ^ 0.5
+  camera-delta := camera - [predicted-state[1,1]; predicted-state[2,1]]
+  predicted-dx := camera-delta[1,1]
+  predicted-dy := camera-delta[2,1]
+  predicted-q := predicted-dx * predicted-dx + predicted-dy * predicted-dy
+  predicted-range := math/sqrt(predicted-q)
   predicted-observation := [predicted-range
-                            math/atan2(predicted-dy, predicted-dx) - predicted-estimate[3]]
-  observation-jacobian := [-predicted-dx / predicted-range -predicted-dy / predicted-range 0.0
-                            predicted-dy / predicted-q     -predicted-dx / predicted-q -1.0]
+                            math/atan2(predicted-dy, predicted-dx) - predicted-state[3,1]]
+  observation-jacobian := [-predicted-dx / predicted-range -predicted-dy / predicted-range 0f32
+                            predicted-dy / predicted-q     -predicted-dx / predicted-q -1f32]
   innovation-covariance := observation-jacobian ** predicted-covariance ** observation-jacobian' + measurement-covariance
   innovation-determinant := innovation-covariance[1,1] * innovation-covariance[2,2] - innovation-covariance[1,2] * innovation-covariance[2,1]
   innovation-inverse := [ innovation-covariance[2,2] / innovation-determinant -innovation-covariance[1,2] / innovation-determinant
                          -innovation-covariance[2,1] / innovation-determinant  innovation-covariance[1,1] / innovation-determinant]
   kalman-gain := predicted-covariance ** observation-jacobian' ** innovation-inverse
-  bearing-residual := observation[2] - predicted-observation[2]
-  innovation := [observation[1] - predicted-observation[1]
+  bearing-residual := measurement[2,1] - predicted-observation[2,1]
+  innovation := [measurement[1,1] - predicted-observation[1,1]
                  math/atan2(math/sin(bearing-residual), math/cos(bearing-residual))]
-  observed-estimate := predicted-estimate + kalman-gain ** innovation
+  observed-state := predicted-state + kalman-gain ** innovation
   joseph-a := identity-3 - kalman-gain ** observation-jacobian
   observed-covariance-raw := joseph-a ** predicted-covariance ** joseph-a' + kalman-gain ** measurement-covariance ** kalman-gain'
-  observed-covariance := 0.5 * (observed-covariance-raw + observed-covariance-raw')
-  corrected-estimate := predicted-estimate + active-camera-visibility * (observed-estimate - predicted-estimate)
-  corrected-covariance := predicted-covariance + active-camera-visibility * (observed-covariance - predicted-covariance)
+  observed-covariance := 0.5<f32> * (observed-covariance-raw + observed-covariance-raw')
+  next-state := predicted-state + visibility * (observed-state - predicted-state)
+  next-covariance := predicted-covariance + visibility * (observed-covariance - predicted-covariance)
 
-  estimate = corrected-estimate
-  covariance = corrected-covariance
+  finite-limit := 3.402823466e38<f32>
+  finite-state! := math/abs(next-state[1,1]) <= finite-limit && math/abs(next-state[2,1]) <= finite-limit && math/abs(next-state[3,1]) <= finite-limit
+  positive-covariance! := next-covariance[1,1] > 0f32 && next-covariance[2,2] > 0f32 && next-covariance[3,3] > 0f32
+  symmetric-covariance! := math/abs(next-covariance[1,2] - next-covariance[2,1]) <= 0.0001<f32> && math/abs(next-covariance[1,3] - next-covariance[3,1]) <= 0.0001<f32> && math/abs(next-covariance[2,3] - next-covariance[3,2]) <= 0.0001<f32>
+
+  next-filter-state := [next-state[1,1]
+                        next-state[2,1]
+                        next-state[3,1]
+                        next-covariance[1,1]
+                        next-covariance[2,1]
+                        next-covariance[3,1]
+                        next-covariance[1,2]
+                        next-covariance[2,2]
+                        next-covariance[3,2]
+                        next-covariance[1,3]
+                        next-covariance[2,3]
+                        next-covariance[3,3]
+                        predicted-state[1,1]
+                        predicted-state[2,1]
+                        predicted-state[3,1]]
+  filter-state = next-filter-state
+  (filter-state, filter-state)
 
 
 5. Live Tracking Field
@@ -330,8 +429,11 @@ range. Only the scheduled in-range camera's noisy values enter the filter.
   ~estimate-path := [initial-estimate-path-x initial-estimate-path-y]
   truth-screen-point := ([truth-screen-x truth-screen-y])
   estimate-screen-point := ([estimate-screen-x estimate-screen-y])
-  next-truth-path := matrix/vertcat(truth-path[2..=376,:], truth-screen-point)
-  next-estimate-path := matrix/vertcat(estimate-path[2..=376,:], estimate-screen-point)
+  advanced-truth-path := matrix/vertcat(truth-path[2..=376,:], truth-screen-point)
+  advanced-estimate-path := matrix/vertcat(estimate-path[2..=376,:], estimate-screen-point)
+  next-truth-path := truth-path + turn-pulse * (advanced-truth-path - truth-path)
+  sample-pulse := 1.0 - turn-pulse
+  next-estimate-path := estimate-path + sample-pulse * (advanced-estimate-path - estimate-path)
   truth-path = next-truth-path
   estimate-path = next-estimate-path
 

--- a/examples/ekf/localization.mec
+++ b/examples/ekf/localization.mec
@@ -339,12 +339,17 @@ ekf-batch @compute
                ω * δt]
     Σ- := G ** Σ ** G' + V ** Q ** V'.
 
-  ekf-correct(μ-<[f32]:3,1>, Σ-<[f32]:3,3>, camera<[f32]:2,1>, z<[f32]:2,1>, R<[f32]:2,2>) = (μ+<[f32]:3,1>, Σ+<[f32]:3,3>) :=
+  -- Visibility is part of the numerical observation contract, not merely an
+  -- output mask. The inactive guard makes zero-visibility geometry
+  -- nonsingular before divisions and atan2 are evaluated while leaving every
+  -- active measurement's original equations unchanged.
+  ekf-correct(μ-<[f32]:3,1>, Σ-<[f32]:3,3>, camera<[f32]:2,1>, z<[f32]:3,1>, R<[f32]:2,2>) = (μ+<[f32]:3,1>, Σ+<[f32]:3,3>) :=
     Δ := camera - μ-[1..=2]
-    q := Δ · Δ
+    observation-guard := 1f32 - z[3]
+    q := Δ · Δ + observation-guard
     r := math/sqrt(q)
     ẑ := [r
-          math/atan2(Δ[2], Δ[1]) - μ-[3]]
+          math/atan2(Δ[2], Δ[1] + observation-guard) - μ-[3]]
     H := [-Δ[1] / r -Δ[2] / r 0f32
            Δ[2] / q -Δ[1] / q -1f32]
     S := H ** Σ- ** H' + R
@@ -364,12 +369,21 @@ ekf-batch @compute
   control := [0.05<f32>; 1f32; 0f32]
   camera := [1f32; 1f32]
   measurement := [1f32; 0f32; 0f32]
-  z := [measurement[1]; measurement[2]]
   γ := measurement[3]
   Q := [0.08<f32> 0f32
         0f32 0.018<f32>]
   R := [0.0225<f32> 0f32
         0f32 0.0004<f32>]
+
+  -- Qualify the inactive-measurement boundary directly: the camera and prior
+  -- position coincide while visibility is exactly zero. This used to evaluate
+  -- 0 / 0 before the later visibility interpolation could discard the result.
+  inactive-witness-state := [1f32; 1f32; 0f32]
+  inactive-witness-covariance := [0.45<f32> 0f32 0f32
+                                  0f32 0.45<f32> 0f32
+                                  0f32 0f32 0.08<f32>]
+  (inactive-witness-μ, inactive-witness-Σ) := ekf-correct(inactive-witness-state, inactive-witness-covariance, [1f32; 1f32], [0f32; 0f32; 0f32], R)
+  inactive-correction-finite! := math/abs(inactive-witness-μ[1]) <= 3.402823466e38<f32> && math/abs(inactive-witness-μ[2]) <= 3.402823466e38<f32> && math/abs(inactive-witness-μ[3]) <= 3.402823466e38<f32> && inactive-witness-Σ[1,1] > 0f32 && inactive-witness-Σ[2,2] > 0f32 && inactive-witness-Σ[3,3] > 0f32
 
   -- These two fixed-shape calls are the whole filter. The compute host maps
   -- them over the outer lane arrays supplied by the document; increasing the
@@ -383,7 +397,7 @@ ekf-batch @compute
   μ := filter-sample[:,1]
   Σ := filter-sample[:,2..=4]
   (μ-, Σ-) := ekf-predict(μ, Σ, control, Q)
-  (μ+, Σ+) := ekf-correct(μ-, Σ-, camera, z, R)
+  (μ+, Σ+) := ekf-correct(μ-, Σ-, camera, measurement, R)
   μ-next := μ- + γ * (μ+ - μ-)
   Σ-next := Σ- + γ * (Σ+ - Σ-)
 

--- a/examples/ekf/localization.mec
+++ b/examples/ekf/localization.mec
@@ -75,8 +75,7 @@ the same camera and measurement path.
   scene-pointer-position := @scene/pointer-position
   scene-pointer-pressed := @scene/pointer-pressed
   scene-pointer-delta := scene-pointer-pulse - last-scene-pointer-pulse
-  scene-pointer-delta-relu := (scene-pointer-delta + (scene-pointer-delta ^ 2) ^ 0.5) / 2.0
-  scene-pointer-edge := scene-pointer-delta-relu - (scene-pointer-delta-relu - 1.0 + ((scene-pointer-delta-relu - 1.0) ^ 2) ^ 0.5) / 2.0
+  scene-pointer-toggle-parity := scene-pointer-delta % 2.0
   scene-pointer-screen-x := (scene-pointer-position[1] + 1.0) * 430.0
   scene-pointer-screen-y := (1.0 - scene-pointer-position[2]) * 385.0
   camera-screen-x := [182.0; 678.0; 678.0; 182.0]
@@ -85,10 +84,10 @@ the same camera and measurement path.
   scene-pointer-hit-raw := 484.0 - scene-pointer-camera-distance-square
   scene-pointer-hit-relu := (scene-pointer-hit-raw + (scene-pointer-hit-raw ^ 2) ^ 0.5) / 2.0
   scene-pointer-hit := scene-pointer-hit-relu - (scene-pointer-hit-relu - 1.0 + ((scene-pointer-hit-relu - 1.0) ^ 2) ^ 0.5) / 2.0
-  -- The scene host publishes pulse + position as one activation payload and
-  -- publishes release/cancel as level-only updates. This edge therefore
-  -- survives a coalesced quick click without being replayed by a later release.
-  camera-toggle := scene-pointer-edge * scene-pointer-hit
+  -- A gesture group coalesces down/up but never crosses into the next press.
+  -- Parity still preserves an even count jump if an activation history is
+  -- restored or replayed without exposing every intermediate turn.
+  camera-toggle := scene-pointer-toggle-parity * scene-pointer-hit
   next-camera-enabled := camera-enabled + camera-toggle * (1.0 - 2.0 * camera-enabled)
   camera-enabled = next-camera-enabled
   last-scene-pointer-pulse = scene-pointer-pulse

--- a/examples/ekf/localization.mec
+++ b/examples/ekf/localization.mec
@@ -34,12 +34,19 @@ robot and contracts after the next camera reacquires it.
   ~last-clock-tick := 0.0
   clock-delta := @clock/tick - last-clock-tick
   clock-delta-positive := (clock-delta + (clock-delta ^ 2) ^ 0.5) / 2.0
-  turn-pulse := clock-delta-positive - (clock-delta-positive - 1.0 + ((clock-delta-positive - 1.0) ^ 2) ^ 0.5) / 2.0
+  clock-pulse := clock-delta-positive - (clock-delta-positive - 1.0 + ((clock-delta-positive - 1.0) ^ 2) ^ 0.5) / 2.0
+  ~requested-compute-turn := 0.0
+  compute-inflight-gap := requested-compute-turn - @filters/turns
+  compute-inflight-gap-absolute := (compute-inflight-gap ^ 2) ^ 0.5
+  compute-idle-raw := 1.0 - compute-inflight-gap-absolute
+  compute-idle := (compute-idle-raw + (compute-idle-raw ^ 2) ^ 0.5) / 2.0
+  request-pulse := clock-pulse * compute-idle
+  next-requested-compute-turn := requested-compute-turn + request-pulse
   ~last-filter-turn := 0.0
   filter-turn-delta := @filters/turns - last-filter-turn
   filter-turn-delta-positive := (filter-turn-delta + (filter-turn-delta ^ 2) ^ 0.5) / 2.0
   sample-pulse := filter-turn-delta-positive - (filter-turn-delta-positive - 1.0 + ((filter-turn-delta-positive - 1.0) ^ 2) ^ 0.5) / 2.0
-  Δt := turn-pulse * 0.05
+  Δt := 0.05
   cruise-speed := 1.15
   turn-rate-limit := 1.75
   heading-gain := 4.0
@@ -96,11 +103,14 @@ reduction make the corners smooth without position clamps.
   drive-phases<[f64]:1,376> := #SquareDrive(side-ticks)
   lap-ticks := 4.0 * side-ticks
   ~simulation-step := 0.0
-  next-simulation-step := simulation-step + turn-pulse
+  ~pending-simulation-step := 1.0
+  attempted-simulation-step := simulation-step + 1.0
+  next-simulation-step := simulation-step + sample-pulse * (pending-simulation-step - simulation-step)
   ~drive-phase-index := 1.0
+  ~pending-drive-phase-index := 2.0
   drive-phase := drive-phases[1,drive-phase-index]
   advanced-drive-phase-index := (drive-phase-index % lap-ticks) + 1.0
-  next-drive-phase-index := drive-phase-index + turn-pulse * (advanced-drive-phase-index - drive-phase-index)
+  next-drive-phase-index := drive-phase-index + sample-pulse * (pending-drive-phase-index - drive-phase-index)
   phase-progress := ((drive-phase-index - 1.0) % side-ticks) / side-ticks
   path-parameter := drive-phase + phase-progress
   lookahead-parameter := (path-parameter + 0.15) % 4.0
@@ -118,7 +128,10 @@ reduction make the corners smooth without position clamps.
   ~truth := [2.5
              2.5
              0.0]
-  simulation-time := next-simulation-step * 0.05
+  ~pending-truth := [2.5
+                     2.5
+                     0.0]
+  simulation-time := attempted-simulation-step * 0.05
   target-heading := math/atan2(target-y - truth[2], target-x - truth[1])
   heading-error-raw := target-heading - truth[3]
   heading-error := math/atan2(math/sin(heading-error-raw), math/cos(heading-error-raw))
@@ -132,12 +145,18 @@ reduction make the corners smooth without position clamps.
   actual-omega := commanded-omega * actual-omega-scale
   truth-mid-heading := truth[3] + actual-omega * Δt / 2.0
 
-  next-truth := truth + [actual-speed * math/cos(truth-mid-heading) * Δt
-                         actual-speed * math/sin(truth-mid-heading) * Δt
-                         actual-omega * Δt]
+  attempted-truth := truth + [actual-speed * math/cos(truth-mid-heading) * Δt
+                              actual-speed * math/sin(truth-mid-heading) * Δt
+                              actual-omega * Δt]
+  next-truth := truth + sample-pulse * (pending-truth - truth)
 
   truth = next-truth
+  pending-truth = attempted-truth
   simulation-step = next-simulation-step
+  pending-simulation-step = attempted-simulation-step
+  drive-phase-index = next-drive-phase-index
+  pending-drive-phase-index = advanced-drive-phase-index
+  requested-compute-turn = next-requested-compute-turn
 
 
 3. Noisy Camera Observations
@@ -190,8 +209,8 @@ than pretending that every camera sees through the entire field.
   camera-schedule<[f64]:1,376> := #CameraSchedule(camera-dwell-ticks)
   camera-index := camera-schedule[1,drive-phase-index]
   active-camera := cameras[camera-index,:]
-  camera-dx-all := cameras[:,1] - next-truth[1]
-  camera-dy-all := cameras[:,2] - next-truth[2]
+  camera-dx-all := cameras[:,1] - attempted-truth[1]
+  camera-dy-all := cameras[:,2] - attempted-truth[2]
   camera-range-all := (camera-dx-all ^ 2 + camera-dy-all ^ 2) ^ 0.5
   camera-inside-fade-raw := (camera-max-range - camera-range-all) / camera-range-fade
   camera-inside-fade-relu := (camera-inside-fade-raw + (camera-inside-fade-raw ^ 2) ^ 0.5) / 2.0
@@ -217,11 +236,11 @@ than pretending that every camera sees through the entire field.
                                        13.0 + camera-boundary-probe-visibility[3] * (23.0 - 13.0)
                                        14.0 + camera-boundary-probe-visibility[4] * (24.0 - 14.0)]
   active-camera-visibility := camera-visibility[camera-index]
-  camera-dx := active-camera[1] - next-truth[1]
-  camera-dy := active-camera[2] - next-truth[2]
+  camera-dx := active-camera[1] - attempted-truth[1]
+  camera-dy := active-camera[2] - attempted-truth[2]
   camera-range := (camera-dx ^ 2 + camera-dy ^ 2) ^ 0.5
   measured-range := camera-range + 0.11 * math/sin(simulation-time * 1.57 + camera-index * 0.7)
-  measured-bearing := math/atan2(camera-dy, camera-dx) - next-truth[3] + 0.011 * math/sin(simulation-time * 1.91 + camera-index)
+  measured-bearing := math/atan2(camera-dy, camera-dx) - attempted-truth[3] + 0.011 * math/sin(simulation-time * 1.91 + camera-index)
   observation := [measured-range
                   measured-bearing]
 
@@ -265,7 +284,7 @@ one arithmetic result. Only lane zero is sampled back for the scene.
   @filters/input/control <- lane-control
   @filters/input/camera <- lane-camera
   @filters/input/measurement <- lane-measurement
-  @filters/turn <- @clock/tick
+  @filters/turn <- next-requested-compute-turn
 
   filter-sample := @filters/sample/result.0
   corrected-estimate := [filter-sample[1]
@@ -397,6 +416,13 @@ range. Only the scheduled in-range camera's noisy values enter the filter.
   screen-origin-y := 700.0
   truth-screen-x := screen-origin-x + next-truth[1] * screen-scale
   truth-screen-y := screen-origin-y - next-truth[2] * screen-scale
+  display-camera-dx-all := cameras[:,1] - next-truth[1]
+  display-camera-dy-all := cameras[:,2] - next-truth[2]
+  display-camera-range-all := (display-camera-dx-all ^ 2 + display-camera-dy-all ^ 2) ^ 0.5
+  display-camera-inside-fade-raw := (camera-max-range - display-camera-range-all) / camera-range-fade
+  display-camera-inside-fade-relu := (display-camera-inside-fade-raw + (display-camera-inside-fade-raw ^ 2) ^ 0.5) / 2.0
+  display-camera-inside-fade-one-relu := (display-camera-inside-fade-raw - 1.0 + ((display-camera-inside-fade-raw - 1.0) ^ 2) ^ 0.5) / 2.0
+  display-camera-visibility := display-camera-inside-fade-relu - display-camera-inside-fade-one-relu
   predicted-screen-x := screen-origin-x + predicted-estimate[1] * screen-scale
   predicted-screen-y := screen-origin-y - predicted-estimate[2] * screen-scale
   estimate-screen-x := screen-origin-x + corrected-estimate[1] * screen-scale
@@ -439,7 +465,7 @@ range. Only the scheduled in-range camera's noisy values enter the filter.
   estimate-screen-point := ([estimate-screen-x estimate-screen-y])
   advanced-truth-path := matrix/vertcat(truth-path[2..=376,:], truth-screen-point)
   advanced-estimate-path := matrix/vertcat(estimate-path[2..=376,:], estimate-screen-point)
-  next-truth-path := truth-path + turn-pulse * (advanced-truth-path - truth-path)
+  next-truth-path := truth-path + sample-pulse * (advanced-truth-path - truth-path)
   next-estimate-path := estimate-path + sample-pulse * (advanced-estimate-path - estimate-path)
   truth-path = next-truth-path
   estimate-path = next-estimate-path
@@ -472,10 +498,10 @@ range. Only the scheduled in-range camera's noisy values enter the filter.
     {id: "frame-right", x1: 740, y1: 80, x2: 740, y2: 700, stroke: "#27313d", stroke-width: 1, line-cap: "butt", opacity: 1, rotation: 0, origin-x: 0, origin-y: 0},
     {id: "frame-bottom", x1: 740, y1: 700, x2: 120, y2: 700, stroke: "#27313d", stroke-width: 1, line-cap: "butt", opacity: 1, rotation: 0, origin-x: 0, origin-y: 0},
     {id: "frame-left", x1: 120, y1: 700, x2: 120, y2: 80, stroke: "#27313d", stroke-width: 1, line-cap: "butt", opacity: 1, rotation: 0, origin-x: 0, origin-y: 0},
-    {id: "ray-1", x1: 182, y1: 638, x2: truth-screen-x, y2: truth-screen-y, stroke: "#d9b652", stroke-width: 0.7, line-cap: "round", opacity: 0.4 * camera-visibility[1], rotation: 0, origin-x: 0, origin-y: 0},
-    {id: "ray-2", x1: 678, y1: 638, x2: truth-screen-x, y2: truth-screen-y, stroke: "#d9b652", stroke-width: 0.7, line-cap: "round", opacity: 0.4 * camera-visibility[2], rotation: 0, origin-x: 0, origin-y: 0},
-    {id: "ray-3", x1: 678, y1: 142, x2: truth-screen-x, y2: truth-screen-y, stroke: "#d9b652", stroke-width: 0.7, line-cap: "round", opacity: 0.4 * camera-visibility[3], rotation: 0, origin-x: 0, origin-y: 0},
-    {id: "ray-4", x1: 182, y1: 142, x2: truth-screen-x, y2: truth-screen-y, stroke: "#d9b652", stroke-width: 0.7, line-cap: "round", opacity: 0.4 * camera-visibility[4], rotation: 0, origin-x: 0, origin-y: 0},
+    {id: "ray-1", x1: 182, y1: 638, x2: truth-screen-x, y2: truth-screen-y, stroke: "#d9b652", stroke-width: 0.7, line-cap: "round", opacity: 0.4 * display-camera-visibility[1], rotation: 0, origin-x: 0, origin-y: 0},
+    {id: "ray-2", x1: 678, y1: 638, x2: truth-screen-x, y2: truth-screen-y, stroke: "#d9b652", stroke-width: 0.7, line-cap: "round", opacity: 0.4 * display-camera-visibility[2], rotation: 0, origin-x: 0, origin-y: 0},
+    {id: "ray-3", x1: 678, y1: 142, x2: truth-screen-x, y2: truth-screen-y, stroke: "#d9b652", stroke-width: 0.7, line-cap: "round", opacity: 0.4 * display-camera-visibility[3], rotation: 0, origin-x: 0, origin-y: 0},
+    {id: "ray-4", x1: 182, y1: 142, x2: truth-screen-x, y2: truth-screen-y, stroke: "#d9b652", stroke-width: 0.7, line-cap: "round", opacity: 0.4 * display-camera-visibility[4], rotation: 0, origin-x: 0, origin-y: 0},
     {id: "truth-heading", x1: truth-screen-x, y1: truth-screen-y, x2: truth-screen-x + 18.0 * math/cos(next-truth[3]), y2: truth-screen-y - 18.0 * math/sin(next-truth[3]), stroke: "#d7fff8", stroke-width: 2, line-cap: "round", opacity: 1, rotation: 0, origin-x: 0, origin-y: 0},
     {id: "estimate-heading", x1: estimate-screen-x, y1: estimate-screen-y, x2: estimate-screen-x + 16.0 * math/cos(corrected-estimate[3]), y2: estimate-screen-y - 16.0 * math/sin(corrected-estimate[3]), stroke: "#ffe1ef", stroke-width: 1.5, line-cap: "round", opacity: 1, rotation: 0, origin-x: 0, origin-y: 0}
   )
@@ -511,6 +537,5 @@ range. Only the scheduled in-range camera's noisy values enter the filter.
     texts: scene-text
   }
 
-  drive-phase-index = next-drive-phase-index
   @scene/replace <- field-presentation
   position-error

--- a/examples/ekf/localization.mec
+++ b/examples/ekf/localization.mec
@@ -90,6 +90,8 @@ reduction make the corners smooth without position clamps.
   side-ticks := 94.0
   drive-phases<[f64]:1,376> := #SquareDrive(side-ticks)
   lap-ticks := 4.0 * side-ticks
+  ~simulation-step := 0.0
+  next-simulation-step := simulation-step + turn-pulse
   ~drive-phase-index := 1.0
   drive-phase := drive-phases[1,drive-phase-index]
   advanced-drive-phase-index := (drive-phase-index % lap-ticks) + 1.0
@@ -111,7 +113,7 @@ reduction make the corners smooth without position clamps.
   ~truth := [2.5
              2.5
              0.0]
-  simulation-time := @clock/tick * 0.05
+  simulation-time := next-simulation-step * 0.05
   target-heading := math/atan2(target-y - truth[2], target-x - truth[1])
   heading-error-raw := target-heading - truth[3]
   heading-error := math/atan2(math/sin(heading-error-raw), math/cos(heading-error-raw))
@@ -130,6 +132,7 @@ reduction make the corners smooth without position clamps.
                          actual-omega * Δt]
 
   truth = next-truth
+  simulation-step = next-simulation-step
 
 
 3. Noisy Camera Observations

--- a/examples/ekf/localization.mec
+++ b/examples/ekf/localization.mec
@@ -345,7 +345,7 @@ ekf-batch @compute
   -- active measurement's original equations unchanged.
   ekf-correct(μ-<[f32]:3,1>, Σ-<[f32]:3,3>, camera<[f32]:2,1>, z<[f32]:3,1>, R<[f32]:2,2>) = (μ+<[f32]:3,1>, Σ+<[f32]:3,3>) :=
     Δ := camera - μ-[1..=2]
-    observation-guard := 1f32 - z[3]
+    observation-guard := 1f32 - math/ceil(z[3])
     q := Δ · Δ + observation-guard
     r := math/sqrt(q)
     ẑ := [r

--- a/examples/ekf/localization.mec
+++ b/examples/ekf/localization.mec
@@ -85,10 +85,10 @@ the same camera and measurement path.
   scene-pointer-hit-raw := 484.0 - scene-pointer-camera-distance-square
   scene-pointer-hit-relu := (scene-pointer-hit-raw + (scene-pointer-hit-raw ^ 2) ^ 0.5) / 2.0
   scene-pointer-hit := scene-pointer-hit-relu - (scene-pointer-hit-relu - 1.0 + ((scene-pointer-hit-relu - 1.0) ^ 2) ^ 0.5) / 2.0
-  -- A release may arrive on a later resident turn before every downstream
-  -- pulse-history consumer has settled. Gate the activation by the pressed
-  -- phase as well as the monotonic edge so release/cancel can never toggle.
-  camera-toggle := scene-pointer-edge * scene-pointer-hit * scene-pointer-pressed
+  -- The scene host publishes pulse + position as one activation payload and
+  -- publishes release/cancel as level-only updates. This edge therefore
+  -- survives a coalesced quick click without being replayed by a later release.
+  camera-toggle := scene-pointer-edge * scene-pointer-hit
   next-camera-enabled := camera-enabled + camera-toggle * (1.0 - 2.0 * camera-enabled)
   camera-enabled = next-camera-enabled
   last-scene-pointer-pulse = scene-pointer-pulse

--- a/examples/ekf/localization.mec
+++ b/examples/ekf/localization.mec
@@ -290,73 +290,77 @@ one arithmetic result. Only lane zero is sampled back for the scene.
 ekf-batch @compute
 -------------------------------------------------------------------------------
 
+  ekf-predict(μ<[f32]:3,1>, Σ<[f32]:3,3>, u<[f32]:3,1>, Q<[f32]:2,2>) = (μ-<[f32]:3,1>, Σ-<[f32]:3,3>) :=
+    δt := u[1]
+    v := u[2]
+    ω := u[3]
+    θ := μ[3] + ω * δt / 2f32
+    c := math/cos(θ)
+    s := math/sin(θ)
+    G := [1f32 0f32 -v * s * δt
+          0f32 1f32  v * c * δt
+          0f32 0f32 1f32]
+    V := [c * δt -v * s * δt * δt / 2f32
+          s * δt  v * c * δt * δt / 2f32
+          0f32     δt]
+    μ- := μ + [v * c * δt
+               v * s * δt
+               ω * δt]
+    Σ- := G ** Σ ** G' + V ** Q ** V'.
+
+  ekf-correct(μ-<[f32]:3,1>, Σ-<[f32]:3,3>, camera<[f32]:2,1>, z<[f32]:2,1>, R<[f32]:2,2>) = (μ+<[f32]:3,1>, Σ+<[f32]:3,3>) :=
+    Δ := camera - μ-[1..=2]
+    q := Δ · Δ
+    r := math/sqrt(q)
+    ẑ := [r
+          math/atan2(Δ[2], Δ[1]) - μ-[3]]
+    H := [-Δ[1] / r -Δ[2] / r 0f32
+           Δ[2] / q -Δ[1] / q -1f32]
+    S := H ** Σ- ** H' + R
+    B := H ** Σ-
+    K := (S \ B)'
+    νθ := z[2] - ẑ[2]
+    ν := [z[1] - ẑ[1]
+          math/atan2(math/sin(νθ), math/cos(νθ))]
+    μ+ := μ- + K ** ν
+    I := [1f32 0f32 0f32
+          0f32 1f32 0f32
+          0f32 0f32 1f32]
+    A := I - K ** H
+    Σ-raw := A ** Σ- ** A' + K ** R ** K'
+    Σ+ := 0.5<f32> * (Σ-raw + Σ-raw').
+
   control := [0.05<f32>; 1f32; 0f32]
   camera := [1f32; 1f32]
   measurement := [1f32; 0f32; 0f32]
-  dt := control[1,1]
-  linear-velocity := control[2,1]
-  angular-velocity := control[3,1]
-  visibility := measurement[3,1]
+  z := [measurement[1]; measurement[2]]
+  γ := measurement[3]
+  Q := [0.08<f32> 0f32
+        0f32 0.018<f32>]
+  R := [0.0225<f32> 0f32
+        0f32 0.0004<f32>]
 
-  identity-3 := [1f32 0f32 0f32
-                 0f32 1f32 0f32
-                 0f32 0f32 1f32]
-  process-covariance := [0.08<f32> 0f32
-                         0f32 0.018<f32>]
-  measurement-covariance := [0.0225<f32> 0f32
-                             0f32 0.0004<f32>]
+  -- These two fixed-shape calls are the whole filter. The compute host maps
+  -- them over the outer lane arrays supplied by the document; increasing the
+  -- lane count does not duplicate this source graph.
   -- The resident value is the whole filter checkpoint. Its columns are the
-  -- corrected state, the 3x3 covariance, and the uncorrected prediction.
+  -- posterior state, its 3x3 covariance, and the prior state.
   ~filter-sample := [2.9<f32>  0.45<f32> 0f32       0f32       2.9<f32>
                      2.15<f32> 0f32       0.45<f32> 0f32       2.15<f32>
                      0.16<f32> 0f32       0f32       0.08<f32> 0.16<f32>]
-  state := filter-sample[:,1]
-  covariance := filter-sample[:,2..=4]
-
-  mid-heading := state[3,1] + angular-velocity * dt / 2f32
-  mid-cos := math/cos(mid-heading)
-  mid-sin := math/sin(mid-heading)
-  motion-jacobian := [1f32 0f32 -linear-velocity * mid-sin * dt
-                      0f32 1f32  linear-velocity * mid-cos * dt
-                      0f32 0f32 1f32]
-  control-jacobian := [mid-cos * dt -linear-velocity * mid-sin * dt * dt / 2f32
-                       mid-sin * dt  linear-velocity * mid-cos * dt * dt / 2f32
-                       0f32          dt]
-  predicted-state := state + [linear-velocity * mid-cos * dt
-                              linear-velocity * mid-sin * dt
-                              angular-velocity * dt]
-  predicted-covariance := motion-jacobian ** covariance ** motion-jacobian' + control-jacobian ** process-covariance ** control-jacobian'
-
-  camera-delta := camera - [predicted-state[1,1]; predicted-state[2,1]]
-  predicted-dx := camera-delta[1,1]
-  predicted-dy := camera-delta[2,1]
-  predicted-q := predicted-dx * predicted-dx + predicted-dy * predicted-dy
-  predicted-range := math/sqrt(predicted-q)
-  predicted-observation := [predicted-range
-                            math/atan2(predicted-dy, predicted-dx) - predicted-state[3,1]]
-  observation-jacobian := [-predicted-dx / predicted-range -predicted-dy / predicted-range 0f32
-                            predicted-dy / predicted-q     -predicted-dx / predicted-q -1f32]
-  innovation-covariance := observation-jacobian ** predicted-covariance ** observation-jacobian' + measurement-covariance
-  innovation-determinant := innovation-covariance[1,1] * innovation-covariance[2,2] - innovation-covariance[1,2] * innovation-covariance[2,1]
-  innovation-inverse := [ innovation-covariance[2,2] / innovation-determinant -innovation-covariance[1,2] / innovation-determinant
-                         -innovation-covariance[2,1] / innovation-determinant  innovation-covariance[1,1] / innovation-determinant]
-  kalman-gain := predicted-covariance ** observation-jacobian' ** innovation-inverse
-  bearing-residual := measurement[2,1] - predicted-observation[2,1]
-  innovation := [measurement[1,1] - predicted-observation[1,1]
-                 math/atan2(math/sin(bearing-residual), math/cos(bearing-residual))]
-  observed-state := predicted-state + kalman-gain ** innovation
-  joseph-a := identity-3 - kalman-gain ** observation-jacobian
-  observed-covariance-raw := joseph-a ** predicted-covariance ** joseph-a' + kalman-gain ** measurement-covariance ** kalman-gain'
-  observed-covariance := 0.5<f32> * (observed-covariance-raw + observed-covariance-raw')
-  next-state := predicted-state + visibility * (observed-state - predicted-state)
-  next-covariance := predicted-covariance + visibility * (observed-covariance - predicted-covariance)
+  μ := filter-sample[:,1]
+  Σ := filter-sample[:,2..=4]
+  (μ-, Σ-) := ekf-predict(μ, Σ, control, Q)
+  (μ+, Σ+) := ekf-correct(μ-, Σ-, camera, z, R)
+  μ-next := μ- + γ * (μ+ - μ-)
+  Σ-next := Σ- + γ * (Σ+ - Σ-)
 
   finite-limit := 3.402823466e38<f32>
-  finite-state! := math/abs(next-state[1,1]) <= finite-limit && math/abs(next-state[2,1]) <= finite-limit && math/abs(next-state[3,1]) <= finite-limit
-  positive-covariance! := next-covariance[1,1] > 0f32 && next-covariance[2,2] > 0f32 && next-covariance[3,3] > 0f32
-  symmetric-covariance! := math/abs(next-covariance[1,2] - next-covariance[2,1]) <= 0.0001<f32> && math/abs(next-covariance[1,3] - next-covariance[3,1]) <= 0.0001<f32> && math/abs(next-covariance[2,3] - next-covariance[3,2]) <= 0.0001<f32>
+  finite-state! := math/abs(μ-next[1,1]) <= finite-limit && math/abs(μ-next[2,1]) <= finite-limit && math/abs(μ-next[3,1]) <= finite-limit
+  positive-covariance! := Σ-next[1,1] > 0f32 && Σ-next[2,2] > 0f32 && Σ-next[3,3] > 0f32
+  symmetric-covariance! := math/abs(Σ-next[1,2] - Σ-next[2,1]) <= 0.0001<f32> && math/abs(Σ-next[1,3] - Σ-next[3,1]) <= 0.0001<f32> && math/abs(Σ-next[2,3] - Σ-next[3,2]) <= 0.0001<f32>
 
-  filter-sample = [next-state next-covariance predicted-state]
+  filter-sample = [μ-next Σ-next μ-]
   (filter-sample, filter-sample)
 
 

--- a/examples/ekf/localization.mec
+++ b/examples/ekf/localization.mec
@@ -26,8 +26,12 @@ but each has a finite 3.6-unit sensing radius. The uncovered middle of every
 side is an intentional dead zone: covariance grows while no camera can see the
 robot and contracts after the next camera reacquires it.
 
+Click a camera to disable it. Its color mutes, its range ring disappears, and
+its measurements are removed before the EKF update. Click it again to restore
+the same camera and measurement path.
+
 @clock := timer://clock/tick{:read(tick)}
-@scene := scene://localization/frame{:write(replace)}
+@scene := scene://localization/frame{:read(pointer-pulse), :read(pointer-position), :read(pointer-pressed), :read(pointer-delta-seconds), :write(replace)}
 @filters := compute://filters/kernel{:read(sample/result.0), :read(sample/result.2), :read(turns), :write(input/control), :write(input/camera), :write(input/measurement), :write(turn)}
 
   π := 3.141592654
@@ -61,6 +65,29 @@ robot and contracts after the next camera reacquires it.
               9.0 1.0
               9.0 9.0
               1.0 9.0]
+
+  -- Scene pointer presses toggle the camera under the cursor. The enable mask
+  -- is resident Mech state: it gates the measurement before the EKF input and
+  -- drives the active, muted, range-ring, label, and ray presentation below.
+  ~camera-enabled := [1.0; 1.0; 1.0; 1.0]
+  ~last-scene-pointer-pulse := 0.0
+  scene-pointer-pulse := @scene/pointer-pulse
+  scene-pointer-position := @scene/pointer-position
+  scene-pointer-delta := scene-pointer-pulse - last-scene-pointer-pulse
+  scene-pointer-delta-relu := (scene-pointer-delta + (scene-pointer-delta ^ 2) ^ 0.5) / 2.0
+  scene-pointer-edge := scene-pointer-delta-relu - (scene-pointer-delta-relu - 1.0 + ((scene-pointer-delta-relu - 1.0) ^ 2) ^ 0.5) / 2.0
+  scene-pointer-screen-x := (scene-pointer-position[1] + 1.0) * 430.0
+  scene-pointer-screen-y := (1.0 - scene-pointer-position[2]) * 385.0
+  camera-screen-x := [182.0; 678.0; 678.0; 182.0]
+  camera-screen-y := [638.0; 638.0; 142.0; 142.0]
+  scene-pointer-camera-distance-square := (camera-screen-x - scene-pointer-screen-x) ^ 2 + (camera-screen-y - scene-pointer-screen-y) ^ 2
+  scene-pointer-hit-raw := 484.0 - scene-pointer-camera-distance-square
+  scene-pointer-hit-relu := (scene-pointer-hit-raw + (scene-pointer-hit-raw ^ 2) ^ 0.5) / 2.0
+  scene-pointer-hit := scene-pointer-hit-relu - (scene-pointer-hit-relu - 1.0 + ((scene-pointer-hit-relu - 1.0) ^ 2) ^ 0.5) / 2.0
+  camera-toggle := scene-pointer-edge * scene-pointer-hit
+  next-camera-enabled := camera-enabled + camera-toggle * (1.0 - 2.0 * camera-enabled)
+  camera-enabled = next-camera-enabled
+  last-scene-pointer-pulse = scene-pointer-pulse
 
   last-clock-tick = @clock/tick
   last-filter-turn = @filters/turns
@@ -210,7 +237,7 @@ than pretending that every camera sees through the entire field.
   camera-inside-fade-raw := (camera-max-range - camera-range-all) / camera-range-fade
   camera-inside-fade-relu := (camera-inside-fade-raw + (camera-inside-fade-raw ^ 2) ^ 0.5) / 2.0
   camera-inside-fade-one-relu := (camera-inside-fade-raw - 1.0 + ((camera-inside-fade-raw - 1.0) ^ 2) ^ 0.5) / 2.0
-  camera-visibility := camera-inside-fade-relu - camera-inside-fade-one-relu
+  camera-visibility := (camera-inside-fade-relu - camera-inside-fade-one-relu) * camera-enabled
 
   -- These boundary witnesses exercise the exact same resident visibility
   -- graph at the inner fade edge, the physical boundary, and two points
@@ -389,7 +416,7 @@ range. Only the scheduled in-range camera's noisy values enter the filter.
   display-camera-inside-fade-raw := (camera-max-range - display-camera-range-all) / camera-range-fade
   display-camera-inside-fade-relu := (display-camera-inside-fade-raw + (display-camera-inside-fade-raw ^ 2) ^ 0.5) / 2.0
   display-camera-inside-fade-one-relu := (display-camera-inside-fade-raw - 1.0 + ((display-camera-inside-fade-raw - 1.0) ^ 2) ^ 0.5) / 2.0
-  display-camera-visibility := display-camera-inside-fade-relu - display-camera-inside-fade-one-relu
+  display-camera-visibility := (display-camera-inside-fade-relu - display-camera-inside-fade-one-relu) * camera-enabled
   predicted-screen-x := screen-origin-x + predicted-estimate[1] * screen-scale
   predicted-screen-y := screen-origin-y - predicted-estimate[2] * screen-scale
   estimate-screen-x := screen-origin-x + corrected-estimate[1] * screen-scale
@@ -444,14 +471,18 @@ range. Only the scheduled in-range camera's noisy values enter the filter.
                    275.0 545.0]
 
   scene-circles := (
-    {id: "camera-range-1", x: 182, y: 638, radius: camera-max-range * screen-scale, fill: "none", stroke: "#f4c95d", stroke-width: 0.8, opacity: 0.16},
-    {id: "camera-range-2", x: 678, y: 638, radius: camera-max-range * screen-scale, fill: "none", stroke: "#f4c95d", stroke-width: 0.8, opacity: 0.16},
-    {id: "camera-range-3", x: 678, y: 142, radius: camera-max-range * screen-scale, fill: "none", stroke: "#f4c95d", stroke-width: 0.8, opacity: 0.16},
-    {id: "camera-range-4", x: 182, y: 142, radius: camera-max-range * screen-scale, fill: "none", stroke: "#f4c95d", stroke-width: 0.8, opacity: 0.16},
-    {id: "camera-1", x: 182, y: 638, radius: 9, fill: "#f4c95d", stroke: "#fff1b8", stroke-width: 2, opacity: 1},
-    {id: "camera-2", x: 678, y: 638, radius: 9, fill: "#f4c95d", stroke: "#fff1b8", stroke-width: 2, opacity: 1},
-    {id: "camera-3", x: 678, y: 142, radius: 9, fill: "#f4c95d", stroke: "#fff1b8", stroke-width: 2, opacity: 1},
-    {id: "camera-4", x: 182, y: 142, radius: 9, fill: "#f4c95d", stroke: "#fff1b8", stroke-width: 2, opacity: 1},
+    {id: "camera-range-1", x: 182, y: 638, radius: camera-max-range * screen-scale, fill: "none", stroke: "#f4c95d", stroke-width: 0.8, opacity: 0.16 * camera-enabled[1]},
+    {id: "camera-range-2", x: 678, y: 638, radius: camera-max-range * screen-scale, fill: "none", stroke: "#f4c95d", stroke-width: 0.8, opacity: 0.16 * camera-enabled[2]},
+    {id: "camera-range-3", x: 678, y: 142, radius: camera-max-range * screen-scale, fill: "none", stroke: "#f4c95d", stroke-width: 0.8, opacity: 0.16 * camera-enabled[3]},
+    {id: "camera-range-4", x: 182, y: 142, radius: camera-max-range * screen-scale, fill: "none", stroke: "#f4c95d", stroke-width: 0.8, opacity: 0.16 * camera-enabled[4]},
+    {id: "camera-disabled-1", x: 182, y: 638, radius: 9, fill: "#59616b", stroke: "none", stroke-width: 0, opacity: 1.0 - camera-enabled[1]},
+    {id: "camera-disabled-2", x: 678, y: 638, radius: 9, fill: "#59616b", stroke: "none", stroke-width: 0, opacity: 1.0 - camera-enabled[2]},
+    {id: "camera-disabled-3", x: 678, y: 142, radius: 9, fill: "#59616b", stroke: "none", stroke-width: 0, opacity: 1.0 - camera-enabled[3]},
+    {id: "camera-disabled-4", x: 182, y: 142, radius: 9, fill: "#59616b", stroke: "none", stroke-width: 0, opacity: 1.0 - camera-enabled[4]},
+    {id: "camera-1", x: 182, y: 638, radius: 9, fill: "#f4c95d", stroke: "#fff1b8", stroke-width: 2, opacity: camera-enabled[1]},
+    {id: "camera-2", x: 678, y: 638, radius: 9, fill: "#f4c95d", stroke: "#fff1b8", stroke-width: 2, opacity: camera-enabled[2]},
+    {id: "camera-3", x: 678, y: 142, radius: 9, fill: "#f4c95d", stroke: "#fff1b8", stroke-width: 2, opacity: camera-enabled[3]},
+    {id: "camera-4", x: 182, y: 142, radius: 9, fill: "#f4c95d", stroke: "#fff1b8", stroke-width: 2, opacity: camera-enabled[4]},
     {id: "truth", x: truth-screen-x, y: truth-screen-y, radius: 8, fill: "#63d6c5", stroke: "#d7fff8", stroke-width: 1.5, opacity: 1},
     {id: "prediction", x: predicted-screen-x, y: predicted-screen-y, radius: 6, fill: "none", stroke: "#f2b84b", stroke-width: 2, opacity: 1},
     {id: "estimate", x: estimate-screen-x, y: estimate-screen-y, radius: 7, fill: "#f087b8", stroke: "#ffe1ef", stroke-width: 1.5, opacity: 1},
@@ -484,10 +515,10 @@ range. Only the scheduled in-range camera's noisy values enter the filter.
     {id: "eyebrow", x: 24, y: 26, fill: "#8fa3b8", font-size: 12, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "650", text-anchor: "start", opacity: 1, value: "MECH RESIDENT SENSOR FUSION"},
     {id: "title", x: 24, y: 62, fill: "#edf2f7", font-size: 36, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "620", text-anchor: "start", opacity: 1, value: "Camera EKF Localization"},
     {id: "state-label", x: 602, y: 58, fill: "#f4c95d", font-size: 13, font-family: "ui-monospace, SFMono-Regular, Menlo, monospace", font-weight: "650", text-anchor: "start", opacity: 1, value: "V/Ω SQUARE-DRIVE FSM"},
-    {id: "camera-label-1", x: 195, y: 636, fill: "#d7c27f", font-size: 11, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "500", text-anchor: "start", opacity: 1, value: "CAM 1"},
-    {id: "camera-label-2", x: 665, y: 636, fill: "#d7c27f", font-size: 11, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "500", text-anchor: "end", opacity: 1, value: "CAM 2"},
-    {id: "camera-label-3", x: 665, y: 140, fill: "#d7c27f", font-size: 11, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "500", text-anchor: "end", opacity: 1, value: "CAM 3"},
-    {id: "camera-label-4", x: 195, y: 140, fill: "#d7c27f", font-size: 11, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "500", text-anchor: "start", opacity: 1, value: "CAM 4"},
+    {id: "camera-label-1", x: 195, y: 636, fill: "#d7c27f", font-size: 11, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "500", text-anchor: "start", opacity: 0.32 + 0.68 * camera-enabled[1], value: "CAM 1"},
+    {id: "camera-label-2", x: 665, y: 636, fill: "#d7c27f", font-size: 11, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "500", text-anchor: "end", opacity: 0.32 + 0.68 * camera-enabled[2], value: "CAM 2"},
+    {id: "camera-label-3", x: 665, y: 140, fill: "#d7c27f", font-size: 11, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "500", text-anchor: "end", opacity: 0.32 + 0.68 * camera-enabled[3], value: "CAM 3"},
+    {id: "camera-label-4", x: 195, y: 140, fill: "#d7c27f", font-size: 11, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "500", text-anchor: "start", opacity: 0.32 + 0.68 * camera-enabled[4], value: "CAM 4"},
     {id: "legend-truth-label", x: 40, y: 722, fill: "#bdc8d2", font-size: 12, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "400", text-anchor: "start", opacity: 1, value: "actual robot + path"},
     {id: "legend-prediction-label", x: 215, y: 722, fill: "#bdc8d2", font-size: 12, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "400", text-anchor: "start", opacity: 1, value: "motion prediction"},
     {id: "legend-estimate-label", x: 415, y: 722, fill: "#bdc8d2", font-size: 12, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "400", text-anchor: "start", opacity: 1, value: "EKF estimate + 2σ covariance"},

--- a/examples/ekf/localization.mec
+++ b/examples/ekf/localization.mec
@@ -36,6 +36,7 @@ robot and contracts after the next camera reacquires it.
   clock-delta-positive := (clock-delta + (clock-delta ^ 2) ^ 0.5) / 2.0
   clock-pulse := clock-delta-positive - (clock-delta-positive - 1.0 + ((clock-delta-positive - 1.0) ^ 2) ^ 0.5) / 2.0
   ~requested-compute-turn := 0.0
+  ~last-requested-simulation-step := 0.0
   compute-inflight-gap := requested-compute-turn - @filters/turns
   compute-inflight-gap-absolute := (compute-inflight-gap ^ 2) ^ 0.5
   compute-idle-raw := 1.0 - compute-inflight-gap-absolute
@@ -103,14 +104,13 @@ reduction make the corners smooth without position clamps.
   drive-phases<[f64]:1,376> := #SquareDrive(side-ticks)
   lap-ticks := 4.0 * side-ticks
   ~simulation-step := 0.0
-  ~pending-simulation-step := 1.0
-  attempted-simulation-step := simulation-step + 1.0
-  next-simulation-step := simulation-step + sample-pulse * (pending-simulation-step - simulation-step)
+  next-simulation-step := simulation-step + clock-pulse
+  filter-step-span := next-simulation-step - last-requested-simulation-step
+  next-last-requested-simulation-step := last-requested-simulation-step + request-pulse * filter-step-span
   ~drive-phase-index := 1.0
-  ~pending-drive-phase-index := 2.0
   drive-phase := drive-phases[1,drive-phase-index]
   advanced-drive-phase-index := (drive-phase-index % lap-ticks) + 1.0
-  next-drive-phase-index := drive-phase-index + sample-pulse * (pending-drive-phase-index - drive-phase-index)
+  next-drive-phase-index := drive-phase-index + clock-pulse * (advanced-drive-phase-index - drive-phase-index)
   phase-progress := ((drive-phase-index - 1.0) % side-ticks) / side-ticks
   path-parameter := drive-phase + phase-progress
   lookahead-parameter := (path-parameter + 0.15) % 4.0
@@ -128,10 +128,7 @@ reduction make the corners smooth without position clamps.
   ~truth := [2.5
              2.5
              0.0]
-  ~pending-truth := [2.5
-                     2.5
-                     0.0]
-  simulation-time := attempted-simulation-step * 0.05
+  simulation-time := next-simulation-step * 0.05
   target-heading := math/atan2(target-y - truth[2], target-x - truth[1])
   heading-error-raw := target-heading - truth[3]
   heading-error := math/atan2(math/sin(heading-error-raw), math/cos(heading-error-raw))
@@ -148,15 +145,13 @@ reduction make the corners smooth without position clamps.
   attempted-truth := truth + [actual-speed * math/cos(truth-mid-heading) * Δt
                               actual-speed * math/sin(truth-mid-heading) * Δt
                               actual-omega * Δt]
-  next-truth := truth + sample-pulse * (pending-truth - truth)
+  next-truth := truth + clock-pulse * (attempted-truth - truth)
 
   truth = next-truth
-  pending-truth = attempted-truth
   simulation-step = next-simulation-step
-  pending-simulation-step = attempted-simulation-step
   drive-phase-index = next-drive-phase-index
-  pending-drive-phase-index = advanced-drive-phase-index
   requested-compute-turn = next-requested-compute-turn
+  last-requested-simulation-step = next-last-requested-simulation-step
 
 
 3. Noisy Camera Observations
@@ -260,7 +255,7 @@ one arithmetic result. Only lane zero is sampled back for the scene.
   filter-count := 1000.0
   filter-index := 1.0..=filter-count
   filter-phase := 2.0 * 3.141592654 * (filter-index - 1.0) / filter-count
-  lane-dt-base := Δt
+  lane-dt-base := Δt * filter-step-span
   lane-speed-base := commanded-speed
   lane-omega-base := commanded-omega
   lane-camera-x-base := active-camera[1]
@@ -287,15 +282,9 @@ one arithmetic result. Only lane zero is sampled back for the scene.
   @filters/turn <- next-requested-compute-turn
 
   filter-sample := @filters/sample/result.0
-  corrected-estimate := [filter-sample[1]
-                         filter-sample[2]
-                         filter-sample[3]]
-  corrected-covariance := [filter-sample[4] filter-sample[7] filter-sample[10]
-                           filter-sample[5] filter-sample[8] filter-sample[11]
-                           filter-sample[6] filter-sample[9] filter-sample[12]]
-  predicted-estimate := [filter-sample[13]
-                         filter-sample[14]
-                         filter-sample[15]]
+  corrected-estimate := filter-sample[:,1]
+  corrected-covariance := filter-sample[:,2..=4]
+  predicted-estimate := filter-sample[:,5]
 
 
 ekf-batch @compute
@@ -316,27 +305,13 @@ ekf-batch @compute
                          0f32 0.018<f32>]
   measurement-covariance := [0.0225<f32> 0f32
                              0f32 0.0004<f32>]
-  ~filter-state := [2.9<f32>
-                    2.15<f32>
-                    0.16<f32>
-                    0.45<f32>
-                    0f32
-                    0f32
-                    0f32
-                    0.45<f32>
-                    0f32
-                    0f32
-                    0f32
-                    0.08<f32>
-                    2.9<f32>
-                    2.15<f32>
-                    0.16<f32>]
-  state := [filter-state[1,1]
-            filter-state[2,1]
-            filter-state[3,1]]
-  covariance := [filter-state[4,1] filter-state[7,1] filter-state[10,1]
-                 filter-state[5,1] filter-state[8,1] filter-state[11,1]
-                 filter-state[6,1] filter-state[9,1] filter-state[12,1]]
+  -- The resident value is the whole filter checkpoint. Its columns are the
+  -- corrected state, the 3x3 covariance, and the uncorrected prediction.
+  ~filter-sample := [2.9<f32>  0.45<f32> 0f32       0f32       2.9<f32>
+                     2.15<f32> 0f32       0.45<f32> 0f32       2.15<f32>
+                     0.16<f32> 0f32       0f32       0.08<f32> 0.16<f32>]
+  state := filter-sample[:,1]
+  covariance := filter-sample[:,2..=4]
 
   mid-heading := state[3,1] + angular-velocity * dt / 2f32
   mid-cos := math/cos(mid-heading)
@@ -381,23 +356,8 @@ ekf-batch @compute
   positive-covariance! := next-covariance[1,1] > 0f32 && next-covariance[2,2] > 0f32 && next-covariance[3,3] > 0f32
   symmetric-covariance! := math/abs(next-covariance[1,2] - next-covariance[2,1]) <= 0.0001<f32> && math/abs(next-covariance[1,3] - next-covariance[3,1]) <= 0.0001<f32> && math/abs(next-covariance[2,3] - next-covariance[3,2]) <= 0.0001<f32>
 
-  next-filter-state := [next-state[1,1]
-                        next-state[2,1]
-                        next-state[3,1]
-                        next-covariance[1,1]
-                        next-covariance[2,1]
-                        next-covariance[3,1]
-                        next-covariance[1,2]
-                        next-covariance[2,2]
-                        next-covariance[3,2]
-                        next-covariance[1,3]
-                        next-covariance[2,3]
-                        next-covariance[3,3]
-                        predicted-state[1,1]
-                        predicted-state[2,1]
-                        predicted-state[3,1]]
-  filter-state = next-filter-state
-  (filter-state, filter-state)
+  filter-sample = [next-state next-covariance predicted-state]
+  (filter-sample, filter-sample)
 
 
 5. Live Tracking Field

--- a/examples/ekf/localization.mec
+++ b/examples/ekf/localization.mec
@@ -73,6 +73,7 @@ the same camera and measurement path.
   ~last-scene-pointer-pulse := 0.0
   scene-pointer-pulse := @scene/pointer-pulse
   scene-pointer-position := @scene/pointer-position
+  scene-pointer-pressed := @scene/pointer-pressed
   scene-pointer-delta := scene-pointer-pulse - last-scene-pointer-pulse
   scene-pointer-delta-relu := (scene-pointer-delta + (scene-pointer-delta ^ 2) ^ 0.5) / 2.0
   scene-pointer-edge := scene-pointer-delta-relu - (scene-pointer-delta-relu - 1.0 + ((scene-pointer-delta-relu - 1.0) ^ 2) ^ 0.5) / 2.0
@@ -84,7 +85,10 @@ the same camera and measurement path.
   scene-pointer-hit-raw := 484.0 - scene-pointer-camera-distance-square
   scene-pointer-hit-relu := (scene-pointer-hit-raw + (scene-pointer-hit-raw ^ 2) ^ 0.5) / 2.0
   scene-pointer-hit := scene-pointer-hit-relu - (scene-pointer-hit-relu - 1.0 + ((scene-pointer-hit-relu - 1.0) ^ 2) ^ 0.5) / 2.0
-  camera-toggle := scene-pointer-edge * scene-pointer-hit
+  -- A release may arrive on a later resident turn before every downstream
+  -- pulse-history consumer has settled. Gate the activation by the pressed
+  -- phase as well as the monotonic edge so release/cancel can never toggle.
+  camera-toggle := scene-pointer-edge * scene-pointer-hit * scene-pointer-pressed
   next-camera-enabled := camera-enabled + camera-toggle * (1.0 - 2.0 * camera-enabled)
   camera-enabled = next-camera-enabled
   last-scene-pointer-pulse = scene-pointer-pulse

--- a/examples/ekf/localization.mec
+++ b/examples/ekf/localization.mec
@@ -28,7 +28,7 @@ robot and contracts after the next camera reacquires it.
 
 @clock := timer://clock/tick{:read(tick)}
 @scene := scene://localization/frame{:write(replace)}
-@filters := compute://filters/kernel{:read(sample/result.0), :read(turns), :write(input/control), :write(input/camera), :write(input/measurement), :write(turn)}
+@filters := compute://filters/kernel{:read(sample/result.0), :read(sample/result.2), :read(turns), :write(input/control), :write(input/camera), :write(input/measurement), :write(turn)}
 
   π := 3.141592654
   ~last-clock-tick := 0.0
@@ -282,6 +282,7 @@ one arithmetic result. Only lane zero is sampled back for the scene.
   @filters/turn <- next-requested-compute-turn
 
   filter-sample := @filters/sample/result.0
+  filter-camera-visibility := @filters/sample/result.2
   corrected-estimate := filter-sample[:,1]
   corrected-covariance := filter-sample[:,2..=4]
   predicted-estimate := filter-sample[:,5]
@@ -348,6 +349,7 @@ ekf-batch @compute
   ~filter-sample := [2.9<f32>  0.45<f32> 0f32       0f32       2.9<f32>
                      2.15<f32> 0f32       0.45<f32> 0f32       2.15<f32>
                      0.16<f32> 0f32       0f32       0.08<f32> 0.16<f32>]
+  ~applied-visibility := 0f32
   μ := filter-sample[:,1]
   Σ := filter-sample[:,2..=4]
   (μ-, Σ-) := ekf-predict(μ, Σ, control, Q)
@@ -361,7 +363,8 @@ ekf-batch @compute
   symmetric-covariance! := math/abs(Σ-next[1,2] - Σ-next[2,1]) <= 0.0001<f32> && math/abs(Σ-next[1,3] - Σ-next[3,1]) <= 0.0001<f32> && math/abs(Σ-next[2,3] - Σ-next[3,2]) <= 0.0001<f32>
 
   filter-sample = [μ-next Σ-next μ-]
-  (filter-sample, filter-sample)
+  applied-visibility = γ
+  (filter-sample, filter-sample, applied-visibility)
 
 
 5. Live Tracking Field

--- a/examples/ekf/localization.mec
+++ b/examples/ekf/localization.mec
@@ -28,13 +28,17 @@ robot and contracts after the next camera reacquires it.
 
 @clock := timer://clock/tick{:read(tick)}
 @scene := scene://localization/frame{:write(replace)}
-@filters := compute://filters/kernel{:read(sample/result.0), :write(input/control), :write(input/camera), :write(input/measurement), :write(turn)}
+@filters := compute://filters/kernel{:read(sample/result.0), :read(turns), :write(input/control), :write(input/camera), :write(input/measurement), :write(turn)}
 
   π := 3.141592654
   ~last-clock-tick := 0.0
   clock-delta := @clock/tick - last-clock-tick
   clock-delta-positive := (clock-delta + (clock-delta ^ 2) ^ 0.5) / 2.0
   turn-pulse := clock-delta-positive - (clock-delta-positive - 1.0 + ((clock-delta-positive - 1.0) ^ 2) ^ 0.5) / 2.0
+  ~last-filter-turn := 0.0
+  filter-turn-delta := @filters/turns - last-filter-turn
+  filter-turn-delta-positive := (filter-turn-delta + (filter-turn-delta ^ 2) ^ 0.5) / 2.0
+  sample-pulse := filter-turn-delta-positive - (filter-turn-delta-positive - 1.0 + ((filter-turn-delta-positive - 1.0) ^ 2) ^ 0.5) / 2.0
   Δt := turn-pulse * 0.05
   cruise-speed := 1.15
   turn-rate-limit := 1.75
@@ -51,6 +55,7 @@ robot and contracts after the next camera reacquires it.
               1.0 9.0]
 
   last-clock-tick = @clock/tick
+  last-filter-turn = @filters/turns
 
 
 2. Square-Drive State Machine
@@ -435,7 +440,6 @@ range. Only the scheduled in-range camera's noisy values enter the filter.
   advanced-truth-path := matrix/vertcat(truth-path[2..=376,:], truth-screen-point)
   advanced-estimate-path := matrix/vertcat(estimate-path[2..=376,:], estimate-screen-point)
   next-truth-path := truth-path + turn-pulse * (advanced-truth-path - truth-path)
-  sample-pulse := 1.0 - turn-pulse
   next-estimate-path := estimate-path + sample-pulse * (advanced-estimate-path - estimate-path)
   truth-path = next-truth-path
   estimate-path = next-estimate-path

--- a/examples/ekf/mech.mcfg
+++ b/examples/ekf/mech.mcfg
@@ -69,6 +69,7 @@ config := {
           "input/camera"
           "input/measurement"
           "sample/result.0"
+          "sample/result.2"
           "turns"
           "turn"
         ]

--- a/examples/ekf/mech.mcfg
+++ b/examples/ekf/mech.mcfg
@@ -34,6 +34,15 @@ config := {
         renderer: "output"
       }
     }
+
+    {
+      name: "filters"
+      provider: "compute"
+      settings: {
+        region: "ekf-batch"
+        backend: "auto"
+      }
+    }
   ]
 
   run: {
@@ -50,6 +59,18 @@ config := {
         target: "localization/frame"
         operations: ["write"]
         paths: ["replace"]
+      }
+
+      {
+        target: "filters/kernel"
+        operations: ["read", "write"]
+        paths: [
+          "input/control"
+          "input/camera"
+          "input/measurement"
+          "sample/result.0"
+          "turn"
+        ]
       }
     ]
   }

--- a/examples/ekf/mech.mcfg
+++ b/examples/ekf/mech.mcfg
@@ -57,8 +57,14 @@ config := {
 
       {
         target: "localization/frame"
-        operations: ["write"]
-        paths: ["replace"]
+        operations: ["read", "write"]
+        paths: [
+          "pointer-pulse"
+          "pointer-position"
+          "pointer-pressed"
+          "pointer-delta-seconds"
+          "replace"
+        ]
       }
 
       {

--- a/examples/ekf/mech.mcfg
+++ b/examples/ekf/mech.mcfg
@@ -69,6 +69,7 @@ config := {
           "input/camera"
           "input/measurement"
           "sample/result.0"
+          "turns"
           "turn"
         ]
       }

--- a/examples/gpu-particles/README.md
+++ b/examples/gpu-particles/README.md
@@ -111,11 +111,12 @@ the canonical product-only `build-mech` scripts above.
 The command defaults to the shipped one-million-particle source. A bounded
 software-GPU run can be requested with `--particle-count`; it copies the same
 project under `target`, changes only the canonical particle-count declaration,
-and leaves the checked-in application untouched. CI uses 16,384 lanes (256
-workgroups) because GitHub's SwiftShader adapter does not finish even its first
-one-million-lane dispatch within the browser gate's two-minute deadline. The
-CI run retains the same two-turn lifecycle, backpressure, input, zero-readback,
-error, and disposal assertions.
+and leaves the checked-in application untouched. `--software-adapter` selects
+the same dedicated Chromium WebGPU SwiftShader test adapter used by CI. CI uses
+16,384 lanes (256 workgroups) because its software adapter does not finish even
+its first one-million-lane dispatch within the browser gate's two-minute
+deadline. The CI run retains the same two-turn lifecycle, backpressure, input,
+zero-readback, error, and disposal assertions.
 
 ## Full-size acceptance
 

--- a/examples/gpu-particles/README.md
+++ b/examples/gpu-particles/README.md
@@ -108,6 +108,15 @@ transaction. Failure artifacts are retained in the printed temporary folder.
 This acceptance command builds and runs the application; it is separate from
 the canonical product-only `build-mech` scripts above.
 
+The command defaults to the shipped one-million-particle source. A bounded
+software-GPU run can be requested with `--particle-count`; it copies the same
+project under `target`, changes only the canonical particle-count declaration,
+and leaves the checked-in application untouched. CI uses 16,384 lanes (256
+workgroups) because GitHub's SwiftShader adapter does not finish even its first
+one-million-lane dispatch within the browser gate's two-minute deadline. The
+CI run retains the same two-turn lifecycle, backpressure, input, zero-readback,
+error, and disposal assertions.
+
 ## Full-size acceptance
 
 These tests compile the unchanged one-million-particle source. They do not

--- a/examples/gpu-particles/README.md
+++ b/examples/gpu-particles/README.md
@@ -108,15 +108,15 @@ transaction. Failure artifacts are retained in the printed temporary folder.
 This acceptance command builds and runs the application; it is separate from
 the canonical product-only `build-mech` scripts above.
 
-The command defaults to the shipped one-million-particle source. A bounded
-software-GPU run can be requested with `--particle-count`; it copies the same
-project under `target`, changes only the canonical particle-count declaration,
-and leaves the checked-in application untouched. `--software-adapter` selects
-the same dedicated Chromium WebGPU SwiftShader test adapter used by CI. CI uses
-16,384 lanes (256 workgroups) because its software adapter does not finish even
-its first one-million-lane dispatch within the browser gate's two-minute
-deadline. The CI run retains the same two-turn lifecycle, backpressure, input,
-zero-readback, error, and disposal assertions.
+The command defaults to the unchanged shipped one-million-particle source.
+`--software-adapter` selects the same dedicated Chromium WebGPU SwiftShader
+test adapter used by CI. A bounded software-GPU run can be requested with
+`--particle-count`; it copies the same project under `target`, changes only the
+canonical particle-count declaration, and leaves the checked-in application
+untouched. CI uses 16,384 lanes (256 workgroups) because GitHub's software
+adapter accepts but does not finish its first one-million-lane dispatch within
+the browser gate's two-minute deadline. The CI run retains the same two-turn
+lifecycle, backpressure, input, zero-readback, error, and disposal assertions.
 
 ## Full-size acceptance
 

--- a/hosts/gpu/Cargo.toml
+++ b/hosts/gpu/Cargo.toml
@@ -30,6 +30,7 @@ mech-runtime = { version = "0.3.5", path = "../../src/runtime", default-features
 bytemuck = { version = "1.24.0", optional = true }
 pollster = { version = "0.3.0", optional = true }
 web-time = "1.1.0"
+serde = { version = "1.0", features = ["derive"] }
 wgpu = { version = "0.20.1", optional = true }
 wide = "0.7.33"
 cranelift-codegen = { version = "=0.131.3", optional = true }
@@ -57,6 +58,7 @@ name = "parallel_ekf_rust_scalar"
 path = "examples/parallel_ekf_rust_scalar.rs"
 
 [dev-dependencies]
+serde_json = "1.0"
 mech-core = { version = "0.3.5", default-features = false, features = ["f32", "matrixd"] }
 mech-engine = { version = "0.3.5", default-features = false, features = ["full_compiler"] }
 mech-stdlib = { version = "0.3.5", default-features = false, features = ["full_compiler", "native-plan"] }

--- a/hosts/gpu/Cargo.toml
+++ b/hosts/gpu/Cargo.toml
@@ -31,6 +31,8 @@ bytemuck = { version = "1.24.0", optional = true }
 pollster = { version = "0.3.0", optional = true }
 web-time = "1.1.0"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+sha2 = { version = "0.11.0", default-features = false }
 wgpu = { version = "0.20.1", optional = true }
 wide = "0.7.33"
 cranelift-codegen = { version = "=0.131.3", optional = true }
@@ -58,7 +60,6 @@ name = "parallel_ekf_rust_scalar"
 path = "examples/parallel_ekf_rust_scalar.rs"
 
 [dev-dependencies]
-serde_json = "1.0"
 mech-core = { version = "0.3.5", default-features = false, features = ["f32", "matrixd"] }
 mech-engine = { version = "0.3.5", default-features = false, features = ["full_compiler"] }
 mech-stdlib = { version = "0.3.5", default-features = false, features = ["full_compiler", "native-plan"] }

--- a/hosts/gpu/src/batched/jit.rs
+++ b/hosts/gpu/src/batched/jit.rs
@@ -163,6 +163,7 @@ impl NativeKernel {
         jit_builder
             .symbol("mech_jit_sinf", mech_jit_sinf as *const u8)
             .symbol("mech_jit_cosf", mech_jit_cosf as *const u8)
+            .symbol("mech_jit_sqrtf", mech_jit_sqrtf as *const u8)
             .symbol("mech_jit_atan2f", mech_jit_atan2f as *const u8);
         let mut module = JITModule::new(jit_builder);
 
@@ -184,6 +185,9 @@ impl NativeKernel {
             .map_err(native_error)?;
         let cos_id = module
             .declare_function("mech_jit_cosf", Linkage::Import, &unary_signature)
+            .map_err(native_error)?;
+        let sqrt_id = module
+            .declare_function("mech_jit_sqrtf", Linkage::Import, &unary_signature)
             .map_err(native_error)?;
         let atan2_id = module
             .declare_function("mech_jit_atan2f", Linkage::Import, &binary_signature)
@@ -267,10 +271,12 @@ impl NativeKernel {
             builder.switch_to_block(body);
             let sin_ref = module.declare_func_in_func(sin_id, builder.func);
             let cos_ref = module.declare_func_in_func(cos_id, builder.func);
+            let sqrt_ref = module.declare_func_in_func(sqrt_id, builder.func);
             let atan2_ref = module.declare_func_in_func(atan2_id, builder.func);
             let functions = MathFunctions {
                 sin: sin_ref,
                 cos: cos_ref,
+                sqrt: sqrt_ref,
                 atan2: atan2_ref,
             };
             let mut registers = vec![None; program.fixed_ir().register_count];
@@ -386,6 +392,7 @@ impl NativeKernel {
 struct MathFunctions {
     sin: cranelift_codegen::ir::FuncRef,
     cos: cranelift_codegen::ir::FuncRef,
+    sqrt: cranelift_codegen::ir::FuncRef,
     atan2: cranelift_codegen::ir::FuncRef,
 }
 
@@ -466,6 +473,7 @@ fn lower_computation(
                 ElementwiseOperation::Unary(operation) => match operation {
                     UnaryOperation::Sin => call_math(builder, functions.sin, &values),
                     UnaryOperation::Cos => call_math(builder, functions.cos, &values),
+                    UnaryOperation::Sqrt => call_math(builder, functions.sqrt, &values),
                 },
                 ElementwiseOperation::Atan2 => call_math(builder, functions.atan2, &values),
                 ElementwiseOperation::Identity => values[0],
@@ -680,6 +688,10 @@ extern "C" fn mech_jit_sinf(value: f32) -> f32 {
 
 extern "C" fn mech_jit_cosf(value: f32) -> f32 {
     value.cos()
+}
+
+extern "C" fn mech_jit_sqrtf(value: f32) -> f32 {
+    value.sqrt()
 }
 
 extern "C" fn mech_jit_atan2f(y: f32, x: f32) -> f32 {

--- a/hosts/gpu/src/batched/jit.rs
+++ b/hosts/gpu/src/batched/jit.rs
@@ -164,6 +164,7 @@ impl NativeKernel {
             .symbol("mech_jit_sinf", mech_jit_sinf as *const u8)
             .symbol("mech_jit_cosf", mech_jit_cosf as *const u8)
             .symbol("mech_jit_sqrtf", mech_jit_sqrtf as *const u8)
+            .symbol("mech_jit_ceilf", mech_jit_ceilf as *const u8)
             .symbol("mech_jit_atan2f", mech_jit_atan2f as *const u8);
         let mut module = JITModule::new(jit_builder);
 
@@ -188,6 +189,9 @@ impl NativeKernel {
             .map_err(native_error)?;
         let sqrt_id = module
             .declare_function("mech_jit_sqrtf", Linkage::Import, &unary_signature)
+            .map_err(native_error)?;
+        let ceil_id = module
+            .declare_function("mech_jit_ceilf", Linkage::Import, &unary_signature)
             .map_err(native_error)?;
         let atan2_id = module
             .declare_function("mech_jit_atan2f", Linkage::Import, &binary_signature)
@@ -272,11 +276,13 @@ impl NativeKernel {
             let sin_ref = module.declare_func_in_func(sin_id, builder.func);
             let cos_ref = module.declare_func_in_func(cos_id, builder.func);
             let sqrt_ref = module.declare_func_in_func(sqrt_id, builder.func);
+            let ceil_ref = module.declare_func_in_func(ceil_id, builder.func);
             let atan2_ref = module.declare_func_in_func(atan2_id, builder.func);
             let functions = MathFunctions {
                 sin: sin_ref,
                 cos: cos_ref,
                 sqrt: sqrt_ref,
+                ceil: ceil_ref,
                 atan2: atan2_ref,
             };
             let mut registers = vec![None; program.fixed_ir().register_count];
@@ -393,6 +399,7 @@ struct MathFunctions {
     sin: cranelift_codegen::ir::FuncRef,
     cos: cranelift_codegen::ir::FuncRef,
     sqrt: cranelift_codegen::ir::FuncRef,
+    ceil: cranelift_codegen::ir::FuncRef,
     atan2: cranelift_codegen::ir::FuncRef,
 }
 
@@ -474,6 +481,7 @@ fn lower_computation(
                     UnaryOperation::Sin => call_math(builder, functions.sin, &values),
                     UnaryOperation::Cos => call_math(builder, functions.cos, &values),
                     UnaryOperation::Sqrt => call_math(builder, functions.sqrt, &values),
+                    UnaryOperation::Ceil => call_math(builder, functions.ceil, &values),
                 },
                 ElementwiseOperation::Atan2 => call_math(builder, functions.atan2, &values),
                 ElementwiseOperation::Identity => values[0],
@@ -692,6 +700,10 @@ extern "C" fn mech_jit_cosf(value: f32) -> f32 {
 
 extern "C" fn mech_jit_sqrtf(value: f32) -> f32 {
     value.sqrt()
+}
+
+extern "C" fn mech_jit_ceilf(value: f32) -> f32 {
+    value.ceil()
 }
 
 extern "C" fn mech_jit_atan2f(y: f32, x: f32) -> f32 {

--- a/hosts/gpu/src/batched/mod.rs
+++ b/hosts/gpu/src/batched/mod.rs
@@ -588,6 +588,22 @@ impl FixedShapeKernel {
                 "resident fixed-shape storage requires a fixed-shape kernel",
             ));
         }
+        let state_slots = storage
+            .states
+            .iter()
+            .map(|state| state.slot)
+            .collect::<BTreeSet<_>>();
+        if let Some(output) = program
+            .interface()
+            .outputs
+            .iter()
+            .find(|output| !state_slots.contains(&output.slot))
+        {
+            return Err(fixed_shape_program_error(format!(
+                "fixed-shape output `{}` is derived storage; browser and native GPU backends require every published output to be resident state",
+                output.name,
+            )));
+        }
 
         let mut binding = 0_u32;
         let inputs = storage

--- a/hosts/gpu/src/batched/mod.rs
+++ b/hosts/gpu/src/batched/mod.rs
@@ -2473,11 +2473,14 @@ mod native {
         time::{Duration, Instant},
     };
 
-    use mech_core::CellSlotId;
+    use mech_core::{CellSlotId, IntegrityConstraintId};
     use wgpu::util::DeviceExt;
 
     use super::{
         BatchedExecutionError, BatchedFaultRecorder, BatchedIntegrityFault, FixedShapeKernel,
+    };
+    use crate::{
+        GpuPlanBindingAccess, GpuPlanBindingRole, GpuPlanConstraint, GpuPlanInitialValues,
     };
 
     const GPU_FAULT_WORDS: usize = 2;
@@ -2493,7 +2496,7 @@ mod native {
         output_buffers: [BTreeMap<CellSlotId, Arc<wgpu::Buffer>>; 2],
         output_elements: BTreeMap<CellSlotId, usize>,
         output_elements_per_instance: BTreeMap<CellSlotId, usize>,
-        constraints: Box<[super::BatchedConstraint]>,
+        constraints: Box<[GpuPlanConstraint]>,
         integrity_fault: Option<Arc<wgpu::Buffer>>,
         integrity_readback: Option<wgpu::Buffer>,
         workgroups: u32,
@@ -2523,11 +2526,11 @@ mod native {
             &self,
             inputs: &BTreeMap<String, Vec<f32>>,
         ) -> Result<BatchedResidentGpuSession, BatchedExecutionError> {
-            if !self.constraints.is_empty() && self.instances >= (1 << 24) {
-                return Err(BatchedExecutionError::IntegrityConfiguration(
-                    "checked GPU fault records support fewer than 2^24 instances".to_owned(),
-                ));
-            }
+            let execution_plan = crate::GpuExecutionPlan::build(
+                crate::GpuKernelPlanSource::FixedShape(self),
+                inputs,
+            )
+            .map_err(|failure| BatchedExecutionError::Native(failure.to_string()))?;
             let instance = wgpu::Instance::default();
             let adapter = instance
                 .request_adapter(&wgpu::RequestAdapterOptions {
@@ -2541,10 +2544,7 @@ mod native {
                 })?;
             let adapter_info = adapter.get_info();
             let adapter_name = format!("{} ({:?})", adapter_info.name, adapter_info.backend);
-            let required_storage_buffers = (self.inputs.len()
-                + self.states.len() * 2
-                + usize::from(!self.constraints.is_empty()))
-                as u32;
+            let required_storage_buffers = execution_plan.bindings.len() as u32;
             let limits = adapter.limits();
             if required_storage_buffers > limits.max_storage_buffers_per_shader_stage {
                 return Err(BatchedExecutionError::Native(format!(
@@ -2552,16 +2552,18 @@ mod native {
                     limits.max_storage_buffers_per_shader_stage
                 )));
             }
-            if self.workgroup_count() > limits.max_compute_workgroups_per_dimension {
+            let workgroup_count = execution_plan
+                .dispatch_elements
+                .div_ceil(execution_plan.workgroup_size);
+            if workgroup_count > limits.max_compute_workgroups_per_dimension {
                 return Err(BatchedExecutionError::Native(format!(
                     "kernel requires {} workgroups; adapter supports {}",
-                    self.workgroup_count(),
-                    limits.max_compute_workgroups_per_dimension
+                    workgroup_count, limits.max_compute_workgroups_per_dimension
                 )));
             }
             let required_limits = wgpu::Limits {
                 max_storage_buffers_per_shader_stage: required_storage_buffers,
-                max_compute_workgroups_per_dimension: self.workgroup_count(),
+                max_compute_workgroups_per_dimension: workgroup_count,
                 ..wgpu::Limits::downlevel_defaults()
             };
             let (device, queue) = adapter
@@ -2576,121 +2578,122 @@ mod native {
                 .await
                 .map_err(|error| BatchedExecutionError::Native(error.to_string()))?;
 
-            let expanded_inputs = self.expand_inputs(inputs)?;
             let mut input_buffers = BTreeMap::new();
-            for input in &self.inputs {
+            for binding in execution_plan
+                .bindings
+                .iter()
+                .filter(|binding| binding.role == GpuPlanBindingRole::Input)
+            {
+                let Some(GpuPlanInitialValues::F32(values)) = &binding.initial_values else {
+                    return Err(BatchedExecutionError::Native(format!(
+                        "GPU input `{}` has no f32 initializer",
+                        binding.name
+                    )));
+                };
                 input_buffers.insert(
-                    input.slot,
+                    CellSlotId::new(binding.slot),
                     Arc::new(
                         device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                            label: Some(&input.name),
-                            contents: bytemuck::cast_slice(&expanded_inputs[&input.slot]),
+                            label: Some(&binding.name),
+                            contents: bytemuck::cast_slice(values),
                             usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
                         }),
                     ),
                 );
             }
 
-            let initial_state = self.initial_state();
             let mut state_buffers = BTreeMap::new();
-            for state in &self.states {
+            for state in &execution_plan.states {
+                let slot = CellSlotId::new(state.slot);
                 let initial = Arc::new(device.create_buffer_init(
                     &wgpu::util::BufferInitDescriptor {
                         label: Some("Mech fixed-shape initial state"),
-                        contents: bytemuck::cast_slice(&initial_state[&state.slot]),
+                        contents: bytemuck::cast_slice(&state.initial_values),
                         usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
                     },
                 ));
                 let alternate = Arc::new(device.create_buffer(&wgpu::BufferDescriptor {
                     label: Some("Mech fixed-shape alternate state"),
-                    size: (initial_state[&state.slot].len() * std::mem::size_of::<f32>()) as u64,
+                    size: state.elements * std::mem::size_of::<f32>() as u64,
                     usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
                     mapped_at_creation: false,
                 }));
-                state_buffers.insert(state.slot, [initial, alternate]);
+                state_buffers.insert(slot, [initial, alternate]);
             }
 
-            let integrity_fault = (!self.constraints.is_empty()).then(|| {
+            let integrity_binding = execution_plan
+                .bindings
+                .iter()
+                .find(|binding| binding.role == GpuPlanBindingRole::IntegrityFault);
+            let integrity_fault = integrity_binding.map(|binding| {
                 Arc::new(device.create_buffer(&wgpu::BufferDescriptor {
                     label: Some("Mech integrity-constraint fault"),
-                    size: (GPU_FAULT_WORDS * std::mem::size_of::<u32>()) as u64,
+                    size: binding.elements * std::mem::size_of::<u32>() as u64,
                     usage: wgpu::BufferUsages::STORAGE
                         | wgpu::BufferUsages::COPY_SRC
                         | wgpu::BufferUsages::COPY_DST,
                     mapped_at_creation: false,
                 }))
             });
-            let integrity_readback = (!self.constraints.is_empty()).then(|| {
+            let integrity_readback = integrity_binding.map(|binding| {
                 device.create_buffer(&wgpu::BufferDescriptor {
                     label: Some("Mech integrity-constraint readback"),
-                    size: (GPU_FAULT_WORDS * std::mem::size_of::<u32>()) as u64,
+                    size: binding.elements * std::mem::size_of::<u32>() as u64,
                     usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
                     mapped_at_creation: false,
                 })
             });
 
-            let mut layout_entries =
-                self.inputs
-                    .iter()
-                    .map(|input| (input.binding, true))
-                    .chain(self.states.iter().flat_map(|state| {
-                        [(state.read_binding, true), (state.write_binding, false)]
-                    }))
-                    .map(|(binding, read_only)| wgpu::BindGroupLayoutEntry {
-                        binding,
-                        visibility: wgpu::ShaderStages::COMPUTE,
-                        ty: wgpu::BindingType::Buffer {
-                            ty: wgpu::BufferBindingType::Storage { read_only },
-                            has_dynamic_offset: false,
-                            min_binding_size: None,
-                        },
-                        count: None,
-                    })
-                    .collect::<Vec<_>>();
-            if !self.constraints.is_empty() {
-                layout_entries.push(wgpu::BindGroupLayoutEntry {
-                    binding: (self.inputs.len() + self.states.len() * 2) as u32,
+            let layout_entries = execution_plan
+                .bindings
+                .iter()
+                .map(|binding| wgpu::BindGroupLayoutEntry {
+                    binding: binding.binding,
                     visibility: wgpu::ShaderStages::COMPUTE,
                     ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Storage { read_only: false },
+                        ty: wgpu::BufferBindingType::Storage {
+                            read_only: binding.access == GpuPlanBindingAccess::Read,
+                        },
                         has_dynamic_offset: false,
                         min_binding_size: None,
                     },
                     count: None,
-                });
-            }
+                })
+                .collect::<Vec<_>>();
             let bind_group_layout =
                 device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
                     label: Some("Mech fixed-shape batch bindings"),
                     entries: &layout_entries,
                 });
             let bind_groups = [0, 1].map(|group| {
-                let mut entries = self
-                    .inputs
+                let entries = execution_plan
+                    .bindings
                     .iter()
-                    .map(|input| wgpu::BindGroupEntry {
-                        binding: input.binding,
-                        resource: input_buffers[&input.slot].as_entire_binding(),
+                    .map(|binding| {
+                        let resource = match binding.role {
+                            GpuPlanBindingRole::Input => {
+                                input_buffers[&CellSlotId::new(binding.slot)].as_entire_binding()
+                            }
+                            GpuPlanBindingRole::StateRead => state_buffers
+                                [&CellSlotId::new(binding.slot)][group]
+                                .as_entire_binding(),
+                            GpuPlanBindingRole::StateWrite => state_buffers
+                                [&CellSlotId::new(binding.slot)][1 - group]
+                                .as_entire_binding(),
+                            GpuPlanBindingRole::IntegrityFault => integrity_fault
+                                .as_ref()
+                                .expect("integrity plan has a fault buffer")
+                                .as_entire_binding(),
+                            GpuPlanBindingRole::Output => {
+                                unreachable!("fixed-shape outputs alias resident state buffers")
+                            }
+                        };
+                        wgpu::BindGroupEntry {
+                            binding: binding.binding,
+                            resource,
+                        }
                     })
-                    .chain(self.states.iter().flat_map(|state| {
-                        [
-                            wgpu::BindGroupEntry {
-                                binding: state.read_binding,
-                                resource: state_buffers[&state.slot][group].as_entire_binding(),
-                            },
-                            wgpu::BindGroupEntry {
-                                binding: state.write_binding,
-                                resource: state_buffers[&state.slot][1 - group].as_entire_binding(),
-                            },
-                        ]
-                    }))
                     .collect::<Vec<_>>();
-                if let Some(fault) = &integrity_fault {
-                    entries.push(wgpu::BindGroupEntry {
-                        binding: (self.inputs.len() + self.states.len() * 2) as u32,
-                        resource: fault.as_entire_binding(),
-                    });
-                }
                 device.create_bind_group(&wgpu::BindGroupDescriptor {
                     label: Some("Mech fixed-shape batch bind group"),
                     layout: &bind_group_layout,
@@ -2699,7 +2702,7 @@ mod native {
             });
             let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
                 label: Some("Scalarized Mech fixed-shape batch"),
-                source: wgpu::ShaderSource::Wgsl(self.wgsl.clone().into()),
+                source: wgpu::ShaderSource::Wgsl(execution_plan.wgsl.clone().into()),
             });
             let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: Some("Mech fixed-shape batch pipeline layout"),
@@ -2715,20 +2718,29 @@ mod native {
             });
 
             let output_buffers = [0, 1].map(|group| {
-                self.states
+                execution_plan
+                    .physical_outputs
                     .iter()
-                    .map(|state| (state.slot, state_buffers[&state.slot][1 - group].clone()))
+                    .map(|output| {
+                        let slot = CellSlotId::new(output.slot);
+                        (slot, state_buffers[&slot][1 - group].clone())
+                    })
                     .collect()
             });
-            let output_elements = self
-                .states
+            let output_elements = execution_plan
+                .outputs
                 .iter()
-                .map(|state| (state.slot, state.shape.elements() * self.instances as usize))
+                .map(|output| (CellSlotId::new(output.slot), output.elements as usize))
                 .collect();
-            let output_elements_per_instance = self
-                .states
+            let output_elements_per_instance = execution_plan
+                .outputs
                 .iter()
-                .map(|state| (state.slot, state.shape.elements()))
+                .map(|output| {
+                    (
+                        CellSlotId::new(output.slot),
+                        output.elements_per_instance as usize,
+                    )
+                })
                 .collect();
             Ok(BatchedResidentGpuSession {
                 adapter: adapter_name,
@@ -2740,10 +2752,10 @@ mod native {
                 output_buffers,
                 output_elements,
                 output_elements_per_instance,
-                constraints: self.constraints.clone().into_boxed_slice(),
+                constraints: execution_plan.constraints.into_boxed_slice(),
                 integrity_fault,
                 integrity_readback,
-                workgroups: self.workgroup_count(),
+                workgroups: workgroup_count,
                 next_group: 0,
                 last_output_group: None,
                 faults: BatchedFaultRecorder::default(),
@@ -2867,8 +2879,8 @@ mod native {
                     let fault = BatchedIntegrityFault {
                         attempted_turn,
                         instance: packed >> 8,
-                        constraint: constraint.id,
-                        constraint_name: constraint.name.clone(),
+                        constraint: IntegrityConstraintId::new(constraint.id),
+                        constraint_name: constraint.name.clone().into_boxed_str(),
                     };
                     return Err(self.faults.record(fault));
                 }

--- a/hosts/gpu/src/batched/mod.rs
+++ b/hosts/gpu/src/batched/mod.rs
@@ -30,6 +30,7 @@ mod jit;
 pub use jit::*;
 
 const SIMD_LANES: usize = 4;
+const FIXED_SHAPE_INTEGRITY_WORDS: usize = 2;
 
 fn evaluate_operand_simd(operand: ScalarOperand, registers: &[f32x4]) -> f32x4 {
     match operand {
@@ -419,6 +420,37 @@ pub struct FixedShapeKernel {
     wgsl: String,
 }
 
+/// One immutable browser/native storage binding for a fixed-shape input after
+/// scalar or per-lane source values have been expanded to the physical batch.
+#[derive(Clone, Debug, PartialEq)]
+pub struct FixedShapeInputBuffer {
+    pub slot: CellSlotId,
+    pub name: String,
+    pub binding: u32,
+    pub elements: usize,
+    pub initial_values: Vec<f32>,
+}
+
+/// Ping-pong storage metadata for one resident fixed-shape state. The physical
+/// buffer is lane-contiguous, so one sampled lane can later be copied without
+/// materializing the rest of the batch on the CPU.
+#[derive(Clone, Debug, PartialEq)]
+pub struct FixedShapeStateBuffer {
+    pub slot: CellSlotId,
+    pub read_binding: u32,
+    pub write_binding: u32,
+    pub elements_per_instance: usize,
+    pub elements: usize,
+    pub initial_values: Vec<f32>,
+}
+
+/// Optional two-word atomic fault buffer used by checked fixed-shape kernels.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FixedShapeIntegrityBuffer {
+    pub binding: u32,
+    pub words: usize,
+}
+
 /// Bounded fault evidence for one rejected candidate. Sessions retain only the
 /// latest record plus a total count, never an append-only transaction log.
 #[derive(Clone, Debug, PartialEq)]
@@ -651,6 +683,63 @@ impl FixedShapeKernel {
         self.states
             .iter()
             .map(|state| (state.slot, state.shape.elements()))
+    }
+
+    /// Materializes the backend-neutral physical input plan used by both the
+    /// native wgpu session and the browser WebGPU bridge.
+    pub fn physical_inputs(
+        &self,
+        provided: &BTreeMap<String, Vec<f32>>,
+    ) -> Result<Vec<FixedShapeInputBuffer>, BatchedExecutionError> {
+        self.inputs
+            .iter()
+            .map(|input| {
+                let values = provided
+                    .get(&input.name)
+                    .ok_or_else(|| BatchedExecutionError::MissingInput(input.name.clone()))?;
+                let initial_values = self.expand_input(input, values)?;
+                Ok(FixedShapeInputBuffer {
+                    slot: input.slot,
+                    name: input.name.clone(),
+                    binding: input.binding,
+                    elements: initial_values.len(),
+                    initial_values,
+                })
+            })
+            .collect()
+    }
+
+    /// Materializes the initial ping-pong state plan without selecting a GPU
+    /// API. Each instance owns one contiguous fixed-shape value.
+    pub fn physical_states(&self) -> Vec<FixedShapeStateBuffer> {
+        self.states
+            .iter()
+            .map(|state| {
+                let elements_per_instance = state.shape.elements();
+                let initial_values = state
+                    .initializer
+                    .iter()
+                    .copied()
+                    .cycle()
+                    .take(elements_per_instance * self.instances as usize)
+                    .collect::<Vec<_>>();
+                FixedShapeStateBuffer {
+                    slot: state.slot,
+                    read_binding: state.read_binding,
+                    write_binding: state.write_binding,
+                    elements_per_instance,
+                    elements: initial_values.len(),
+                    initial_values,
+                }
+            })
+            .collect()
+    }
+
+    pub fn integrity_buffer(&self) -> Option<FixedShapeIntegrityBuffer> {
+        (!self.constraints.is_empty()).then_some(FixedShapeIntegrityBuffer {
+            binding: (self.inputs.len() + self.states.len() * 2) as u32,
+            words: FIXED_SHAPE_INTEGRITY_WORDS,
+        })
     }
 
     pub fn integrity_constraints(&self) -> impl Iterator<Item = IntegrityConstraintId> + '_ {

--- a/hosts/gpu/src/batched/mod.rs
+++ b/hosts/gpu/src/batched/mod.rs
@@ -2251,7 +2251,7 @@ fn generate_wgsl(
 #[cfg(feature = "native")]
 mod native {
     use std::{
-        collections::BTreeMap,
+        collections::{BTreeMap, BTreeSet},
         sync::{Arc, mpsc},
         time::{Duration, Instant},
     };
@@ -2275,6 +2275,7 @@ mod native {
         input_buffers: BTreeMap<CellSlotId, Arc<wgpu::Buffer>>,
         output_buffers: [BTreeMap<CellSlotId, Arc<wgpu::Buffer>>; 2],
         output_elements: BTreeMap<CellSlotId, usize>,
+        output_elements_per_instance: BTreeMap<CellSlotId, usize>,
         constraints: Box<[super::BatchedConstraint]>,
         integrity_fault: Option<Arc<wgpu::Buffer>>,
         integrity_readback: Option<wgpu::Buffer>,
@@ -2507,6 +2508,11 @@ mod native {
                 .iter()
                 .map(|state| (state.slot, state.shape.elements() * self.instances as usize))
                 .collect();
+            let output_elements_per_instance = self
+                .states
+                .iter()
+                .map(|state| (state.slot, state.shape.elements()))
+                .collect();
             Ok(BatchedResidentGpuSession {
                 adapter: adapter_name,
                 device,
@@ -2516,6 +2522,7 @@ mod native {
                 input_buffers,
                 output_buffers,
                 output_elements,
+                output_elements_per_instance,
                 constraints: self.constraints.clone().into_boxed_slice(),
                 integrity_fault,
                 integrity_readback,
@@ -2695,7 +2702,7 @@ mod native {
             let group = self.last_output_group.ok_or_else(|| {
                 BatchedExecutionError::Native("no batch turns have run".to_owned())
             })?;
-            self.read_state_group(group)
+            self.read_state_group(group, None, false)
         }
 
         /// Reads the currently published state, including the initial state or
@@ -2703,12 +2710,25 @@ mod native {
         pub fn read_published_state(
             &self,
         ) -> Result<(Duration, BTreeMap<CellSlotId, Vec<f32>>), BatchedExecutionError> {
-            self.read_state_group(1 - self.next_group)
+            self.read_state_group(1 - self.next_group, None, false)
+        }
+
+        /// Reads lane zero for only the selected published state buffers.
+        /// This is the physical sampling boundary used by resident hosts: the
+        /// full outer batch never crosses from device memory to the CPU.
+        pub fn read_published_samples(
+            &self,
+            slots: &BTreeSet<CellSlotId>,
+        ) -> Result<BTreeMap<CellSlotId, Vec<f32>>, BatchedExecutionError> {
+            self.read_state_group(1 - self.next_group, Some(slots), true)
+                .map(|(_, state)| state)
         }
 
         fn read_state_group(
             &self,
             group: usize,
+            selected: Option<&BTreeSet<CellSlotId>>,
+            sample_first_lane: bool,
         ) -> Result<(Duration, BTreeMap<CellSlotId, Vec<f32>>), BatchedExecutionError> {
             let started = Instant::now();
             let mut encoder = self
@@ -2718,7 +2738,15 @@ mod native {
                 });
             let mut readbacks = Vec::new();
             for (slot, buffer) in &self.output_buffers[group] {
-                let size = (self.output_elements[slot] * std::mem::size_of::<f32>()) as u64;
+                if selected.is_some_and(|selected| !selected.contains(slot)) {
+                    continue;
+                }
+                let elements = if sample_first_lane {
+                    self.output_elements_per_instance[slot]
+                } else {
+                    self.output_elements[slot]
+                };
+                let size = (elements * std::mem::size_of::<f32>()) as u64;
                 let readback = self.device.create_buffer(&wgpu::BufferDescriptor {
                     label: Some("Mech fixed-shape batch readback"),
                     size,

--- a/hosts/gpu/src/batched/mod.rs
+++ b/hosts/gpu/src/batched/mod.rs
@@ -97,6 +97,7 @@ fn evaluate_scalar_computation_simd(computation: &ScalarComputation, registers: 
                     UnaryOperation::Sin => values[0].sin(),
                     UnaryOperation::Cos => values[0].cos(),
                     UnaryOperation::Sqrt => values[0].sqrt(),
+                    UnaryOperation::Ceil => values[0].ceil(),
                 },
                 ElementwiseOperation::Atan2 => values[0].atan2(values[1]),
                 ElementwiseOperation::Identity => values[0],
@@ -2238,6 +2239,7 @@ fn scalar_operation(name: &str) -> Option<ElementwiseOperation> {
         "math/sin" => Some(ElementwiseOperation::Unary(UnaryOperation::Sin)),
         "math/cos" => Some(ElementwiseOperation::Unary(UnaryOperation::Cos)),
         "math/sqrt" => Some(ElementwiseOperation::Unary(UnaryOperation::Sqrt)),
+        "math/ceil" => Some(ElementwiseOperation::Unary(UnaryOperation::Ceil)),
         "math/atan2" => Some(ElementwiseOperation::Atan2),
         _ => None,
     }

--- a/hosts/gpu/src/batched/mod.rs
+++ b/hosts/gpu/src/batched/mod.rs
@@ -1597,6 +1597,8 @@ impl<'a> BatchCompiler<'a> {
                 self.lower_transpose(output, &inputs)
             } else if operation == "matrix/multiply" {
                 self.lower_matmul(output, &inputs)
+            } else if operation == "matrix/solve" {
+                self.lower_solve(output, &inputs)
             } else if operation == "matrix/dot" {
                 self.lower_dot(output, &inputs)
             } else if operation == "math/neg" {
@@ -1927,6 +1929,107 @@ impl<'a> BatchCompiler<'a> {
         Ok(())
     }
 
+    fn lower_solve(&mut self, output: CellSlotId, inputs: &[ArtifactSource]) -> Result<(), String> {
+        if inputs.len() != 2 {
+            return Err(
+                "matrix solve requires a coefficient matrix and right-hand side".to_owned(),
+            );
+        }
+        let coefficients = self.source_shape(inputs[0])?;
+        let rhs = self.source_shape(inputs[1])?;
+        let result = self.shape(output)?;
+        if coefficients.rows != coefficients.columns
+            || rhs.rows != coefficients.rows
+            || result != rhs
+        {
+            return Err(format!(
+                "invalid matrix solve {}x{} \\ {}x{} -> {}x{}",
+                coefficients.rows,
+                coefficients.columns,
+                rhs.rows,
+                rhs.columns,
+                result.rows,
+                result.columns
+            ));
+        }
+
+        match coefficients.rows {
+            1 => {
+                let denominator = self.operand(inputs[0], 0)?;
+                for component in 0..rhs.elements() {
+                    let numerator = self.operand(inputs[1], component)?;
+                    self.emit(
+                        output,
+                        component,
+                        ScalarComputation::Elementwise {
+                            operation: ElementwiseOperation::Binary(BinaryOperation::Divide),
+                            inputs: vec![numerator, denominator],
+                        },
+                    );
+                }
+            }
+            2 => {
+                // A fixed 2x2 solve is scalarized once at compile time. The
+                // resulting arithmetic is shared by CPU SIMD and WebGPU, so
+                // ordinary Mech `A \\ b` source does not need to spell out an
+                // inverse or depend on an accelerator-specific EKF primitive.
+                let a00 = self.operand(inputs[0], coefficients.index(0, 0))?;
+                let a01 = self.operand(inputs[0], coefficients.index(0, 1))?;
+                let a10 = self.operand(inputs[0], coefficients.index(1, 0))?;
+                let a11 = self.operand(inputs[0], coefficients.index(1, 1))?;
+                let diagonal = self.emit_temporary_binary(BinaryOperation::Multiply, a00, a11);
+                let off_diagonal = self.emit_temporary_binary(BinaryOperation::Multiply, a01, a10);
+                let determinant =
+                    self.emit_temporary_binary(BinaryOperation::Subtract, diagonal, off_diagonal);
+
+                for column in 0..rhs.columns {
+                    let b0 = self.operand(inputs[1], rhs.index(0, column))?;
+                    let b1 = self.operand(inputs[1], rhs.index(1, column))?;
+                    let numerator0_diagonal =
+                        self.emit_temporary_binary(BinaryOperation::Multiply, a11, b0);
+                    let numerator0_off_diagonal =
+                        self.emit_temporary_binary(BinaryOperation::Multiply, a01, b1);
+                    let numerator0 = self.emit_temporary_binary(
+                        BinaryOperation::Subtract,
+                        numerator0_diagonal,
+                        numerator0_off_diagonal,
+                    );
+                    let numerator1_diagonal =
+                        self.emit_temporary_binary(BinaryOperation::Multiply, a00, b1);
+                    let numerator1_off_diagonal =
+                        self.emit_temporary_binary(BinaryOperation::Multiply, a10, b0);
+                    let numerator1 = self.emit_temporary_binary(
+                        BinaryOperation::Subtract,
+                        numerator1_diagonal,
+                        numerator1_off_diagonal,
+                    );
+                    self.emit(
+                        output,
+                        result.index(0, column),
+                        ScalarComputation::Elementwise {
+                            operation: ElementwiseOperation::Binary(BinaryOperation::Divide),
+                            inputs: vec![numerator0, determinant],
+                        },
+                    );
+                    self.emit(
+                        output,
+                        result.index(1, column),
+                        ScalarComputation::Elementwise {
+                            operation: ElementwiseOperation::Binary(BinaryOperation::Divide),
+                            inputs: vec![numerator1, determinant],
+                        },
+                    );
+                }
+            }
+            rows => {
+                return Err(format!(
+                    "fixed-shape matrix solve currently supports 1x1 and 2x2 coefficient matrices, found {rows}x{rows}"
+                ));
+            }
+        }
+        Ok(())
+    }
+
     fn lower_transpose(
         &mut self,
         output: CellSlotId,
@@ -1996,6 +2099,24 @@ impl<'a> BatchCompiler<'a> {
             output: self.register_offsets[&slot] + component,
             computation,
         });
+    }
+
+    fn emit_temporary_binary(
+        &mut self,
+        operation: BinaryOperation,
+        left: ScalarOperand,
+        right: ScalarOperand,
+    ) -> ScalarOperand {
+        let output = self.register_count;
+        self.register_count += 1;
+        self.instructions.push(ScalarInstruction {
+            output,
+            computation: ScalarComputation::Elementwise {
+                operation: ElementwiseOperation::Binary(operation),
+                inputs: vec![left, right],
+            },
+        });
+        ScalarOperand::Register(output)
     }
 
     fn operand(&self, source: ArtifactSource, component: usize) -> Result<ScalarOperand, String> {

--- a/hosts/gpu/src/batched/mod.rs
+++ b/hosts/gpu/src/batched/mod.rs
@@ -96,6 +96,7 @@ fn evaluate_scalar_computation_simd(computation: &ScalarComputation, registers: 
                 ElementwiseOperation::Unary(operation) => match operation {
                     UnaryOperation::Sin => values[0].sin(),
                     UnaryOperation::Cos => values[0].cos(),
+                    UnaryOperation::Sqrt => values[0].sqrt(),
                 },
                 ElementwiseOperation::Atan2 => values[0].atan2(values[1]),
                 ElementwiseOperation::Identity => values[0],
@@ -2003,6 +2004,7 @@ fn scalar_operation(name: &str) -> Option<ElementwiseOperation> {
         "math/div" => Some(ElementwiseOperation::Binary(BinaryOperation::Divide)),
         "math/sin" => Some(ElementwiseOperation::Unary(UnaryOperation::Sin)),
         "math/cos" => Some(ElementwiseOperation::Unary(UnaryOperation::Cos)),
+        "math/sqrt" => Some(ElementwiseOperation::Unary(UnaryOperation::Sqrt)),
         "math/atan2" => Some(ElementwiseOperation::Atan2),
         _ => None,
     }

--- a/hosts/gpu/src/batched/mod.rs
+++ b/hosts/gpu/src/batched/mod.rs
@@ -1440,11 +1440,43 @@ impl<'a> BatchCompiler<'a> {
     }
 
     fn collect_slots(&mut self) {
+        let required_nodes = turn_required_nodes(self.artifact);
+        let required_slots = required_nodes
+            .iter()
+            .flat_map(|node| {
+                let node = &self.artifact.nodes()[node.get() as usize];
+                node.input_bindings
+                    .clone()
+                    .filter_map(
+                        |binding| match self.artifact.bindings().get(binding as usize) {
+                            Some(BindingDeclaration::Input {
+                                source: ArtifactSource::Slot(slot),
+                                ..
+                            }) => Some(*slot),
+                            _ => None,
+                        },
+                    )
+                    .chain(node.output_bindings.clone().filter_map(|binding| {
+                        match self.artifact.bindings().get(binding as usize) {
+                            Some(BindingDeclaration::Output { target, .. }) => Some(*target),
+                            _ => None,
+                        }
+                    }))
+            })
+            .collect::<BTreeSet<_>>();
         for slot in self.artifact.slots() {
             // E3 gives public outputs dedicated publication slots. Batched
             // kernels operate on the underlying numeric graph and persistent
             // state, so the output aliases are not registers of their own.
             if slot.role == SlotRole::Output {
+                continue;
+            }
+            // The semantic artifact can retain selector temporaries whose
+            // constant result was folded directly into a later access node.
+            // They are not part of the executable turn graph and may use
+            // selector-only schemas (for example a matrix of indices), so do
+            // not allocate numeric registers or reject them as data slots.
+            if !required_slots.contains(&slot.slot) {
                 continue;
             }
             if let ProducerReference::NodeOutput { node, .. } = slot.producer {
@@ -1555,8 +1587,8 @@ impl<'a> BatchCompiler<'a> {
                 continue;
             }
             let output = outputs[0];
-            let result = if operation == "access/scalar" {
-                self.lower_access_2d(output, &inputs)
+            let result = if operation == "access/scalar" || operation == "access/range" {
+                self.lower_access(output, &inputs)
             } else if operation == "matrix/horzcat" {
                 self.lower_concatenate(output, &inputs, true)
             } else if operation == "matrix/vertcat" {
@@ -1657,34 +1689,73 @@ impl<'a> BatchCompiler<'a> {
         Ok(())
     }
 
-    fn lower_access_2d(
+    fn lower_access(
         &mut self,
         output: CellSlotId,
         inputs: &[ArtifactSource],
     ) -> Result<(), String> {
-        if inputs.len() != 3 || self.shape(output)?.elements() != 1 {
-            return Err(
-                "fixed scalar matrix access requires a matrix, row, column, and scalar output"
-                    .to_owned(),
-            );
-        }
-        let shape = self.source_shape(inputs[0])?;
-        let row = self.constant_index(inputs[1], "row")?;
-        let column = self.constant_index(inputs[2], "column")?;
-        if row >= shape.rows || column >= shape.columns {
+        if inputs.len() != 2 && inputs.len() != 3 {
             return Err(format!(
-                "matrix access [{},{}] is outside {}x{}",
-                row + 1,
-                column + 1,
-                shape.rows,
-                shape.columns
+                "fixed matrix access requires a source and one or two static selectors, found {} inputs",
+                inputs.len()
             ));
         }
-        self.emit(
-            output,
-            0,
-            ScalarComputation::Copy(self.operand(inputs[0], shape.index(row, column))?),
-        );
+        let source = self.source_shape(inputs[0])?;
+        let result = self.shape(output)?;
+        let (rows, columns) = if inputs.len() == 3 {
+            (
+                self.constant_indices(inputs[1], source.rows, "row")?,
+                self.constant_indices(inputs[2], source.columns, "column")?,
+            )
+        } else {
+            let selector =
+                self.constant_indices(inputs[1], source.rows.max(source.columns), "matrix")?;
+            let selects_columns = result.rows == source.rows && result.columns == selector.len();
+            let selects_rows = result.rows == selector.len() && result.columns == source.columns;
+            match (selects_rows, selects_columns) {
+                (false, true) => ((0..source.rows).collect(), selector),
+                (true, false) => (selector, (0..source.columns).collect()),
+                (true, true) if source.rows == 1 || source.columns == 1 => {
+                    if result.rows == source.rows {
+                        ((0..source.rows).collect(), selector)
+                    } else {
+                        (selector, (0..source.columns).collect())
+                    }
+                }
+                (true, true) => {
+                    return Err(format!(
+                        "matrix access selector is ambiguous for {}x{} -> {}x{}",
+                        source.rows, source.columns, result.rows, result.columns
+                    ));
+                }
+                (false, false) => {
+                    return Err(format!(
+                        "matrix access selector cannot produce {}x{} from {}x{}",
+                        result.rows, result.columns, source.rows, source.columns
+                    ));
+                }
+            }
+        };
+        if result.rows != rows.len() || result.columns != columns.len() {
+            return Err(format!(
+                "matrix access selected {}x{} elements but output is {}x{}",
+                rows.len(),
+                columns.len(),
+                result.rows,
+                result.columns
+            ));
+        }
+        for (result_column, source_column) in columns.into_iter().enumerate() {
+            for (result_row, source_row) in rows.iter().copied().enumerate() {
+                self.emit(
+                    output,
+                    result.index(result_row, result_column),
+                    ScalarComputation::Copy(
+                        self.operand(inputs[0], source.index(source_row, source_column))?,
+                    ),
+                );
+            }
+        }
         Ok(())
     }
 
@@ -1952,22 +2023,47 @@ impl<'a> BatchCompiler<'a> {
         }
     }
 
-    fn constant_index(&self, source: ArtifactSource, role: &str) -> Result<usize, String> {
+    fn constant_indices(
+        &self,
+        source: ArtifactSource,
+        upper: usize,
+        role: &str,
+    ) -> Result<Vec<usize>, String> {
         let ArtifactSource::Constant(constant) = source else {
-            return Err(format!("matrix {role} index must be compile-time constant"));
+            return Err(format!(
+                "matrix {role} selector must be compile-time constant"
+            ));
         };
         let value = self
             .artifact
             .constants()
             .get(constant)
             .ok_or_else(|| format!("constant {} does not exist", constant.get()))?;
-        let ValueData::Index(index) = value.data() else {
-            return Err(format!("matrix {role} index is not an index value"));
+        let one_based = match value.data() {
+            ValueData::Index(index) => vec![*index],
+            ValueData::Matrix(matrix) => match matrix.elements() {
+                SequenceView::Index(indices) => indices.to_vec(),
+                _ => return Err(format!("matrix {role} selector is not an index vector")),
+            },
+            _ => return Err(format!("matrix {role} selector is not an index value")),
         };
-        let zero_based = index
-            .checked_sub(1)
-            .ok_or_else(|| format!("matrix {role} index must be at least 1"))?;
-        usize::try_from(zero_based).map_err(|_| format!("matrix {role} index does not fit usize"))
+        one_based
+            .into_iter()
+            .map(|index| {
+                let zero_based = index
+                    .checked_sub(1)
+                    .ok_or_else(|| format!("matrix {role} index must be at least 1"))?;
+                let index = usize::try_from(zero_based)
+                    .map_err(|_| format!("matrix {role} index does not fit usize"))?;
+                if index >= upper {
+                    return Err(format!(
+                        "matrix {role} index {} is outside 1..={upper}",
+                        index + 1
+                    ));
+                }
+                Ok(index)
+            })
+            .collect()
     }
 
     fn source_shape(&self, source: ArtifactSource) -> Result<FixedShape, String> {

--- a/hosts/gpu/src/compute_backends.rs
+++ b/hosts/gpu/src/compute_backends.rs
@@ -732,10 +732,24 @@ impl ComputeSession for FixedWgpuSession {
         &mut self,
         selection: &ComputeOutputSelection,
     ) -> Result<ComputeOutputSnapshot, ComputeExecutionError> {
-        let (_, state) = self
-            .session
-            .read_published_state()
-            .map_err(|error| execution_error(&self.backend, "read outputs", error.to_string()))?;
+        let state = match selection {
+            ComputeOutputSelection::Samples(ports) => {
+                let slots = self
+                    .program
+                    .compute_program()
+                    .interface()
+                    .outputs
+                    .iter()
+                    .filter(|port| ports.contains(&port.id))
+                    .map(|port| port.slot)
+                    .collect();
+                self.session.read_published_samples(&slots)
+            }
+            ComputeOutputSelection::All | ComputeOutputSelection::Ports(_) => {
+                self.session.read_published_state().map(|(_, state)| state)
+            }
+        }
+        .map_err(|error| execution_error(&self.backend, "read outputs", error.to_string()))?;
         fixed_output_snapshot(&self.program, selection, &state)
             .map_err(|detail| execution_error(&self.backend, "read outputs", detail))
     }
@@ -880,7 +894,9 @@ fn output_snapshot(
 ) -> Result<ComputeOutputSnapshot, String> {
     let selected = |port: &ComputePort| match selection {
         ComputeOutputSelection::All => true,
-        ComputeOutputSelection::Ports(ports) => ports.contains(&port.id),
+        ComputeOutputSelection::Ports(ports) | ComputeOutputSelection::Samples(ports) => {
+            ports.contains(&port.id)
+        }
     };
     let values = program
         .compute_program()
@@ -921,8 +937,11 @@ fn fixed_output_snapshot(
 ) -> Result<ComputeOutputSnapshot, String> {
     let selected = |port: &ComputePort| match selection {
         ComputeOutputSelection::All => true,
-        ComputeOutputSelection::Ports(ports) => ports.contains(&port.id),
+        ComputeOutputSelection::Ports(ports) | ComputeOutputSelection::Samples(ports) => {
+            ports.contains(&port.id)
+        }
     };
+    let sampled = matches!(selection, ComputeOutputSelection::Samples(_));
     let values = program
         .compute_program()
         .interface()
@@ -933,12 +952,28 @@ fn fixed_output_snapshot(
             let physical = state
                 .get(&port.slot)
                 .ok_or_else(|| format!("backend did not publish output `{}`", port.name))?;
-            let logical = fixed_column_major_to_row_major(
-                physical,
-                &port.dimensions,
-                program.instances() as usize,
-            )?;
-            let value = if port.dimensions.is_empty() && program.instances() == 1 {
+            let instances = if sampled {
+                1
+            } else {
+                program.instances() as usize
+            };
+            let elements = port
+                .elements()
+                .map_err(|error| format!("output `{}` has an invalid shape: {error}", port.name))?;
+            let physical = if sampled {
+                physical.get(..elements).ok_or_else(|| {
+                    format!(
+                        "backend returned {} elements for sampled output `{}`, expected at least {elements}",
+                        physical.len(),
+                        port.name,
+                    )
+                })?
+            } else {
+                physical.as_slice()
+            };
+            let logical =
+                fixed_column_major_to_row_major(physical, &port.dimensions, instances)?;
+            let value = if port.dimensions.is_empty() && instances == 1 {
                 let [value] = logical.as_slice() else {
                     return Err(format!(
                         "scalar output `{}` returned {} elements",
@@ -949,8 +984,8 @@ fn fixed_output_snapshot(
                 ComputeValue::ScalarF32(*value)
             } else {
                 let mut dimensions = Vec::from(port.dimensions.as_ref());
-                if program.instances() > 1 {
-                    dimensions.insert(0, u64::from(program.instances()));
+                if instances > 1 {
+                    dimensions.insert(0, instances as u64);
                 }
                 ComputeValue::TensorF32 {
                     dimensions: dimensions.into_boxed_slice(),
@@ -1026,7 +1061,7 @@ fn fixed_dispatch_report(
 
 fn compute_fault_evidence(fault: &BatchedIntegrityFault) -> ComputeFaultEvidence {
     ComputeFaultEvidence {
-        attempted_turn: fault.attempted_turn,
+        attempted_turn: u128::from(fault.attempted_turn),
         constraint: fault.constraint_name.clone(),
         detail: format!("candidate rejected at batch instance {}", fault.instance).into_boxed_str(),
     }
@@ -1053,6 +1088,7 @@ fn execution_error(
         backend: backend.clone(),
         operation,
         detail: detail.into(),
+        state_advanced: false,
     }
 }
 

--- a/hosts/gpu/src/compute_provider.rs
+++ b/hosts/gpu/src/compute_provider.rs
@@ -237,9 +237,16 @@ impl RuntimeHostFactory for ComputeHostFactory {
         // capability contract. They stay current across compatible source
         // generations, while outputs absent from that contract remain entirely
         // backend-resident and incur no CPU readback.
-        let mut sampled_outputs = initial_sampled_outputs(&self.program)?;
+        let mut sampled_outputs = initial_sampled_outputs(&self.program, &self.retained_outputs)?;
         if let Some(resume) = resume {
-            sampled_outputs.extend(resume.sampled_outputs.clone());
+            sampled_outputs.extend(
+                resume
+                    .sampled_outputs
+                    .iter()
+                    .filter(|(name, _)| self.retained_outputs.contains(name.as_str()))
+                    .map(|(name, value)| Ok((name.clone(), value.try_deep_snapshot()?)))
+                    .collect::<MResult<BTreeMap<_, _>>>()?,
+            );
         }
         let state = Arc::new(Mutex::new(ComputeHostState {
             backend: backend_id.to_string(),
@@ -348,6 +355,24 @@ impl std::fmt::Debug for ComputeHostStateSnapshotHandle {
 
 impl ComputeHostStateSnapshotHandle {
     pub fn snapshot(&self) -> MResult<Option<ComputeHostResumeState>> {
+        self.snapshot_retaining(None)
+    }
+
+    /// Captures host state for a compatible source replacement while copying
+    /// only the samples named by the replacement's static retention contract.
+    /// Runtime-only reads may populate other samples lazily, but those values
+    /// must not silently become persistent migration state.
+    pub fn snapshot_retained(
+        &self,
+        retained_outputs: &BTreeSet<String>,
+    ) -> MResult<Option<ComputeHostResumeState>> {
+        self.snapshot_retaining(Some(retained_outputs))
+    }
+
+    fn snapshot_retaining(
+        &self,
+        retained_outputs: Option<&BTreeSet<String>>,
+    ) -> MResult<Option<ComputeHostResumeState>> {
         let state = self
             .state
             .lock()
@@ -385,6 +410,9 @@ impl ComputeHostStateSnapshotHandle {
         let sampled_outputs = state
             .sampled_outputs
             .iter()
+            .filter(|(name, _)| {
+                retained_outputs.is_none_or(|outputs| outputs.contains(name.as_str()))
+            })
             .map(|(name, value)| Ok((name.clone(), value.try_deep_snapshot()?)))
             .collect::<MResult<_>>()?;
         Ok(Some(ComputeHostResumeState {
@@ -697,6 +725,10 @@ impl ComputeResourceProvider {
                 return zero_sample_value(port);
             }
             state.sample_subscriptions.insert(port.name.to_string());
+            if !state.sampled_outputs.contains_key(port.name.as_ref()) {
+                let initial = initial_sampled_output(&state.program, port)?;
+                state.sampled_outputs.insert(port.name.to_string(), initial);
+            }
             return state
                 .sampled_outputs
                 .get(port.name.as_ref())
@@ -1400,47 +1432,55 @@ fn compute_value_elements(value: &ComputeValue) -> u64 {
     }
 }
 
-fn initial_sampled_outputs(program: &ComputeProgram) -> MResult<BTreeMap<String, LegacyValue>> {
+fn initial_sampled_outputs(
+    program: &ComputeProgram,
+    retained_outputs: &BTreeSet<String>,
+) -> MResult<BTreeMap<String, LegacyValue>> {
     program
         .interface()
         .outputs
         .iter()
+        .filter(|port| retained_outputs.contains(port.name.as_ref()))
         .map(|port| {
-            let value = program
-                .fixed_shape_storage()
-                .and_then(|storage| storage.states.iter().find(|state| state.slot == port.slot))
-                .map(|state| ComputeValue::TensorF32 {
-                    dimensions: port.dimensions.clone(),
-                    layout: TensorLayout::ColumnMajor,
-                    values: Arc::clone(&state.initializer),
-                })
-                .or_else(|| {
-                    program.elementwise_storage().and_then(|storage| {
-                        storage
-                            .states
-                            .iter()
-                            .find(|state| state.slot == port.slot)
-                            .map(|state| ComputeValue::TensorF32 {
-                                dimensions: port.dimensions.clone(),
-                                layout: TensorLayout::RowMajor,
-                                values: Arc::clone(&state.initializer),
-                            })
-                    })
-                });
             Ok((
                 port.name.to_string(),
-                match value {
-                    Some(ComputeValue::TensorF32 { values, .. })
-                        if port.dimensions.is_empty() && values.len() == 1 =>
-                    {
-                        sampled_output_value(port, ComputeValue::ScalarF32(values[0]))?
-                    }
-                    Some(value) => sampled_output_value(port, value)?,
-                    None => zero_sample_value(port)?,
-                },
+                initial_sampled_output(program, port)?,
             ))
         })
         .collect()
+}
+
+fn initial_sampled_output(program: &ComputeProgram, port: &ComputePort) -> MResult<LegacyValue> {
+    let value = program
+        .fixed_shape_storage()
+        .and_then(|storage| storage.states.iter().find(|state| state.slot == port.slot))
+        .map(|state| ComputeValue::TensorF32 {
+            dimensions: port.dimensions.clone(),
+            layout: TensorLayout::ColumnMajor,
+            values: Arc::clone(&state.initializer),
+        })
+        .or_else(|| {
+            program.elementwise_storage().and_then(|storage| {
+                storage
+                    .states
+                    .iter()
+                    .find(|state| state.slot == port.slot)
+                    .map(|state| ComputeValue::TensorF32 {
+                        dimensions: port.dimensions.clone(),
+                        layout: TensorLayout::RowMajor,
+                        values: Arc::clone(&state.initializer),
+                    })
+            })
+        });
+    match value {
+        Some(ComputeValue::TensorF32 { values, .. })
+            if port.dimensions.is_empty() && values.len() == 1 =>
+        {
+            sampled_output_value(port, ComputeValue::ScalarF32(values[0]))
+        }
+        Some(value) => sampled_output_value(port, value),
+        None => zero_sample_value(port),
+    }
 }
 
 fn zero_sample_value(port: &ComputePort) -> MResult<LegacyValue> {
@@ -2176,6 +2216,91 @@ mod tests {
     }
 
     #[test]
+    fn report_only_factory_does_not_materialize_or_migrate_declared_outputs() {
+        let stale = RuntimeHostInputValue::F32(42.0).into_mech_value().unwrap();
+        let resume = ComputeHostResumeState {
+            turns: 120.0,
+            dispatch_ms: 3.25,
+            fault_count: 0.0,
+            last_fault: String::new(),
+            sampled_outputs: BTreeMap::from([("result".to_owned(), stale)]),
+            last_submitted_turn: Some(120),
+        };
+        let factory = ComputeHostFactory::new(
+            "particle-field",
+            ComputePlacement::Compute,
+            program_with_sample_output(),
+            ComputeInitializerSet::default(),
+            registry(),
+            ComputePlatform::Native,
+        )
+        .unwrap()
+        .with_resume_state(resume);
+        let snapshot = factory.state_snapshot_handle();
+        let _installation = factory.instantiate("particles", &settings()).unwrap();
+
+        assert!(
+            snapshot
+                .snapshot()
+                .unwrap()
+                .unwrap()
+                .sampled_outputs
+                .is_empty(),
+            "outputs absent from the retained contract must remain backend-resident",
+        );
+    }
+
+    #[test]
+    fn an_unplanned_actual_sample_read_materializes_only_that_output() {
+        let factory = ComputeHostFactory::new(
+            "particle-field",
+            ComputePlacement::Compute,
+            program_with_sample_output(),
+            ComputeInitializerSet::default(),
+            registry(),
+            ComputePlatform::Native,
+        )
+        .unwrap();
+        let snapshot = factory.state_snapshot_handle();
+        let installation = factory.instantiate("particles", &settings()).unwrap();
+        assert!(
+            snapshot
+                .snapshot()
+                .unwrap()
+                .unwrap()
+                .sampled_outputs
+                .is_empty(),
+        );
+
+        let observed = installation.resource_providers[0]
+            .read(RuntimeResourceReadRequest {
+                base_uri: "compute://particles/kernel".to_owned(),
+                path: "sample/result".to_owned(),
+                context_name: "candidate".to_owned(),
+            })
+            .unwrap();
+
+        assert_eq!(
+            RuntimeHostInputValue::from_numeric_mech_value(&observed).unwrap(),
+            RuntimeHostInputValue::F64(0.0),
+        );
+        let resumed = snapshot.snapshot().unwrap().unwrap();
+        assert_eq!(
+            resumed.sampled_outputs.keys().cloned().collect::<Vec<_>>(),
+            ["result"],
+        );
+        assert!(
+            snapshot
+                .snapshot_retained(&BTreeSet::new())
+                .unwrap()
+                .unwrap()
+                .sampled_outputs
+                .is_empty(),
+            "a runtime-only sample must not become replacement migration state",
+        );
+    }
+
+    #[test]
     fn report_only_dispatch_keeps_declared_outputs_backend_resident() {
         let calls = Arc::new(Mutex::new(Vec::new()));
         let program = Arc::new(program_with_sample_output());
@@ -2185,7 +2310,7 @@ mod tests {
             dispatch_ms: Ref::new(0.0),
             fault_count: Ref::new(0.0),
             last_fault: Ref::new(String::new()),
-            sampled_outputs: initial_sampled_outputs(&program).unwrap(),
+            sampled_outputs: BTreeMap::new(),
             sample_subscriptions: BTreeSet::new(),
             phase: ComputeHostPhase::Ready {
                 last_submitted_turn: None,

--- a/hosts/gpu/src/compute_provider.rs
+++ b/hosts/gpu/src/compute_provider.rs
@@ -41,6 +41,7 @@ pub struct ComputeHostFactory {
     installed_instance: Mutex<Option<String>>,
     state_snapshot: ComputeHostStateSnapshotHandle,
     resume_state: Option<ComputeHostResumeState>,
+    retained_outputs: BTreeSet<String>,
     manifest: HostManifestConfig,
 }
 
@@ -84,6 +85,7 @@ impl ComputeHostFactory {
             installed_instance: Mutex::new(None),
             state_snapshot: ComputeHostStateSnapshotHandle::default(),
             resume_state: None,
+            retained_outputs: BTreeSet::new(),
             manifest: compute_host_manifest(),
         })
     }
@@ -100,6 +102,25 @@ impl ComputeHostFactory {
     pub fn with_resume_state(mut self, state: ComputeHostResumeState) -> Self {
         self.resume_state = Some(state);
         self
+    }
+
+    pub fn with_retained_outputs(mut self, outputs: BTreeSet<String>) -> MResult<Self> {
+        for output in &outputs {
+            if !self
+                .program
+                .interface()
+                .outputs
+                .iter()
+                .any(|port| port.name.as_ref() == output)
+            {
+                return Err(compute_host_error(
+                    "ComputeHostConfiguration",
+                    format!("retained compute output `{output}` is not declared"),
+                ));
+            }
+        }
+        self.retained_outputs = outputs;
+        Ok(self)
     }
 
     pub fn resolved_backend_id(&self, settings: &ConfigValue) -> MResult<mech_compute::BackendId> {
@@ -212,17 +233,10 @@ impl RuntimeHostFactory for ComputeHostFactory {
         let base_uri = format!("compute://{instance_name}/kernel");
         let resume = self.resume_state.as_ref();
         let replay_on_start = resume.is_some();
-        // A compute output is a level-valued resource, not an edge subscription.
-        // Keep one lane-zero sample of every declared output current so a
-        // compatible outer-program replacement can begin observing any output
-        // without mixing the current turn counter with an initializer value.
-        let level_outputs = self
-            .program
-            .interface()
-            .outputs
-            .iter()
-            .map(|port| port.name.to_string())
-            .collect();
+        // Retained outputs come from the coordinator's explicit sample-read
+        // capability contract. They stay current across compatible source
+        // generations, while outputs absent from that contract remain entirely
+        // backend-resident and incur no CPU readback.
         let mut sampled_outputs = initial_sampled_outputs(&self.program)?;
         if let Some(resume) = resume {
             sampled_outputs.extend(resume.sampled_outputs.clone());
@@ -235,8 +249,13 @@ impl RuntimeHostFactory for ComputeHostFactory {
             fault_count: Ref::new(resume.map_or(0.0, |state| state.fault_count)),
             last_fault: Ref::new(resume.map_or_else(String::new, |state| state.last_fault.clone())),
             sampled_outputs,
-            sample_requests: BTreeSet::new(),
-            level_outputs,
+            // A declared sample read is both a retention contract and a
+            // persistent telemetry subscription. Compatible coordinator
+            // replacement does not necessarily repeat the non-planning read
+            // that dynamically registers a sample, so seed the subscription
+            // set from the source contract instead of depending on that
+            // lifecycle side effect.
+            sample_subscriptions: self.retained_outputs.clone(),
             phase: ComputeHostPhase::Ready {
                 last_submitted_turn: resume
                     .and_then(|state| state.last_submitted_turn)
@@ -387,8 +406,7 @@ struct ComputeHostState {
     fault_count: Ref<f64>,
     last_fault: Ref<String>,
     sampled_outputs: BTreeMap<String, LegacyValue>,
-    sample_requests: BTreeSet<String>,
-    level_outputs: BTreeSet<String>,
+    sample_subscriptions: BTreeSet<String>,
     phase: ComputeHostPhase,
     session: Box<dyn ComputeSession>,
 }
@@ -566,7 +584,7 @@ impl ComputeCompletionTarget for ComputeHostCompletionTarget {
             candidate_dispatch_ms,
             candidate_fault_count,
             &candidate_last_fault,
-            &state.sample_requests,
+            &state.sample_subscriptions,
             &candidate_outputs,
         )
         .map_err(|error| {
@@ -628,8 +646,7 @@ impl std::fmt::Debug for ComputeHostState {
             .field("dispatch_ms", &self.dispatch_ms)
             .field("fault_count", &self.fault_count)
             .field("last_fault", &self.last_fault)
-            .field("sample_requests", &self.sample_requests)
-            .field("level_outputs", &self.level_outputs)
+            .field("sample_subscriptions", &self.sample_subscriptions)
             .field("phase", &self.phase)
             .field("session", &"<dyn ComputeSession>")
             .finish()
@@ -679,7 +696,7 @@ impl ComputeResourceProvider {
             if planning {
                 return zero_sample_value(port);
             }
-            state.sample_requests.insert(port.name.to_string());
+            state.sample_subscriptions.insert(port.name.to_string());
             return state
                 .sampled_outputs
                 .get(port.name.as_ref())
@@ -921,7 +938,7 @@ impl RuntimeAfterCommitEffect for ComputeDispatchEffect {
             .interface()
             .outputs
             .iter()
-            .filter(|port| state.level_outputs.contains(port.name.as_ref()))
+            .filter(|port| state.sample_subscriptions.contains(port.name.as_ref()))
             .map(|port| port.id)
             .collect();
         let request = ComputeDispatchRequest {
@@ -952,13 +969,13 @@ impl RuntimeAfterCommitEffect for ComputeDispatchEffect {
             return Ok(());
         }
         let mut sampled = None;
-        if report.completed_turns > 0 && !state.level_outputs.is_empty() {
+        if report.completed_turns > 0 && !state.sample_subscriptions.is_empty() {
             let selected = state
                 .program
                 .interface()
                 .outputs
                 .iter()
-                .filter(|port| state.level_outputs.contains(port.name.as_ref()))
+                .filter(|port| state.sample_subscriptions.contains(port.name.as_ref()))
                 .map(|port| port.id)
                 .collect();
             let snapshot = match state
@@ -1002,7 +1019,7 @@ impl RuntimeAfterCommitEffect for ComputeDispatchEffect {
             candidate_dispatch_ms,
             candidate_fault_count,
             &candidate_last_fault,
-            &state.sample_requests,
+            &state.sample_subscriptions,
             &candidate_outputs,
         )
         .map_err(|error| {
@@ -1089,7 +1106,7 @@ fn telemetry_updates_from_values(
     dispatch_ms: f64,
     fault_count: f64,
     last_fault: &str,
-    sample_requests: &BTreeSet<String>,
+    sample_subscriptions: &BTreeSet<String>,
     sampled_outputs: &BTreeMap<String, LegacyValue>,
 ) -> MResult<Vec<RuntimeHostInputUpdate>> {
     let mut updates = vec![
@@ -1115,7 +1132,7 @@ fn telemetry_updates_from_values(
             RuntimeHostInputValue::String(last_fault.to_owned()),
         )?,
     ];
-    for name in sample_requests {
+    for name in sample_subscriptions {
         let value = sampled_outputs.get(name).ok_or_else(|| {
             compute_host_error(
                 "ComputeHostRead",
@@ -1213,7 +1230,7 @@ impl RuntimeHostInputDriver for ComputeTelemetryDriver {
                     *state.dispatch_ms.borrow(),
                     *state.fault_count.borrow(),
                     &state.last_fault.borrow(),
-                    &state.sample_requests,
+                    &state.sample_subscriptions,
                     &state.sampled_outputs,
                 )?)?
             };
@@ -1459,7 +1476,7 @@ fn materialize_sampled_outputs(
         .interface()
         .outputs
         .iter()
-        .filter(|port| state.level_outputs.contains(port.name.as_ref()))
+        .filter(|port| state.sample_subscriptions.contains(port.name.as_ref()))
         .cloned()
         .collect::<Vec<_>>();
     let mut sampled = BTreeMap::new();
@@ -1943,8 +1960,7 @@ mod tests {
             fault_count: Ref::new(0.0),
             last_fault: Ref::new(String::new()),
             sampled_outputs: BTreeMap::new(),
-            sample_requests: BTreeSet::new(),
-            level_outputs: BTreeSet::new(),
+            sample_subscriptions: BTreeSet::new(),
             phase,
             session: Box::new(FakeSession {
                 backend: BackendId::new(CPU_SCALAR_BACKEND).unwrap(),
@@ -2112,7 +2128,7 @@ mod tests {
     }
 
     #[test]
-    fn compatible_factory_preserves_current_sample_for_every_declared_output() {
+    fn compatible_factory_preserves_current_sample_for_retained_output_contract() {
         let current = RuntimeHostInputValue::F32(42.0).into_mech_value().unwrap();
         let resume = ComputeHostResumeState {
             turns: 120.0,
@@ -2130,6 +2146,8 @@ mod tests {
             registry(),
             ComputePlatform::Native,
         )
+        .unwrap()
+        .with_retained_outputs(BTreeSet::from(["result".to_owned()]))
         .unwrap()
         .with_resume_state(resume);
         let snapshot = factory.state_snapshot_handle();
@@ -2155,6 +2173,44 @@ mod tests {
             .unwrap(),
             RuntimeHostInputValue::F32(42.0)
         );
+    }
+
+    #[test]
+    fn report_only_dispatch_keeps_declared_outputs_backend_resident() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let program = Arc::new(program_with_sample_output());
+        let state = Arc::new(Mutex::new(ComputeHostState {
+            backend: CPU_SCALAR_BACKEND.to_owned(),
+            turns: Ref::new(0.0),
+            dispatch_ms: Ref::new(0.0),
+            fault_count: Ref::new(0.0),
+            last_fault: Ref::new(String::new()),
+            sampled_outputs: initial_sampled_outputs(&program).unwrap(),
+            sample_subscriptions: BTreeSet::new(),
+            phase: ComputeHostPhase::Ready {
+                last_submitted_turn: None,
+            },
+            session: Box::new(FakeSession {
+                backend: BackendId::new(CPU_SCALAR_BACKEND).unwrap(),
+                calls: Arc::clone(&calls),
+                result: Ok(ComputeDispatchReport {
+                    completed_turns: 1,
+                    ..Default::default()
+                }),
+            }),
+            program,
+        }));
+        let mut effect = ComputeDispatchEffect {
+            resource: "compute://particles/kernel".to_owned(),
+            region: "particle-field".into(),
+            turn: ComputeTurnToken(1),
+            state,
+            telemetry: Arc::new(Mutex::new(None)),
+        };
+
+        effect.deliver().unwrap();
+
+        assert_eq!(calls.lock().unwrap().as_slice(), [FakeCall::Dispatch(1)]);
     }
 
     #[test]

--- a/hosts/gpu/src/compute_provider.rs
+++ b/hosts/gpu/src/compute_provider.rs
@@ -211,6 +211,7 @@ impl RuntimeHostFactory for ComputeHostFactory {
         let live = Arc::new(AtomicBool::new(false));
         let base_uri = format!("compute://{instance_name}/kernel");
         let resume = self.resume_state.as_ref();
+        let replay_on_start = resume.is_some();
         let state = Arc::new(Mutex::new(ComputeHostState {
             backend: backend_id.to_string(),
             program: Arc::clone(&self.program),
@@ -269,13 +270,15 @@ impl RuntimeHostFactory for ComputeHostFactory {
                 instance: instance_name.to_owned(),
                 region: self.region.clone(),
                 program: Arc::clone(&self.program),
-                state,
+                state: Arc::clone(&state),
                 telemetry: Arc::clone(&telemetry),
             })],
             input_drivers: vec![Box::new(ComputeTelemetryDriver {
                 base_uri,
                 ingress: telemetry,
                 live,
+                state,
+                replay_on_start,
                 sample_outputs: self
                     .program
                     .interface()
@@ -1132,6 +1135,8 @@ struct ComputeTelemetryDriver {
     base_uri: String,
     ingress: Arc<Mutex<Option<RuntimeIngress>>>,
     live: Arc<AtomicBool>,
+    state: Arc<Mutex<ComputeHostState>>,
+    replay_on_start: bool,
     sample_outputs: BTreeSet<String>,
 }
 
@@ -1165,7 +1170,7 @@ impl RuntimeHostInputDriver for ComputeTelemetryDriver {
     }
 
     fn start(&mut self) -> MResult<()> {
-        if self
+        let ingress = self
             .ingress
             .lock()
             .map_err(|_| {
@@ -1174,12 +1179,38 @@ impl RuntimeHostInputDriver for ComputeTelemetryDriver {
                     "compute telemetry ingress lock is poisoned",
                 )
             })?
-            .is_none()
-        {
-            return Err(compute_host_error(
-                "ComputeTelemetryDriver",
-                "compute telemetry driver must be attached before start",
-            ));
+            .clone()
+            .ok_or_else(|| {
+                compute_host_error(
+                    "ComputeTelemetryDriver",
+                    "compute telemetry driver must be attached before start",
+                )
+            })?;
+        if self.replay_on_start {
+            let packet = {
+                let state = self.state.lock().map_err(|_| {
+                    compute_host_error(
+                        "ComputeTelemetryDriver",
+                        "compute host state lock is poisoned while starting telemetry",
+                    )
+                })?;
+                state.require_ready("ComputeTelemetryDriver")?;
+                RuntimeHostInput::new(telemetry_updates_from_values(
+                    &self.base_uri,
+                    &state.backend,
+                    *state.turns.borrow(),
+                    *state.dispatch_ms.borrow(),
+                    *state.fault_count.borrow(),
+                    &state.last_fault.borrow(),
+                    &state.sample_requests,
+                    &state.sampled_outputs,
+                )?)?
+            };
+            // A resumed level-valued host may already be ahead of the last
+            // snapshot accepted by the replacement runtime. Publish that state
+            // as an explicit ingress packet instead of forcing the coordinator
+            // to synthesize absent fields from a future provider read.
+            ingress.submit_latest(packet)?;
         }
         self.live.store(true, Ordering::SeqCst);
         Ok(())
@@ -2047,6 +2078,56 @@ mod tests {
         assert_eq!(resumed.last_submitted_turn, Some(120));
         drop(installation);
         assert!(snapshot.snapshot().unwrap().is_none());
+    }
+
+    #[test]
+    fn telemetry_start_replays_the_resumed_level_snapshot() {
+        let state = provider_state(
+            ComputeHostPhase::Ready {
+                last_submitted_turn: Some(ComputeTurnToken(120)),
+            },
+            Arc::new(Mutex::new(Vec::new())),
+        );
+        *state.lock().unwrap().turns.borrow_mut() = 120.0;
+        let runtime = RuntimeBuilder::new().build().unwrap();
+        let mut driver = ComputeTelemetryDriver {
+            base_uri: "compute://particles/kernel".to_owned(),
+            ingress: Arc::new(Mutex::new(None)),
+            live: Arc::new(AtomicBool::new(false)),
+            state,
+            replay_on_start: true,
+            sample_outputs: BTreeSet::new(),
+        };
+
+        driver.attach(runtime.ingress()).unwrap();
+        assert_eq!(runtime.pending_host_input_count().unwrap(), 0);
+        driver.start().unwrap();
+        assert_eq!(runtime.pending_host_input_count().unwrap(), 1);
+        assert!(driver.is_live());
+    }
+
+    #[test]
+    fn telemetry_start_does_not_inject_a_fresh_host_turn() {
+        let state = provider_state(
+            ComputeHostPhase::Ready {
+                last_submitted_turn: None,
+            },
+            Arc::new(Mutex::new(Vec::new())),
+        );
+        let runtime = RuntimeBuilder::new().build().unwrap();
+        let mut driver = ComputeTelemetryDriver {
+            base_uri: "compute://particles/kernel".to_owned(),
+            ingress: Arc::new(Mutex::new(None)),
+            live: Arc::new(AtomicBool::new(false)),
+            state,
+            replay_on_start: false,
+            sample_outputs: BTreeSet::new(),
+        };
+
+        driver.attach(runtime.ingress()).unwrap();
+        driver.start().unwrap();
+        assert_eq!(runtime.pending_host_input_count().unwrap(), 0);
+        assert!(driver.is_live());
     }
 
     #[test]

--- a/hosts/gpu/src/compute_provider.rs
+++ b/hosts/gpu/src/compute_provider.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::{BTreeMap, BTreeSet},
     num::NonZeroU32,
     sync::{
         Arc, Mutex,
@@ -8,8 +9,8 @@ use std::{
 
 use mech_compute::{
     BackendRequest, ComputeBackendRegistry, ComputeDispatchReport, ComputeInitializerSet,
-    ComputeInputUpdate, ComputePlatform, ComputePort, ComputeProgram, ComputeSession, ComputeValue,
-    TensorLayout,
+    ComputeInputUpdate, ComputeOutputSelection, ComputeOutputSnapshot, ComputePlatform,
+    ComputePort, ComputeProgram, ComputeSession, ComputeValue, TensorLayout,
 };
 use mech_core::{
     ComputePlacement, LegacyValue, MResult, MechError, MechErrorKind, OperationContractDeclaration,
@@ -195,12 +196,23 @@ impl RuntimeHostFactory for ComputeHostFactory {
         let telemetry = Arc::new(Mutex::new(None));
         let live = Arc::new(AtomicBool::new(false));
         let base_uri = format!("compute://{instance_name}/kernel");
+        let sample_requests = self
+            .program
+            .interface()
+            .outputs
+            .iter()
+            .map(|port| port.name.to_string())
+            .collect();
         let state = Arc::new(Mutex::new(ComputeHostState {
             backend: backend_id.to_string(),
+            program: Arc::clone(&self.program),
             turns: Ref::new(0.0),
             dispatch_ms: Ref::new(0.0),
             fault_count: Ref::new(0.0),
             last_fault: Ref::new(String::new()),
+            sampled_outputs: initial_sampled_outputs(&self.program)?,
+            sample_requests,
+            last_turn: None,
             session,
         }));
         let installation = RuntimeHostInstallation {
@@ -216,6 +228,13 @@ impl RuntimeHostFactory for ComputeHostFactory {
                 base_uri,
                 ingress: telemetry,
                 live,
+                sample_outputs: self
+                    .program
+                    .interface()
+                    .outputs
+                    .iter()
+                    .map(|port| port.name.to_string())
+                    .collect(),
             })],
         };
         *installed = Some(instance_name.to_owned());
@@ -225,10 +244,14 @@ impl RuntimeHostFactory for ComputeHostFactory {
 
 struct ComputeHostState {
     backend: String,
+    program: Arc<ComputeProgram>,
     turns: Ref<f64>,
     dispatch_ms: Ref<f64>,
     fault_count: Ref<f64>,
     last_fault: Ref<String>,
+    sampled_outputs: BTreeMap<String, LegacyValue>,
+    sample_requests: BTreeSet<String>,
+    last_turn: Option<RuntimeHostInputValue>,
     session: Box<dyn ComputeSession>,
 }
 
@@ -237,10 +260,12 @@ impl std::fmt::Debug for ComputeHostState {
         formatter
             .debug_struct("ComputeHostState")
             .field("backend", &self.backend)
+            .field("program", &self.program)
             .field("turns", &self.turns)
             .field("dispatch_ms", &self.dispatch_ms)
             .field("fault_count", &self.fault_count)
             .field("last_fault", &self.last_fault)
+            .field("sample_requests", &self.sample_requests)
             .field("session", &"<dyn ComputeSession>")
             .finish()
     }
@@ -267,7 +292,39 @@ impl ComputeResourceProvider {
             .flatten()
     }
 
+    fn declared_sample_output(&self, path: &str) -> Option<&ComputePort> {
+        let name = path.strip_prefix("sample/")?;
+        (!name.is_empty())
+            .then(|| {
+                self.program
+                    .interface()
+                    .outputs
+                    .iter()
+                    .find(|port| port.name.as_ref() == name)
+            })
+            .flatten()
+    }
+
     fn telemetry_value(&self, path: &str, planning: bool) -> MResult<LegacyValue> {
+        if let Some(port) = self.declared_sample_output(path) {
+            if planning {
+                return zero_sample_value(port);
+            }
+            let mut state = self.state.lock().map_err(|_| {
+                compute_host_error("ComputeHostRead", "compute host state lock is poisoned")
+            })?;
+            state.sample_requests.insert(port.name.to_string());
+            return state
+                .sampled_outputs
+                .get(port.name.as_ref())
+                .ok_or_else(|| {
+                    compute_host_error(
+                        "ComputeHostRead",
+                        format!("sampled output `{}` was not initialized", port.name),
+                    )
+                })?
+                .try_deep_snapshot();
+        }
         if planning {
             return match path {
                 "backend" | "last-fault" => {
@@ -362,7 +419,9 @@ impl RuntimeResourceProvider for ComputeResourceProvider {
             intent: request.intent,
         })?;
         if let Some(port) = self.declared_input(&request.path) {
-            compute_input_update(port, request.value.try_deep_snapshot()?)?;
+            compute_input_update(&self.program, port, request.value.try_deep_snapshot()?)?;
+        } else {
+            compute_turn_token(&request.value)?;
         }
         Ok(())
     }
@@ -379,7 +438,8 @@ impl RuntimeResourceProvider for ComputeResourceProvider {
             intent: request.intent,
         })?;
         if let Some(port) = self.declared_input(&request.path) {
-            let update = compute_input_update(port, request.value.try_deep_snapshot()?)?;
+            let update =
+                compute_input_update(&self.program, port, request.value.try_deep_snapshot()?)?;
             return Ok(PreparedRuntimeEffect::AfterCommit(Box::new(
                 ComputeInputEffect {
                     resource: request.base_uri,
@@ -389,10 +449,12 @@ impl RuntimeResourceProvider for ComputeResourceProvider {
                 },
             )));
         }
+        let turn = compute_turn_token(&request.value)?;
         Ok(PreparedRuntimeEffect::AfterCommit(Box::new(
             ComputeDispatchEffect {
                 resource: request.base_uri,
                 region: self.region.clone(),
+                turn,
                 state: Arc::clone(&self.state),
                 telemetry: Arc::clone(&self.telemetry),
             },
@@ -453,6 +515,7 @@ impl RuntimeAfterCommitEffect for ComputeInputEffect {
 struct ComputeDispatchEffect {
     resource: String,
     region: Box<str>,
+    turn: RuntimeHostInputValue,
     state: Arc<Mutex<ComputeHostState>>,
     telemetry: Arc<Mutex<Option<RuntimeIngress>>>,
 }
@@ -473,10 +536,29 @@ impl RuntimeAfterCommitEffect for ComputeDispatchEffect {
         let mut state = self.state.lock().map_err(|_| {
             compute_host_error("ComputeHostDispatch", "compute host state lock is poisoned")
         })?;
+        if state.last_turn.as_ref() == Some(&self.turn) {
+            return Ok(());
+        }
         let report = state
             .session
             .dispatch(NonZeroU32::new(1).expect("one is nonzero"))
             .map_err(|error| compute_host_error("ComputeHostDispatch", error.to_string()))?;
+        state.last_turn = Some(self.turn.clone());
+        if report.completed_turns > 0 && !state.sample_requests.is_empty() {
+            let selected = state
+                .program
+                .interface()
+                .outputs
+                .iter()
+                .filter(|port| state.sample_requests.contains(port.name.as_ref()))
+                .map(|port| port.id)
+                .collect();
+            let snapshot = state
+                .session
+                .read_outputs(&ComputeOutputSelection::Ports(selected))
+                .map_err(|error| compute_host_error("ComputeHostRead", error.to_string()))?;
+            update_sampled_outputs(&mut state, snapshot)?;
+        }
         apply_report(&mut state, &report);
         let updates = telemetry_updates(&self.resource, &state)?;
         drop(state);
@@ -513,7 +595,7 @@ fn telemetry_updates(
     resource: &str,
     state: &ComputeHostState,
 ) -> MResult<Vec<RuntimeHostInputUpdate>> {
-    Ok(vec![
+    let mut updates = vec![
         telemetry_update(
             resource,
             "backend",
@@ -539,7 +621,20 @@ fn telemetry_updates(
             "last-fault",
             RuntimeHostInputValue::String(state.last_fault.borrow().clone()),
         )?,
-    ])
+    ];
+    for name in &state.sample_requests {
+        let value = state.sampled_outputs.get(name).ok_or_else(|| {
+            compute_host_error(
+                "ComputeHostRead",
+                format!("requested sampled output `{name}` has no retained value"),
+            )
+        })?;
+        updates.push(RuntimeHostInputUpdate {
+            source: RuntimeHostInputSource::new(resource, format!("sample/{name}"))?,
+            value: RuntimeHostInputValue::from_numeric_mech_value(value)?,
+        });
+    }
+    Ok(updates)
 }
 
 fn telemetry_update(
@@ -558,15 +653,19 @@ struct ComputeTelemetryDriver {
     base_uri: String,
     ingress: Arc<Mutex<Option<RuntimeIngress>>>,
     live: Arc<AtomicBool>,
+    sample_outputs: BTreeSet<String>,
 }
 
 impl RuntimeHostInputDriver for ComputeTelemetryDriver {
     fn drives(&self, source: &RuntimeHostInputSource) -> bool {
         source.base_uri() == self.base_uri
-            && matches!(
+            && (matches!(
                 source.path(),
                 "backend" | "turns" | "dispatch-ms" | "fault-count" | "last-fault"
-            )
+            ) || source
+                .path()
+                .strip_prefix("sample/")
+                .is_some_and(|name| self.sample_outputs.contains(name)))
     }
 
     fn attach(&mut self, ingress: RuntimeIngress) -> MResult<()> {
@@ -628,6 +727,10 @@ pub fn compute_host_manifest() -> HostManifestConfig {
     }
 }
 
+pub fn validate_compute_host_settings(settings: &ConfigValue) -> MResult<()> {
+    configured_compute_settings(settings).map(|_| ())
+}
+
 struct ConfiguredComputeSettings {
     region: String,
     backend: BackendRequest,
@@ -681,10 +784,17 @@ fn configured_compute_settings(settings: &ConfigValue) -> MResult<ConfiguredComp
     })
 }
 
-fn compute_input_update(port: &ComputePort, value: LegacyValue) -> MResult<ComputeInputUpdate> {
+fn compute_input_update(
+    program: &ComputeProgram,
+    port: &ComputePort,
+    value: LegacyValue,
+) -> MResult<ComputeInputUpdate> {
     let detached = RuntimeHostInputValue::from_numeric_mech_value(&value)?;
     let value = match detached {
         RuntimeHostInputValue::F32(value) => ComputeValue::ScalarF32(value),
+        RuntimeHostInputValue::F64(value) => {
+            ComputeValue::ScalarF32(narrow_f64_input(port.name.as_ref(), value)?)
+        }
         RuntimeHostInputValue::F32Matrix {
             rows,
             columns,
@@ -693,6 +803,19 @@ fn compute_input_update(port: &ComputePort, value: LegacyValue) -> MResult<Compu
             dimensions: vec![rows as u64, columns as u64].into_boxed_slice(),
             layout: TensorLayout::ColumnMajor,
             values: Arc::from(values),
+        },
+        RuntimeHostInputValue::F64Matrix {
+            rows,
+            columns,
+            values,
+        } => ComputeValue::TensorF32 {
+            dimensions: vec![rows as u64, columns as u64].into_boxed_slice(),
+            layout: TensorLayout::ColumnMajor,
+            values: values
+                .into_iter()
+                .map(|value| narrow_f64_input(port.name.as_ref(), value))
+                .collect::<MResult<Vec<_>>>()?
+                .into(),
         },
         other => {
             return Err(compute_host_error(
@@ -704,16 +827,49 @@ fn compute_input_update(port: &ComputePort, value: LegacyValue) -> MResult<Compu
             ));
         }
     };
-    let value = port.normalize_value(value).map_err(|error| {
-        compute_host_error(
+    let update = program
+        .normalize_input_update(ComputeInputUpdate {
+            port: port.id,
+            value,
+        })
+        .map_err(|error| {
+            compute_host_error(
+                "ComputeHostWrite",
+                format!("compute input `{}` is invalid: {error}", port.name),
+            )
+        })?;
+    Ok(update)
+}
+
+fn compute_turn_token(value: &LegacyValue) -> MResult<RuntimeHostInputValue> {
+    let token = RuntimeHostInputValue::from_numeric_mech_value(value)?;
+    match token {
+        RuntimeHostInputValue::F32(value) if value.is_finite() => {
+            Ok(RuntimeHostInputValue::F32(value))
+        }
+        RuntimeHostInputValue::F64(value) if value.is_finite() => {
+            Ok(RuntimeHostInputValue::F64(value))
+        }
+        RuntimeHostInputValue::F32(_) | RuntimeHostInputValue::F64(_) => Err(compute_host_error(
             "ComputeHostWrite",
-            format!("compute input `{}` is invalid: {error}", port.name),
-        )
-    })?;
-    Ok(ComputeInputUpdate {
-        port: port.id,
-        value,
-    })
+            "compute turn token must be finite",
+        )),
+        other => Err(compute_host_error(
+            "ComputeHostWrite",
+            format!("compute turn token must be a scalar number, found `{other:?}`"),
+        )),
+    }
+}
+
+fn narrow_f64_input(port: &str, value: f64) -> MResult<f32> {
+    let narrowed = value as f32;
+    if value.is_finite() && !narrowed.is_finite() {
+        return Err(compute_host_error(
+            "ComputeHostWrite",
+            format!("compute input `{port}` contains f64 value {value} outside the f32 range"),
+        ));
+    }
+    Ok(narrowed)
 }
 
 fn compute_value_elements(value: &ComputeValue) -> u64 {
@@ -721,6 +877,217 @@ fn compute_value_elements(value: &ComputeValue) -> u64 {
         ComputeValue::ScalarF32(_) => 1,
         ComputeValue::TensorF32 { values, .. } => u64::try_from(values.len()).unwrap_or(u64::MAX),
     }
+}
+
+fn initial_sampled_outputs(program: &ComputeProgram) -> MResult<BTreeMap<String, LegacyValue>> {
+    program
+        .interface()
+        .outputs
+        .iter()
+        .map(|port| {
+            let value = program
+                .fixed_shape_storage()
+                .and_then(|storage| storage.states.iter().find(|state| state.slot == port.slot))
+                .map(|state| ComputeValue::TensorF32 {
+                    dimensions: port.dimensions.clone(),
+                    layout: TensorLayout::ColumnMajor,
+                    values: Arc::clone(&state.initializer),
+                })
+                .or_else(|| {
+                    program.elementwise_storage().and_then(|storage| {
+                        storage
+                            .states
+                            .iter()
+                            .find(|state| state.slot == port.slot)
+                            .map(|state| ComputeValue::TensorF32 {
+                                dimensions: port.dimensions.clone(),
+                                layout: TensorLayout::RowMajor,
+                                values: Arc::clone(&state.initializer),
+                            })
+                    })
+                });
+            Ok((
+                port.name.to_string(),
+                match value {
+                    Some(ComputeValue::TensorF32 { values, .. })
+                        if port.dimensions.is_empty() && values.len() == 1 =>
+                    {
+                        sampled_output_value(port, ComputeValue::ScalarF32(values[0]))?
+                    }
+                    Some(value) => sampled_output_value(port, value)?,
+                    None => zero_sample_value(port)?,
+                },
+            ))
+        })
+        .collect()
+}
+
+fn zero_sample_value(port: &ComputePort) -> MResult<LegacyValue> {
+    let elements = port.elements().map_err(|error| {
+        compute_host_error(
+            "ComputeHostConfiguration",
+            format!(
+                "compute output `{}` has an invalid shape: {error}",
+                port.name
+            ),
+        )
+    })?;
+    sampled_output_value(
+        port,
+        if port.dimensions.is_empty() {
+            ComputeValue::ScalarF32(0.0)
+        } else {
+            ComputeValue::TensorF32 {
+                dimensions: port.dimensions.clone(),
+                layout: TensorLayout::RowMajor,
+                values: vec![0.0; elements].into(),
+            }
+        },
+    )
+}
+
+fn update_sampled_outputs(
+    state: &mut ComputeHostState,
+    snapshot: ComputeOutputSnapshot,
+) -> MResult<()> {
+    let ports = state
+        .program
+        .interface()
+        .outputs
+        .iter()
+        .filter(|port| state.sample_requests.contains(port.name.as_ref()))
+        .cloned()
+        .collect::<Vec<_>>();
+    for port in ports {
+        let value = snapshot.values.get(&port.id).ok_or_else(|| {
+            compute_host_error(
+                "ComputeHostRead",
+                format!("backend omitted sampled output `{}`", port.name),
+            )
+        })?;
+        state.sampled_outputs.insert(
+            port.name.to_string(),
+            sampled_output_value(&port, value.clone())?,
+        );
+    }
+    Ok(())
+}
+
+fn sampled_output_value(port: &ComputePort, value: ComputeValue) -> MResult<LegacyValue> {
+    let inner_elements = port.elements().map_err(|error| {
+        compute_host_error(
+            "ComputeHostRead",
+            format!(
+                "compute output `{}` has an invalid shape: {error}",
+                port.name
+            ),
+        )
+    })?;
+    let row_major = match value {
+        ComputeValue::ScalarF32(value) if port.dimensions.is_empty() => vec![value],
+        ComputeValue::TensorF32 {
+            dimensions,
+            layout: TensorLayout::RowMajor,
+            values,
+        } => {
+            let inner_shape = port.dimensions.as_ref();
+            let expected_elements = if dimensions.as_ref() == inner_shape {
+                Some(inner_elements)
+            } else if dimensions.len() == inner_shape.len() + 1 && dimensions[1..] == *inner_shape {
+                usize::try_from(dimensions[0])
+                    .ok()
+                    .and_then(|instances| instances.checked_mul(inner_elements))
+            } else {
+                None
+            };
+            if expected_elements != Some(values.len()) || values.len() < inner_elements {
+                return Err(compute_host_error(
+                    "ComputeHostRead",
+                    format!(
+                        "sampled output `{}` returned shape {:?} with {} elements; expected one or more {:?} values",
+                        port.name,
+                        dimensions,
+                        values.len(),
+                        inner_shape,
+                    ),
+                ));
+            }
+            values[..inner_elements].to_vec()
+        }
+        ComputeValue::TensorF32 {
+            dimensions,
+            layout: TensorLayout::ColumnMajor,
+            values,
+        } if dimensions.as_ref() == port.dimensions.as_ref() => {
+            column_major_sample_to_row_major(&port.dimensions, values.as_ref())?
+        }
+        other => {
+            return Err(compute_host_error(
+                "ComputeHostRead",
+                format!(
+                    "sampled output `{}` does not match its inner {:?} contract: {other:?}",
+                    port.name, port.dimensions,
+                ),
+            ));
+        }
+    };
+    let row_major = row_major.into_iter().map(f64::from).collect::<Vec<_>>();
+    let detached = match port.dimensions.as_ref() {
+        [] => RuntimeHostInputValue::F64(row_major[0]),
+        [columns] => RuntimeHostInputValue::F64Matrix {
+            rows: 1,
+            columns: *columns as usize,
+            values: row_major,
+        },
+        [rows, columns] => RuntimeHostInputValue::F64Matrix {
+            rows: *rows as usize,
+            columns: *columns as usize,
+            values: row_major_sample_to_column_major_f64(
+                *rows as usize,
+                *columns as usize,
+                &row_major,
+            ),
+        },
+        dimensions => {
+            return Err(compute_host_error(
+                "ComputeHostRead",
+                format!(
+                    "sampled output `{}` has unsupported rank {}",
+                    port.name,
+                    dimensions.len(),
+                ),
+            ));
+        }
+    };
+    detached.into_mech_value()
+}
+
+fn column_major_sample_to_row_major(dimensions: &[u64], values: &[f32]) -> MResult<Vec<f32>> {
+    let rows = dimensions.first().copied().unwrap_or(1) as usize;
+    let columns = dimensions.get(1).copied().unwrap_or(1) as usize;
+    if values.len() != rows.saturating_mul(columns) {
+        return Err(compute_host_error(
+            "ComputeHostRead",
+            "sampled column-major output has the wrong element count",
+        ));
+    }
+    let mut row_major = vec![0.0; values.len()];
+    for row in 0..rows {
+        for column in 0..columns {
+            row_major[row * columns + column] = values[row + column * rows];
+        }
+    }
+    Ok(row_major)
+}
+
+fn row_major_sample_to_column_major_f64(rows: usize, columns: usize, values: &[f64]) -> Vec<f64> {
+    let mut column_major = vec![0.0; values.len()];
+    for row in 0..rows {
+        for column in 0..columns {
+            column_major[row + column * rows] = values[row * columns + column];
+        }
+    }
+    column_major
 }
 
 #[derive(Clone, Debug)]
@@ -970,12 +1337,16 @@ mod tests {
     }
 
     fn turn_write() -> RuntimeResourceWriteRequest {
+        turn_write_with(1.0)
+    }
+
+    fn turn_write_with(value: f32) -> RuntimeResourceWriteRequest {
         RuntimeResourceWriteRequest {
             base_uri: "compute://particles/kernel".to_owned(),
             path: "turn".to_owned(),
             context_name: "particles".to_owned(),
             operation: RuntimeCapabilityOperation::Write,
-            value: LegacyValue::from(1.0_f32),
+            value: LegacyValue::from(value),
             intent: RuntimeResourceWriteIntent::Send,
         }
     }
@@ -1001,7 +1372,7 @@ mod tests {
         }
         .into_mech_value()
         .unwrap();
-        let update = compute_input_update(port, valid).unwrap();
+        let update = compute_input_update(&program, port, valid).unwrap();
         let ComputeValue::TensorF32 { layout, values, .. } = update.value else {
             panic!("matrix became a scalar")
         };
@@ -1015,7 +1386,65 @@ mod tests {
         }
         .into_mech_value()
         .unwrap();
-        assert!(compute_input_update(port, wrong_shape).is_err());
+        assert!(compute_input_update(&program, port, wrong_shape).is_err());
+    }
+
+    #[test]
+    fn f64_resident_inputs_narrow_once_at_the_f32_compute_boundary() {
+        let program = program();
+        let port = &program.interface().inputs[0];
+        let value = RuntimeHostInputValue::F64Matrix {
+            rows: 2,
+            columns: 3,
+            values: vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0],
+        }
+        .into_mech_value()
+        .unwrap();
+        let update = compute_input_update(&program, port, value).unwrap();
+        let ComputeValue::TensorF32 { layout, values, .. } = update.value else {
+            panic!("f64 matrix became a scalar")
+        };
+        assert_eq!(layout, TensorLayout::RowMajor);
+        assert_eq!(values.as_ref(), [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+        let overflow = RuntimeHostInputValue::F64Matrix {
+            rows: 2,
+            columns: 3,
+            values: vec![f64::MAX; 6],
+        }
+        .into_mech_value()
+        .unwrap();
+        let error = compute_input_update(&program, port, overflow).unwrap_err();
+        assert!(error.display_message().contains("outside the f32 range"));
+    }
+
+    #[test]
+    fn sampled_batch_returns_lane_zero_as_a_resident_f64_matrix() {
+        let port = ComputePort {
+            id: mech_compute::ComputePortId::new(1),
+            name: "matrix".into(),
+            slot: CellSlotId::new(1),
+            schema: SchemaId::new(1),
+            element: mech_compute::ComputeElementType::F32,
+            dimensions: vec![2, 2].into_boxed_slice(),
+        };
+        let sampled = sampled_output_value(
+            &port,
+            ComputeValue::TensorF32 {
+                dimensions: vec![2, 2, 2].into_boxed_slice(),
+                layout: TensorLayout::RowMajor,
+                values: Arc::from([1.0, 2.0, 3.0, 4.0, 10.0, 20.0, 30.0, 40.0]),
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            RuntimeHostInputValue::from_numeric_mech_value(&sampled).unwrap(),
+            RuntimeHostInputValue::F64Matrix {
+                rows: 2,
+                columns: 2,
+                values: vec![1.0, 3.0, 2.0, 4.0],
+            },
+        );
     }
 
     #[test]
@@ -1094,6 +1523,16 @@ mod tests {
         assert_eq!(values.as_ref(), [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
         assert_eq!(observed[1], FakeCall::Dispatch(1));
         assert_eq!(runtime.pending_host_input_count().unwrap(), 1);
+
+        runtime.write_resource(turn_write()).unwrap();
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            observed.as_slice(),
+            "repeating a compute turn token must not create a feedback dispatch",
+        );
+        runtime.write_resource(turn_write_with(2.0)).unwrap();
+        assert_eq!(calls.lock().unwrap().last(), Some(&FakeCall::Dispatch(1)));
+        assert_eq!(calls.lock().unwrap().len(), 3);
     }
 
     #[test]

--- a/hosts/gpu/src/compute_provider.rs
+++ b/hosts/gpu/src/compute_provider.rs
@@ -39,6 +39,8 @@ pub struct ComputeHostFactory {
     platform: ComputePlatform,
     backend_override: Option<BackendRequest>,
     installed_instance: Mutex<Option<String>>,
+    state_snapshot: ComputeHostStateSnapshotHandle,
+    resume_state: Option<ComputeHostResumeState>,
     manifest: HostManifestConfig,
 }
 
@@ -80,12 +82,23 @@ impl ComputeHostFactory {
             platform,
             backend_override: None,
             installed_instance: Mutex::new(None),
+            state_snapshot: ComputeHostStateSnapshotHandle::default(),
+            resume_state: None,
             manifest: compute_host_manifest(),
         })
     }
 
     pub fn with_backend_override(mut self, request: BackendRequest) -> Self {
         self.backend_override = Some(request);
+        self
+    }
+
+    pub fn state_snapshot_handle(&self) -> ComputeHostStateSnapshotHandle {
+        self.state_snapshot.clone()
+    }
+
+    pub fn with_resume_state(mut self, state: ComputeHostResumeState) -> Self {
+        self.resume_state = Some(state);
         self
     }
 
@@ -197,20 +210,34 @@ impl RuntimeHostFactory for ComputeHostFactory {
         let telemetry = Arc::new(Mutex::new(None));
         let live = Arc::new(AtomicBool::new(false));
         let base_uri = format!("compute://{instance_name}/kernel");
+        let resume = self.resume_state.as_ref();
         let state = Arc::new(Mutex::new(ComputeHostState {
             backend: backend_id.to_string(),
             program: Arc::clone(&self.program),
-            turns: Ref::new(0.0),
-            dispatch_ms: Ref::new(0.0),
-            fault_count: Ref::new(0.0),
-            last_fault: Ref::new(String::new()),
-            sampled_outputs: initial_sampled_outputs(&self.program)?,
-            sample_requests: BTreeSet::new(),
+            turns: Ref::new(resume.map_or(0.0, |state| state.turns)),
+            dispatch_ms: Ref::new(resume.map_or(0.0, |state| state.dispatch_ms)),
+            fault_count: Ref::new(resume.map_or(0.0, |state| state.fault_count)),
+            last_fault: Ref::new(resume.map_or_else(String::new, |state| state.last_fault.clone())),
+            sampled_outputs: match resume {
+                Some(state) => state.sampled_outputs.clone(),
+                None => initial_sampled_outputs(&self.program)?,
+            },
+            sample_requests: resume
+                .map(|state| state.sample_requests.clone())
+                .unwrap_or_default(),
             phase: ComputeHostPhase::Ready {
-                last_submitted_turn: None,
+                last_submitted_turn: resume
+                    .and_then(|state| state.last_submitted_turn)
+                    .map(ComputeTurnToken),
             },
             session,
         }));
+        *self.state_snapshot.state.lock().map_err(|_| {
+            compute_host_error(
+                "ComputeBackendInitialize",
+                "compute host snapshot handle lock is poisoned",
+            )
+        })? = Some(Arc::downgrade(&state));
         let completion_target = Arc::new(ComputeHostCompletionTarget {
             backend: backend_id.clone(),
             resource: base_uri.clone(),
@@ -260,6 +287,83 @@ impl RuntimeHostFactory for ComputeHostFactory {
         };
         *installed = Some(instance_name.to_owned());
         Ok(installation)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ComputeHostResumeState {
+    turns: f64,
+    dispatch_ms: f64,
+    fault_count: f64,
+    last_fault: String,
+    sampled_outputs: BTreeMap<String, LegacyValue>,
+    sample_requests: BTreeSet<String>,
+    last_submitted_turn: Option<u128>,
+}
+
+#[derive(Clone, Default)]
+pub struct ComputeHostStateSnapshotHandle {
+    state: Arc<Mutex<Option<Weak<Mutex<ComputeHostState>>>>>,
+}
+
+impl std::fmt::Debug for ComputeHostStateSnapshotHandle {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ComputeHostStateSnapshotHandle")
+            .finish_non_exhaustive()
+    }
+}
+
+impl ComputeHostStateSnapshotHandle {
+    pub fn snapshot(&self) -> MResult<Option<ComputeHostResumeState>> {
+        let state = self
+            .state
+            .lock()
+            .map_err(|_| {
+                compute_host_error(
+                    "ComputeHostSnapshot",
+                    "compute host snapshot handle lock is poisoned",
+                )
+            })?
+            .as_ref()
+            .and_then(Weak::upgrade);
+        let Some(state) = state else {
+            return Ok(None);
+        };
+        let state = state.lock().map_err(|_| {
+            compute_host_error("ComputeHostSnapshot", "compute host state lock is poisoned")
+        })?;
+        let last_submitted_turn = match &state.phase {
+            ComputeHostPhase::Ready {
+                last_submitted_turn,
+            } => last_submitted_turn.map(|turn| turn.0),
+            ComputeHostPhase::InFlight { turn } => {
+                return Err(compute_host_error(
+                    "ComputeHostSnapshot",
+                    format!("compute turn {} is still in flight", turn.0),
+                ));
+            }
+            ComputeHostPhase::Failed { reason } => {
+                return Err(compute_host_error(
+                    "ComputeHostSnapshot",
+                    format!("compute host is terminal: {reason}"),
+                ));
+            }
+        };
+        let sampled_outputs = state
+            .sampled_outputs
+            .iter()
+            .map(|(name, value)| Ok((name.clone(), value.try_deep_snapshot()?)))
+            .collect::<MResult<_>>()?;
+        Ok(Some(ComputeHostResumeState {
+            turns: *state.turns.borrow(),
+            dispatch_ms: *state.dispatch_ms.borrow(),
+            fault_count: *state.fault_count.borrow(),
+            last_fault: state.last_fault.borrow().clone(),
+            sampled_outputs,
+            sample_requests: state.sample_requests.clone(),
+            last_submitted_turn,
+        }))
     }
 }
 
@@ -1910,6 +2014,54 @@ mod tests {
         factory.instantiate("particles", &settings()).unwrap();
         let error = factory.instantiate("second", &settings()).unwrap_err();
         assert_eq!(error.kind_name(), "MultipleComputeHostsUnsupported");
+    }
+
+    #[test]
+    fn compatible_factory_resumes_completed_host_turn_state() {
+        let resume = ComputeHostResumeState {
+            turns: 120.0,
+            dispatch_ms: 3.25,
+            fault_count: 2.0,
+            last_fault: "retained diagnostic".to_owned(),
+            sampled_outputs: BTreeMap::new(),
+            sample_requests: BTreeSet::new(),
+            last_submitted_turn: Some(120),
+        };
+        let factory = ComputeHostFactory::new(
+            "particle-field",
+            ComputePlacement::Compute,
+            program(),
+            ComputeInitializerSet::default(),
+            registry(),
+            ComputePlatform::Native,
+        )
+        .unwrap()
+        .with_resume_state(resume);
+        let snapshot = factory.state_snapshot_handle();
+        let installation = factory.instantiate("particles", &settings()).unwrap();
+        let resumed = snapshot.snapshot().unwrap().unwrap();
+        assert_eq!(resumed.turns, 120.0);
+        assert_eq!(resumed.dispatch_ms, 3.25);
+        assert_eq!(resumed.fault_count, 2.0);
+        assert_eq!(resumed.last_fault, "retained diagnostic");
+        assert_eq!(resumed.last_submitted_turn, Some(120));
+        drop(installation);
+        assert!(snapshot.snapshot().unwrap().is_none());
+    }
+
+    #[test]
+    fn in_flight_host_state_cannot_be_snapshotted_for_replacement() {
+        let state = provider_state(
+            ComputeHostPhase::InFlight {
+                turn: ComputeTurnToken(121),
+            },
+            Arc::new(Mutex::new(Vec::new())),
+        );
+        let snapshot = ComputeHostStateSnapshotHandle::default();
+        *snapshot.state.lock().unwrap() = Some(Arc::downgrade(&state));
+        let error = snapshot.snapshot().unwrap_err();
+        assert_eq!(error.kind_name(), "ComputeHostSnapshot");
+        assert!(error.display_message().contains("121 is still in flight"));
     }
 
     #[test]

--- a/hosts/gpu/src/compute_provider.rs
+++ b/hosts/gpu/src/compute_provider.rs
@@ -212,6 +212,21 @@ impl RuntimeHostFactory for ComputeHostFactory {
         let base_uri = format!("compute://{instance_name}/kernel");
         let resume = self.resume_state.as_ref();
         let replay_on_start = resume.is_some();
+        // A compute output is a level-valued resource, not an edge subscription.
+        // Keep one lane-zero sample of every declared output current so a
+        // compatible outer-program replacement can begin observing any output
+        // without mixing the current turn counter with an initializer value.
+        let level_outputs = self
+            .program
+            .interface()
+            .outputs
+            .iter()
+            .map(|port| port.name.to_string())
+            .collect();
+        let mut sampled_outputs = initial_sampled_outputs(&self.program)?;
+        if let Some(resume) = resume {
+            sampled_outputs.extend(resume.sampled_outputs.clone());
+        }
         let state = Arc::new(Mutex::new(ComputeHostState {
             backend: backend_id.to_string(),
             program: Arc::clone(&self.program),
@@ -219,13 +234,9 @@ impl RuntimeHostFactory for ComputeHostFactory {
             dispatch_ms: Ref::new(resume.map_or(0.0, |state| state.dispatch_ms)),
             fault_count: Ref::new(resume.map_or(0.0, |state| state.fault_count)),
             last_fault: Ref::new(resume.map_or_else(String::new, |state| state.last_fault.clone())),
-            sampled_outputs: match resume {
-                Some(state) => state.sampled_outputs.clone(),
-                None => initial_sampled_outputs(&self.program)?,
-            },
-            sample_requests: resume
-                .map(|state| state.sample_requests.clone())
-                .unwrap_or_default(),
+            sampled_outputs,
+            sample_requests: BTreeSet::new(),
+            level_outputs,
             phase: ComputeHostPhase::Ready {
                 last_submitted_turn: resume
                     .and_then(|state| state.last_submitted_turn)
@@ -300,7 +311,6 @@ pub struct ComputeHostResumeState {
     fault_count: f64,
     last_fault: String,
     sampled_outputs: BTreeMap<String, LegacyValue>,
-    sample_requests: BTreeSet<String>,
     last_submitted_turn: Option<u128>,
 }
 
@@ -364,7 +374,6 @@ impl ComputeHostStateSnapshotHandle {
             fault_count: *state.fault_count.borrow(),
             last_fault: state.last_fault.borrow().clone(),
             sampled_outputs,
-            sample_requests: state.sample_requests.clone(),
             last_submitted_turn,
         }))
     }
@@ -379,6 +388,7 @@ struct ComputeHostState {
     last_fault: Ref<String>,
     sampled_outputs: BTreeMap<String, LegacyValue>,
     sample_requests: BTreeSet<String>,
+    level_outputs: BTreeSet<String>,
     phase: ComputeHostPhase,
     session: Box<dyn ComputeSession>,
 }
@@ -619,6 +629,7 @@ impl std::fmt::Debug for ComputeHostState {
             .field("fault_count", &self.fault_count)
             .field("last_fault", &self.last_fault)
             .field("sample_requests", &self.sample_requests)
+            .field("level_outputs", &self.level_outputs)
             .field("phase", &self.phase)
             .field("session", &"<dyn ComputeSession>")
             .finish()
@@ -910,7 +921,7 @@ impl RuntimeAfterCommitEffect for ComputeDispatchEffect {
             .interface()
             .outputs
             .iter()
-            .filter(|port| state.sample_requests.contains(port.name.as_ref()))
+            .filter(|port| state.level_outputs.contains(port.name.as_ref()))
             .map(|port| port.id)
             .collect();
         let request = ComputeDispatchRequest {
@@ -941,13 +952,13 @@ impl RuntimeAfterCommitEffect for ComputeDispatchEffect {
             return Ok(());
         }
         let mut sampled = None;
-        if report.completed_turns > 0 && !state.sample_requests.is_empty() {
+        if report.completed_turns > 0 && !state.level_outputs.is_empty() {
             let selected = state
                 .program
                 .interface()
                 .outputs
                 .iter()
-                .filter(|port| state.sample_requests.contains(port.name.as_ref()))
+                .filter(|port| state.level_outputs.contains(port.name.as_ref()))
                 .map(|port| port.id)
                 .collect();
             let snapshot = match state
@@ -1108,7 +1119,7 @@ fn telemetry_updates_from_values(
         let value = sampled_outputs.get(name).ok_or_else(|| {
             compute_host_error(
                 "ComputeHostRead",
-                format!("requested sampled output `{name}` has no retained value"),
+                format!("level output `{name}` has no retained sample"),
             )
         })?;
         updates.push(RuntimeHostInputUpdate {
@@ -1448,7 +1459,7 @@ fn materialize_sampled_outputs(
         .interface()
         .outputs
         .iter()
-        .filter(|port| state.sample_requests.contains(port.name.as_ref()))
+        .filter(|port| state.level_outputs.contains(port.name.as_ref()))
         .cloned()
         .collect::<Vec<_>>();
     let mut sampled = BTreeMap::new();
@@ -1624,6 +1635,7 @@ mod tests {
     use mech_core::{CellSlotId, SchemaId};
     use mech_runtime::{
         HostInstanceConfig, RunResourceGrantConfig, RuntimeBuilder, RuntimeCapabilityOperation,
+        RuntimeResourceReadRequest,
     };
 
     #[derive(Clone, Debug, PartialEq)]
@@ -1732,6 +1744,25 @@ mod tests {
                     schema: SchemaId::new(0),
                     element: mech_compute::ComputeElementType::F32,
                     dimensions: vec![2, 3].into_boxed_slice(),
+                }]
+                .into_boxed_slice(),
+                ..Default::default()
+            },
+            ComputePhysicalPlan::default(),
+            ComputeKernel::Elementwise(ElementwiseIr::default()),
+        )
+    }
+
+    fn program_with_sample_output() -> ComputeProgram {
+        ComputeProgram::new(
+            ComputeRegionInterface {
+                outputs: vec![ComputePort {
+                    id: mech_compute::ComputePortId::new(1),
+                    name: "result".into(),
+                    slot: CellSlotId::new(1),
+                    schema: SchemaId::new(1),
+                    element: mech_compute::ComputeElementType::F32,
+                    dimensions: Vec::new().into_boxed_slice(),
                 }]
                 .into_boxed_slice(),
                 ..Default::default()
@@ -1913,6 +1944,7 @@ mod tests {
             last_fault: Ref::new(String::new()),
             sampled_outputs: BTreeMap::new(),
             sample_requests: BTreeSet::new(),
+            level_outputs: BTreeSet::new(),
             phase,
             session: Box::new(FakeSession {
                 backend: BackendId::new(CPU_SCALAR_BACKEND).unwrap(),
@@ -2055,7 +2087,6 @@ mod tests {
             fault_count: 2.0,
             last_fault: "retained diagnostic".to_owned(),
             sampled_outputs: BTreeMap::new(),
-            sample_requests: BTreeSet::new(),
             last_submitted_turn: Some(120),
         };
         let factory = ComputeHostFactory::new(
@@ -2078,6 +2109,52 @@ mod tests {
         assert_eq!(resumed.last_submitted_turn, Some(120));
         drop(installation);
         assert!(snapshot.snapshot().unwrap().is_none());
+    }
+
+    #[test]
+    fn compatible_factory_preserves_current_sample_for_every_declared_output() {
+        let current = RuntimeHostInputValue::F32(42.0).into_mech_value().unwrap();
+        let resume = ComputeHostResumeState {
+            turns: 120.0,
+            dispatch_ms: 3.25,
+            fault_count: 2.0,
+            last_fault: "retained diagnostic".to_owned(),
+            sampled_outputs: BTreeMap::from([("result".to_owned(), current)]),
+            last_submitted_turn: Some(120),
+        };
+        let factory = ComputeHostFactory::new(
+            "particle-field",
+            ComputePlacement::Compute,
+            program_with_sample_output(),
+            ComputeInitializerSet::default(),
+            registry(),
+            ComputePlatform::Native,
+        )
+        .unwrap()
+        .with_resume_state(resume);
+        let snapshot = factory.state_snapshot_handle();
+        let installation = factory.instantiate("particles", &settings()).unwrap();
+        let observed = installation.resource_providers[0]
+            .read(RuntimeResourceReadRequest {
+                base_uri: "compute://particles/kernel".to_owned(),
+                path: "sample/result".to_owned(),
+                context_name: "candidate".to_owned(),
+            })
+            .unwrap();
+        let resumed = snapshot.snapshot().unwrap().unwrap();
+
+        assert_eq!(
+            RuntimeHostInputValue::from_numeric_mech_value(&observed).unwrap(),
+            RuntimeHostInputValue::F32(42.0),
+            "a newly demanded candidate output must read the current generation",
+        );
+        assert_eq!(
+            RuntimeHostInputValue::from_numeric_mech_value(
+                resumed.sampled_outputs.get("result").unwrap()
+            )
+            .unwrap(),
+            RuntimeHostInputValue::F32(42.0)
+        );
     }
 
     #[test]

--- a/hosts/gpu/src/compute_provider.rs
+++ b/hosts/gpu/src/compute_provider.rs
@@ -8,10 +8,10 @@ use std::{
 };
 
 use mech_compute::{
-    BackendId, BackendRequest, ComputeBackendRegistry, ComputeCompletionTarget,
-    ComputeDispatchReport, ComputeExecutionError, ComputeInitializerSet, ComputeInputUpdate,
-    ComputeOutputSelection, ComputeOutputSnapshot, ComputePlatform, ComputePort, ComputeProgram,
-    ComputeSession, ComputeValue, TensorLayout,
+    BackendId, BackendRequest, ComputeBackendRegistry, ComputeCompletionOutcome,
+    ComputeCompletionTarget, ComputeDispatchReport, ComputeDispatchRequest, ComputeExecutionError,
+    ComputeInitializerSet, ComputeInputUpdate, ComputeOutputSelection, ComputeOutputSnapshot,
+    ComputePlatform, ComputePort, ComputeProgram, ComputeSession, ComputeValue, TensorLayout,
 };
 use mech_core::{
     ComputePlacement, LegacyValue, MResult, MechError, MechErrorKind, OperationContractDeclaration,
@@ -210,13 +210,22 @@ impl RuntimeHostFactory for ComputeHostFactory {
             terminal_failure: None,
             session,
         }));
-        backend
-            .bind_completion_target(Arc::new(ComputeHostCompletionTarget {
-                backend: backend_id.clone(),
-                resource: base_uri.clone(),
-                state: Arc::downgrade(&state),
-                telemetry: Arc::clone(&telemetry),
-            }))
+        let completion_target = Arc::new(ComputeHostCompletionTarget {
+            backend: backend_id.clone(),
+            resource: base_uri.clone(),
+            state: Arc::downgrade(&state),
+            telemetry: Arc::clone(&telemetry),
+        });
+        state
+            .lock()
+            .map_err(|_| {
+                compute_host_error(
+                    "ComputeBackendInitialize",
+                    "compute host state lock is poisoned",
+                )
+            })?
+            .session
+            .bind_completion_target(completion_target)
             .map_err(|error| {
                 compute_host_error(
                     "ComputeBackendInitialize",
@@ -278,11 +287,7 @@ struct ComputeHostCompletionTarget {
 }
 
 impl ComputeCompletionTarget for ComputeHostCompletionTarget {
-    fn complete(
-        &self,
-        report: ComputeDispatchReport,
-        snapshot: ComputeOutputSnapshot,
-    ) -> Result<(), ComputeExecutionError> {
+    fn complete(&self, outcome: ComputeCompletionOutcome) -> Result<(), ComputeExecutionError> {
         let state = self.state.upgrade().ok_or_else(|| {
             completion_error(&self.backend, "resident compute host has been retired")
         })?;
@@ -295,32 +300,99 @@ impl ComputeCompletionTarget for ComputeHostCompletionTarget {
                 format!("compute host is stopped after an incomplete transaction: {failure}"),
             ));
         }
-        let sampled = if report.completed_turns > 0 {
-            materialize_sampled_outputs(&state, &snapshot)
-                .map_err(|error| completion_error(&self.backend, format!("{error:?}")))?
-        } else {
-            BTreeMap::new()
+        let (report, sampled, transport_failure) = match outcome {
+            ComputeCompletionOutcome::Completed { report, snapshot } => {
+                let sampled = if report.completed_turns > 0 {
+                    match materialize_sampled_outputs(&state, &snapshot) {
+                        Ok(sampled) => sampled,
+                        Err(error) => {
+                            state.terminal_failure =
+                                Some(format!("sample publication failed: {error:?}"));
+                            return Err(completion_error(&self.backend, format!("{error:?}")));
+                        }
+                    }
+                } else {
+                    BTreeMap::new()
+                };
+                (report, sampled, None)
+            }
+            ComputeCompletionOutcome::IntegrityRejected { report } => {
+                (report, BTreeMap::new(), None)
+            }
+            ComputeCompletionOutcome::TransportFailed {
+                attempted_turn,
+                reason,
+            } => (
+                ComputeDispatchReport {
+                    completed_turns: 0,
+                    fault_count: (*state.fault_count.borrow() as u64).saturating_add(1),
+                    last_fault: Some(mech_compute::ComputeFaultEvidence {
+                        attempted_turn,
+                        constraint: "backend-transport".into(),
+                        detail: reason.clone(),
+                    }),
+                    ..Default::default()
+                },
+                BTreeMap::new(),
+                Some(reason.to_string()),
+            ),
         };
-        let updates = {
-            state.sampled_outputs.extend(sampled);
-            apply_report(&mut state, &report);
-            telemetry_updates(&self.resource, &state)
-                .map_err(|error| completion_error(&self.backend, format!("{error:?}")))?
-        };
-        drop(state);
-        if let Some(ingress) = self
-            .telemetry
-            .lock()
-            .map_err(|_| completion_error(&self.backend, "telemetry ingress lock is poisoned"))?
-            .as_ref()
-        {
-            ingress
-                .submit_latest(
-                    RuntimeHostInput::new(updates)
-                        .map_err(|error| completion_error(&self.backend, format!("{error:?}")))?,
+        let mut candidate_outputs = state.sampled_outputs.clone();
+        candidate_outputs.extend(sampled);
+        let candidate_turns = *state.turns.borrow() + f64::from(report.completed_turns);
+        let candidate_dispatch_ms = report.dispatch_milliseconds;
+        let candidate_fault_count = report.fault_count as f64;
+        let candidate_last_fault = report.last_fault.as_ref().map_or_else(
+            || state.last_fault.borrow().clone(),
+            |fault| {
+                format!(
+                    "turn {}: {}: {}",
+                    fault.attempted_turn, fault.constraint, fault.detail
                 )
-                .map_err(|error| completion_error(&self.backend, format!("{error:?}")))?;
+            },
+        );
+        let updates = telemetry_updates_from_values(
+            &self.resource,
+            &state.backend,
+            candidate_turns,
+            candidate_dispatch_ms,
+            candidate_fault_count,
+            &candidate_last_fault,
+            &state.sample_requests,
+            &candidate_outputs,
+        )
+        .map_err(|error| {
+            state.terminal_failure = Some(
+                transport_failure
+                    .clone()
+                    .unwrap_or_else(|| format!("telemetry encoding failed: {error:?}")),
+            );
+            completion_error(&self.backend, format!("{error:?}"))
+        })?;
+        let packet = RuntimeHostInput::new(updates).map_err(|error| {
+            state.terminal_failure = Some(
+                transport_failure
+                    .clone()
+                    .unwrap_or_else(|| format!("telemetry packet creation failed: {error:?}")),
+            );
+            completion_error(&self.backend, format!("{error:?}"))
+        })?;
+        let telemetry = self.telemetry.lock().map_err(|_| {
+            state.terminal_failure = Some("telemetry ingress lock is poisoned".to_owned());
+            completion_error(&self.backend, "telemetry ingress lock is poisoned")
+        })?;
+        if let Some(ingress) = telemetry.as_ref() {
+            if let Err(error) = ingress.submit_latest(packet) {
+                state.terminal_failure = Some(format!("telemetry publication failed: {error:?}"));
+                return Err(completion_error(&self.backend, format!("{error:?}")));
+            }
         }
+        state.sampled_outputs = candidate_outputs;
+        *state.turns.borrow_mut() = candidate_turns;
+        *state.dispatch_ms.borrow_mut() = candidate_dispatch_ms;
+        *state.fault_count.borrow_mut() = candidate_fault_count;
+        *state.last_fault.borrow_mut() = candidate_last_fault;
+        state.terminal_failure = transport_failure;
         Ok(())
     }
 }
@@ -330,6 +402,7 @@ fn completion_error(backend: &BackendId, detail: impl Into<String>) -> ComputeEx
         backend: backend.clone(),
         operation: "complete asynchronous dispatch",
         detail: detail.into().into_boxed_str(),
+        state_advanced: true,
     }
 }
 
@@ -593,7 +666,7 @@ impl RuntimeAfterCommitEffect for ComputeInputEffect {
 struct ComputeDispatchEffect {
     resource: String,
     region: Box<str>,
-    turn: RuntimeHostInputValue,
+    turn: ComputeTurnToken,
     state: Arc<Mutex<ComputeHostState>>,
     telemetry: Arc<Mutex<Option<RuntimeIngress>>>,
 }
@@ -611,7 +684,7 @@ impl RuntimeAfterCommitEffect for ComputeDispatchEffect {
     }
 
     fn deliver(&mut self) -> MResult<()> {
-        let turn = canonical_turn_token(&self.turn)?;
+        let turn = self.turn;
         let mut state = self.state.lock().map_err(|_| {
             compute_host_error("ComputeHostDispatch", "compute host state lock is poisoned")
         })?;
@@ -627,12 +700,27 @@ impl RuntimeAfterCommitEffect for ComputeDispatchEffect {
         {
             return Ok(());
         }
+        let outputs = state
+            .program
+            .interface()
+            .outputs
+            .iter()
+            .filter(|port| state.sample_requests.contains(port.name.as_ref()))
+            .map(|port| port.id)
+            .collect();
+        let request = ComputeDispatchRequest {
+            outputs,
+            logical_turn: turn.0,
+        };
         let report = match state
             .session
-            .dispatch(NonZeroU32::new(1).expect("one is nonzero"))
+            .dispatch_requested(NonZeroU32::new(1).expect("one is nonzero"), &request)
         {
             Ok(report) => report,
             Err(error) => {
+                if error.state_advanced {
+                    state.terminal_failure = Some(error.to_string());
+                }
                 return Err(compute_host_error("ComputeHostDispatch", error.to_string()));
             }
         };
@@ -648,7 +736,7 @@ impl RuntimeAfterCommitEffect for ComputeDispatchEffect {
                 .collect();
             let snapshot = match state
                 .session
-                .read_outputs(&ComputeOutputSelection::Ports(selected))
+                .read_outputs(&ComputeOutputSelection::Samples(selected))
             {
                 Ok(snapshot) => snapshot,
                 Err(error) => {
@@ -664,35 +752,73 @@ impl RuntimeAfterCommitEffect for ComputeDispatchEffect {
                 }
             });
         }
+        let mut candidate_outputs = state.sampled_outputs.clone();
         if let Some(sampled) = sampled {
-            state.sampled_outputs.extend(sampled);
+            candidate_outputs.extend(sampled);
         }
-        state.last_submitted_turn = Some(turn);
-        apply_report(&mut state, &report);
-        let updates = telemetry_updates(&self.resource, &state)?;
-        drop(state);
-        if let Some(ingress) = self
-            .telemetry
-            .lock()
-            .map_err(|_| {
-                compute_host_error(
-                    "ComputeHostDispatch",
-                    "compute telemetry ingress lock is poisoned",
+        let candidate_turns = *state.turns.borrow() + f64::from(report.completed_turns);
+        let candidate_dispatch_ms = report.dispatch_milliseconds;
+        let candidate_fault_count = report.fault_count as f64;
+        let candidate_last_fault = report.last_fault.as_ref().map_or_else(
+            || state.last_fault.borrow().clone(),
+            |fault| {
+                format!(
+                    "turn {}: {}: {}",
+                    fault.attempted_turn, fault.constraint, fault.detail
                 )
-            })?
-            .as_ref()
-        {
-            ingress.submit(RuntimeHostInput::new(updates)?)?;
+            },
+        );
+        let updates = telemetry_updates_from_values(
+            &self.resource,
+            &state.backend,
+            candidate_turns,
+            candidate_dispatch_ms,
+            candidate_fault_count,
+            &candidate_last_fault,
+            &state.sample_requests,
+            &candidate_outputs,
+        )
+        .map_err(|error| {
+            state.terminal_failure = Some(format!("telemetry encoding failed: {error:?}"));
+            error
+        })?;
+        let packet = RuntimeHostInput::new(updates).map_err(|error| {
+            state.terminal_failure = Some(format!("telemetry packet creation failed: {error:?}"));
+            error
+        })?;
+        let telemetry = self.telemetry.lock().map_err(|_| {
+            state.terminal_failure = Some("compute telemetry ingress lock is poisoned".to_owned());
+            compute_host_error(
+                "ComputeHostDispatch",
+                "compute telemetry ingress lock is poisoned",
+            )
+        })?;
+        if let Some(ingress) = telemetry.as_ref() {
+            if let Err(error) = ingress.submit(packet) {
+                state.terminal_failure = Some(format!("telemetry publication failed: {error:?}"));
+                return Err(error);
+            }
         }
+        state.sampled_outputs = candidate_outputs;
+        state.last_submitted_turn = Some(turn);
+        *state.turns.borrow_mut() = candidate_turns;
+        *state.dispatch_ms.borrow_mut() = candidate_dispatch_ms;
+        *state.fault_count.borrow_mut() = candidate_fault_count;
+        *state.last_fault.borrow_mut() = candidate_last_fault;
         Ok(())
     }
 }
 
 fn canonical_turn_token(value: &RuntimeHostInputValue) -> MResult<ComputeTurnToken> {
+    // `u128::MAX as f64` rounds to 2^128, the exclusive upper bound. Keeping
+    // the comparison in floating point rejects that boundary and every larger
+    // finite value before Rust's saturating float-to-integer cast can alias
+    // distinct source tokens to `u128::MAX`.
+    const U128_EXCLUSIVE_UPPER_BOUND: f64 = 340282366920938463463374607431768211456.0_f64;
     let invalid = || {
         compute_host_error(
             "ComputeHostDispatch",
-            "compute turn tokens must be non-negative, finite integers",
+            "compute turn tokens must be non-negative, finite integers representable as u128",
         )
     };
     let token = match value {
@@ -708,12 +834,18 @@ fn canonical_turn_token(value: &RuntimeHostInputValue) -> MResult<ComputeTurnTok
         RuntimeHostInputValue::I64(value) if *value >= 0 => *value as u128,
         RuntimeHostInputValue::I128(value) if *value >= 0 => *value as u128,
         RuntimeHostInputValue::F32(value)
-            if value.is_finite() && *value >= 0.0 && value.fract() == 0.0 =>
+            if value.is_finite()
+                && *value >= 0.0
+                && value.fract() == 0.0
+                && f64::from(*value) < U128_EXCLUSIVE_UPPER_BOUND =>
         {
             *value as u128
         }
         RuntimeHostInputValue::F64(value)
-            if value.is_finite() && *value >= 0.0 && value.fract() == 0.0 =>
+            if value.is_finite()
+                && *value >= 0.0
+                && value.fract() == 0.0
+                && *value < U128_EXCLUSIVE_UPPER_BOUND =>
         {
             *value as u128
         }
@@ -722,51 +854,42 @@ fn canonical_turn_token(value: &RuntimeHostInputValue) -> MResult<ComputeTurnTok
     Ok(ComputeTurnToken(token))
 }
 
-fn apply_report(state: &mut ComputeHostState, report: &ComputeDispatchReport) {
-    *state.turns.borrow_mut() += f64::from(report.completed_turns);
-    *state.dispatch_ms.borrow_mut() = report.dispatch_milliseconds;
-    *state.fault_count.borrow_mut() = report.fault_count as f64;
-    if let Some(fault) = &report.last_fault {
-        *state.last_fault.borrow_mut() = format!(
-            "turn {}: {}: {}",
-            fault.attempted_turn, fault.constraint, fault.detail
-        );
-    }
-}
-
-fn telemetry_updates(
+#[allow(clippy::too_many_arguments)]
+fn telemetry_updates_from_values(
     resource: &str,
-    state: &ComputeHostState,
+    backend: &str,
+    turns: f64,
+    dispatch_ms: f64,
+    fault_count: f64,
+    last_fault: &str,
+    sample_requests: &BTreeSet<String>,
+    sampled_outputs: &BTreeMap<String, LegacyValue>,
 ) -> MResult<Vec<RuntimeHostInputUpdate>> {
     let mut updates = vec![
         telemetry_update(
             resource,
             "backend",
-            RuntimeHostInputValue::String(state.backend.clone()),
+            RuntimeHostInputValue::String(backend.to_owned()),
         )?,
-        telemetry_update(
-            resource,
-            "turns",
-            RuntimeHostInputValue::F64(*state.turns.borrow()),
-        )?,
+        telemetry_update(resource, "turns", RuntimeHostInputValue::F64(turns))?,
         telemetry_update(
             resource,
             "dispatch-ms",
-            RuntimeHostInputValue::F64(*state.dispatch_ms.borrow()),
+            RuntimeHostInputValue::F64(dispatch_ms),
         )?,
         telemetry_update(
             resource,
             "fault-count",
-            RuntimeHostInputValue::F64(*state.fault_count.borrow()),
+            RuntimeHostInputValue::F64(fault_count),
         )?,
         telemetry_update(
             resource,
             "last-fault",
-            RuntimeHostInputValue::String(state.last_fault.borrow().clone()),
+            RuntimeHostInputValue::String(last_fault.to_owned()),
         )?,
     ];
-    for name in &state.sample_requests {
-        let value = state.sampled_outputs.get(name).ok_or_else(|| {
+    for name in sample_requests {
+        let value = sampled_outputs.get(name).ok_or_else(|| {
             compute_host_error(
                 "ComputeHostRead",
                 format!("requested sampled output `{name}` has no retained value"),
@@ -984,35 +1107,18 @@ fn compute_input_update(
     Ok(update)
 }
 
-fn compute_turn_token(value: &LegacyValue) -> MResult<RuntimeHostInputValue> {
+fn compute_turn_token(value: &LegacyValue) -> MResult<ComputeTurnToken> {
     let token = RuntimeHostInputValue::from_numeric_mech_value(value)?;
-    match token {
-        RuntimeHostInputValue::F32(value) if value.is_finite() => {
-            Ok(RuntimeHostInputValue::F32(value))
-        }
-        RuntimeHostInputValue::F64(value) if value.is_finite() => {
-            Ok(RuntimeHostInputValue::F64(value))
-        }
-        RuntimeHostInputValue::F32(_) | RuntimeHostInputValue::F64(_) => Err(compute_host_error(
-            "ComputeHostWrite",
-            "compute turn token must be finite",
-        )),
-        other => Err(compute_host_error(
-            "ComputeHostWrite",
-            format!("compute turn token must be a scalar number, found `{other:?}`"),
-        )),
-    }
+    canonical_turn_token(&token)
 }
 
 fn narrow_f64_input(port: &str, value: f64) -> MResult<f32> {
-    let narrowed = value as f32;
-    if value.is_finite() && !narrowed.is_finite() {
-        return Err(compute_host_error(
+    mech_compute::narrow_compute_f64(value).map_err(|value| {
+        compute_host_error(
             "ComputeHostWrite",
             format!("compute input `{port}` contains f64 value {value} outside the f32 range"),
-        ));
-    }
-    Ok(narrowed)
+        )
+    })
 }
 
 fn compute_value_elements(value: &ComputeValue) -> u64 {
@@ -1284,7 +1390,7 @@ mod tests {
     struct FakeBackend {
         descriptor: ComputeBackendDescriptor,
         calls: Arc<Mutex<Vec<FakeCall>>>,
-        report: ComputeDispatchReport,
+        result: Result<ComputeDispatchReport, ComputeExecutionError>,
     }
 
     impl ComputeBackendFactory for FakeBackend {
@@ -1303,7 +1409,7 @@ mod tests {
             Ok(Box::new(FakeExecutable {
                 backend: self.descriptor.id.clone(),
                 calls: Arc::clone(&self.calls),
-                report: self.report.clone(),
+                result: self.result.clone(),
             }))
         }
     }
@@ -1311,7 +1417,7 @@ mod tests {
     struct FakeExecutable {
         backend: mech_compute::BackendId,
         calls: Arc<Mutex<Vec<FakeCall>>>,
-        report: ComputeDispatchReport,
+        result: Result<ComputeDispatchReport, ComputeExecutionError>,
     }
 
     impl ComputeExecutable for FakeExecutable {
@@ -1322,7 +1428,7 @@ mod tests {
             Ok(Box::new(FakeSession {
                 backend: self.backend.clone(),
                 calls: Arc::clone(&self.calls),
-                report: self.report.clone(),
+                result: self.result.clone(),
             }))
         }
     }
@@ -1330,7 +1436,7 @@ mod tests {
     struct FakeSession {
         backend: mech_compute::BackendId,
         calls: Arc<Mutex<Vec<FakeCall>>>,
-        report: ComputeDispatchReport,
+        result: Result<ComputeDispatchReport, ComputeExecutionError>,
     }
 
     impl ComputeSession for FakeSession {
@@ -1353,7 +1459,7 @@ mod tests {
                 .lock()
                 .unwrap()
                 .push(FakeCall::Dispatch(turns.get()));
-            Ok(self.report.clone())
+            self.result.clone()
         }
 
         fn read_outputs(
@@ -1389,6 +1495,13 @@ mod tests {
         calls: Arc<Mutex<Vec<FakeCall>>>,
         report: ComputeDispatchReport,
     ) -> Arc<ComputeBackendRegistry> {
+        registry_with_result(calls, Ok(report))
+    }
+
+    fn registry_with_result(
+        calls: Arc<Mutex<Vec<FakeCall>>>,
+        result: Result<ComputeDispatchReport, ComputeExecutionError>,
+    ) -> Arc<ComputeBackendRegistry> {
         let mut registry = ComputeBackendRegistry::default();
         registry
             .register(Arc::new(FakeBackend {
@@ -1403,7 +1516,7 @@ mod tests {
                     },
                 },
                 calls,
-                report,
+                result,
             }))
             .unwrap();
         Arc::new(registry)
@@ -1461,6 +1574,44 @@ mod tests {
             builder
         };
         builder.build().unwrap()
+    }
+
+    fn runtime_with_advancing_failure(
+        calls: Arc<Mutex<Vec<FakeCall>>>,
+    ) -> mech_runtime::MechRuntime {
+        let backend = mech_compute::BackendId::new("cpu-scalar").unwrap();
+        let factory = ComputeHostFactory::new(
+            "particle-field",
+            ComputePlacement::Compute,
+            program(),
+            ComputeInitializerSet::default(),
+            registry_with_result(
+                calls,
+                Err(ComputeExecutionError {
+                    backend,
+                    operation: "publish outputs",
+                    detail: "accepted state could not be published".into(),
+                    state_advanced: true,
+                }),
+            ),
+            ComputePlatform::Native,
+        )
+        .unwrap();
+        RuntimeBuilder::new()
+            .host_factory(Box::new(factory))
+            .unwrap()
+            .host_instance(HostInstanceConfig {
+                name: "particles".to_owned(),
+                provider: "compute".to_owned(),
+                settings: settings(),
+            })
+            .run_resource_grant(RunResourceGrantConfig {
+                target: "particles/kernel".to_owned(),
+                operations: vec!["read".to_owned(), "write".to_owned()],
+                paths: vec!["*".to_owned()],
+            })
+            .build()
+            .unwrap()
     }
 
     fn input_write(values: Vec<f32>) -> RuntimeResourceWriteRequest {
@@ -1725,6 +1876,57 @@ mod tests {
             2,
         );
         assert!(canonical_turn_token(&RuntimeHostInputValue::F64(3.5)).is_err());
+        assert!(canonical_turn_token(&RuntimeHostInputValue::F64(f64::MAX)).is_err());
+        assert!(
+            canonical_turn_token(&RuntimeHostInputValue::F64(u128::MAX as f64)).is_err(),
+            "the rounded 2^128 boundary must not saturate to u128::MAX",
+        );
+        assert_eq!(
+            canonical_turn_token(&RuntimeHostInputValue::F64(2.0_f64.powi(127))).unwrap(),
+            ComputeTurnToken(1_u128 << 127),
+        );
+    }
+
+    #[test]
+    fn accepted_but_unpublished_dispatch_stops_retries() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let mut runtime = runtime_with_advancing_failure(Arc::clone(&calls));
+
+        let mut context = runtime.runtime_context().unwrap();
+        runtime.begin_transaction(&mut context).unwrap();
+        runtime
+            .write_resource_with_context(&mut context, turn_write())
+            .unwrap();
+        let first = runtime
+            .commit_runtime_transaction_detailed(&mut context)
+            .unwrap();
+        assert!(
+            first.delivery_failures[0]
+                .message
+                .contains("accepted state could not be published")
+        );
+
+        runtime.begin_transaction(&mut context).unwrap();
+        runtime
+            .write_resource_with_context(&mut context, turn_write_with(2.0))
+            .unwrap();
+        let second = runtime
+            .commit_runtime_transaction_detailed(&mut context)
+            .unwrap();
+        assert!(
+            second.delivery_failures[0]
+                .message
+                .contains("incomplete transaction")
+        );
+        assert_eq!(
+            calls
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|call| matches!(call, FakeCall::Dispatch(_)))
+                .count(),
+            1,
+        );
     }
 
     #[test]

--- a/hosts/gpu/src/compute_provider.rs
+++ b/hosts/gpu/src/compute_provider.rs
@@ -206,8 +206,9 @@ impl RuntimeHostFactory for ComputeHostFactory {
             last_fault: Ref::new(String::new()),
             sampled_outputs: initial_sampled_outputs(&self.program)?,
             sample_requests: BTreeSet::new(),
-            last_submitted_turn: None,
-            terminal_failure: None,
+            phase: ComputeHostPhase::Ready {
+                last_submitted_turn: None,
+            },
             session,
         }));
         let completion_target = Arc::new(ComputeHostCompletionTarget {
@@ -271,9 +272,78 @@ struct ComputeHostState {
     last_fault: Ref<String>,
     sampled_outputs: BTreeMap<String, LegacyValue>,
     sample_requests: BTreeSet<String>,
-    last_submitted_turn: Option<ComputeTurnToken>,
-    terminal_failure: Option<String>,
+    phase: ComputeHostPhase,
     session: Box<dyn ComputeSession>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum ComputeHostPhase {
+    Ready {
+        last_submitted_turn: Option<ComputeTurnToken>,
+    },
+    InFlight {
+        turn: ComputeTurnToken,
+    },
+    Failed {
+        reason: Box<str>,
+    },
+}
+
+impl ComputeHostState {
+    fn require_ready(&self, operation: &'static str) -> MResult<Option<ComputeTurnToken>> {
+        match &self.phase {
+            ComputeHostPhase::Ready {
+                last_submitted_turn,
+            } => Ok(*last_submitted_turn),
+            ComputeHostPhase::InFlight { turn } => Err(compute_host_error(
+                operation,
+                format!("compute turn {} is still in flight", turn.0),
+            )),
+            ComputeHostPhase::Failed { reason } => Err(compute_host_error(
+                operation,
+                format!("compute host is stopped after an incomplete transaction: {reason}"),
+            )),
+        }
+    }
+
+    fn require_in_flight(
+        &mut self,
+        operation: &'static str,
+        turn: ComputeTurnToken,
+    ) -> MResult<()> {
+        match &self.phase {
+            ComputeHostPhase::InFlight { turn: current } if *current == turn => Ok(()),
+            ComputeHostPhase::Failed { reason } => Err(compute_host_error(
+                operation,
+                format!("compute host is stopped after an incomplete transaction: {reason}"),
+            )),
+            other => {
+                let reason = format!(
+                    "completion for compute turn {} does not match host phase {other:?}",
+                    turn.0
+                );
+                self.fail(reason.clone());
+                Err(compute_host_error(operation, reason))
+            }
+        }
+    }
+
+    fn ready_after(&mut self, turn: ComputeTurnToken) {
+        self.phase = ComputeHostPhase::Ready {
+            last_submitted_turn: Some(turn),
+        };
+    }
+
+    fn fail(&mut self, reason: impl Into<String>) -> Box<str> {
+        if let ComputeHostPhase::Failed { reason } = &self.phase {
+            return reason.clone();
+        }
+        let reason = reason.into().into_boxed_str();
+        self.phase = ComputeHostPhase::Failed {
+            reason: reason.clone(),
+        };
+        reason
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -294,49 +364,70 @@ impl ComputeCompletionTarget for ComputeHostCompletionTarget {
         let mut state = state
             .lock()
             .map_err(|_| completion_error(&self.backend, "compute host state lock is poisoned"))?;
-        if let Some(failure) = state.terminal_failure.as_ref() {
-            return Err(completion_error(
-                &self.backend,
-                format!("compute host is stopped after an incomplete transaction: {failure}"),
-            ));
-        }
-        let (report, sampled, transport_failure) = match outcome {
-            ComputeCompletionOutcome::Completed { report, snapshot } => {
+        let (attempted_turn, report, sampled, transport_failure) = match outcome {
+            ComputeCompletionOutcome::Completed {
+                attempted_turn,
+                report,
+                snapshot,
+            } => {
+                let turn = ComputeTurnToken(attempted_turn);
+                state
+                    .require_in_flight("ComputeHostCompletion", turn)
+                    .map_err(|error| completion_error(&self.backend, format!("{error:?}")))?;
                 let sampled = if report.completed_turns > 0 {
                     match materialize_sampled_outputs(&state, &snapshot) {
                         Ok(sampled) => sampled,
                         Err(error) => {
-                            state.terminal_failure =
-                                Some(format!("sample publication failed: {error:?}"));
+                            state.fail(format!("sample publication failed: {error:?}"));
                             return Err(completion_error(&self.backend, format!("{error:?}")));
                         }
                     }
                 } else {
                     BTreeMap::new()
                 };
-                (report, sampled, None)
+                (turn, report, sampled, None)
             }
-            ComputeCompletionOutcome::IntegrityRejected { report } => {
-                (report, BTreeMap::new(), None)
+            ComputeCompletionOutcome::IntegrityRejected {
+                attempted_turn,
+                report,
+            } => {
+                let turn = ComputeTurnToken(attempted_turn);
+                state
+                    .require_in_flight("ComputeHostCompletion", turn)
+                    .map_err(|error| completion_error(&self.backend, format!("{error:?}")))?;
+                (turn, report, BTreeMap::new(), None)
             }
             ComputeCompletionOutcome::TransportFailed {
                 attempted_turn,
                 reason,
-            } => (
-                ComputeDispatchReport {
-                    completed_turns: 0,
-                    fault_count: (*state.fault_count.borrow() as u64).saturating_add(1),
-                    last_fault: Some(mech_compute::ComputeFaultEvidence {
-                        attempted_turn,
-                        constraint: "backend-transport".into(),
-                        detail: reason.clone(),
-                    }),
-                    ..Default::default()
-                },
-                BTreeMap::new(),
-                Some(reason.to_string()),
-            ),
+            } => {
+                let turn = ComputeTurnToken(attempted_turn);
+                state
+                    .require_in_flight("ComputeHostCompletion", turn)
+                    .map_err(|error| completion_error(&self.backend, format!("{error:?}")))?;
+                (
+                    turn,
+                    ComputeDispatchReport {
+                        completed_turns: 0,
+                        fault_count: (*state.fault_count.borrow() as u64).saturating_add(1),
+                        last_fault: Some(mech_compute::ComputeFaultEvidence {
+                            attempted_turn,
+                            constraint: "backend-transport".into(),
+                            detail: reason.clone(),
+                        }),
+                        ..Default::default()
+                    },
+                    BTreeMap::new(),
+                    Some(reason.to_string()),
+                )
+            }
         };
+        if let Some(failure) = transport_failure.as_ref() {
+            // The backend transport is the first terminal failure. Preserve
+            // it even if best-effort fault telemetry subsequently encounters
+            // another error.
+            state.fail(failure.clone());
+        }
         let mut candidate_outputs = state.sampled_outputs.clone();
         candidate_outputs.extend(sampled);
         let candidate_turns = *state.turns.borrow() + f64::from(report.completed_turns);
@@ -362,7 +453,7 @@ impl ComputeCompletionTarget for ComputeHostCompletionTarget {
             &candidate_outputs,
         )
         .map_err(|error| {
-            state.terminal_failure = Some(
+            state.fail(
                 transport_failure
                     .clone()
                     .unwrap_or_else(|| format!("telemetry encoding failed: {error:?}")),
@@ -370,7 +461,7 @@ impl ComputeCompletionTarget for ComputeHostCompletionTarget {
             completion_error(&self.backend, format!("{error:?}"))
         })?;
         let packet = RuntimeHostInput::new(updates).map_err(|error| {
-            state.terminal_failure = Some(
+            state.fail(
                 transport_failure
                     .clone()
                     .unwrap_or_else(|| format!("telemetry packet creation failed: {error:?}")),
@@ -378,12 +469,12 @@ impl ComputeCompletionTarget for ComputeHostCompletionTarget {
             completion_error(&self.backend, format!("{error:?}"))
         })?;
         let telemetry = self.telemetry.lock().map_err(|_| {
-            state.terminal_failure = Some("telemetry ingress lock is poisoned".to_owned());
+            state.fail("telemetry ingress lock is poisoned");
             completion_error(&self.backend, "telemetry ingress lock is poisoned")
         })?;
         if let Some(ingress) = telemetry.as_ref() {
             if let Err(error) = ingress.submit_latest(packet) {
-                state.terminal_failure = Some(format!("telemetry publication failed: {error:?}"));
+                state.fail(format!("telemetry publication failed: {error:?}"));
                 return Err(completion_error(&self.backend, format!("{error:?}")));
             }
         }
@@ -392,7 +483,11 @@ impl ComputeCompletionTarget for ComputeHostCompletionTarget {
         *state.dispatch_ms.borrow_mut() = candidate_dispatch_ms;
         *state.fault_count.borrow_mut() = candidate_fault_count;
         *state.last_fault.borrow_mut() = candidate_last_fault;
-        state.terminal_failure = transport_failure;
+        if let Some(failure) = transport_failure {
+            state.fail(failure);
+        } else {
+            state.ready_after(attempted_turn);
+        }
         Ok(())
     }
 }
@@ -417,6 +512,7 @@ impl std::fmt::Debug for ComputeHostState {
             .field("fault_count", &self.fault_count)
             .field("last_fault", &self.last_fault)
             .field("sample_requests", &self.sample_requests)
+            .field("phase", &self.phase)
             .field("session", &"<dyn ComputeSession>")
             .finish()
     }
@@ -457,13 +553,14 @@ impl ComputeResourceProvider {
     }
 
     fn telemetry_value(&self, path: &str, planning: bool) -> MResult<LegacyValue> {
+        let mut state = self.state.lock().map_err(|_| {
+            compute_host_error("ComputeHostRead", "compute host state lock is poisoned")
+        })?;
+        state.require_ready("ComputeHostRead")?;
         if let Some(port) = self.declared_sample_output(path) {
             if planning {
                 return zero_sample_value(port);
             }
-            let mut state = self.state.lock().map_err(|_| {
-                compute_host_error("ComputeHostRead", "compute host state lock is poisoned")
-            })?;
             state.sample_requests.insert(port.name.to_string());
             return state
                 .sampled_outputs
@@ -490,9 +587,6 @@ impl ComputeResourceProvider {
                 )),
             };
         }
-        let state = self.state.lock().map_err(|_| {
-            compute_host_error("ComputeHostRead", "compute host state lock is poisoned")
-        })?;
         match path {
             "backend" => RuntimeHostInputValue::String(state.backend.clone()).into_mech_value(),
             "turns" => RuntimeHostInputValue::F64(*state.turns.borrow()).into_mech_value(),
@@ -546,6 +640,12 @@ impl RuntimeResourceProvider for ComputeResourceProvider {
 
     fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
         self.validate_base_uri(&request.base_uri, "ComputeHostWrite")?;
+        self.state
+            .lock()
+            .map_err(|_| {
+                compute_host_error("ComputeHostWrite", "compute host state lock is poisoned")
+            })?
+            .require_ready("ComputeHostWrite")?;
         if request.intent != RuntimeResourceWriteIntent::Send {
             return Err(compute_host_error(
                 "ComputeHostWrite",
@@ -651,14 +751,20 @@ impl RuntimeAfterCommitEffect for ComputeInputEffect {
     }
 
     fn deliver(&mut self) -> MResult<()> {
-        self.state
-            .lock()
-            .map_err(|_| {
-                compute_host_error("ComputeHostWrite", "compute host state lock is poisoned")
-            })?
+        let mut state = self.state.lock().map_err(|_| {
+            compute_host_error("ComputeHostWrite", "compute host state lock is poisoned")
+        })?;
+        state.require_ready("ComputeHostWrite")?;
+        if let Err(error) = state
             .session
             .update_inputs(std::slice::from_ref(&self.update))
-            .map_err(|error| compute_host_error("ComputeHostWrite", error.to_string()))
+        {
+            if error.state_advanced {
+                state.fail(error.to_string());
+            }
+            return Err(compute_host_error("ComputeHostWrite", error.to_string()));
+        }
+        Ok(())
     }
 }
 
@@ -688,16 +794,8 @@ impl RuntimeAfterCommitEffect for ComputeDispatchEffect {
         let mut state = self.state.lock().map_err(|_| {
             compute_host_error("ComputeHostDispatch", "compute host state lock is poisoned")
         })?;
-        if let Some(failure) = state.terminal_failure.as_ref() {
-            return Err(compute_host_error(
-                "ComputeHostDispatch",
-                format!("compute host is stopped after an incomplete transaction: {failure}"),
-            ));
-        }
-        if state
-            .last_submitted_turn
-            .is_some_and(|submitted| turn <= submitted)
-        {
+        let previous_turn = state.require_ready("ComputeHostDispatch")?;
+        if previous_turn.is_some_and(|submitted| turn <= submitted) {
             return Ok(());
         }
         let outputs = state
@@ -712,6 +810,7 @@ impl RuntimeAfterCommitEffect for ComputeDispatchEffect {
             outputs,
             logical_turn: turn.0,
         };
+        state.phase = ComputeHostPhase::InFlight { turn };
         let report = match state
             .session
             .dispatch_requested(NonZeroU32::new(1).expect("one is nonzero"), &request)
@@ -719,11 +818,21 @@ impl RuntimeAfterCommitEffect for ComputeDispatchEffect {
             Ok(report) => report,
             Err(error) => {
                 if error.state_advanced {
-                    state.terminal_failure = Some(error.to_string());
+                    state.fail(error.to_string());
+                } else {
+                    state.phase = ComputeHostPhase::Ready {
+                        last_submitted_turn: previous_turn,
+                    };
                 }
                 return Err(compute_host_error("ComputeHostDispatch", error.to_string()));
             }
         };
+        // Asynchronous browser compute has accepted this exact logical turn
+        // and will complete it through ComputeHostCompletionTarget. Do not
+        // publish a speculative telemetry packet while the host is InFlight.
+        if report.completed_turns == 0 && report.last_fault.is_none() {
+            return Ok(());
+        }
         let mut sampled = None;
         if report.completed_turns > 0 && !state.sample_requests.is_empty() {
             let selected = state
@@ -740,14 +849,14 @@ impl RuntimeAfterCommitEffect for ComputeDispatchEffect {
             {
                 Ok(snapshot) => snapshot,
                 Err(error) => {
-                    state.terminal_failure = Some(error.to_string());
+                    state.fail(error.to_string());
                     return Err(compute_host_error("ComputeHostRead", error.to_string()));
                 }
             };
             sampled = Some(match materialize_sampled_outputs(&state, &snapshot) {
                 Ok(sampled) => sampled,
                 Err(error) => {
-                    state.terminal_failure = Some(format!("{error:?}"));
+                    state.fail(format!("{error:?}"));
                     return Err(error);
                 }
             });
@@ -779,15 +888,15 @@ impl RuntimeAfterCommitEffect for ComputeDispatchEffect {
             &candidate_outputs,
         )
         .map_err(|error| {
-            state.terminal_failure = Some(format!("telemetry encoding failed: {error:?}"));
+            state.fail(format!("telemetry encoding failed: {error:?}"));
             error
         })?;
         let packet = RuntimeHostInput::new(updates).map_err(|error| {
-            state.terminal_failure = Some(format!("telemetry packet creation failed: {error:?}"));
+            state.fail(format!("telemetry packet creation failed: {error:?}"));
             error
         })?;
         let telemetry = self.telemetry.lock().map_err(|_| {
-            state.terminal_failure = Some("compute telemetry ingress lock is poisoned".to_owned());
+            state.fail("compute telemetry ingress lock is poisoned");
             compute_host_error(
                 "ComputeHostDispatch",
                 "compute telemetry ingress lock is poisoned",
@@ -795,16 +904,16 @@ impl RuntimeAfterCommitEffect for ComputeDispatchEffect {
         })?;
         if let Some(ingress) = telemetry.as_ref() {
             if let Err(error) = ingress.submit(packet) {
-                state.terminal_failure = Some(format!("telemetry publication failed: {error:?}"));
+                state.fail(format!("telemetry publication failed: {error:?}"));
                 return Err(error);
             }
         }
         state.sampled_outputs = candidate_outputs;
-        state.last_submitted_turn = Some(turn);
         *state.turns.borrow_mut() = candidate_turns;
         *state.dispatch_ms.borrow_mut() = candidate_dispatch_ms;
         *state.fault_count.borrow_mut() = candidate_fault_count;
         *state.last_fault.borrow_mut() = candidate_last_fault;
+        state.ready_after(turn);
         Ok(())
     }
 }
@@ -1372,9 +1481,10 @@ mod tests {
     use std::collections::BTreeMap;
 
     use mech_compute::{
-        BackendClass, ComputeBackendCapabilities, ComputeBackendDescriptor, ComputeBackendError,
-        ComputeBackendFactory, ComputeBackendRejection, ComputeExecutable, ComputeFaultEvidence,
-        ComputeKernel, ComputePhysicalPlan, ComputeRegionInterface, ElementwiseIr,
+        BackendClass, CPU_SCALAR_BACKEND, ComputeBackendCapabilities, ComputeBackendDescriptor,
+        ComputeBackendError, ComputeBackendFactory, ComputeBackendRejection, ComputeExecutable,
+        ComputeFaultEvidence, ComputeKernel, ComputePhysicalPlan, ComputeRegionInterface,
+        ElementwiseIr,
     };
     use mech_core::{CellSlotId, SchemaId};
     use mech_runtime::{
@@ -1385,6 +1495,7 @@ mod tests {
     enum FakeCall {
         Update(ComputeInputUpdate),
         Dispatch(u32),
+        Read(ComputeOutputSelection),
     }
 
     struct FakeBackend {
@@ -1464,10 +1575,14 @@ mod tests {
 
         fn read_outputs(
             &mut self,
-            _selection: &mech_compute::ComputeOutputSelection,
+            selection: &mech_compute::ComputeOutputSelection,
         ) -> Result<mech_compute::ComputeOutputSnapshot, mech_compute::ComputeExecutionError>
         {
             let _ = &self.backend;
+            self.calls
+                .lock()
+                .unwrap()
+                .push(FakeCall::Read(selection.clone()));
             Ok(Default::default())
         }
     }
@@ -1647,6 +1762,41 @@ mod tests {
             operation: RuntimeCapabilityOperation::Write,
             value: value.into_mech_value().unwrap(),
             intent: RuntimeResourceWriteIntent::Send,
+        }
+    }
+
+    fn provider_state(
+        phase: ComputeHostPhase,
+        calls: Arc<Mutex<Vec<FakeCall>>>,
+    ) -> Arc<Mutex<ComputeHostState>> {
+        Arc::new(Mutex::new(ComputeHostState {
+            backend: CPU_SCALAR_BACKEND.to_owned(),
+            program: Arc::new(program()),
+            turns: Ref::new(0.0),
+            dispatch_ms: Ref::new(0.0),
+            fault_count: Ref::new(0.0),
+            last_fault: Ref::new(String::new()),
+            sampled_outputs: BTreeMap::new(),
+            sample_requests: BTreeSet::new(),
+            phase,
+            session: Box::new(FakeSession {
+                backend: BackendId::new(CPU_SCALAR_BACKEND).unwrap(),
+                calls,
+                result: Ok(ComputeDispatchReport {
+                    completed_turns: 1,
+                    ..Default::default()
+                }),
+            }),
+        }))
+    }
+
+    fn provider_for_state(state: Arc<Mutex<ComputeHostState>>) -> ComputeResourceProvider {
+        ComputeResourceProvider {
+            instance: "particles".to_owned(),
+            region: "particle-field".into(),
+            program: Arc::new(program()),
+            state,
+            telemetry: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -1907,17 +2057,13 @@ mod tests {
         );
 
         runtime.begin_transaction(&mut context).unwrap();
-        runtime
-            .write_resource_with_context(&mut context, turn_write_with(2.0))
-            .unwrap();
         let second = runtime
-            .commit_runtime_transaction_detailed(&mut context)
+            .write_resource_with_context(&mut context, turn_write_with(2.0))
+            .unwrap_err();
+        assert!(second.kind_message().contains("incomplete transaction"));
+        runtime
+            .abort_runtime_transaction(&mut context, "expected failed-host rejection")
             .unwrap();
-        assert!(
-            second.delivery_failures[0]
-                .message
-                .contains("incomplete transaction")
-        );
         assert_eq!(
             calls
                 .lock()
@@ -1926,6 +2072,137 @@ mod tests {
                 .filter(|call| matches!(call, FakeCall::Dispatch(_)))
                 .count(),
             1,
+        );
+    }
+
+    #[test]
+    fn failed_and_inflight_phases_guard_every_resource_and_effect_boundary() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let state = provider_state(
+            ComputeHostPhase::Ready {
+                last_submitted_turn: None,
+            },
+            Arc::clone(&calls),
+        );
+        let provider = provider_for_state(Arc::clone(&state));
+        let prepared = provider.prepare_write(input_write(vec![0.0; 6])).unwrap();
+
+        state.lock().unwrap().phase = ComputeHostPhase::InFlight {
+            turn: ComputeTurnToken(1),
+        };
+        let read = RuntimeResourceReadRequest {
+            base_uri: "compute://particles/kernel".to_owned(),
+            path: "turns".to_owned(),
+            context_name: "particles".to_owned(),
+        };
+        assert!(provider.plan_read(read.clone()).is_err());
+        assert!(provider.read(read.clone()).is_err());
+        assert!(
+            provider
+                .preflight_write(RuntimeResourceWritePreflightRequest {
+                    base_uri: "compute://particles/kernel".to_owned(),
+                    path: "turn".to_owned(),
+                    context_name: "particles".to_owned(),
+                    operation: RuntimeCapabilityOperation::Write,
+                    intent: RuntimeResourceWriteIntent::Send,
+                })
+                .is_err()
+        );
+        assert!(provider.plan_write(turn_write()).is_err());
+        assert!(provider.prepare_write(turn_write()).is_err());
+        let PreparedRuntimeEffect::AfterCommit(mut effect) = prepared else {
+            panic!("compute input must remain an after-commit effect")
+        };
+        assert!(effect.deliver().is_err());
+        assert!(calls.lock().unwrap().is_empty());
+
+        state.lock().unwrap().fail("first terminal reason");
+        assert!(provider.plan_read(read.clone()).is_err());
+        assert!(provider.read(read).is_err());
+        assert!(provider.plan_write(turn_write()).is_err());
+        assert!(provider.prepare_write(turn_write()).is_err());
+        assert!(calls.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn asynchronous_completion_requires_the_exact_inflight_turn_and_failure_is_absorbing() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let state = provider_state(
+            ComputeHostPhase::InFlight {
+                turn: ComputeTurnToken(7),
+            },
+            calls,
+        );
+        let target = ComputeHostCompletionTarget {
+            backend: BackendId::new(CPU_SCALAR_BACKEND).unwrap(),
+            resource: "compute://particles/kernel".to_owned(),
+            state: Arc::downgrade(&state),
+            telemetry: Arc::new(Mutex::new(None)),
+        };
+        let mismatch = target.complete(ComputeCompletionOutcome::Completed {
+            attempted_turn: 6,
+            report: ComputeDispatchReport {
+                completed_turns: 1,
+                ..Default::default()
+            },
+            snapshot: ComputeOutputSnapshot::default(),
+        });
+        assert!(mismatch.is_err());
+        let first_reason = match &state.lock().unwrap().phase {
+            ComputeHostPhase::Failed { reason } => reason.clone(),
+            phase => panic!("mismatch did not stop the host: {phase:?}"),
+        };
+        let later = target.complete(ComputeCompletionOutcome::TransportFailed {
+            attempted_turn: 7,
+            reason: "later transport failure".into(),
+        });
+        assert!(later.is_err());
+        assert!(matches!(
+            &state.lock().unwrap().phase,
+            ComputeHostPhase::Failed { reason } if *reason == first_reason
+        ));
+    }
+
+    #[test]
+    fn integrity_rejection_returns_the_matching_host_to_ready() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let state = provider_state(
+            ComputeHostPhase::InFlight {
+                turn: ComputeTurnToken(9),
+            },
+            calls,
+        );
+        let target = ComputeHostCompletionTarget {
+            backend: BackendId::new(CPU_SCALAR_BACKEND).unwrap(),
+            resource: "compute://particles/kernel".to_owned(),
+            state: Arc::downgrade(&state),
+            telemetry: Arc::new(Mutex::new(None)),
+        };
+        target
+            .complete(ComputeCompletionOutcome::IntegrityRejected {
+                attempted_turn: 9,
+                report: ComputeDispatchReport {
+                    completed_turns: 0,
+                    fault_count: 1,
+                    last_fault: Some(ComputeFaultEvidence {
+                        attempted_turn: 9,
+                        constraint: "finite".into(),
+                        detail: "candidate rejected".into(),
+                    }),
+                    ..Default::default()
+                },
+            })
+            .unwrap();
+        assert_eq!(
+            state.lock().unwrap().phase,
+            ComputeHostPhase::Ready {
+                last_submitted_turn: Some(ComputeTurnToken(9)),
+            }
+        );
+        assert!(
+            provider_for_state(state)
+                .plan_write(turn_write_with(10.0))
+                .is_ok()
         );
     }
 

--- a/hosts/gpu/src/compute_provider.rs
+++ b/hosts/gpu/src/compute_provider.rs
@@ -2,15 +2,16 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     num::NonZeroU32,
     sync::{
-        Arc, Mutex,
+        Arc, Mutex, Weak,
         atomic::{AtomicBool, Ordering},
     },
 };
 
 use mech_compute::{
-    BackendRequest, ComputeBackendRegistry, ComputeDispatchReport, ComputeInitializerSet,
-    ComputeInputUpdate, ComputeOutputSelection, ComputeOutputSnapshot, ComputePlatform,
-    ComputePort, ComputeProgram, ComputeSession, ComputeValue, TensorLayout,
+    BackendId, BackendRequest, ComputeBackendRegistry, ComputeCompletionTarget,
+    ComputeDispatchReport, ComputeExecutionError, ComputeInitializerSet, ComputeInputUpdate,
+    ComputeOutputSelection, ComputeOutputSnapshot, ComputePlatform, ComputePort, ComputeProgram,
+    ComputeSession, ComputeValue, TensorLayout,
 };
 use mech_core::{
     ComputePlacement, LegacyValue, MResult, MechError, MechErrorKind, OperationContractDeclaration,
@@ -196,13 +197,6 @@ impl RuntimeHostFactory for ComputeHostFactory {
         let telemetry = Arc::new(Mutex::new(None));
         let live = Arc::new(AtomicBool::new(false));
         let base_uri = format!("compute://{instance_name}/kernel");
-        let sample_requests = self
-            .program
-            .interface()
-            .outputs
-            .iter()
-            .map(|port| port.name.to_string())
-            .collect();
         let state = Arc::new(Mutex::new(ComputeHostState {
             backend: backend_id.to_string(),
             program: Arc::clone(&self.program),
@@ -211,10 +205,27 @@ impl RuntimeHostFactory for ComputeHostFactory {
             fault_count: Ref::new(0.0),
             last_fault: Ref::new(String::new()),
             sampled_outputs: initial_sampled_outputs(&self.program)?,
-            sample_requests,
-            last_turn: None,
+            sample_requests: BTreeSet::new(),
+            last_submitted_turn: None,
+            terminal_failure: None,
             session,
         }));
+        backend
+            .bind_completion_target(Arc::new(ComputeHostCompletionTarget {
+                backend: backend_id.clone(),
+                resource: base_uri.clone(),
+                state: Arc::downgrade(&state),
+                telemetry: Arc::clone(&telemetry),
+            }))
+            .map_err(|error| {
+                compute_host_error(
+                    "ComputeBackendInitialize",
+                    format!(
+                        "region `{}` could not bind completion: {error}",
+                        self.region
+                    ),
+                )
+            })?;
         let installation = RuntimeHostInstallation {
             interface: materialize_host_manifest(instance_name, &self.manifest)?,
             resource_providers: vec![Box::new(ComputeResourceProvider {
@@ -251,8 +262,75 @@ struct ComputeHostState {
     last_fault: Ref<String>,
     sampled_outputs: BTreeMap<String, LegacyValue>,
     sample_requests: BTreeSet<String>,
-    last_turn: Option<RuntimeHostInputValue>,
+    last_submitted_turn: Option<ComputeTurnToken>,
+    terminal_failure: Option<String>,
     session: Box<dyn ComputeSession>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct ComputeTurnToken(u128);
+
+struct ComputeHostCompletionTarget {
+    backend: BackendId,
+    resource: String,
+    state: Weak<Mutex<ComputeHostState>>,
+    telemetry: Arc<Mutex<Option<RuntimeIngress>>>,
+}
+
+impl ComputeCompletionTarget for ComputeHostCompletionTarget {
+    fn complete(
+        &self,
+        report: ComputeDispatchReport,
+        snapshot: ComputeOutputSnapshot,
+    ) -> Result<(), ComputeExecutionError> {
+        let state = self.state.upgrade().ok_or_else(|| {
+            completion_error(&self.backend, "resident compute host has been retired")
+        })?;
+        let mut state = state
+            .lock()
+            .map_err(|_| completion_error(&self.backend, "compute host state lock is poisoned"))?;
+        if let Some(failure) = state.terminal_failure.as_ref() {
+            return Err(completion_error(
+                &self.backend,
+                format!("compute host is stopped after an incomplete transaction: {failure}"),
+            ));
+        }
+        let sampled = if report.completed_turns > 0 {
+            materialize_sampled_outputs(&state, &snapshot)
+                .map_err(|error| completion_error(&self.backend, format!("{error:?}")))?
+        } else {
+            BTreeMap::new()
+        };
+        let updates = {
+            state.sampled_outputs.extend(sampled);
+            apply_report(&mut state, &report);
+            telemetry_updates(&self.resource, &state)
+                .map_err(|error| completion_error(&self.backend, format!("{error:?}")))?
+        };
+        drop(state);
+        if let Some(ingress) = self
+            .telemetry
+            .lock()
+            .map_err(|_| completion_error(&self.backend, "telemetry ingress lock is poisoned"))?
+            .as_ref()
+        {
+            ingress
+                .submit_latest(
+                    RuntimeHostInput::new(updates)
+                        .map_err(|error| completion_error(&self.backend, format!("{error:?}")))?,
+                )
+                .map_err(|error| completion_error(&self.backend, format!("{error:?}")))?;
+        }
+        Ok(())
+    }
+}
+
+fn completion_error(backend: &BackendId, detail: impl Into<String>) -> ComputeExecutionError {
+    ComputeExecutionError {
+        backend: backend.clone(),
+        operation: "complete asynchronous dispatch",
+        detail: detail.into().into_boxed_str(),
+    }
 }
 
 impl std::fmt::Debug for ComputeHostState {
@@ -533,17 +611,32 @@ impl RuntimeAfterCommitEffect for ComputeDispatchEffect {
     }
 
     fn deliver(&mut self) -> MResult<()> {
+        let turn = canonical_turn_token(&self.turn)?;
         let mut state = self.state.lock().map_err(|_| {
             compute_host_error("ComputeHostDispatch", "compute host state lock is poisoned")
         })?;
-        if state.last_turn.as_ref() == Some(&self.turn) {
+        if let Some(failure) = state.terminal_failure.as_ref() {
+            return Err(compute_host_error(
+                "ComputeHostDispatch",
+                format!("compute host is stopped after an incomplete transaction: {failure}"),
+            ));
+        }
+        if state
+            .last_submitted_turn
+            .is_some_and(|submitted| turn <= submitted)
+        {
             return Ok(());
         }
-        let report = state
+        let report = match state
             .session
             .dispatch(NonZeroU32::new(1).expect("one is nonzero"))
-            .map_err(|error| compute_host_error("ComputeHostDispatch", error.to_string()))?;
-        state.last_turn = Some(self.turn.clone());
+        {
+            Ok(report) => report,
+            Err(error) => {
+                return Err(compute_host_error("ComputeHostDispatch", error.to_string()));
+            }
+        };
+        let mut sampled = None;
         if report.completed_turns > 0 && !state.sample_requests.is_empty() {
             let selected = state
                 .program
@@ -553,12 +646,28 @@ impl RuntimeAfterCommitEffect for ComputeDispatchEffect {
                 .filter(|port| state.sample_requests.contains(port.name.as_ref()))
                 .map(|port| port.id)
                 .collect();
-            let snapshot = state
+            let snapshot = match state
                 .session
                 .read_outputs(&ComputeOutputSelection::Ports(selected))
-                .map_err(|error| compute_host_error("ComputeHostRead", error.to_string()))?;
-            update_sampled_outputs(&mut state, snapshot)?;
+            {
+                Ok(snapshot) => snapshot,
+                Err(error) => {
+                    state.terminal_failure = Some(error.to_string());
+                    return Err(compute_host_error("ComputeHostRead", error.to_string()));
+                }
+            };
+            sampled = Some(match materialize_sampled_outputs(&state, &snapshot) {
+                Ok(sampled) => sampled,
+                Err(error) => {
+                    state.terminal_failure = Some(format!("{error:?}"));
+                    return Err(error);
+                }
+            });
         }
+        if let Some(sampled) = sampled {
+            state.sampled_outputs.extend(sampled);
+        }
+        state.last_submitted_turn = Some(turn);
         apply_report(&mut state, &report);
         let updates = telemetry_updates(&self.resource, &state)?;
         drop(state);
@@ -577,6 +686,40 @@ impl RuntimeAfterCommitEffect for ComputeDispatchEffect {
         }
         Ok(())
     }
+}
+
+fn canonical_turn_token(value: &RuntimeHostInputValue) -> MResult<ComputeTurnToken> {
+    let invalid = || {
+        compute_host_error(
+            "ComputeHostDispatch",
+            "compute turn tokens must be non-negative, finite integers",
+        )
+    };
+    let token = match value {
+        RuntimeHostInputValue::U8(value) => u128::from(*value),
+        RuntimeHostInputValue::U16(value) => u128::from(*value),
+        RuntimeHostInputValue::U32(value) => u128::from(*value),
+        RuntimeHostInputValue::U64(value) => u128::from(*value),
+        RuntimeHostInputValue::U128(value) => *value,
+        RuntimeHostInputValue::Index(value) => *value as u128,
+        RuntimeHostInputValue::I8(value) if *value >= 0 => *value as u128,
+        RuntimeHostInputValue::I16(value) if *value >= 0 => *value as u128,
+        RuntimeHostInputValue::I32(value) if *value >= 0 => *value as u128,
+        RuntimeHostInputValue::I64(value) if *value >= 0 => *value as u128,
+        RuntimeHostInputValue::I128(value) if *value >= 0 => *value as u128,
+        RuntimeHostInputValue::F32(value)
+            if value.is_finite() && *value >= 0.0 && value.fract() == 0.0 =>
+        {
+            *value as u128
+        }
+        RuntimeHostInputValue::F64(value)
+            if value.is_finite() && *value >= 0.0 && value.fract() == 0.0 =>
+        {
+            *value as u128
+        }
+        _ => return Err(invalid()),
+    };
+    Ok(ComputeTurnToken(token))
 }
 
 fn apply_report(state: &mut ComputeHostState, report: &ComputeDispatchReport) {
@@ -946,10 +1089,10 @@ fn zero_sample_value(port: &ComputePort) -> MResult<LegacyValue> {
     )
 }
 
-fn update_sampled_outputs(
-    state: &mut ComputeHostState,
-    snapshot: ComputeOutputSnapshot,
-) -> MResult<()> {
+fn materialize_sampled_outputs(
+    state: &ComputeHostState,
+    snapshot: &ComputeOutputSnapshot,
+) -> MResult<BTreeMap<String, LegacyValue>> {
     let ports = state
         .program
         .interface()
@@ -958,6 +1101,7 @@ fn update_sampled_outputs(
         .filter(|port| state.sample_requests.contains(port.name.as_ref()))
         .cloned()
         .collect::<Vec<_>>();
+    let mut sampled = BTreeMap::new();
     for port in ports {
         let value = snapshot.values.get(&port.id).ok_or_else(|| {
             compute_host_error(
@@ -965,12 +1109,12 @@ fn update_sampled_outputs(
                 format!("backend omitted sampled output `{}`", port.name),
             )
         })?;
-        state.sampled_outputs.insert(
+        sampled.insert(
             port.name.to_string(),
             sampled_output_value(&port, value.clone())?,
         );
     }
-    Ok(())
+    Ok(sampled)
 }
 
 fn sampled_output_value(port: &ComputePort, value: ComputeValue) -> MResult<LegacyValue> {
@@ -1341,12 +1485,16 @@ mod tests {
     }
 
     fn turn_write_with(value: f32) -> RuntimeResourceWriteRequest {
+        turn_write_value(RuntimeHostInputValue::F32(value))
+    }
+
+    fn turn_write_value(value: RuntimeHostInputValue) -> RuntimeResourceWriteRequest {
         RuntimeResourceWriteRequest {
             base_uri: "compute://particles/kernel".to_owned(),
             path: "turn".to_owned(),
             context_name: "particles".to_owned(),
             operation: RuntimeCapabilityOperation::Write,
-            value: LegacyValue::from(value),
+            value: value.into_mech_value().unwrap(),
             intent: RuntimeResourceWriteIntent::Send,
         }
     }
@@ -1533,6 +1681,50 @@ mod tests {
         runtime.write_resource(turn_write_with(2.0)).unwrap();
         assert_eq!(calls.lock().unwrap().last(), Some(&FakeCall::Dispatch(1)));
         assert_eq!(calls.lock().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn turn_tokens_are_width_independent_and_never_move_backwards() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let mut runtime = runtime_with_fake_backend(
+            true,
+            Arc::clone(&calls),
+            ComputeDispatchReport {
+                completed_turns: 1,
+                ..Default::default()
+            },
+        );
+
+        runtime.write_resource(turn_write_with(2.0)).unwrap();
+        runtime
+            .write_resource(turn_write_value(RuntimeHostInputValue::F64(2.0)))
+            .unwrap();
+        runtime
+            .write_resource(turn_write_value(RuntimeHostInputValue::F64(1.0)))
+            .unwrap();
+        assert_eq!(
+            calls
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|call| matches!(call, FakeCall::Dispatch(_)))
+                .count(),
+            1,
+        );
+
+        runtime
+            .write_resource(turn_write_value(RuntimeHostInputValue::F64(3.0)))
+            .unwrap();
+        assert_eq!(
+            calls
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|call| matches!(call, FakeCall::Dispatch(_)))
+                .count(),
+            2,
+        );
+        assert!(canonical_turn_token(&RuntimeHostInputValue::F64(3.5)).is_err());
     }
 
     #[test]

--- a/hosts/gpu/src/execution_plan.rs
+++ b/hosts/gpu/src/execution_plan.rs
@@ -304,14 +304,36 @@ impl GpuExecutionPlan {
     /// this digest: generations own commands and completions, while equal
     /// revisions may adopt the same device, pipeline, and state buffers.
     pub fn physical_revision(&self, backend: &str) -> Result<String, GpuExecutionPlanError> {
+        self.physical_revision_with_retained_outputs(backend, &BTreeSet::new())
+    }
+
+    /// Return the stable identity of the physical plan together with the
+    /// coordinator's CPU-observable sample contract. Changing that contract
+    /// must replace the physical generation: otherwise a newly observed
+    /// sample would begin at its initializer while the retained compute state
+    /// and turn counter belong to a later generation.
+    pub fn physical_revision_with_retained_outputs(
+        &self,
+        backend: &str,
+        retained_outputs: &BTreeSet<String>,
+    ) -> Result<String, GpuExecutionPlanError> {
         self.validate()?;
-        let encoded = serde_json::to_vec(self).map_err(|failure| {
+        let encoded = if retained_outputs.is_empty() {
+            serde_json::to_vec(self)
+        } else {
+            serde_json::to_vec(&(self, retained_outputs))
+        }
+        .map_err(|failure| {
             GpuExecutionPlanError::Invalid(format!(
                 "GPU execution plan revision serialization failed: {failure}"
             ))
         })?;
         let mut digest = Sha256::new();
-        digest.update(b"mech-gpu-physical-revision-v1\0");
+        digest.update(if retained_outputs.is_empty() {
+            b"mech-gpu-physical-revision-v1\0".as_slice()
+        } else {
+            b"mech-gpu-physical-revision-v2-retained-outputs\0".as_slice()
+        });
         digest.update(backend.as_bytes());
         digest.update(b"\0");
         digest.update(encoded);
@@ -764,5 +786,24 @@ mod tests {
         changed = plan.clone();
         changed.wgsl.push_str(" // changed kernel");
         assert_ne!(revision, changed.physical_revision("wgpu").unwrap());
+
+        let retained = BTreeSet::from(["estimate".to_owned()]);
+        let retained_revision = plan
+            .physical_revision_with_retained_outputs("wgpu", &retained)
+            .unwrap();
+        assert_ne!(revision, retained_revision);
+        assert_eq!(
+            retained_revision,
+            plan.physical_revision_with_retained_outputs("wgpu", &retained)
+                .unwrap()
+        );
+        assert_ne!(
+            retained_revision,
+            plan.physical_revision_with_retained_outputs(
+                "wgpu",
+                &BTreeSet::from(["other".to_owned()]),
+            )
+            .unwrap()
+        );
     }
 }

--- a/hosts/gpu/src/execution_plan.rs
+++ b/hosts/gpu/src/execution_plan.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use crate::{
     ElementwiseKernel, FixedShapeKernel, GpuBindingAccess, GpuBindingRole, WORKGROUP_SIZE,
@@ -296,6 +297,32 @@ impl GpuExecutionPlan {
             ));
         }
         Ok(())
+    }
+
+    /// Return the stable identity of the browser/native physical allocation
+    /// contract. A resident runtime generation is deliberately not part of
+    /// this digest: generations own commands and completions, while equal
+    /// revisions may adopt the same device, pipeline, and state buffers.
+    pub fn physical_revision(&self, backend: &str) -> Result<String, GpuExecutionPlanError> {
+        self.validate()?;
+        let encoded = serde_json::to_vec(self).map_err(|failure| {
+            GpuExecutionPlanError::Invalid(format!(
+                "GPU execution plan revision serialization failed: {failure}"
+            ))
+        })?;
+        let mut digest = Sha256::new();
+        digest.update(b"mech-gpu-physical-revision-v1\0");
+        digest.update(backend.as_bytes());
+        digest.update(b"\0");
+        digest.update(encoded);
+        let digest = digest.finalize();
+        let mut revision = String::with_capacity("sha256:".len() + digest.len() * 2);
+        revision.push_str("sha256:");
+        for byte in digest {
+            use std::fmt::Write as _;
+            write!(revision, "{byte:02x}").expect("writing to a string is infallible");
+        }
+        Ok(revision)
     }
 }
 
@@ -699,5 +726,43 @@ mod tests {
             physical_layout: GpuPlanLayout::RowMajor,
         });
         assert!(plan.validate().is_err());
+    }
+
+    #[test]
+    fn physical_revision_tracks_the_complete_allocation_contract() {
+        let plan = GpuExecutionPlan {
+            version: GPU_EXECUTION_PLAN_VERSION,
+            kernel_kind: GpuPlanKernelKind::Elementwise,
+            wgsl: "@compute @workgroup_size(64) fn main() {}".to_owned(),
+            workgroup_size: 64,
+            dispatch_elements: 1,
+            bindings: vec![GpuPlanBinding {
+                binding: 0,
+                name: "input".to_owned(),
+                access: GpuPlanBindingAccess::Read,
+                role: GpuPlanBindingRole::Input,
+                slot: 1,
+                elements: 2,
+                scalar: GpuPlanScalar::F32,
+                initial_values: Some(GpuPlanInitialValues::F32(vec![1.0, 2.0])),
+            }],
+            states: Vec::new(),
+            outputs: Vec::new(),
+            physical_outputs: Vec::new(),
+            constraints: Vec::new(),
+        };
+        let revision = plan.physical_revision("wgpu").unwrap();
+        assert_eq!(revision, plan.physical_revision("wgpu").unwrap());
+        assert_ne!(revision, plan.physical_revision("cpu-scalar").unwrap());
+
+        let mut changed = plan.clone();
+        changed.dispatch_elements = 2;
+        assert_ne!(revision, changed.physical_revision("wgpu").unwrap());
+        changed = plan.clone();
+        changed.bindings[0].initial_values = Some(GpuPlanInitialValues::F32(vec![1.0, 3.0]));
+        assert_ne!(revision, changed.physical_revision("wgpu").unwrap());
+        changed = plan.clone();
+        changed.wgsl.push_str(" // changed kernel");
+        assert_ne!(revision, changed.physical_revision("wgpu").unwrap());
     }
 }

--- a/hosts/gpu/src/execution_plan.rs
+++ b/hosts/gpu/src/execution_plan.rs
@@ -1,0 +1,703 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    ElementwiseKernel, FixedShapeKernel, GpuBindingAccess, GpuBindingRole, WORKGROUP_SIZE,
+};
+
+pub const GPU_EXECUTION_PLAN_VERSION: u32 = 1;
+
+#[derive(Clone, Copy, Debug)]
+pub enum GpuKernelPlanSource<'a> {
+    Elementwise(&'a ElementwiseKernel),
+    FixedShape(&'a FixedShapeKernel),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum GpuPlanKernelKind {
+    Elementwise,
+    FixedShape,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum GpuPlanBindingAccess {
+    Read,
+    ReadWrite,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum GpuPlanBindingRole {
+    Input,
+    StateRead,
+    StateWrite,
+    Output,
+    IntegrityFault,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum GpuPlanScalar {
+    F32,
+    U32,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum GpuPlanLayout {
+    RowMajor,
+    ColumnMajor,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "scalar", content = "values", rename_all = "kebab-case")]
+pub enum GpuPlanInitialValues {
+    F32(Vec<f32>),
+    U32(Vec<u32>),
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct GpuPlanBinding {
+    pub binding: u32,
+    pub name: String,
+    pub access: GpuPlanBindingAccess,
+    pub role: GpuPlanBindingRole,
+    pub slot: u32,
+    pub elements: u64,
+    pub scalar: GpuPlanScalar,
+    pub initial_values: Option<GpuPlanInitialValues>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct GpuPlanState {
+    pub slot: u32,
+    pub elements: u64,
+    pub elements_per_instance: u64,
+    pub initial_values: Vec<f32>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct GpuPlanOutput {
+    pub name: String,
+    pub slot: u32,
+    pub physical_output: u32,
+    pub elements: u64,
+    pub elements_per_instance: u64,
+    pub dimensions: Vec<u64>,
+    pub sample_dimensions: Vec<u64>,
+    pub physical_layout: GpuPlanLayout,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct GpuPhysicalOutputPlan {
+    pub id: u32,
+    pub slot: u32,
+    pub binding: Option<u32>,
+    pub sample_elements: u64,
+    pub aliases: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct GpuPlanConstraint {
+    pub code: u32,
+    pub id: u32,
+    pub name: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct GpuExecutionPlan {
+    pub version: u32,
+    pub kernel_kind: GpuPlanKernelKind,
+    pub wgsl: String,
+    pub workgroup_size: u32,
+    pub dispatch_elements: u32,
+    pub bindings: Vec<GpuPlanBinding>,
+    pub states: Vec<GpuPlanState>,
+    pub outputs: Vec<GpuPlanOutput>,
+    pub physical_outputs: Vec<GpuPhysicalOutputPlan>,
+    pub constraints: Vec<GpuPlanConstraint>,
+}
+
+impl GpuExecutionPlan {
+    pub fn build(
+        source: GpuKernelPlanSource<'_>,
+        input_values: &BTreeMap<String, Vec<f32>>,
+    ) -> Result<Self, GpuExecutionPlanError> {
+        let plan = match source {
+            GpuKernelPlanSource::Elementwise(kernel) => {
+                build_elementwise_plan(kernel, input_values)?
+            }
+            GpuKernelPlanSource::FixedShape(kernel) => {
+                build_fixed_shape_plan(kernel, input_values)?
+            }
+        };
+        plan.validate()?;
+        Ok(plan)
+    }
+
+    pub fn validate(&self) -> Result<(), GpuExecutionPlanError> {
+        if self.version != GPU_EXECUTION_PLAN_VERSION {
+            return Err(GpuExecutionPlanError::UnsupportedVersion(self.version));
+        }
+        if self.workgroup_size == 0 || self.dispatch_elements == 0 {
+            return Err(GpuExecutionPlanError::Invalid(
+                "workgroup and dispatch sizes must be nonzero".to_owned(),
+            ));
+        }
+        let bindings = self
+            .bindings
+            .iter()
+            .map(|binding| binding.binding)
+            .collect::<BTreeSet<_>>();
+        if bindings.len() != self.bindings.len() {
+            return Err(GpuExecutionPlanError::Invalid(
+                "GPU binding numbers must be unique".to_owned(),
+            ));
+        }
+        if self.bindings.iter().any(|binding| binding.elements == 0) {
+            return Err(GpuExecutionPlanError::Invalid(
+                "GPU bindings must contain at least one scalar".to_owned(),
+            ));
+        }
+        for binding in &self.bindings {
+            let Some(initial) = &binding.initial_values else {
+                continue;
+            };
+            let length = match initial {
+                GpuPlanInitialValues::F32(values) if binding.scalar == GpuPlanScalar::F32 => {
+                    values.len()
+                }
+                GpuPlanInitialValues::U32(values) if binding.scalar == GpuPlanScalar::U32 => {
+                    values.len()
+                }
+                _ => {
+                    return Err(GpuExecutionPlanError::Invalid(format!(
+                        "GPU binding `{}` initializer scalar does not match its declaration",
+                        binding.name
+                    )));
+                }
+            };
+            if u64::try_from(length).ok() != Some(binding.elements) {
+                return Err(GpuExecutionPlanError::Invalid(format!(
+                    "GPU binding `{}` has {length} initial values but declares {} elements",
+                    binding.name, binding.elements
+                )));
+            }
+        }
+        let physical = self
+            .physical_outputs
+            .iter()
+            .map(|output| output.id)
+            .collect::<BTreeSet<_>>();
+        if physical.len() != self.physical_outputs.len() {
+            return Err(GpuExecutionPlanError::Invalid(
+                "physical output identifiers must be unique".to_owned(),
+            ));
+        }
+        let mut physical_aliases = BTreeSet::new();
+        for output in &self.physical_outputs {
+            if output.sample_elements == 0 || output.aliases.is_empty() {
+                return Err(GpuExecutionPlanError::Invalid(format!(
+                    "physical output {} must have a nonempty sample and alias set",
+                    output.id
+                )));
+            }
+            if let Some(binding) = output.binding {
+                if !bindings.contains(&binding) {
+                    return Err(GpuExecutionPlanError::Invalid(format!(
+                        "physical output {} references unknown binding {binding}",
+                        output.id
+                    )));
+                }
+            }
+            for alias in &output.aliases {
+                if !physical_aliases.insert(alias.as_str()) {
+                    return Err(GpuExecutionPlanError::Invalid(format!(
+                        "logical output alias `{alias}` appears in more than one physical transfer"
+                    )));
+                }
+            }
+        }
+        for output in &self.outputs {
+            if !physical.contains(&output.physical_output) {
+                return Err(GpuExecutionPlanError::Invalid(format!(
+                    "logical output `{}` references unknown physical output {}",
+                    output.name, output.physical_output
+                )));
+            }
+            let Some(physical_output) = self
+                .physical_outputs
+                .iter()
+                .find(|physical| physical.id == output.physical_output)
+            else {
+                unreachable!("physical output identity was checked above")
+            };
+            if !physical_output.aliases.contains(&output.name)
+                || physical_output.slot != output.slot
+                || physical_output.sample_elements != output.elements_per_instance
+            {
+                return Err(GpuExecutionPlanError::Invalid(format!(
+                    "logical output `{}` does not match physical output {}",
+                    output.name, output.physical_output
+                )));
+            }
+        }
+        if physical_aliases.len() != self.outputs.len() {
+            return Err(GpuExecutionPlanError::Invalid(
+                "physical aliases and logical outputs are not one-to-one".to_owned(),
+            ));
+        }
+        for state in &self.states {
+            if state.elements == 0
+                || state.elements_per_instance == 0
+                || state.initial_values.len() as u64 != state.elements
+            {
+                return Err(GpuExecutionPlanError::Invalid(format!(
+                    "resident state {} has an invalid physical shape or initializer",
+                    state.slot
+                )));
+            }
+            for role in [
+                GpuPlanBindingRole::StateRead,
+                GpuPlanBindingRole::StateWrite,
+            ] {
+                if !self.bindings.iter().any(|binding| {
+                    binding.role == role
+                        && binding.slot == state.slot
+                        && binding.elements == state.elements
+                }) {
+                    return Err(GpuExecutionPlanError::Invalid(format!(
+                        "resident state {} has no matching {role:?} binding",
+                        state.slot
+                    )));
+                }
+            }
+        }
+        let constraint_codes = self
+            .constraints
+            .iter()
+            .map(|constraint| constraint.code)
+            .collect::<BTreeSet<_>>();
+        if constraint_codes.len() != self.constraints.len()
+            || constraint_codes.contains(&0)
+            || (!self.constraints.is_empty()
+                && !self
+                    .bindings
+                    .iter()
+                    .any(|binding| binding.role == GpuPlanBindingRole::IntegrityFault))
+        {
+            return Err(GpuExecutionPlanError::Invalid(
+                "integrity constraints require unique nonzero codes and one fault binding"
+                    .to_owned(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum GpuExecutionPlanError {
+    Invalid(String),
+    UnsupportedVersion(u32),
+}
+
+impl fmt::Display for GpuExecutionPlanError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Invalid(reason) => write!(formatter, "invalid GPU execution plan: {reason}"),
+            Self::UnsupportedVersion(version) => write!(
+                formatter,
+                "GPU execution plan version {version} is unsupported; expected {GPU_EXECUTION_PLAN_VERSION}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for GpuExecutionPlanError {}
+
+fn build_elementwise_plan(
+    kernel: &ElementwiseKernel,
+    input_values: &BTreeMap<String, Vec<f32>>,
+) -> Result<GpuExecutionPlan, GpuExecutionPlanError> {
+    let mut bindings = Vec::new();
+    for binding in kernel.bindings() {
+        let initial_values = match binding.role() {
+            GpuBindingRole::Input => {
+                let values = input_values.get(&binding.name).ok_or_else(|| {
+                    GpuExecutionPlanError::Invalid(format!(
+                        "elementwise input `{}` has no initializer",
+                        binding.name
+                    ))
+                })?;
+                if values.len() as u64 != binding.elements {
+                    return Err(GpuExecutionPlanError::Invalid(format!(
+                        "elementwise input `{}` has {} values; expected {}",
+                        binding.name,
+                        values.len(),
+                        binding.elements
+                    )));
+                }
+                Some(GpuPlanInitialValues::F32(values.clone()))
+            }
+            GpuBindingRole::StateRead => {
+                let (_, _, initializer) = kernel
+                    .state_initializers()
+                    .find(|(slot, _, _)| *slot == binding.slot())
+                    .ok_or_else(|| {
+                        GpuExecutionPlanError::Invalid(format!(
+                            "state-read binding `{}` has no state initializer",
+                            binding.name
+                        ))
+                    })?;
+                Some(GpuPlanInitialValues::F32(initializer.to_vec()))
+            }
+            GpuBindingRole::StateWrite | GpuBindingRole::Output => None,
+        };
+        bindings.push(GpuPlanBinding {
+            binding: binding.binding,
+            name: binding.name.clone(),
+            access: binding.access.into(),
+            role: binding.role().into(),
+            slot: binding.slot().get(),
+            elements: binding.elements,
+            scalar: GpuPlanScalar::F32,
+            initial_values,
+        });
+    }
+    let states = kernel
+        .state_initializers()
+        .map(|(slot, elements, initializer)| GpuPlanState {
+            slot: slot.get(),
+            elements,
+            elements_per_instance: elements,
+            initial_values: initializer.to_vec(),
+        })
+        .collect();
+    let outputs = logical_outputs(
+        GpuPlanKernelKind::Elementwise,
+        kernel.compute_program(),
+        1,
+        &bindings,
+    )?;
+    let physical_outputs = physical_outputs(&outputs, &bindings)?;
+    Ok(GpuExecutionPlan {
+        version: GPU_EXECUTION_PLAN_VERSION,
+        kernel_kind: GpuPlanKernelKind::Elementwise,
+        wgsl: kernel.wgsl().to_owned(),
+        workgroup_size: WORKGROUP_SIZE,
+        dispatch_elements: u32::try_from(kernel.dispatch_elements()).map_err(|_| {
+            GpuExecutionPlanError::Invalid("elementwise dispatch exceeds u32".to_owned())
+        })?,
+        bindings,
+        states,
+        outputs,
+        physical_outputs,
+        constraints: Vec::new(),
+    })
+}
+
+fn build_fixed_shape_plan(
+    kernel: &FixedShapeKernel,
+    input_values: &BTreeMap<String, Vec<f32>>,
+) -> Result<GpuExecutionPlan, GpuExecutionPlanError> {
+    if kernel.integrity_buffer().is_some() && kernel.instances() >= (1 << 24) {
+        return Err(GpuExecutionPlanError::Invalid(
+            "checked GPU fault records support fewer than 2^24 instances".to_owned(),
+        ));
+    }
+    let physical_inputs = kernel
+        .physical_inputs(input_values)
+        .map_err(|failure| GpuExecutionPlanError::Invalid(failure.to_string()))?;
+    let physical_states = kernel.physical_states();
+    let mut bindings = physical_inputs
+        .iter()
+        .map(|input| GpuPlanBinding {
+            binding: input.binding,
+            name: input.name.clone(),
+            access: GpuPlanBindingAccess::Read,
+            role: GpuPlanBindingRole::Input,
+            slot: input.slot.get(),
+            elements: input.elements as u64,
+            scalar: GpuPlanScalar::F32,
+            initial_values: Some(GpuPlanInitialValues::F32(input.initial_values.clone())),
+        })
+        .collect::<Vec<_>>();
+    for state in &physical_states {
+        bindings.push(GpuPlanBinding {
+            binding: state.read_binding,
+            name: format!("state.{}.read", state.slot.get()),
+            access: GpuPlanBindingAccess::Read,
+            role: GpuPlanBindingRole::StateRead,
+            slot: state.slot.get(),
+            elements: state.elements as u64,
+            scalar: GpuPlanScalar::F32,
+            initial_values: None,
+        });
+        bindings.push(GpuPlanBinding {
+            binding: state.write_binding,
+            name: format!("state.{}.write", state.slot.get()),
+            access: GpuPlanBindingAccess::ReadWrite,
+            role: GpuPlanBindingRole::StateWrite,
+            slot: state.slot.get(),
+            elements: state.elements as u64,
+            scalar: GpuPlanScalar::F32,
+            initial_values: None,
+        });
+    }
+    if let Some(integrity) = kernel.integrity_buffer() {
+        bindings.push(GpuPlanBinding {
+            binding: integrity.binding,
+            name: "integrity-fault".to_owned(),
+            access: GpuPlanBindingAccess::ReadWrite,
+            role: GpuPlanBindingRole::IntegrityFault,
+            slot: 0,
+            elements: integrity.words as u64,
+            scalar: GpuPlanScalar::U32,
+            initial_values: Some(GpuPlanInitialValues::U32(vec![0, u32::MAX])),
+        });
+    }
+    bindings.sort_by_key(|binding| binding.binding);
+    let states = physical_states
+        .iter()
+        .map(|state| GpuPlanState {
+            slot: state.slot.get(),
+            elements: state.elements as u64,
+            elements_per_instance: state.elements_per_instance as u64,
+            initial_values: state.initial_values.clone(),
+        })
+        .collect();
+    let outputs = logical_outputs(
+        GpuPlanKernelKind::FixedShape,
+        kernel.compute_program(),
+        kernel.instances(),
+        &bindings,
+    )?;
+    let physical_outputs = physical_outputs(&outputs, &bindings)?;
+    let constraints = kernel
+        .named_integrity_constraints()
+        .enumerate()
+        .map(|(index, (id, name))| {
+            Ok(GpuPlanConstraint {
+                code: u32::try_from(index + 1).map_err(|_| {
+                    GpuExecutionPlanError::Invalid(
+                        "integrity constraint count exceeds u32".to_owned(),
+                    )
+                })?,
+                id: id.get(),
+                name: name.to_owned(),
+            })
+        })
+        .collect::<Result<Vec<_>, GpuExecutionPlanError>>()?;
+    Ok(GpuExecutionPlan {
+        version: GPU_EXECUTION_PLAN_VERSION,
+        kernel_kind: GpuPlanKernelKind::FixedShape,
+        wgsl: kernel.wgsl().to_owned(),
+        workgroup_size: WORKGROUP_SIZE,
+        dispatch_elements: kernel.instances(),
+        bindings,
+        states,
+        outputs,
+        physical_outputs,
+        constraints,
+    })
+}
+
+fn logical_outputs(
+    kind: GpuPlanKernelKind,
+    compute: &mech_compute::ComputeProgram,
+    instances: u32,
+    bindings: &[GpuPlanBinding],
+) -> Result<Vec<GpuPlanOutput>, GpuExecutionPlanError> {
+    let mut physical_ids = BTreeMap::<u32, u32>::new();
+    compute
+        .interface()
+        .outputs
+        .iter()
+        .map(|output| {
+            let per_instance = output.elements().map_err(|failure| {
+                GpuExecutionPlanError::Invalid(format!(
+                    "output `{}` has an invalid shape: {failure}",
+                    output.name
+                ))
+            })? as u64;
+            let elements = per_instance
+                .checked_mul(u64::from(instances))
+                .ok_or_else(|| {
+                    GpuExecutionPlanError::Invalid(format!(
+                        "output `{}` size overflows u64",
+                        output.name
+                    ))
+                })?;
+            let next_id = u32::try_from(physical_ids.len()).map_err(|_| {
+                GpuExecutionPlanError::Invalid("physical output count exceeds u32".to_owned())
+            })?;
+            let physical_output = *physical_ids.entry(output.slot.get()).or_insert(next_id);
+            let mut dimensions = Vec::new();
+            if kind == GpuPlanKernelKind::FixedShape {
+                dimensions.push(u64::from(instances));
+            }
+            dimensions.extend(output.dimensions.iter().copied());
+            let _ = bindings;
+            Ok(GpuPlanOutput {
+                name: output.name.to_string(),
+                slot: output.slot.get(),
+                physical_output,
+                elements,
+                elements_per_instance: per_instance,
+                dimensions,
+                sample_dimensions: output.dimensions.to_vec(),
+                physical_layout: if kind == GpuPlanKernelKind::FixedShape {
+                    GpuPlanLayout::ColumnMajor
+                } else {
+                    GpuPlanLayout::RowMajor
+                },
+            })
+        })
+        .collect()
+}
+
+fn physical_outputs(
+    outputs: &[GpuPlanOutput],
+    bindings: &[GpuPlanBinding],
+) -> Result<Vec<GpuPhysicalOutputPlan>, GpuExecutionPlanError> {
+    let state_slots = bindings
+        .iter()
+        .filter(|binding| binding.role == GpuPlanBindingRole::StateWrite)
+        .map(|binding| binding.slot)
+        .collect::<BTreeSet<_>>();
+    let mut physical = BTreeMap::<u32, GpuPhysicalOutputPlan>::new();
+    for output in outputs {
+        let binding = if state_slots.contains(&output.slot) {
+            None
+        } else {
+            Some(
+                bindings
+                    .iter()
+                    .find(|binding| {
+                        binding.role == GpuPlanBindingRole::Output && binding.slot == output.slot
+                    })
+                    .ok_or_else(|| {
+                        GpuExecutionPlanError::Invalid(format!(
+                            "output `{}` has no physical binding",
+                            output.name
+                        ))
+                    })?
+                    .binding,
+            )
+        };
+        let entry =
+            physical
+                .entry(output.physical_output)
+                .or_insert_with(|| GpuPhysicalOutputPlan {
+                    id: output.physical_output,
+                    slot: output.slot,
+                    binding,
+                    sample_elements: output.elements_per_instance,
+                    aliases: Vec::new(),
+                });
+        if entry.slot != output.slot
+            || entry.binding != binding
+            || entry.sample_elements != output.elements_per_instance
+        {
+            return Err(GpuExecutionPlanError::Invalid(format!(
+                "logical output `{}` is incompatible with its physical alias group",
+                output.name
+            )));
+        }
+        entry.aliases.push(output.name.clone());
+    }
+    Ok(physical.into_values().collect())
+}
+
+impl From<GpuBindingAccess> for GpuPlanBindingAccess {
+    fn from(access: GpuBindingAccess) -> Self {
+        match access {
+            GpuBindingAccess::Read => Self::Read,
+            GpuBindingAccess::ReadWrite => Self::ReadWrite,
+        }
+    }
+}
+
+impl From<GpuBindingRole> for GpuPlanBindingRole {
+    fn from(role: GpuBindingRole) -> Self {
+        match role {
+            GpuBindingRole::Input => Self::Input,
+            GpuBindingRole::StateRead => Self::StateRead,
+            GpuBindingRole::StateWrite => Self::StateWrite,
+            GpuBindingRole::Output => Self::Output,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialized_execution_plan_rejects_unknown_versions() {
+        let mut plan = GpuExecutionPlan {
+            version: GPU_EXECUTION_PLAN_VERSION,
+            kernel_kind: GpuPlanKernelKind::Elementwise,
+            wgsl: "shader".to_owned(),
+            workgroup_size: 64,
+            dispatch_elements: 1,
+            bindings: Vec::new(),
+            states: Vec::new(),
+            outputs: Vec::new(),
+            physical_outputs: Vec::new(),
+            constraints: Vec::new(),
+        };
+        let encoded = serde_json::to_string(&plan).unwrap();
+        let decoded: GpuExecutionPlan = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, plan);
+        plan.version += 1;
+        assert_eq!(
+            plan.validate(),
+            Err(GpuExecutionPlanError::UnsupportedVersion(
+                GPU_EXECUTION_PLAN_VERSION + 1
+            ))
+        );
+    }
+
+    #[test]
+    fn invalid_binding_sizes_and_aliases_are_rejected() {
+        let mut plan = GpuExecutionPlan {
+            version: GPU_EXECUTION_PLAN_VERSION,
+            kernel_kind: GpuPlanKernelKind::Elementwise,
+            wgsl: "shader".to_owned(),
+            workgroup_size: 64,
+            dispatch_elements: 1,
+            bindings: vec![GpuPlanBinding {
+                binding: 0,
+                name: "input".to_owned(),
+                access: GpuPlanBindingAccess::Read,
+                role: GpuPlanBindingRole::Input,
+                slot: 1,
+                elements: 2,
+                scalar: GpuPlanScalar::F32,
+                initial_values: Some(GpuPlanInitialValues::F32(vec![1.0])),
+            }],
+            states: Vec::new(),
+            outputs: Vec::new(),
+            physical_outputs: Vec::new(),
+            constraints: Vec::new(),
+        };
+        assert!(plan.validate().is_err());
+        plan.bindings[0].initial_values = Some(GpuPlanInitialValues::F32(vec![1.0, 2.0]));
+        plan.outputs.push(GpuPlanOutput {
+            name: "missing".to_owned(),
+            slot: 2,
+            physical_output: 5,
+            elements: 1,
+            elements_per_instance: 1,
+            dimensions: vec![1],
+            sample_dimensions: vec![1],
+            physical_layout: GpuPlanLayout::RowMajor,
+        });
+        assert!(plan.validate().is_err());
+    }
+}

--- a/hosts/gpu/src/lib.rs
+++ b/hosts/gpu/src/lib.rs
@@ -43,6 +43,8 @@ mod compute_provider;
 pub use compute_provider::*;
 mod compute_backends;
 pub use compute_backends::*;
+mod execution_plan;
+pub use execution_plan::*;
 pub const WORKGROUP_SIZE: u32 = 64;
 
 #[cfg(test)]
@@ -122,8 +124,6 @@ struct KernelOutput {
     source: CellSlotId,
     elements: u64,
     dimensions: Vec<u64>,
-    #[cfg_attr(not(feature = "native"), allow(dead_code))]
-    binding: u32,
 }
 
 #[derive(Clone, Debug)]
@@ -246,9 +246,7 @@ impl ElementwiseKernel {
                     format!("output `{}` element count exceeds u64", output.name),
                 )
             })?;
-            let binding = if let Some(binding) = state_write_bindings.get(&output.slot) {
-                *binding
-            } else {
+            if !state_write_bindings.contains_key(&output.slot) {
                 let binding = bindings.len() as u32;
                 bindings.push(GpuBinding {
                     binding,
@@ -257,14 +255,12 @@ impl ElementwiseKernel {
                     elements,
                     kind: GpuBindingKind::Output(output.slot),
                 });
-                binding
-            };
+            }
             outputs.push(KernelOutput {
                 name: output.name.to_string(),
                 source: output.slot,
                 elements,
                 dimensions: output.dimensions.to_vec(),
-                binding,
             });
         }
 
@@ -1419,7 +1415,7 @@ impl<'a> Compiler<'a> {
                 };
                 let dimensions = self.slot_dimensions(source);
                 if let Some(state) = self.state_slots.get(&source) {
-                    let Some(binding) = state.write_binding else {
+                    let Some(_) = state.write_binding else {
                         continue;
                     };
                     self.outputs.push(KernelOutput {
@@ -1427,7 +1423,6 @@ impl<'a> Compiler<'a> {
                         source,
                         elements,
                         dimensions,
-                        binding,
                     });
                     continue;
                 }
@@ -1444,7 +1439,6 @@ impl<'a> Compiler<'a> {
                     source,
                     elements,
                     dimensions,
-                    binding,
                 });
             }
         }
@@ -1984,7 +1978,6 @@ mod tests {
                 source: output,
                 elements,
                 dimensions: vec![elements],
-                binding: 0,
             }],
             states: Vec::new(),
             input_slots: BTreeMap::new(),

--- a/hosts/gpu/src/lib.rs
+++ b/hosts/gpu/src/lib.rs
@@ -1836,6 +1836,7 @@ fn wgsl_elementwise_expression(operation: ElementwiseOperation, inputs: &[String
                 UnaryOperation::Sin => "sin",
                 UnaryOperation::Cos => "cos",
                 UnaryOperation::Sqrt => "sqrt",
+                UnaryOperation::Ceil => "ceil",
             };
             format!("{function}({})", inputs[0])
         }

--- a/hosts/gpu/src/lib.rs
+++ b/hosts/gpu/src/lib.rs
@@ -1841,6 +1841,7 @@ fn wgsl_elementwise_expression(operation: ElementwiseOperation, inputs: &[String
             let function = match operation {
                 UnaryOperation::Sin => "sin",
                 UnaryOperation::Cos => "cos",
+                UnaryOperation::Sqrt => "sqrt",
             };
             format!("{function}({})", inputs[0])
         }

--- a/hosts/gpu/src/native.rs
+++ b/hosts/gpu/src/native.rs
@@ -6,9 +6,13 @@ use std::{
     time::{Duration, Instant},
 };
 
+use mech_core::CellSlotId;
 use wgpu::util::DeviceExt;
 
-use super::{ElementwiseKernel, GpuBindingAccess, GpuBindingKind};
+use super::{
+    ElementwiseKernel, GpuExecutionPlan, GpuKernelPlanSource, GpuPhysicalOutputPlan,
+    GpuPlanBindingAccess, GpuPlanBindingRole, GpuPlanInitialValues, GpuPlanScalar,
+};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum GpuExecutionError {
@@ -28,6 +32,7 @@ pub enum GpuExecutionError {
         required: u32,
         supported: u32,
     },
+    InvalidPlan(String),
 }
 
 impl fmt::Display for GpuExecutionError {
@@ -103,6 +108,9 @@ impl ElementwiseKernel {
         inputs: &BTreeMap<String, Vec<f32>>,
     ) -> Result<GpuExecutionProfile, GpuExecutionError> {
         let total_started = Instant::now();
+        let execution_plan =
+            GpuExecutionPlan::build(GpuKernelPlanSource::Elementwise(self), inputs)
+                .map_err(|failure| GpuExecutionError::InvalidPlan(failure.to_string()))?;
         let setup_started = Instant::now();
         let instance = wgpu::Instance::default();
         let adapter = instance
@@ -118,7 +126,8 @@ impl ElementwiseKernel {
             format!("{} ({:?})", info.name, info.backend)
         };
         let adapter_limits = adapter.limits();
-        let (required_limits, workgroups) = self.required_device_limits(&adapter_limits)?;
+        let (required_limits, workgroups) =
+            required_device_limits_for_plan(&execution_plan, &adapter_limits)?;
         let (device, queue) = adapter
             .request_device(
                 &wgpu::DeviceDescriptor {
@@ -133,51 +142,43 @@ impl ElementwiseKernel {
         let setup = setup_started.elapsed();
 
         let pipeline_started = Instant::now();
-        let mut buffers = Vec::with_capacity(self.bindings.len());
-        for binding in &self.bindings {
-            let buffer = match binding.kind {
-                GpuBindingKind::Input(_) => {
-                    let values = inputs
-                        .get(&binding.name)
-                        .ok_or_else(|| GpuExecutionError::MissingInput(binding.name.clone()))?;
-                    if values.len() != binding.elements as usize {
-                        return Err(GpuExecutionError::InputLength {
-                            name: binding.name.clone(),
-                            expected: binding.elements,
-                            actual: values.len(),
-                        });
-                    }
+        let mut buffers = BTreeMap::new();
+        for binding in &execution_plan.bindings {
+            let usage = wgpu::BufferUsages::STORAGE
+                | if matches!(
+                    binding.role,
+                    GpuPlanBindingRole::StateWrite | GpuPlanBindingRole::Output
+                ) {
+                    wgpu::BufferUsages::COPY_SRC
+                } else {
+                    wgpu::BufferUsages::empty()
+                };
+            let buffer = match &binding.initial_values {
+                Some(GpuPlanInitialValues::F32(values)) => {
                     device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
                         label: Some(&binding.name),
                         contents: bytemuck::cast_slice(values),
-                        usage: wgpu::BufferUsages::STORAGE,
+                        usage,
                     })
                 }
-                GpuBindingKind::StateRead(slot) => {
-                    let state = self
-                        .states
-                        .iter()
-                        .find(|state| state.slot == slot)
-                        .expect("state binding references known state");
+                Some(GpuPlanInitialValues::U32(values)) => {
                     device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
                         label: Some(&binding.name),
-                        contents: bytemuck::cast_slice(&state.initializer),
-                        usage: wgpu::BufferUsages::STORAGE,
+                        contents: bytemuck::cast_slice(values),
+                        usage,
                     })
                 }
-                GpuBindingKind::StateWrite(_) | GpuBindingKind::Output(_) => {
-                    device.create_buffer(&wgpu::BufferDescriptor {
-                        label: Some(&binding.name),
-                        size: binding.elements * std::mem::size_of::<f32>() as u64,
-                        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
-                        mapped_at_creation: false,
-                    })
-                }
+                None => device.create_buffer(&wgpu::BufferDescriptor {
+                    label: Some(&binding.name),
+                    size: binding.elements * scalar_size(binding.scalar),
+                    usage,
+                    mapped_at_creation: false,
+                }),
             };
-            buffers.push(buffer);
+            buffers.insert(binding.binding, buffer);
         }
 
-        let layout_entries = self
+        let layout_entries = execution_plan
             .bindings
             .iter()
             .map(|binding| wgpu::BindGroupLayoutEntry {
@@ -185,7 +186,7 @@ impl ElementwiseKernel {
                 visibility: wgpu::ShaderStages::COMPUTE,
                 ty: wgpu::BindingType::Buffer {
                     ty: wgpu::BufferBindingType::Storage {
-                        read_only: binding.access == GpuBindingAccess::Read,
+                        read_only: binding.access == GpuPlanBindingAccess::Read,
                     },
                     has_dynamic_offset: false,
                     min_binding_size: None,
@@ -197,13 +198,12 @@ impl ElementwiseKernel {
             label: Some("Mech GPU bindings"),
             entries: &layout_entries,
         });
-        let bind_entries = self
+        let bind_entries = execution_plan
             .bindings
             .iter()
-            .zip(&buffers)
-            .map(|(binding, buffer)| wgpu::BindGroupEntry {
+            .map(|binding| wgpu::BindGroupEntry {
                 binding: binding.binding,
-                resource: buffer.as_entire_binding(),
+                resource: buffers[&binding.binding].as_entire_binding(),
             })
             .collect::<Vec<_>>();
         let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
@@ -213,7 +213,7 @@ impl ElementwiseKernel {
         });
         let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("Generated Mech WGSL"),
-            source: wgpu::ShaderSource::Wgsl(self.wgsl.clone().into()),
+            source: wgpu::ShaderSource::Wgsl(execution_plan.wgsl.clone().into()),
         });
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("Mech GPU pipeline layout"),
@@ -243,21 +243,22 @@ impl ElementwiseKernel {
             pass.set_bind_group(0, &bind_group, &[]);
             pass.dispatch_workgroups(workgroups, 1, 1);
         }
-        for output in &self.outputs {
-            let size = output.elements * std::mem::size_of::<f32>() as u64;
+        for output in &execution_plan.physical_outputs {
+            let size = output.sample_elements * std::mem::size_of::<f32>() as u64;
             let readback = device.create_buffer(&wgpu::BufferDescriptor {
                 label: Some("Mech GPU readback"),
                 size,
                 usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
                 mapped_at_creation: false,
             });
-            encoder.copy_buffer_to_buffer(&buffers[output.binding as usize], 0, &readback, 0, size);
-            readbacks.push((output.name.clone(), readback));
+            let binding = physical_output_binding(&execution_plan, output)?;
+            encoder.copy_buffer_to_buffer(&buffers[&binding], 0, &readback, 0, size);
+            readbacks.push((output.aliases.clone(), readback));
         }
         queue.submit(Some(encoder.finish()));
 
         let mut outputs = BTreeMap::new();
-        for (name, readback) in readbacks {
+        for (aliases, readback) in readbacks {
             let slice = readback.slice(..);
             let (sender, receiver) = mpsc::channel();
             slice.map_async(wgpu::MapMode::Read, move |result| {
@@ -269,7 +270,10 @@ impl ElementwiseKernel {
                 .map_err(|_| GpuExecutionError::ChannelClosed)?
                 .map_err(|error| GpuExecutionError::BufferMap(error.to_string()))?;
             let mapped = slice.get_mapped_range();
-            outputs.insert(name, bytemuck::cast_slice::<u8, f32>(&mapped).to_vec());
+            let values = bytemuck::cast_slice::<u8, f32>(&mapped).to_vec();
+            for name in aliases {
+                outputs.insert(name, values.clone());
+            }
             drop(mapped);
             readback.unmap();
         }
@@ -294,6 +298,9 @@ impl ElementwiseKernel {
         &self,
         inputs: &BTreeMap<String, Vec<f32>>,
     ) -> Result<ResidentGpuSession, GpuExecutionError> {
+        let execution_plan =
+            GpuExecutionPlan::build(GpuKernelPlanSource::Elementwise(self), inputs)
+                .map_err(|failure| GpuExecutionError::InvalidPlan(failure.to_string()))?;
         let instance = wgpu::Instance::default();
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions {
@@ -306,7 +313,8 @@ impl ElementwiseKernel {
         let adapter_info = adapter.get_info();
         let adapter_name = format!("{} ({:?})", adapter_info.name, adapter_info.backend);
         let adapter_limits = adapter.limits();
-        let (required_limits, workgroups) = self.required_device_limits(&adapter_limits)?;
+        let (required_limits, workgroups) =
+            required_device_limits_for_plan(&execution_plan, &adapter_limits)?;
         let (device, queue) = adapter
             .request_device(
                 &wgpu::DeviceDescriptor {
@@ -322,11 +330,12 @@ impl ElementwiseKernel {
         let mut state_buffers = BTreeMap::new();
         let mut fixed_buffers = BTreeMap::new();
         let mut input_buffers = BTreeMap::new();
-        for state in &self.states {
+        for state in &execution_plan.states {
+            let slot = CellSlotId::new(state.slot);
             let initial = Arc::new(
                 device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
                     label: Some("Mech resident initial state"),
-                    contents: bytemuck::cast_slice(&state.initializer),
+                    contents: bytemuck::cast_slice(&state.initial_values),
                     usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
                 }),
             );
@@ -336,22 +345,18 @@ impl ElementwiseKernel {
                 usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
                 mapped_at_creation: false,
             }));
-            state_buffers.insert(state.slot, [initial, alternate]);
+            state_buffers.insert(slot, [initial, alternate]);
         }
-        for binding in &self.bindings {
-            if !matches!(binding.kind, GpuBindingKind::Input(_)) {
+        for binding in &execution_plan.bindings {
+            if binding.role != GpuPlanBindingRole::Input {
                 continue;
             }
-            let values = inputs
-                .get(&binding.name)
-                .ok_or_else(|| GpuExecutionError::MissingInput(binding.name.clone()))?;
-            if values.len() != binding.elements as usize {
-                return Err(GpuExecutionError::InputLength {
-                    name: binding.name.clone(),
-                    expected: binding.elements,
-                    actual: values.len(),
-                });
-            }
+            let Some(GpuPlanInitialValues::F32(values)) = &binding.initial_values else {
+                return Err(GpuExecutionError::InvalidPlan(format!(
+                    "input binding `{}` has no f32 initializer",
+                    binding.name
+                )));
+            };
             let buffer = Arc::new(
                 device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
                     label: Some(&binding.name),
@@ -363,31 +368,39 @@ impl ElementwiseKernel {
             input_buffers.insert(binding.name.clone(), (buffer, binding.elements));
         }
 
-        let mut group_buffers: [Vec<Arc<wgpu::Buffer>>; 2] = [Vec::new(), Vec::new()];
-        for binding in &self.bindings {
-            match binding.kind {
-                GpuBindingKind::Input(_) => {
+        let mut group_buffers: [BTreeMap<u32, Arc<wgpu::Buffer>>; 2] =
+            [BTreeMap::new(), BTreeMap::new()];
+        for binding in &execution_plan.bindings {
+            match binding.role {
+                GpuPlanBindingRole::Input => {
                     let buffer = fixed_buffers[&binding.binding].clone();
-                    group_buffers[0].push(buffer.clone());
-                    group_buffers[1].push(buffer);
+                    group_buffers[0].insert(binding.binding, buffer.clone());
+                    group_buffers[1].insert(binding.binding, buffer);
                 }
-                GpuBindingKind::StateRead(slot) => {
-                    group_buffers[0].push(state_buffers[&slot][0].clone());
-                    group_buffers[1].push(state_buffers[&slot][1].clone());
+                GpuPlanBindingRole::StateRead => {
+                    let slot = CellSlotId::new(binding.slot);
+                    group_buffers[0].insert(binding.binding, state_buffers[&slot][0].clone());
+                    group_buffers[1].insert(binding.binding, state_buffers[&slot][1].clone());
                 }
-                GpuBindingKind::StateWrite(slot) => {
-                    group_buffers[0].push(state_buffers[&slot][1].clone());
-                    group_buffers[1].push(state_buffers[&slot][0].clone());
+                GpuPlanBindingRole::StateWrite => {
+                    let slot = CellSlotId::new(binding.slot);
+                    group_buffers[0].insert(binding.binding, state_buffers[&slot][1].clone());
+                    group_buffers[1].insert(binding.binding, state_buffers[&slot][0].clone());
                 }
-                GpuBindingKind::Output(_) => {
+                GpuPlanBindingRole::Output => {
                     let buffer = Arc::new(device.create_buffer(&wgpu::BufferDescriptor {
                         label: Some(&binding.name),
-                        size: binding.elements * std::mem::size_of::<f32>() as u64,
+                        size: binding.elements * scalar_size(binding.scalar),
                         usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
                         mapped_at_creation: false,
                     }));
-                    group_buffers[0].push(buffer.clone());
-                    group_buffers[1].push(buffer.clone());
+                    group_buffers[0].insert(binding.binding, buffer.clone());
+                    group_buffers[1].insert(binding.binding, buffer.clone());
+                }
+                GpuPlanBindingRole::IntegrityFault => {
+                    return Err(GpuExecutionError::InvalidPlan(
+                        "elementwise plan unexpectedly contains an integrity binding".to_owned(),
+                    ));
                 }
             }
         }
@@ -395,17 +408,25 @@ impl ElementwiseKernel {
         let mut output_buffers: [BTreeMap<String, Arc<wgpu::Buffer>>; 2] =
             [BTreeMap::new(), BTreeMap::new()];
         let mut output_elements = BTreeMap::new();
-        for output in &self.outputs {
+        for output in &execution_plan.outputs {
             for group in 0..2 {
-                output_buffers[group].insert(
-                    output.name.clone(),
-                    group_buffers[group][output.binding as usize].clone(),
-                );
+                let physical = execution_plan
+                    .physical_outputs
+                    .iter()
+                    .find(|physical| physical.id == output.physical_output)
+                    .expect("validated execution plan references a physical output");
+                let buffer = if let Some(binding) = physical.binding {
+                    group_buffers[group][&binding].clone()
+                } else {
+                    let slot = CellSlotId::new(output.slot);
+                    state_buffers[&slot][1 - group].clone()
+                };
+                output_buffers[group].insert(output.name.clone(), buffer);
             }
             output_elements.insert(output.name.clone(), output.elements);
         }
 
-        let layout_entries = self
+        let layout_entries = execution_plan
             .bindings
             .iter()
             .map(|binding| wgpu::BindGroupLayoutEntry {
@@ -413,7 +434,7 @@ impl ElementwiseKernel {
                 visibility: wgpu::ShaderStages::COMPUTE,
                 ty: wgpu::BindingType::Buffer {
                     ty: wgpu::BufferBindingType::Storage {
-                        read_only: binding.access == GpuBindingAccess::Read,
+                        read_only: binding.access == GpuPlanBindingAccess::Read,
                     },
                     has_dynamic_offset: false,
                     min_binding_size: None,
@@ -426,13 +447,12 @@ impl ElementwiseKernel {
             entries: &layout_entries,
         });
         let bind_groups = [0, 1].map(|group| {
-            let entries = self
+            let entries = execution_plan
                 .bindings
                 .iter()
-                .zip(&group_buffers[group])
-                .map(|(binding, buffer)| wgpu::BindGroupEntry {
+                .map(|binding| wgpu::BindGroupEntry {
                     binding: binding.binding,
-                    resource: buffer.as_entire_binding(),
+                    resource: group_buffers[group][&binding.binding].as_entire_binding(),
                 })
                 .collect::<Vec<_>>();
             device.create_bind_group(&wgpu::BindGroupDescriptor {
@@ -443,7 +463,7 @@ impl ElementwiseKernel {
         });
         let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("Generated resident Mech WGSL"),
-            source: wgpu::ShaderSource::Wgsl(self.wgsl.clone().into()),
+            source: wgpu::ShaderSource::Wgsl(execution_plan.wgsl.clone().into()),
         });
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("Mech resident GPU pipeline layout"),
@@ -472,34 +492,62 @@ impl ElementwiseKernel {
             last_output_group: None,
         })
     }
+}
 
-    fn required_device_limits(
-        &self,
-        adapter_limits: &wgpu::Limits,
-    ) -> Result<(wgpu::Limits, u32), GpuExecutionError> {
-        let required_storage_buffers = self.bindings.len() as u32;
-        if required_storage_buffers > adapter_limits.max_storage_buffers_per_shader_stage {
-            return Err(GpuExecutionError::DeviceRequest(format!(
-                "kernel needs {required_storage_buffers} storage buffers, adapter supports {}",
-                adapter_limits.max_storage_buffers_per_shader_stage
-            )));
-        }
-        let workgroups = self.workgroup_count();
-        if workgroups > adapter_limits.max_compute_workgroups_per_dimension {
-            return Err(GpuExecutionError::WorkgroupLimit {
-                required: workgroups,
-                supported: adapter_limits.max_compute_workgroups_per_dimension,
-            });
-        }
-        Ok((
-            wgpu::Limits {
-                max_storage_buffers_per_shader_stage: required_storage_buffers,
-                max_compute_workgroups_per_dimension: workgroups,
-                ..wgpu::Limits::downlevel_defaults()
-            },
-            workgroups,
-        ))
+fn scalar_size(scalar: GpuPlanScalar) -> u64 {
+    match scalar {
+        GpuPlanScalar::F32 | GpuPlanScalar::U32 => 4,
     }
+}
+
+fn physical_output_binding(
+    plan: &GpuExecutionPlan,
+    output: &GpuPhysicalOutputPlan,
+) -> Result<u32, GpuExecutionError> {
+    output
+        .binding
+        .or_else(|| {
+            plan.bindings
+                .iter()
+                .find(|binding| {
+                    binding.role == GpuPlanBindingRole::StateWrite && binding.slot == output.slot
+                })
+                .map(|binding| binding.binding)
+        })
+        .ok_or_else(|| {
+            GpuExecutionError::InvalidPlan(format!(
+                "physical output {} has no readable binding",
+                output.id
+            ))
+        })
+}
+
+fn required_device_limits_for_plan(
+    plan: &GpuExecutionPlan,
+    adapter_limits: &wgpu::Limits,
+) -> Result<(wgpu::Limits, u32), GpuExecutionError> {
+    let required_storage_buffers = plan.bindings.len() as u32;
+    if required_storage_buffers > adapter_limits.max_storage_buffers_per_shader_stage {
+        return Err(GpuExecutionError::DeviceRequest(format!(
+            "kernel needs {required_storage_buffers} storage buffers, adapter supports {}",
+            adapter_limits.max_storage_buffers_per_shader_stage
+        )));
+    }
+    let workgroups = plan.dispatch_elements.div_ceil(plan.workgroup_size);
+    if workgroups > adapter_limits.max_compute_workgroups_per_dimension {
+        return Err(GpuExecutionError::WorkgroupLimit {
+            required: workgroups,
+            supported: adapter_limits.max_compute_workgroups_per_dimension,
+        });
+    }
+    Ok((
+        wgpu::Limits {
+            max_storage_buffers_per_shader_stage: required_storage_buffers,
+            max_compute_workgroups_per_dimension: workgroups,
+            ..wgpu::Limits::downlevel_defaults()
+        },
+        workgroups,
+    ))
 }
 
 impl ResidentGpuSession {
@@ -620,7 +668,7 @@ impl ResidentGpuSession {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::GpuBinding;
+    use crate::{GpuBinding, GpuBindingAccess, GpuBindingKind};
     use mech_core::CellSlotId;
 
     #[test]
@@ -638,8 +686,11 @@ mod tests {
         let mut limits = wgpu::Limits::downlevel_defaults();
         limits.max_compute_workgroups_per_dimension = 1;
 
+        let plan =
+            GpuExecutionPlan::build(GpuKernelPlanSource::Elementwise(&program), &BTreeMap::new())
+                .unwrap();
         assert_eq!(
-            program.required_device_limits(&limits).unwrap_err(),
+            required_device_limits_for_plan(&plan, &limits).unwrap_err(),
             GpuExecutionError::WorkgroupLimit {
                 required: 2,
                 supported: 1,
@@ -671,7 +722,10 @@ mod tests {
             ..wgpu::Limits::downlevel_defaults()
         };
 
-        let (requested, workgroups) = program.required_device_limits(&limits).unwrap();
+        let plan =
+            GpuExecutionPlan::build(GpuKernelPlanSource::Elementwise(&program), &BTreeMap::new())
+                .unwrap();
+        let (requested, workgroups) = required_device_limits_for_plan(&plan, &limits).unwrap();
         assert_eq!(workgroups, 2);
         assert_eq!(requested.max_storage_buffers_per_shader_stage, 1);
         assert_eq!(requested.max_compute_workgroups_per_dimension, 2);

--- a/hosts/gpu/tests/parallel_ekf.rs
+++ b/hosts/gpu/tests/parallel_ekf.rs
@@ -372,6 +372,48 @@ fn source_program_from(
     (program, inputs)
 }
 
+#[test]
+fn fixed_shape_physical_plan_expands_one_thousand_lane_resident_buffers() {
+    let instances = 1_000;
+    let (program, inputs) = source_program(instances);
+    let physical_inputs = program.physical_inputs(&inputs).unwrap();
+    let physical_states = program.physical_states();
+
+    assert_eq!(program.instances(), instances as u32);
+    assert!(
+        physical_inputs
+            .iter()
+            .all(|input| input.elements == instances)
+    );
+    assert_eq!(physical_states.len(), 2);
+    assert!(
+        physical_states
+            .iter()
+            .any(|state| { state.elements_per_instance == 3 && state.elements == instances * 3 })
+    );
+    assert!(
+        physical_states
+            .iter()
+            .any(|state| { state.elements_per_instance == 9 && state.elements == instances * 9 })
+    );
+    let bindings = physical_inputs
+        .iter()
+        .map(|input| input.binding)
+        .chain(
+            physical_states
+                .iter()
+                .flat_map(|state| [state.read_binding, state.write_binding]),
+        )
+        .chain(program.integrity_buffer().map(|fault| fault.binding))
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        bindings.len(),
+        physical_inputs.len() + physical_states.len() * 2 + 1,
+        "every browser/native fixed-shape buffer must have one unique binding",
+    );
+    assert_eq!(program.integrity_buffer().unwrap().words, 2);
+}
+
 fn compute_initializers(
     program: &FixedShapeKernel,
     inputs: &BTreeMap<String, Vec<f32>>,

--- a/hosts/gpu/tests/parallel_ekf.rs
+++ b/hosts/gpu/tests/parallel_ekf.rs
@@ -701,6 +701,74 @@ fn mech_arrays_define_the_broadcast_extent() {
 }
 
 #[test]
+fn lane_zero_recurrence_is_independent_of_broadcast_extent() {
+    let (single_program, single_inputs) = source_program(1);
+    let (batch_program, batch_inputs) = source_program(1_000);
+    let mut single = single_program.prepare_cpu(&single_inputs).unwrap();
+    let mut batch = batch_program.prepare_cpu(&batch_inputs).unwrap();
+
+    for turn in 0..128 {
+        let lane_zero_bearing = -0.55 + 0.012 * (turn as f32 * 0.17).sin();
+        let single_update = BTreeMap::from([("bearing".to_owned(), vec![lane_zero_bearing])]);
+        let mut batch_bearings = batch_inputs["bearing"].clone();
+        batch_bearings[0] = lane_zero_bearing;
+        let batch_update = BTreeMap::from([("bearing".to_owned(), batch_bearings)]);
+        single.update_inputs(&single_update).unwrap();
+        batch.update_inputs(&batch_update).unwrap();
+        single.dispatch_turns(1).unwrap();
+        batch.dispatch_turns(1).unwrap();
+
+        for (slot, elements) in single_program.state_layout() {
+            let single_lane = &single.state()[&slot][..elements];
+            let batch_lane_zero = &batch.state()[&slot][..elements];
+            assert_close(single_lane, batch_lane_zero, 0.0);
+        }
+    }
+}
+
+#[cfg(feature = "native")]
+#[test]
+fn native_gpu_lane_zero_is_independent_of_broadcast_extent() {
+    let (single_program, single_inputs) = source_program(1);
+    let (batch_program, batch_inputs) = source_program(1_000);
+    let mut single = match single_program.prepare_resident(&single_inputs) {
+        Ok(session) => session,
+        Err(BatchedExecutionError::Native(message))
+            if message.to_ascii_lowercase().contains("adapter") =>
+        {
+            return;
+        }
+        Err(error) => panic!("single-lane native GPU preparation failed: {error}"),
+    };
+    let mut batch = batch_program
+        .prepare_resident(&batch_inputs)
+        .expect("the same adapter must admit the 1,000-lane program");
+    let state_slots = single_program
+        .state_layout()
+        .map(|(slot, _)| slot)
+        .collect::<BTreeSet<_>>();
+
+    for turn in 0..128 {
+        let lane_zero_bearing = -0.55 + 0.012 * (turn as f32 * 0.17).sin();
+        let single_update = BTreeMap::from([("bearing".to_owned(), vec![lane_zero_bearing])]);
+        let mut batch_bearings = batch_inputs["bearing"].clone();
+        batch_bearings[0] = lane_zero_bearing;
+        let batch_update = BTreeMap::from([("bearing".to_owned(), batch_bearings)]);
+        single
+            .update_inputs(&single_program, &single_update)
+            .unwrap();
+        batch.update_inputs(&batch_program, &batch_update).unwrap();
+        single.dispatch_turns(1).unwrap();
+        batch.dispatch_turns(1).unwrap();
+        let single_sample = single.read_published_samples(&state_slots).unwrap();
+        let batch_sample = batch.read_published_samples(&state_slots).unwrap();
+        for slot in &state_slots {
+            assert_close(&single_sample[slot], &batch_sample[slot], 1.0e-6);
+        }
+    }
+}
+
+#[test]
 fn conflicting_mech_array_extents_are_rejected() {
     let tree = source_tree(7);
     let driver = evaluate_driver(&tree);

--- a/hosts/gpu/tests/parallel_ekf.rs
+++ b/hosts/gpu/tests/parallel_ekf.rs
@@ -304,7 +304,12 @@ result
         .id;
     let registry = native_compute_backend_registry();
 
-    for backend in ["cpu-scalar", "cpu-simd", "cpu-jit", "wgpu"] {
+    let mut backends = vec!["cpu-scalar", "cpu-simd"];
+    if cfg!(feature = "jit") {
+        backends.push("cpu-jit");
+    }
+    backends.push("wgpu");
+    for backend in backends {
         let request = BackendRequest::parse(backend).unwrap();
         let factory = match registry.resolve(
             &request,
@@ -459,8 +464,8 @@ fn flattened_outputs(
 
 #[cfg(feature = "native")]
 #[test]
-fn registered_backends_share_one_fixed_shape_conformance_contract() {
-    let (program, inputs) = source_program(1);
+fn registered_backends_share_one_thousand_lane_fixed_shape_conformance_contract() {
+    let (program, inputs) = source_program(1_000);
     let initializers = compute_initializers(&program, &inputs);
     let registry = native_compute_backend_registry();
     let bearing = program
@@ -471,7 +476,12 @@ fn registered_backends_share_one_fixed_shape_conformance_contract() {
         .id;
     let mut accepted = BTreeMap::new();
 
-    for backend in ["cpu-scalar", "cpu-simd", "cpu-jit", "wgpu"] {
+    let mut backends = vec!["cpu-scalar", "cpu-simd"];
+    if cfg!(feature = "jit") {
+        backends.push("cpu-jit");
+    }
+    backends.push("wgpu");
+    for backend in backends {
         let request = BackendRequest::parse(backend).unwrap();
         let factory = match registry.resolve(
             &request,
@@ -507,6 +517,23 @@ fn registered_backends_share_one_fixed_shape_conformance_contract() {
             .read_outputs(&ComputeOutputSelection::All)
             .expect("published outputs must be readable");
         assert!(!published.values.is_empty());
+        let sampled_port = program.compute_program().interface().outputs[0].clone();
+        let sampled = session
+            .read_outputs(&ComputeOutputSelection::Samples(BTreeSet::from([
+                sampled_port.id,
+            ])))
+            .expect("lane-zero output sampling must be readable");
+        assert_eq!(sampled.values.len(), 1);
+        let sampled_elements = match &sampled.values[&sampled_port.id] {
+            ComputeValue::ScalarF32(_) => 1,
+            ComputeValue::TensorF32 {
+                dimensions, values, ..
+            } => {
+                assert_eq!(dimensions.as_ref(), sampled_port.dimensions.as_ref());
+                values.len()
+            }
+        };
+        assert_eq!(sampled_elements, sampled_port.elements().unwrap());
 
         session
             .update_inputs(&[ComputeInputUpdate {

--- a/hosts/gpu/tests/parallel_ekf.rs
+++ b/hosts/gpu/tests/parallel_ekf.rs
@@ -359,6 +359,98 @@ result
     }
 }
 
+#[test]
+fn matrix_right_hand_side_solve_is_portable_across_compute_backends() {
+    let tree = mech_syntax::parse(
+        r#"
+portable matrix solve @compute
+-------------------------------------------------------------------------------
+coefficients := source-coefficients
+rhs := source-rhs
+~result := [0f32 0f32 0f32
+            0f32 0f32 0f32]
+result = coefficients \ rhs
+result
+"#,
+    )
+    .unwrap();
+    let planning_inputs = BTreeMap::from([
+        (
+            "source-coefficients".to_owned(),
+            RuntimeHostInputValue::F32Matrix {
+                rows: 2,
+                columns: 2,
+                values: vec![4.0, 2.0, 1.0, 3.0],
+            },
+        ),
+        (
+            "source-rhs".to_owned(),
+            RuntimeHostInputValue::F32Matrix {
+                rows: 2,
+                columns: 3,
+                values: vec![9.0, 8.0, 1.0, 7.0, 5.0, 2.0],
+            },
+        ),
+    ]);
+    let artifact = RuntimeBuilder::new()
+        .function_catalog(mech_stdlib::source_native_plan_catalog())
+        .build_compiler()
+        .unwrap()
+        .compile_tree_artifact_with_inputs(
+            &tree,
+            &planning_inputs,
+            &BTreeSet::from(["coefficients".to_owned(), "rhs".to_owned()]),
+        )
+        .unwrap()
+        .into_artifact();
+    assert!(artifact.nodes().iter().any(|node| {
+        node.operation.module_path.as_ref() == ["matrix"]
+            && node.operation.operation_name == "solve"
+    }));
+    let activation_inputs = BTreeMap::from([
+        ("coefficients".to_owned(), vec![4.0, 2.0, 1.0, 3.0]),
+        ("rhs".to_owned(), vec![9.0, 8.0, 1.0, 7.0, 5.0, 2.0]),
+    ]);
+    let program = ComputeLowerer
+        .compile_broadcast(&artifact, &activation_inputs)
+        .unwrap();
+    let initializers = compute_initializers(&program, &activation_inputs);
+    let registry = native_compute_backend_registry();
+    let expected = [1.9, -0.4, 1.3, 1.4, 2.6, -0.2];
+
+    let mut backends = vec!["cpu-scalar", "cpu-simd"];
+    if cfg!(feature = "jit") {
+        backends.push("cpu-jit");
+    }
+    backends.push("wgpu");
+    for backend in backends {
+        let request = BackendRequest::parse(backend).unwrap();
+        let factory = match registry.resolve(
+            &request,
+            ComputePlatform::Native,
+            ComputePlacement::Compute,
+            program.compute_program(),
+        ) {
+            Ok(factory) => factory,
+            Err(error) if backend == "wgpu" && error.to_string().contains("adapter") => continue,
+            Err(error) => panic!("{backend} rejected the matrix solve program: {error}"),
+        };
+        let executable = factory.compile(program.compute_program()).unwrap();
+        let mut session = executable.create_session(&initializers).unwrap();
+        session.dispatch(NonZeroU32::new(1).unwrap()).unwrap();
+        let outputs =
+            flattened_outputs(&session.read_outputs(&ComputeOutputSelection::All).unwrap());
+        assert!(
+            outputs.values().any(|values| values.len() == expected.len()
+                && values
+                    .iter()
+                    .zip(expected)
+                    .all(|(actual, expected)| (actual - expected).abs() < 1.0e-5)),
+            "{backend} did not publish the expected matrix solution: {outputs:?}",
+        );
+    }
+}
+
 fn source_program(instances: usize) -> (FixedShapeKernel, BTreeMap<String, Vec<f32>>) {
     source_program_from(SOURCE, instances)
 }

--- a/hosts/gpu/tests/parallel_ekf.rs
+++ b/hosts/gpu/tests/parallel_ekf.rs
@@ -13,7 +13,8 @@ use mech_engine::{
     ProgramArtifact, decode_program_artifact_sections, encode_program_artifact_sections,
 };
 use mech_gpu::{
-    BatchedExecutionError, ComputeLowerer, FixedShapeKernel, native_compute_backend_registry,
+    BatchedExecutionError, ComputeLowerer, FixedShapeKernel, GpuExecutionPlan, GpuKernelPlanSource,
+    GpuPlanBindingRole, GpuPlanKernelKind, native_compute_backend_registry,
 };
 use mech_runtime::{RuntimeBuilder, RuntimeHostInputValue};
 
@@ -509,6 +510,45 @@ fn fixed_shape_physical_plan_expands_one_thousand_lane_resident_buffers() {
         "every browser/native fixed-shape buffer must have one unique binding",
     );
     assert_eq!(program.integrity_buffer().unwrap().words, 2);
+
+    let plan = GpuExecutionPlan::build(GpuKernelPlanSource::FixedShape(&program), &inputs)
+        .expect("EKF kernel must produce one portable physical GPU plan");
+    assert_eq!(plan.kernel_kind, GpuPlanKernelKind::FixedShape);
+    assert_eq!(plan.dispatch_elements, instances as u32);
+    assert_eq!(plan.bindings.len(), bindings.len());
+    assert_eq!(plan.states.len(), 2);
+    assert_eq!(plan.constraints.len(), 3);
+    assert_eq!(
+        plan.bindings
+            .iter()
+            .filter(|binding| binding.role == GpuPlanBindingRole::IntegrityFault)
+            .map(|binding| binding.elements)
+            .collect::<Vec<_>>(),
+        vec![2]
+    );
+    assert!(
+        plan.physical_outputs
+            .iter()
+            .all(|output| output.binding.is_none()),
+        "fixed-shape outputs must read from the selected resident-state generation"
+    );
+}
+
+#[test]
+fn fixed_shape_execution_plan_groups_aliased_state_outputs_once() {
+    let source = SOURCE.replacen("(state, covariance)", "(state, state, covariance)", 1);
+    let (program, inputs) = source_program_from(&source, 8);
+    let plan = GpuExecutionPlan::build(GpuKernelPlanSource::FixedShape(&program), &inputs)
+        .expect("aliased EKF outputs must produce a physical execution plan");
+
+    assert_eq!(plan.outputs.len(), 3);
+    assert_eq!(plan.physical_outputs.len(), 2);
+    assert!(
+        plan.physical_outputs
+            .iter()
+            .any(|output| output.aliases.len() == 2),
+        "logical state aliases must share one physical resident readback"
+    );
 }
 
 fn compute_initializers(

--- a/hosts/gpu/tests/particle_source.rs
+++ b/hosts/gpu/tests/particle_source.rs
@@ -11,7 +11,8 @@ use mech_core::{
 use mech_engine::{SlotRole, decode_program_artifact_sections, encode_program_artifact_sections};
 use mech_gpu::{
     ComputeHostFactory, ComputeLowerer, ElementwiseKernel, ExecutionTarget, GpuBindingRole,
-    GpuDiagnosticCode, SlotResidence, TransferDirection, native_compute_backend_registry,
+    GpuDiagnosticCode, GpuExecutionPlan, GpuKernelPlanSource, GpuPlanBindingRole,
+    GpuPlanKernelKind, SlotResidence, TransferDirection, native_compute_backend_registry,
 };
 use mech_runtime::{
     ConfigValue, PreparedRuntimeEffect, ProgramCompiler, RuntimeBuilder,
@@ -540,6 +541,26 @@ fn particle_program_is_lowered_from_mech_to_fused_wgsl() {
     inputs.insert("attraction".to_owned(), vec![0.5]);
     inputs.insert("drag".to_owned(), vec![0.9]);
     inputs.insert("dt".to_owned(), vec![0.1]);
+    let plan = GpuExecutionPlan::build(GpuKernelPlanSource::Elementwise(&program), &inputs)
+        .expect("particle kernel must produce a physical GPU execution plan");
+    assert_eq!(plan.kernel_kind, GpuPlanKernelKind::Elementwise);
+    assert_eq!(plan.wgsl, program.wgsl());
+    assert_eq!(plan.bindings.len(), program.bindings().len());
+    assert_eq!(plan.states.len(), 2);
+    assert_eq!(plan.physical_outputs.len(), 2);
+    assert!(
+        plan.bindings
+            .iter()
+            .filter(|binding| binding.role == GpuPlanBindingRole::StateRead)
+            .all(|binding| binding.initial_values.is_some()),
+        "the physical plan must carry resident state initializers"
+    );
+    assert!(
+        plan.physical_outputs
+            .iter()
+            .all(|output| output.binding.is_none()),
+        "resident particle outputs must read from the selected ping-pong state buffer"
+    );
     let outputs = program.run_cpu(&inputs).expect("CPU backend must run");
 
     let expected_velocities = [-0.045, -0.0225, 0.045, 0.0225, -0.09, -0.18, 0.09, 0.18];
@@ -548,6 +569,38 @@ fn particle_program_is_lowered_from_mech_to_fused_wgsl() {
     ];
     assert_close(&outputs["result.1"], &expected_velocities);
     assert_close(&outputs["result.0"], &expected_positions);
+}
+
+#[test]
+fn particle_execution_plan_groups_logical_output_aliases_once() {
+    let source = PARTICLE_SOURCE.replacen(
+        "(positions, velocities)",
+        "(positions, positions, velocities)",
+        1,
+    );
+    let artifact = compile_source(&source, particle_inputs());
+    let program = ComputeLowerer
+        .compile(&artifact)
+        .expect("aliased particle outputs must lower");
+    let inputs = BTreeMap::from([
+        ("positions".to_owned(), vec![0.0; 8]),
+        ("velocities".to_owned(), vec![0.0; 8]),
+        ("origin".to_owned(), vec![0.0]),
+        ("attraction".to_owned(), vec![0.5]),
+        ("drag".to_owned(), vec![0.9]),
+        ("dt".to_owned(), vec![0.1]),
+    ]);
+    let plan = GpuExecutionPlan::build(GpuKernelPlanSource::Elementwise(&program), &inputs)
+        .expect("aliased particle outputs must produce one physical readback plan");
+
+    assert_eq!(plan.outputs.len(), 3);
+    assert_eq!(plan.physical_outputs.len(), 2);
+    assert!(
+        plan.physical_outputs
+            .iter()
+            .any(|output| output.aliases.len() == 2),
+        "two names for the same resident value must share one physical transfer"
+    );
 }
 
 #[test]

--- a/hosts/scene/Cargo.toml
+++ b/hosts/scene/Cargo.toml
@@ -26,4 +26,5 @@ serde = { version = "1.0.228", features = ["derive"], optional = true }
 serde_json = { version = "1.0.150", optional = true }
 
 [dev-dependencies]
-mech-runtime = { version = "0.3.5", default-features = false, features = ["source"] }
+mech-runtime = { version = "0.3.5", default-features = false, features = ["resident-routing-source", "source_default"] }
+mech-stdlib = { version = "0.3.5", default-features = false, features = ["full_compiler", "native-plan"] }

--- a/hosts/scene/host.mcfg
+++ b/hosts/scene/host.mcfg
@@ -5,7 +5,7 @@ config := {
       {
         name: "frame"
         base-uri: "scene://{instance}/frame"
-        operations: ["write"]
+        operations: ["read", "write"]
       }
     ]
   }

--- a/hosts/scene/src/browser.rs
+++ b/hosts/scene/src/browser.rs
@@ -275,11 +275,14 @@ impl mech_runtime::RuntimeHostFactory for BrowserSceneHostFactory {
         let pointer = self.registry.register(instance_name, parsed.clone())?;
         Ok(mech_runtime::RuntimeHostInstallation {
             interface: mech_runtime::materialize_host_manifest(instance_name, &self.manifest)?,
-            resource_providers: vec![Box::new(crate::SceneResourceProvider::new_with_settings(
-                instance_name,
-                BrowserSceneBackend::new(instance_name, self.registry.clone()),
-                parsed,
-            ))],
+            resource_providers: vec![Box::new(
+                crate::SceneResourceProvider::new_with_settings_and_pointer(
+                    instance_name,
+                    BrowserSceneBackend::new(instance_name, self.registry.clone()),
+                    parsed,
+                    pointer.clone(),
+                ),
+            )],
             input_drivers: vec![pointer.input_driver(instance_name)],
         })
     }

--- a/hosts/scene/src/browser.rs
+++ b/hosts/scene/src/browser.rs
@@ -275,14 +275,11 @@ impl mech_runtime::RuntimeHostFactory for BrowserSceneHostFactory {
         let pointer = self.registry.register(instance_name, parsed.clone())?;
         Ok(mech_runtime::RuntimeHostInstallation {
             interface: mech_runtime::materialize_host_manifest(instance_name, &self.manifest)?,
-            resource_providers: vec![Box::new(
-                crate::SceneResourceProvider::new_with_settings_and_pointer(
-                    instance_name,
-                    BrowserSceneBackend::new(instance_name, self.registry.clone()),
-                    parsed,
-                    pointer.clone(),
-                ),
-            )],
+            resource_providers: vec![Box::new(crate::SceneResourceProvider::new_with_settings(
+                instance_name,
+                BrowserSceneBackend::new(instance_name, self.registry.clone()),
+                parsed,
+            ))],
             input_drivers: vec![pointer.input_driver(instance_name)],
         })
     }

--- a/hosts/scene/src/browser.rs
+++ b/hosts/scene/src/browser.rs
@@ -9,6 +9,7 @@ use mech_runtime::{
 use wasm_bindgen::{JsCast, JsValue};
 use web_sys::{CanvasRenderingContext2d, Element, HtmlCanvasElement, SvgsvgElement};
 
+use crate::ScenePointerHandle;
 use crate::{SceneBackend, SceneHostSettings, SceneRendererKind, SceneSnapshot, scene_error};
 
 #[derive(Clone, Debug, Default)]
@@ -24,6 +25,7 @@ struct BrowserSceneTarget {
     generation: u64,
     rendered_generation: u64,
     published_generation: u64,
+    pointer: ScenePointerHandle,
 }
 
 #[derive(Clone, Debug)]
@@ -43,12 +45,14 @@ impl BrowserSceneRegistry {
         &self,
         instance: impl Into<String>,
         settings: SceneHostSettings,
-    ) -> MResult<()> {
+    ) -> MResult<ScenePointerHandle> {
+        let instance = instance.into();
+        let pointer = ScenePointerHandle::new(&instance);
         self.targets
             .lock()
             .map_err(|_| scene_error("BrowserSceneRegistry", "scene registry lock is poisoned"))?
             .insert(
-                instance.into(),
+                instance,
                 BrowserSceneTarget {
                     selector: settings.selector,
                     renderer: settings.renderer,
@@ -56,9 +60,10 @@ impl BrowserSceneRegistry {
                     generation: 0,
                     rendered_generation: 0,
                     published_generation: 0,
+                    pointer: pointer.clone(),
                 },
             );
-        Ok(())
+        Ok(pointer)
     }
     pub fn replace_scene(&self, instance: &str, scene: SceneSnapshot) -> MResult<()> {
         let mut guard = self
@@ -184,6 +189,29 @@ impl BrowserSceneRegistry {
                 .and_then(|target| target.latest.clone())
         })
     }
+
+    pub fn submit_pointer(
+        &self,
+        instance: &str,
+        x: f64,
+        y: f64,
+        pressed: bool,
+        delta_seconds: f64,
+    ) -> MResult<()> {
+        let pointer = self
+            .targets
+            .lock()
+            .map_err(|_| scene_error("BrowserSceneRegistry", "scene registry lock is poisoned"))?
+            .get(instance)
+            .map(|target| target.pointer.clone())
+            .ok_or_else(|| {
+                scene_error(
+                    "BrowserSceneRegistry",
+                    format!("unknown scene target `{instance}`"),
+                )
+            })?;
+        pointer.submit(x, y, pressed, delta_seconds)
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -244,7 +272,7 @@ impl mech_runtime::RuntimeHostFactory for BrowserSceneHostFactory {
         settings: &mech_runtime::ConfigValue,
     ) -> MResult<mech_runtime::RuntimeHostInstallation> {
         let parsed = crate::scene_settings_from_config(settings)?;
-        self.registry.register(instance_name, parsed.clone())?;
+        let pointer = self.registry.register(instance_name, parsed.clone())?;
         Ok(mech_runtime::RuntimeHostInstallation {
             interface: mech_runtime::materialize_host_manifest(instance_name, &self.manifest)?,
             resource_providers: vec![Box::new(crate::SceneResourceProvider::new_with_settings(
@@ -252,7 +280,7 @@ impl mech_runtime::RuntimeHostFactory for BrowserSceneHostFactory {
                 BrowserSceneBackend::new(instance_name, self.registry.clone()),
                 parsed,
             ))],
-            input_drivers: Vec::new(),
+            input_drivers: vec![pointer.input_driver(instance_name)],
         })
     }
 }

--- a/hosts/scene/src/lib.rs
+++ b/hosts/scene/src/lib.rs
@@ -15,8 +15,8 @@ pub mod native;
 pub use config::{SceneHostSettings, SceneRendererKind, scene_settings_from_config};
 pub use module::scene_host_manifest;
 pub use provider::{
-    RecordingSceneBackend, SceneBackend, SceneHostFactory, SceneResourceProvider,
-    scene_snapshot_from_points,
+    RecordingSceneBackend, SceneBackend, SceneHostFactory, ScenePointerHandle,
+    SceneResourceProvider, scene_snapshot_from_points,
 };
 pub use schema::{CircleElement, LineElement, LineStripElement, SceneSnapshot, TextElement};
 

--- a/hosts/scene/src/module.rs
+++ b/hosts/scene/src/module.rs
@@ -4,7 +4,7 @@ pub fn scene_host_manifest() -> mech_core::MResult<mech_runtime::HostManifestCon
         contexts: vec![mech_runtime::HostContextManifest {
             name: "frame".to_string(),
             base_uri_template: "scene://{instance}/frame".to_string(),
-            operations: vec!["write".to_string()],
+            operations: vec!["read".to_string(), "write".to_string()],
         }],
     })
 }

--- a/hosts/scene/src/native.rs
+++ b/hosts/scene/src/native.rs
@@ -115,11 +115,14 @@ impl RuntimeHostFactory for NativeSceneHostFactory {
         let pointer = ScenePointerHandle::new(instance_name);
         Ok(RuntimeHostInstallation {
             interface: materialize_host_manifest(instance_name, &self.manifest)?,
-            resource_providers: vec![Box::new(SceneResourceProvider::new_with_settings(
-                instance_name,
-                NativeSceneBackend::new(instance_name, self.registry.clone()),
-                settings,
-            ))],
+            resource_providers: vec![Box::new(
+                SceneResourceProvider::new_with_settings_and_pointer(
+                    instance_name,
+                    NativeSceneBackend::new(instance_name, self.registry.clone()),
+                    settings,
+                    pointer.clone(),
+                ),
+            )],
             input_drivers: vec![pointer.input_driver(instance_name)],
         })
     }

--- a/hosts/scene/src/native.rs
+++ b/hosts/scene/src/native.rs
@@ -115,14 +115,11 @@ impl RuntimeHostFactory for NativeSceneHostFactory {
         let pointer = ScenePointerHandle::new(instance_name);
         Ok(RuntimeHostInstallation {
             interface: materialize_host_manifest(instance_name, &self.manifest)?,
-            resource_providers: vec![Box::new(
-                SceneResourceProvider::new_with_settings_and_pointer(
-                    instance_name,
-                    NativeSceneBackend::new(instance_name, self.registry.clone()),
-                    settings,
-                    pointer.clone(),
-                ),
-            )],
+            resource_providers: vec![Box::new(SceneResourceProvider::new_with_settings(
+                instance_name,
+                NativeSceneBackend::new(instance_name, self.registry.clone()),
+                settings,
+            ))],
             input_drivers: vec![pointer.input_driver(instance_name)],
         })
     }

--- a/hosts/scene/src/native.rs
+++ b/hosts/scene/src/native.rs
@@ -8,8 +8,9 @@ use mech_runtime::{
 };
 
 use crate::{
-    RecordingSceneBackend, SceneBackend, SceneHostSettings, SceneResourceProvider, SceneSnapshot,
-    scene_error, scene_host_manifest, scene_settings_from_config,
+    RecordingSceneBackend, SceneBackend, SceneHostSettings, ScenePointerHandle,
+    SceneResourceProvider, SceneSnapshot, scene_error, scene_host_manifest,
+    scene_settings_from_config,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -111,6 +112,7 @@ impl RuntimeHostFactory for NativeSceneHostFactory {
     ) -> MResult<RuntimeHostInstallation> {
         let settings: SceneHostSettings = scene_settings_from_config(settings)?;
         self.registry.register(instance_name)?;
+        let pointer = ScenePointerHandle::new(instance_name);
         Ok(RuntimeHostInstallation {
             interface: materialize_host_manifest(instance_name, &self.manifest)?,
             resource_providers: vec![Box::new(SceneResourceProvider::new_with_settings(
@@ -118,7 +120,7 @@ impl RuntimeHostFactory for NativeSceneHostFactory {
                 NativeSceneBackend::new(instance_name, self.registry.clone()),
                 settings,
             ))],
-            input_drivers: Vec::new(),
+            input_drivers: vec![pointer.input_driver(instance_name)],
         })
     }
 }

--- a/hosts/scene/src/provider.rs
+++ b/hosts/scene/src/provider.rs
@@ -57,9 +57,6 @@ pub struct ScenePointerHandle {
 struct ScenePointerDriverState {
     ingress: Option<RuntimeIngress>,
     pulse: u64,
-    position: [f64; 2],
-    pressed: bool,
-    delta_seconds: f64,
     live: bool,
 }
 
@@ -87,7 +84,12 @@ impl ScenePointerHandle {
         // the final released state cannot erase the click and a separately
         // drained release cannot activate the target twice.
         let pulse = if pressed {
-            state.pulse.saturating_add(1)
+            state.pulse.checked_add(1).ok_or_else(|| {
+                scene_error(
+                    "ScenePointerSequenceExhausted",
+                    "scene pointer activation sequence is exhausted",
+                )
+            })?
         } else {
             state.pulse
         };
@@ -95,19 +97,13 @@ impl ScenePointerHandle {
             .ingress
             .clone()
             .ok_or_else(|| scene_error("ScenePointer", "scene pointer input is not attached"))?;
-        let mut updates = Vec::with_capacity(if pressed { 4 } else { 2 });
-        if pressed {
-            // Pulse and position form one activation payload. A release only
-            // changes the pointer level; republishing the activation payload
-            // would dirty click consumers a second time when release is
-            // drained separately. If down and up coalesce, the activation
-            // payload remains in the merged turn while the level ends at 0.
-            updates.push(scene_pointer_update(
+        let packet = RuntimeHostInput::new(vec![
+            scene_pointer_update(
                 &self.base_uri,
                 "pointer-pulse",
                 RuntimeHostInputValue::F64(pulse as f64),
-            )?);
-            updates.push(scene_pointer_update(
+            )?,
+            scene_pointer_update(
                 &self.base_uri,
                 "pointer-position",
                 RuntimeHostInputValue::F64Matrix {
@@ -115,54 +111,24 @@ impl ScenePointerHandle {
                     columns: 1,
                     values: vec![x, y],
                 },
-            )?);
-        }
-        updates.push(scene_pointer_update(
-            &self.base_uri,
-            "pointer-pressed",
-            RuntimeHostInputValue::F64(f64::from(pressed)),
-        )?);
-        updates.push(scene_pointer_update(
-            &self.base_uri,
-            "pointer-delta-seconds",
-            RuntimeHostInputValue::F64(delta_seconds),
-        )?);
-        // The readable provider snapshot and queued packet are one accepted
-        // input transition. Keep the prior snapshot if ingress rejects the
-        // packet so a later turn cannot observe an activation that was never
-        // admitted to the resident queue.
-        ingress.submit(RuntimeHostInput::new(updates)?)?;
+            )?,
+            scene_pointer_update(
+                &self.base_uri,
+                "pointer-pressed",
+                RuntimeHostInputValue::F64(f64::from(pressed)),
+            )?,
+            scene_pointer_update(
+                &self.base_uri,
+                "pointer-delta-seconds",
+                RuntimeHostInputValue::F64(delta_seconds),
+            )?,
+        ])?
+        .with_coalescing_group(pulse);
+        // The pulse counter advances only after the complete gesture packet is
+        // accepted. Down and up share a group; the next down starts a new one.
+        ingress.submit(packet)?;
         state.pulse = pulse;
-        state.position = [x, y];
-        state.pressed = pressed;
-        state.delta_seconds = delta_seconds;
         Ok(())
-    }
-
-    fn value(&self, path: &str) -> MResult<LegacyValue> {
-        let state = self
-            .state
-            .lock()
-            .map_err(|_| scene_error("ScenePointer", "pointer state lock is poisoned"))?;
-        match path {
-            "pointer-pulse" => RuntimeHostInputValue::F64(state.pulse as f64).into_mech_value(),
-            "pointer-position" => RuntimeHostInputValue::F64Matrix {
-                rows: 2,
-                columns: 1,
-                values: state.position.to_vec(),
-            }
-            .into_mech_value(),
-            "pointer-pressed" => {
-                RuntimeHostInputValue::F64(f64::from(state.pressed)).into_mech_value()
-            }
-            "pointer-delta-seconds" => {
-                RuntimeHostInputValue::F64(state.delta_seconds).into_mech_value()
-            }
-            _ => Err(scene_error(
-                "ScenePointer",
-                format!("unknown scene pointer path `{path}`"),
-            )),
-        }
     }
 
     pub fn input_driver(&self, instance: impl Into<String>) -> Box<dyn RuntimeHostInputDriver> {
@@ -264,7 +230,6 @@ impl SceneBackend for RecordingSceneBackend {
 pub struct SceneResourceProvider<B: SceneBackend> {
     instance: String,
     settings: SceneHostSettings,
-    pointer: ScenePointerHandle,
     backend: Arc<Mutex<B>>,
     last_accepted: Arc<Mutex<Option<SceneSnapshot>>>,
 }
@@ -282,21 +247,9 @@ impl<B: SceneBackend> SceneResourceProvider<B> {
         backend: B,
         settings: SceneHostSettings,
     ) -> Self {
-        let instance = instance.into();
-        let pointer = ScenePointerHandle::new(&instance);
-        Self::new_with_settings_and_pointer(instance, backend, settings, pointer)
-    }
-
-    pub(crate) fn new_with_settings_and_pointer(
-        instance: impl Into<String>,
-        backend: B,
-        settings: SceneHostSettings,
-        pointer: ScenePointerHandle,
-    ) -> Self {
         Self {
             instance: instance.into(),
             settings,
-            pointer,
             backend: Arc::new(Mutex::new(backend)),
             last_accepted: Arc::new(Mutex::new(None)),
         }
@@ -401,7 +354,16 @@ impl<B: SceneBackend> SceneResourceProvider<B> {
                 ),
             ));
         }
-        self.pointer.value(&request.path)
+        if request.path == "pointer-position" {
+            RuntimeHostInputValue::F64Matrix {
+                rows: 2,
+                columns: 1,
+                values: vec![0.0, 0.0],
+            }
+            .into_mech_value()
+        } else {
+            RuntimeHostInputValue::F64(0.0).into_mech_value()
+        }
     }
 }
 
@@ -474,14 +436,11 @@ impl<B: SceneBackend> RuntimeHostFactory for SceneHostFactory<B> {
         let pointer = ScenePointerHandle::new(instance_name);
         Ok(RuntimeHostInstallation {
             interface: materialize_host_manifest(instance_name, &self.manifest)?,
-            resource_providers: vec![Box::new(
-                SceneResourceProvider::new_with_settings_and_pointer(
-                    instance_name,
-                    self.backend.clone(),
-                    settings,
-                    pointer.clone(),
-                ),
-            )],
+            resource_providers: vec![Box::new(SceneResourceProvider::new_with_settings(
+                instance_name,
+                self.backend.clone(),
+                settings,
+            ))],
             input_drivers: vec![pointer.input_driver(instance_name)],
         })
     }

--- a/hosts/scene/src/provider.rs
+++ b/hosts/scene/src/provider.rs
@@ -57,6 +57,9 @@ pub struct ScenePointerHandle {
 struct ScenePointerDriverState {
     ingress: Option<RuntimeIngress>,
     pulse: u64,
+    position: [f64; 2],
+    pressed: bool,
+    delta_seconds: f64,
     live: bool,
 }
 
@@ -83,22 +86,28 @@ impl ScenePointerHandle {
         // packet into one turn. Count activations, not raw state packets, so
         // the final released state cannot erase the click and a separately
         // drained release cannot activate the target twice.
-        if pressed {
-            state.pulse = state.pulse.saturating_add(1);
-        }
-        let pulse = state.pulse;
+        let pulse = if pressed {
+            state.pulse.saturating_add(1)
+        } else {
+            state.pulse
+        };
         let ingress = state
             .ingress
             .clone()
             .ok_or_else(|| scene_error("ScenePointer", "scene pointer input is not attached"))?;
-        drop(state);
-        ingress.submit(RuntimeHostInput::new(vec![
-            scene_pointer_update(
+        let mut updates = Vec::with_capacity(if pressed { 4 } else { 2 });
+        if pressed {
+            // Pulse and position form one activation payload. A release only
+            // changes the pointer level; republishing the activation payload
+            // would dirty click consumers a second time when release is
+            // drained separately. If down and up coalesce, the activation
+            // payload remains in the merged turn while the level ends at 0.
+            updates.push(scene_pointer_update(
                 &self.base_uri,
                 "pointer-pulse",
                 RuntimeHostInputValue::F64(pulse as f64),
-            )?,
-            scene_pointer_update(
+            )?);
+            updates.push(scene_pointer_update(
                 &self.base_uri,
                 "pointer-position",
                 RuntimeHostInputValue::F64Matrix {
@@ -106,18 +115,54 @@ impl ScenePointerHandle {
                     columns: 1,
                     values: vec![x, y],
                 },
-            )?,
-            scene_pointer_update(
-                &self.base_uri,
-                "pointer-pressed",
-                RuntimeHostInputValue::F64(f64::from(pressed)),
-            )?,
-            scene_pointer_update(
-                &self.base_uri,
-                "pointer-delta-seconds",
-                RuntimeHostInputValue::F64(delta_seconds),
-            )?,
-        ])?)
+            )?);
+        }
+        updates.push(scene_pointer_update(
+            &self.base_uri,
+            "pointer-pressed",
+            RuntimeHostInputValue::F64(f64::from(pressed)),
+        )?);
+        updates.push(scene_pointer_update(
+            &self.base_uri,
+            "pointer-delta-seconds",
+            RuntimeHostInputValue::F64(delta_seconds),
+        )?);
+        // The readable provider snapshot and queued packet are one accepted
+        // input transition. Keep the prior snapshot if ingress rejects the
+        // packet so a later turn cannot observe an activation that was never
+        // admitted to the resident queue.
+        ingress.submit(RuntimeHostInput::new(updates)?)?;
+        state.pulse = pulse;
+        state.position = [x, y];
+        state.pressed = pressed;
+        state.delta_seconds = delta_seconds;
+        Ok(())
+    }
+
+    fn value(&self, path: &str) -> MResult<LegacyValue> {
+        let state = self
+            .state
+            .lock()
+            .map_err(|_| scene_error("ScenePointer", "pointer state lock is poisoned"))?;
+        match path {
+            "pointer-pulse" => RuntimeHostInputValue::F64(state.pulse as f64).into_mech_value(),
+            "pointer-position" => RuntimeHostInputValue::F64Matrix {
+                rows: 2,
+                columns: 1,
+                values: state.position.to_vec(),
+            }
+            .into_mech_value(),
+            "pointer-pressed" => {
+                RuntimeHostInputValue::F64(f64::from(state.pressed)).into_mech_value()
+            }
+            "pointer-delta-seconds" => {
+                RuntimeHostInputValue::F64(state.delta_seconds).into_mech_value()
+            }
+            _ => Err(scene_error(
+                "ScenePointer",
+                format!("unknown scene pointer path `{path}`"),
+            )),
+        }
     }
 
     pub fn input_driver(&self, instance: impl Into<String>) -> Box<dyn RuntimeHostInputDriver> {
@@ -219,6 +264,7 @@ impl SceneBackend for RecordingSceneBackend {
 pub struct SceneResourceProvider<B: SceneBackend> {
     instance: String,
     settings: SceneHostSettings,
+    pointer: ScenePointerHandle,
     backend: Arc<Mutex<B>>,
     last_accepted: Arc<Mutex<Option<SceneSnapshot>>>,
 }
@@ -236,9 +282,21 @@ impl<B: SceneBackend> SceneResourceProvider<B> {
         backend: B,
         settings: SceneHostSettings,
     ) -> Self {
+        let instance = instance.into();
+        let pointer = ScenePointerHandle::new(&instance);
+        Self::new_with_settings_and_pointer(instance, backend, settings, pointer)
+    }
+
+    pub(crate) fn new_with_settings_and_pointer(
+        instance: impl Into<String>,
+        backend: B,
+        settings: SceneHostSettings,
+        pointer: ScenePointerHandle,
+    ) -> Self {
         Self {
             instance: instance.into(),
             settings,
+            pointer,
             backend: Arc::new(Mutex::new(backend)),
             last_accepted: Arc::new(Mutex::new(None)),
         }
@@ -343,16 +401,7 @@ impl<B: SceneBackend> SceneResourceProvider<B> {
                 ),
             ));
         }
-        if request.path == "pointer-position" {
-            RuntimeHostInputValue::F64Matrix {
-                rows: 2,
-                columns: 1,
-                values: vec![0.0, 0.0],
-            }
-            .into_mech_value()
-        } else {
-            RuntimeHostInputValue::F64(0.0).into_mech_value()
-        }
+        self.pointer.value(&request.path)
     }
 }
 
@@ -425,11 +474,14 @@ impl<B: SceneBackend> RuntimeHostFactory for SceneHostFactory<B> {
         let pointer = ScenePointerHandle::new(instance_name);
         Ok(RuntimeHostInstallation {
             interface: materialize_host_manifest(instance_name, &self.manifest)?,
-            resource_providers: vec![Box::new(SceneResourceProvider::new_with_settings(
-                instance_name,
-                self.backend.clone(),
-                settings,
-            ))],
+            resource_providers: vec![Box::new(
+                SceneResourceProvider::new_with_settings_and_pointer(
+                    instance_name,
+                    self.backend.clone(),
+                    settings,
+                    pointer.clone(),
+                ),
+            )],
             input_drivers: vec![pointer.input_driver(instance_name)],
         })
     }

--- a/hosts/scene/src/provider.rs
+++ b/hosts/scene/src/provider.rs
@@ -8,9 +8,10 @@ use mech_core::{
 use mech_runtime::{
     ConfigValue, HostManifestConfig, PreparedRuntimeEffect, RuntimeAfterCommitEffect,
     RuntimeEffectCost, RuntimeEffectMetadata, RuntimeEffectSource, RuntimeHostFactory,
-    RuntimeHostInstallation, RuntimeResourceProvider, RuntimeResourceReadRequest,
-    RuntimeResourceWriteIntent, RuntimeResourceWritePreflightRequest, RuntimeResourceWriteRequest,
-    materialize_host_manifest,
+    RuntimeHostInput, RuntimeHostInputDriver, RuntimeHostInputSource, RuntimeHostInputUpdate,
+    RuntimeHostInputValue, RuntimeHostInstallation, RuntimeIngress, RuntimeResourceProvider,
+    RuntimeResourceReadRequest, RuntimeResourceWriteIntent, RuntimeResourceWritePreflightRequest,
+    RuntimeResourceWriteRequest, materialize_host_manifest, resource_observation_contract,
 };
 
 use crate::{
@@ -38,6 +39,146 @@ static SCENE_EFFECT_CONTRACT: LazyLock<OperationContractDeclaration> =
             idempotency: IdempotencyRequirement::NotRequired,
         }),
     });
+
+const POINTER_PATHS: [&str; 4] = [
+    "pointer-pulse",
+    "pointer-position",
+    "pointer-pressed",
+    "pointer-delta-seconds",
+];
+
+#[derive(Clone, Debug)]
+pub struct ScenePointerHandle {
+    base_uri: Arc<str>,
+    state: Arc<Mutex<ScenePointerDriverState>>,
+}
+
+#[derive(Debug, Default)]
+struct ScenePointerDriverState {
+    ingress: Option<RuntimeIngress>,
+    pulse: u64,
+    live: bool,
+}
+
+impl ScenePointerHandle {
+    pub fn new(instance: impl AsRef<str>) -> Self {
+        Self {
+            base_uri: format!("scene://{}/frame", instance.as_ref()).into(),
+            state: Arc::new(Mutex::new(ScenePointerDriverState::default())),
+        }
+    }
+
+    pub fn submit(&self, x: f64, y: f64, pressed: bool, delta_seconds: f64) -> MResult<()> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| scene_error("ScenePointer", "pointer state lock is poisoned"))?;
+        if !state.live {
+            return Err(scene_error(
+                "ScenePointer",
+                "scene pointer input is not running",
+            ));
+        }
+        // Resident input draining may coalesce a pointer-down and pointer-up
+        // packet into one turn. Count activations, not raw state packets, so
+        // the final released state cannot erase the click and a separately
+        // drained release cannot activate the target twice.
+        if pressed {
+            state.pulse = state.pulse.saturating_add(1);
+        }
+        let pulse = state.pulse;
+        let ingress = state
+            .ingress
+            .clone()
+            .ok_or_else(|| scene_error("ScenePointer", "scene pointer input is not attached"))?;
+        drop(state);
+        ingress.submit(RuntimeHostInput::new(vec![
+            scene_pointer_update(
+                &self.base_uri,
+                "pointer-pulse",
+                RuntimeHostInputValue::F64(pulse as f64),
+            )?,
+            scene_pointer_update(
+                &self.base_uri,
+                "pointer-position",
+                RuntimeHostInputValue::F64Matrix {
+                    rows: 2,
+                    columns: 1,
+                    values: vec![x, y],
+                },
+            )?,
+            scene_pointer_update(
+                &self.base_uri,
+                "pointer-pressed",
+                RuntimeHostInputValue::F64(f64::from(pressed)),
+            )?,
+            scene_pointer_update(
+                &self.base_uri,
+                "pointer-delta-seconds",
+                RuntimeHostInputValue::F64(delta_seconds),
+            )?,
+        ])?)
+    }
+
+    pub fn input_driver(&self, instance: impl Into<String>) -> Box<dyn RuntimeHostInputDriver> {
+        Box::new(ScenePointerInputDriver {
+            instance: instance.into(),
+            state: self.state.clone(),
+        })
+    }
+}
+
+fn scene_pointer_update(
+    base_uri: &str,
+    path: &str,
+    value: RuntimeHostInputValue,
+) -> MResult<RuntimeHostInputUpdate> {
+    Ok(RuntimeHostInputUpdate {
+        source: RuntimeHostInputSource::new(base_uri, path)?,
+        value,
+    })
+}
+
+#[derive(Debug)]
+struct ScenePointerInputDriver {
+    instance: String,
+    state: Arc<Mutex<ScenePointerDriverState>>,
+}
+
+impl RuntimeHostInputDriver for ScenePointerInputDriver {
+    fn drives(&self, source: &RuntimeHostInputSource) -> bool {
+        source.base_uri() == format!("scene://{}/frame", self.instance)
+            && POINTER_PATHS.contains(&source.path())
+    }
+
+    fn attach(&mut self, ingress: RuntimeIngress) -> MResult<()> {
+        self.state
+            .lock()
+            .map_err(|_| scene_error("ScenePointer", "pointer state lock is poisoned"))?
+            .ingress = Some(ingress);
+        Ok(())
+    }
+
+    fn start(&mut self) -> MResult<()> {
+        self.state
+            .lock()
+            .map_err(|_| scene_error("ScenePointer", "pointer state lock is poisoned"))?
+            .live = true;
+        Ok(())
+    }
+
+    fn stop(&mut self) -> MResult<()> {
+        self.state
+            .lock()
+            .map_err(|_| scene_error("ScenePointer", "pointer state lock is poisoned"))?
+            .live = false;
+        Ok(())
+    }
+
+    fn is_live(&self) -> bool {
+        self.state.lock().map(|state| state.live).unwrap_or(false)
+    }
+}
 
 pub trait SceneBackend: Clone + std::fmt::Debug + 'static {
     fn replace_scene(&mut self, scene: SceneSnapshot) -> MResult<()>;
@@ -119,11 +260,14 @@ impl<B: SceneBackend> RuntimeResourceProvider for SceneResourceProvider<B> {
     ) -> Option<&'static OperationContractDeclaration> {
         (intent == RuntimeResourceWriteIntent::Send).then_some(&SCENE_EFFECT_CONTRACT)
     }
+    fn semantic_read_contract(&self) -> Option<&'static OperationContractDeclaration> {
+        Some(resource_observation_contract())
+    }
+    fn plan_read(&self, request: RuntimeResourceReadRequest) -> MResult<LegacyValue> {
+        self.pointer_value(request)
+    }
     fn read(&self, request: RuntimeResourceReadRequest) -> MResult<LegacyValue> {
-        Err(scene_error(
-            "SceneResourceProvider",
-            format!("scene resource `{}` is write-only", request.base_uri),
-        ))
+        self.pointer_value(request)
     }
     fn preflight_write(&self, request: RuntimeResourceWritePreflightRequest) -> MResult<()> {
         if request.base_uri != self.base() {
@@ -185,6 +329,30 @@ impl<B: SceneBackend> RuntimeResourceProvider for SceneResourceProvider<B> {
                 operation: request.path,
             },
         )))
+    }
+}
+
+impl<B: SceneBackend> SceneResourceProvider<B> {
+    fn pointer_value(&self, request: RuntimeResourceReadRequest) -> MResult<LegacyValue> {
+        if request.base_uri != self.base() || !POINTER_PATHS.contains(&request.path.as_str()) {
+            return Err(scene_error(
+                "SceneResourceProvider",
+                format!(
+                    "unknown scene pointer input `{}/{}`",
+                    request.base_uri, request.path
+                ),
+            ));
+        }
+        if request.path == "pointer-position" {
+            RuntimeHostInputValue::F64Matrix {
+                rows: 2,
+                columns: 1,
+                values: vec![0.0, 0.0],
+            }
+            .into_mech_value()
+        } else {
+            RuntimeHostInputValue::F64(0.0).into_mech_value()
+        }
     }
 }
 
@@ -254,6 +422,7 @@ impl<B: SceneBackend> RuntimeHostFactory for SceneHostFactory<B> {
         settings: &ConfigValue,
     ) -> MResult<RuntimeHostInstallation> {
         let settings: SceneHostSettings = scene_settings_from_config(settings)?;
+        let pointer = ScenePointerHandle::new(instance_name);
         Ok(RuntimeHostInstallation {
             interface: materialize_host_manifest(instance_name, &self.manifest)?,
             resource_providers: vec![Box::new(SceneResourceProvider::new_with_settings(
@@ -261,7 +430,7 @@ impl<B: SceneBackend> RuntimeHostFactory for SceneHostFactory<B> {
                 self.backend.clone(),
                 settings,
             ))],
-            input_drivers: Vec::new(),
+            input_drivers: vec![pointer.input_driver(instance_name)],
         })
     }
 }

--- a/hosts/scene/tests/provider.rs
+++ b/hosts/scene/tests/provider.rs
@@ -830,7 +830,7 @@ fn native_scene_instances_are_isolated() {
 
 #[cfg(feature = "browser")]
 #[test]
-fn browser_scene_pointer_activation_survives_a_later_release_turn() {
+fn browser_scene_pointer_activation_survives_coalesced_and_later_release() {
     let registry = BrowserSceneRegistry::new();
     let factory = BrowserSceneHostFactory::with_registry(registry.clone()).unwrap();
     let mut runtime = RuntimeBuilder::new()
@@ -863,7 +863,7 @@ position := @scene/pointer-position
 pressed := @scene/pointer-pressed
 ~enabled := 1.0
 ~last-pulse := 0.0
-delta := pressed * (pulse - last-pulse)
+delta := pulse - last-pulse
 next-enabled := enabled + delta * (1.0 - 2.0 * enabled)
 enabled = next-enabled
 last-pulse = pulse
@@ -876,7 +876,10 @@ last-pulse = pulse
     registry
         .submit_pointer("view", 0.25, -0.5, true, 0.0)
         .unwrap();
-    assert_eq!(runtime.pending_host_input_count().unwrap(), 1);
+    registry
+        .submit_pointer("view", 0.25, -0.5, false, 0.01)
+        .unwrap();
+    assert_eq!(runtime.pending_host_input_count().unwrap(), 2);
     runtime.drain_host_inputs(8).unwrap();
 
     let LegacyValue::F64(enabled) = runtime.root_symbol_value("enabled").unwrap().into_value()
@@ -885,8 +888,28 @@ last-pulse = pulse
     };
     assert_eq!(*enabled.borrow(), 0.0);
 
+    let LegacyValue::F64(pressed) = runtime.root_symbol_value("pressed").unwrap().into_value()
+    else {
+        panic!("scene pointer pressed state must remain f64")
+    };
+    assert_eq!(*pressed.borrow(), 0.0);
+
+    // A second activation drains before its release. The release updates the
+    // level only and therefore cannot replay the already-consumed pulse.
     registry
-        .submit_pointer("view", 0.25, -0.5, false, 0.01)
+        .submit_pointer("view", -0.75, 0.5, true, 0.02)
+        .unwrap();
+    assert_eq!(runtime.pending_host_input_count().unwrap(), 1);
+    runtime.drain_host_inputs(8).unwrap();
+
+    let LegacyValue::F64(enabled) = runtime.root_symbol_value("enabled").unwrap().into_value()
+    else {
+        panic!("scene pointer toggle must remain f64")
+    };
+    assert_eq!(*enabled.borrow(), 1.0);
+
+    registry
+        .submit_pointer("view", -0.75, 0.5, false, 0.03)
         .unwrap();
     assert_eq!(runtime.pending_host_input_count().unwrap(), 1);
     runtime.drain_host_inputs(8).unwrap();
@@ -894,7 +917,7 @@ last-pulse = pulse
     let LegacyValue::F64(pulse) = runtime.root_symbol_value("pulse").unwrap().into_value() else {
         panic!("scene pointer pulse must remain f64")
     };
-    assert_eq!(*pulse.borrow(), 1.0);
+    assert_eq!(*pulse.borrow(), 2.0);
     let LegacyValue::F64(pressed) = runtime.root_symbol_value("pressed").unwrap().into_value()
     else {
         panic!("scene pointer pressed state must remain f64")
@@ -905,12 +928,12 @@ last-pulse = pulse
     else {
         panic!("scene pointer position must remain an f64 matrix")
     };
-    assert_eq!(position.as_vec(), [0.25, -0.5]);
+    assert_eq!(position.as_vec(), [-0.75, 0.5]);
     let LegacyValue::F64(enabled) = runtime.root_symbol_value("enabled").unwrap().into_value()
     else {
         panic!("scene pointer toggle must remain f64")
     };
-    assert_eq!(*enabled.borrow(), 0.0);
+    assert_eq!(*enabled.borrow(), 1.0);
 }
 
 #[test]

--- a/hosts/scene/tests/provider.rs
+++ b/hosts/scene/tests/provider.rs
@@ -13,6 +13,7 @@ use mech_runtime::{
 #[cfg(feature = "browser")]
 use mech_runtime::{
     HostInstanceConfig, ResidentDurabilityPolicy, RunResourceGrantConfig, RuntimeBuilder,
+    RuntimeHostInput, RuntimeHostInputSource, RuntimeHostInputValue,
 };
 use mech_scene::*;
 
@@ -863,7 +864,7 @@ position := @scene/pointer-position
 pressed := @scene/pointer-pressed
 ~enabled := 1.0
 ~last-pulse := 0.0
-delta := pulse - last-pulse
+delta := (pulse - last-pulse) % 2.0
 next-enabled := enabled + delta * (1.0 - 2.0 * enabled)
 enabled = next-enabled
 last-pulse = pulse
@@ -894,8 +895,8 @@ last-pulse = pulse
     };
     assert_eq!(*pressed.borrow(), 0.0);
 
-    // A second activation drains before its release. The release updates the
-    // level only and therefore cannot replay the already-consumed pulse.
+    // A second activation drains before its release. The release remains in
+    // the same gesture group and cannot replay the already-consumed pulse.
     registry
         .submit_pointer("view", -0.75, 0.5, true, 0.02)
         .unwrap();
@@ -934,6 +935,112 @@ last-pulse = pulse
         panic!("scene pointer toggle must remain f64")
     };
     assert_eq!(*enabled.borrow(), 1.0);
+
+    // Two complete clicks may already be queued when one drain begins. Each
+    // gesture is still a distinct resident turn even though its own down/up
+    // packets coalesce, so different activation identities cannot disappear.
+    for (x, y, delta) in [(0.5, 0.5, 0.04), (-0.5, -0.5, 0.06)] {
+        registry.submit_pointer("view", x, y, true, delta).unwrap();
+        registry
+            .submit_pointer("view", x, y, false, delta + 0.01)
+            .unwrap();
+    }
+    assert_eq!(runtime.pending_host_input_count().unwrap(), 4);
+    assert_eq!(runtime.drain_host_inputs(8).unwrap().len(), 2);
+    assert_eq!(runtime.pending_host_input_count().unwrap(), 2);
+    let LegacyValue::F64(pulse) = runtime.root_symbol_value("pulse").unwrap().into_value() else {
+        panic!("scene pointer pulse must remain f64")
+    };
+    assert_eq!(*pulse.borrow(), 3.0);
+    let LegacyValue::MatrixF64(position) =
+        runtime.root_symbol_value("position").unwrap().into_value()
+    else {
+        panic!("scene pointer position must remain an f64 matrix")
+    };
+    assert_eq!(position.as_vec(), [0.5, 0.5]);
+    let LegacyValue::F64(enabled) = runtime.root_symbol_value("enabled").unwrap().into_value()
+    else {
+        panic!("scene pointer toggle must remain f64")
+    };
+    assert_eq!(*enabled.borrow(), 0.0);
+    assert_eq!(runtime.drain_host_inputs(8).unwrap().len(), 2);
+    assert_eq!(runtime.pending_host_input_count().unwrap(), 0);
+
+    let LegacyValue::F64(pulse) = runtime.root_symbol_value("pulse").unwrap().into_value() else {
+        panic!("scene pointer pulse must remain f64")
+    };
+    assert_eq!(*pulse.borrow(), 4.0);
+    let LegacyValue::F64(enabled) = runtime.root_symbol_value("enabled").unwrap().into_value()
+    else {
+        panic!("scene pointer toggle must remain f64")
+    };
+    assert_eq!(*enabled.borrow(), 1.0);
+}
+
+#[cfg(feature = "browser")]
+#[test]
+fn browser_scene_pointer_count_jump_preserves_toggle_parity() {
+    let factory = BrowserSceneHostFactory::new().unwrap();
+    let mut runtime = RuntimeBuilder::new()
+        .function_catalog(mech_stdlib::source_native_plan_catalog())
+        .host_factory(Box::new(factory))
+        .unwrap()
+        .host_instance(HostInstanceConfig {
+            name: "view".to_string(),
+            provider: "scene".to_string(),
+            settings: settings("output"),
+        })
+        .run_resource_grant(RunResourceGrantConfig {
+            target: "view/frame".to_string(),
+            operations: vec!["read".to_string()],
+            paths: vec!["pointer-pulse".to_string()],
+        })
+        .build()
+        .unwrap();
+    runtime
+        .load_interactive_source_program(
+            r#"
+@scene := scene://view/frame{:read(pointer-pulse)}
+pulse := @scene/pointer-pulse
+~enabled := 1.0
+~last-pulse := 0.0
+parity := (pulse - last-pulse) % 2.0
+next-enabled := enabled + parity * (1.0 - 2.0 * enabled)
+enabled = next-enabled
+last-pulse = pulse
+"#,
+            ResidentDurabilityPolicy::Volatile,
+        )
+        .unwrap();
+
+    let pulse = RuntimeHostInputSource::new("scene://view/frame", "pointer-pulse").unwrap();
+    runtime
+        .ingress()
+        .submit(RuntimeHostInput::single(
+            pulse.clone(),
+            RuntimeHostInputValue::F64(2.0),
+        ))
+        .unwrap();
+    runtime.drain_host_inputs(1).unwrap();
+    let LegacyValue::F64(enabled) = runtime.root_symbol_value("enabled").unwrap().into_value()
+    else {
+        panic!("scene pointer toggle must remain f64")
+    };
+    assert_eq!(*enabled.borrow(), 1.0);
+
+    runtime
+        .ingress()
+        .submit(RuntimeHostInput::single(
+            pulse,
+            RuntimeHostInputValue::F64(3.0),
+        ))
+        .unwrap();
+    runtime.drain_host_inputs(1).unwrap();
+    let LegacyValue::F64(enabled) = runtime.root_symbol_value("enabled").unwrap().into_value()
+    else {
+        panic!("scene pointer toggle must remain f64")
+    };
+    assert_eq!(*enabled.borrow(), 0.0);
 }
 
 #[test]

--- a/hosts/scene/tests/provider.rs
+++ b/hosts/scene/tests/provider.rs
@@ -830,7 +830,7 @@ fn native_scene_instances_are_isolated() {
 
 #[cfg(feature = "browser")]
 #[test]
-fn browser_scene_pointer_activation_survives_a_coalesced_release() {
+fn browser_scene_pointer_activation_survives_a_later_release_turn() {
     let registry = BrowserSceneRegistry::new();
     let factory = BrowserSceneHostFactory::with_registry(registry.clone()).unwrap();
     let mut runtime = RuntimeBuilder::new()
@@ -863,7 +863,7 @@ position := @scene/pointer-position
 pressed := @scene/pointer-pressed
 ~enabled := 1.0
 ~last-pulse := 0.0
-delta := pulse - last-pulse
+delta := pressed * (pulse - last-pulse)
 next-enabled := enabled + delta * (1.0 - 2.0 * enabled)
 enabled = next-enabled
 last-pulse = pulse
@@ -876,10 +876,19 @@ last-pulse = pulse
     registry
         .submit_pointer("view", 0.25, -0.5, true, 0.0)
         .unwrap();
+    assert_eq!(runtime.pending_host_input_count().unwrap(), 1);
+    runtime.drain_host_inputs(8).unwrap();
+
+    let LegacyValue::F64(enabled) = runtime.root_symbol_value("enabled").unwrap().into_value()
+    else {
+        panic!("scene pointer toggle must remain f64")
+    };
+    assert_eq!(*enabled.borrow(), 0.0);
+
     registry
         .submit_pointer("view", 0.25, -0.5, false, 0.01)
         .unwrap();
-    assert_eq!(runtime.pending_host_input_count().unwrap(), 2);
+    assert_eq!(runtime.pending_host_input_count().unwrap(), 1);
     runtime.drain_host_inputs(8).unwrap();
 
     let LegacyValue::F64(pulse) = runtime.root_symbol_value("pulse").unwrap().into_value() else {

--- a/hosts/scene/tests/provider.rs
+++ b/hosts/scene/tests/provider.rs
@@ -10,6 +10,10 @@ use mech_runtime::{
     ConfigValue, PreparedRuntimeEffect, RuntimeCapabilityOperation, RuntimeResourceProvider,
     RuntimeResourceWriteIntent, RuntimeResourceWritePreflightRequest, RuntimeResourceWriteRequest,
 };
+#[cfg(feature = "browser")]
+use mech_runtime::{
+    HostInstanceConfig, ResidentDurabilityPolicy, RunResourceGrantConfig, RuntimeBuilder,
+};
 use mech_scene::*;
 
 fn deliver_write(
@@ -822,6 +826,82 @@ fn native_scene_instances_are_isolated() {
     .unwrap();
     assert_eq!(registry.latest("main").unwrap().width, 100.0);
     assert_eq!(registry.latest("hud").unwrap().width, 200.0);
+}
+
+#[cfg(feature = "browser")]
+#[test]
+fn browser_scene_pointer_activation_survives_a_coalesced_release() {
+    let registry = BrowserSceneRegistry::new();
+    let factory = BrowserSceneHostFactory::with_registry(registry.clone()).unwrap();
+    let mut runtime = RuntimeBuilder::new()
+        .function_catalog(mech_stdlib::source_native_plan_catalog())
+        .host_factory(Box::new(factory))
+        .unwrap()
+        .host_instance(HostInstanceConfig {
+            name: "view".to_string(),
+            provider: "scene".to_string(),
+            settings: settings("output"),
+        })
+        .run_resource_grant(RunResourceGrantConfig {
+            target: "view/frame".to_string(),
+            operations: vec!["read".to_string(), "write".to_string()],
+            paths: vec![
+                "pointer-pulse".to_string(),
+                "pointer-position".to_string(),
+                "pointer-pressed".to_string(),
+                "replace".to_string(),
+            ],
+        })
+        .build()
+        .unwrap();
+    runtime
+        .load_interactive_source_program(
+            r#"
+@scene := scene://view/frame{:read(pointer-pulse), :read(pointer-position), :read(pointer-pressed), :write(replace)}
+pulse := @scene/pointer-pulse
+position := @scene/pointer-position
+pressed := @scene/pointer-pressed
+~enabled := 1.0
+~last-pulse := 0.0
+delta := pulse - last-pulse
+next-enabled := enabled + delta * (1.0 - 2.0 * enabled)
+enabled = next-enabled
+last-pulse = pulse
+"#,
+            ResidentDurabilityPolicy::Volatile,
+        )
+        .unwrap();
+    runtime.start_input_drivers().unwrap();
+
+    registry
+        .submit_pointer("view", 0.25, -0.5, true, 0.0)
+        .unwrap();
+    registry
+        .submit_pointer("view", 0.25, -0.5, false, 0.01)
+        .unwrap();
+    assert_eq!(runtime.pending_host_input_count().unwrap(), 2);
+    runtime.drain_host_inputs(8).unwrap();
+
+    let LegacyValue::F64(pulse) = runtime.root_symbol_value("pulse").unwrap().into_value() else {
+        panic!("scene pointer pulse must remain f64")
+    };
+    assert_eq!(*pulse.borrow(), 1.0);
+    let LegacyValue::F64(pressed) = runtime.root_symbol_value("pressed").unwrap().into_value()
+    else {
+        panic!("scene pointer pressed state must remain f64")
+    };
+    assert_eq!(*pressed.borrow(), 0.0);
+    let LegacyValue::MatrixF64(position) =
+        runtime.root_symbol_value("position").unwrap().into_value()
+    else {
+        panic!("scene pointer position must remain an f64 matrix")
+    };
+    assert_eq!(position.as_vec(), [0.25, -0.5]);
+    let LegacyValue::F64(enabled) = runtime.root_symbol_value("enabled").unwrap().into_value()
+    else {
+        panic!("scene pointer toggle must remain f64")
+    };
+    assert_eq!(*enabled.borrow(), 0.0);
 }
 
 #[test]

--- a/include/browser-compute.js
+++ b/include/browser-compute.js
@@ -67,6 +67,34 @@ globalThis.MechComputeStateResetLedger ||= class MechComputeStateResetLedger {
   }
 };
 
+// Tracks the physical compute identity independently of the WebGPU transport.
+// Scalar compute intentionally has no DocumentComputeBridge, but it still owns
+// persistent resident state and must report incompatible replacement exactly
+// like WebGPU does.
+globalThis.MechComputeStateResetTracker ||= class MechComputeStateResetTracker {
+  constructor(ledger = new globalThis.MechComputeStateResetLedger()) {
+    this.ledger = ledger;
+    this.previous = null;
+  }
+
+  advance(identity) {
+    const next = {
+      present: identity?.present === true,
+      generation: String(identity?.generation || "none"),
+      revision: String(identity?.revision || "none"),
+    };
+    const previous = this.previous;
+    this.previous = next;
+    if (!previous?.present) return null;
+    return this.ledger.record(
+      previous.generation,
+      next.generation,
+      previous.revision,
+      next.revision,
+    );
+  }
+};
+
 globalThis.MechBrowserComputeDevice ||= class MechBrowserComputeDevice {
   static logicalOutputValues(output, physicalValues) {
     const dimensions = (output.sampleDimensions || []).map(Number);

--- a/include/browser-compute.js
+++ b/include/browser-compute.js
@@ -292,16 +292,32 @@ globalThis.MechBrowserComputeDevice ||= class MechBrowserComputeDevice {
       );
     }
     this.device.queue.submit([encoder.finish()]);
-    return { outputIndex };
+    // Capture completion at the compute submission boundary. Callers may
+    // submit unrelated presentation work to the same queue immediately after
+    // this method returns; resident acknowledgement must not wait for it.
+    let completion;
+    try {
+      completion = this.readback
+        ? this.readback.mapAsync(GPUMapMode.READ, 0, this.readbackBytes)
+        : this.device.queue.onSubmittedWorkDone();
+    } catch (error) {
+      // Submission has already succeeded. Surface setup failure through the
+      // completion channel so the bridge records the accepted submission
+      // before applying its terminal-failure policy.
+      completion = Promise.reject(error);
+    }
+    return { outputIndex, completion };
   }
 
-  async finish() {
+  async finish(completion) {
+    if (!completion || typeof completion.then !== "function") {
+      throw new Error("compute completion requires its exact submission promise");
+    }
+    await completion;
     if (!this.readback) {
-      await this.device.queue.onSubmittedWorkDone();
       this.publishMetrics();
       return { outputs: [], integrity: null };
     }
-    await this.readback.mapAsync(GPUMapMode.READ, 0, this.readbackBytes);
     try {
       const mapped = this.readback.getMappedRange(0, this.readbackBytes);
       // This is the physical mapped transfer. Count it exactly once per

--- a/include/browser-compute.js
+++ b/include/browser-compute.js
@@ -1,5 +1,36 @@
 /* Shared WebGPU resource and completion protocol for Mech browser hosts. */
 globalThis.MechBrowserComputeDevice ||= class MechBrowserComputeDevice {
+  static logicalOutputValues(output, physicalValues) {
+    const dimensions = (output.sampleDimensions || []).map(Number);
+    if (output.physicalLayout !== "column-major" || dimensions.length < 2) {
+      return Float32Array.from(physicalValues);
+    }
+    const elements = dimensions.reduce((product, dimension) => product * dimension, 1);
+    if (elements !== physicalValues.length) {
+      throw new Error(
+        `compute output ${output.name} has ${physicalValues.length} physical values; expected ${elements}`,
+      );
+    }
+    const logical = new Float32Array(elements);
+    const columnMajorStrides = [];
+    let columnMajorStride = 1;
+    for (const dimension of dimensions) {
+      columnMajorStrides.push(columnMajorStride);
+      columnMajorStride *= dimension;
+    }
+    for (let rowMajorIndex = 0; rowMajorIndex < elements; rowMajorIndex += 1) {
+      let remaining = rowMajorIndex;
+      let columnMajorIndex = 0;
+      for (let axis = dimensions.length - 1; axis >= 0; axis -= 1) {
+        const coordinate = remaining % dimensions[axis];
+        remaining = Math.floor(remaining / dimensions[axis]);
+        columnMajorIndex += coordinate * columnMajorStrides[axis];
+      }
+      logical[rowMajorIndex] = physicalValues[columnMajorIndex];
+    }
+    return logical;
+  }
+
   static requiredLimits(manifest, supported, requestedOutputNames = []) {
     const requested = new Set(requestedOutputNames);
     const bindingBytes = manifest.bindings.map((binding) =>
@@ -241,7 +272,8 @@ globalThis.MechBrowserComputeDevice ||= class MechBrowserComputeDevice {
       }
       const outputs = [];
       for (const item of this.readbackPlan) {
-        const values = Float32Array.from(
+        const values = MechBrowserComputeDevice.logicalOutputValues(
+          item.output,
           new Float32Array(mapped, item.offset, item.bytes / Float32Array.BYTES_PER_ELEMENT),
         );
         this.metrics.gpuToCpuReadbackBytes += item.bytes;

--- a/include/browser-compute.js
+++ b/include/browser-compute.js
@@ -1,0 +1,275 @@
+/* Shared WebGPU resource and completion protocol for Mech browser hosts. */
+globalThis.MechBrowserComputeDevice ||= class MechBrowserComputeDevice {
+  static requiredLimits(manifest, supported, requestedOutputNames = []) {
+    const requested = new Set(requestedOutputNames);
+    const bindingBytes = manifest.bindings.map((binding) =>
+      Math.max(4, Number(binding.elements) * Float32Array.BYTES_PER_ELEMENT));
+    const readbackBytes = manifest.outputs
+      .filter((output) => requested.has(output.name))
+      .reduce(
+        (total, output) => total + Number(output.elementsPerInstance) * Float32Array.BYTES_PER_ELEMENT,
+        0,
+      );
+    const integrityBytes = Number(
+      manifest.bindings.find((binding) => binding.role === "integrity-fault")?.elements || 0,
+    ) * Uint32Array.BYTES_PER_ELEMENT;
+    const required = {
+      maxStorageBuffersPerShaderStage: manifest.bindings.length,
+      maxComputeWorkgroupsPerDimension: Math.ceil(
+        manifest.dispatchElements / manifest.workgroupSize,
+      ),
+      maxStorageBufferBindingSize: Math.max(...bindingBytes, 4),
+      maxBufferSize: Math.max(...bindingBytes, readbackBytes + integrityBytes, 4),
+    };
+    for (const [name, value] of Object.entries(required)) {
+      if (!Number.isSafeInteger(value) || value <= 0) {
+        throw new Error(`Mech computed an invalid ${name} requirement: ${value}`);
+      }
+      const limit = Number(supported[name]);
+      if (!Number.isFinite(limit) || limit <= 0) {
+        throw new Error(`this WebGPU adapter does not report the required ${name} limit`);
+      }
+      if (value > limit) {
+        throw new Error(`Mech requires ${value} for ${name}, but this adapter supports ${limit}`);
+      }
+    }
+    return required;
+  }
+
+  static async create(manifest, adapter, requestedOutputNames = []) {
+    const requiredLimits = this.requiredLimits(
+      manifest,
+      adapter.limits,
+      requestedOutputNames,
+    );
+    const device = await adapter.requestDevice({ requiredLimits });
+    try {
+      const module = device.createShaderModule({ code: manifest.wgsl });
+      const compilation = await module.getCompilationInfo();
+      const errors = compilation.messages.filter((message) => message.type === "error");
+      if (errors.length) {
+        throw new Error(errors.map((message) => message.message).join("\n"));
+      }
+      const descriptor = {
+        layout: "auto",
+        compute: { module, entryPoint: "main" },
+      };
+      const pipeline = typeof device.createComputePipelineAsync === "function"
+        ? await device.createComputePipelineAsync(descriptor)
+        : device.createComputePipeline(descriptor);
+      return new this(manifest, device, pipeline, requestedOutputNames);
+    } catch (error) {
+      device.destroy();
+      throw error;
+    }
+  }
+
+  constructor(manifest, device, pipeline, requestedOutputNames = []) {
+    this.manifest = manifest;
+    this.device = device;
+    this.pipeline = pipeline;
+    this.disposed = false;
+    this.metrics = {
+      cpuToGpuInputBytes: 0,
+      gpuToCpuReadbackBytes: 0,
+      logicalOutputs: requestedOutputNames.length,
+      uniquePhysicalOutputBuffers: 0,
+    };
+    this.createBuffers(requestedOutputNames);
+  }
+
+  createBuffers(requestedOutputNames) {
+    this.stateBuffers = new Map();
+    for (const state of this.manifest.states) {
+      const buffers = [0, 1].map(() => this.device.createBuffer({
+        size: Math.max(4, state.elements * Float32Array.BYTES_PER_ELEMENT),
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
+      }));
+      this.device.queue.writeBuffer(buffers[0], 0, state.initialValues);
+      this.stateBuffers.set(state.slot, buffers);
+    }
+    this.fixedBuffers = new Map();
+    this.inputBindings = new Map();
+    for (const binding of this.manifest.bindings) {
+      if (binding.role === "state-read" || binding.role === "state-write") continue;
+      const buffer = this.device.createBuffer({
+        size: Math.max(4, binding.elements * Float32Array.BYTES_PER_ELEMENT),
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
+      });
+      if (binding.initialValues) this.device.queue.writeBuffer(buffer, 0, binding.initialValues);
+      this.fixedBuffers.set(binding.binding, buffer);
+      if (binding.role === "input") this.inputBindings.set(binding.name, { binding, buffer });
+    }
+    this.bindGroups = [0, 1].map((sourceIndex) => this.device.createBindGroup({
+      layout: this.pipeline.getBindGroupLayout(0),
+      entries: this.manifest.bindings.map((binding) => ({
+        binding: binding.binding,
+        resource: { buffer: this.bufferForBinding(binding, sourceIndex) },
+      })),
+    }));
+    this.integrity = this.manifest.bindings.find(
+      (binding) => binding.role === "integrity-fault",
+    );
+    this.configureReadback(requestedOutputNames);
+  }
+
+  configureReadback(requestedOutputNames) {
+    this.metrics.logicalOutputs = requestedOutputNames.length;
+    this.readback?.destroy();
+    const requested = new Set(requestedOutputNames);
+    const physical = new Map();
+    this.readbackPlan = [];
+    let byteLength = 0;
+    for (const output of this.manifest.outputs) {
+      if (!requested.has(output.name)) continue;
+      const key = String(output.slot);
+      let item = physical.get(key);
+      if (!item) {
+        const bytes = output.elementsPerInstance * Float32Array.BYTES_PER_ELEMENT;
+        item = { output, offset: byteLength, bytes, aliases: [] };
+        physical.set(key, item);
+        this.readbackPlan.push(item);
+        byteLength += bytes;
+      }
+      item.aliases.push(output);
+    }
+    this.metrics.uniquePhysicalOutputBuffers = physical.size;
+    this.integrityOffset = this.integrity ? byteLength : null;
+    if (this.integrity) byteLength += this.integrity.elements * Uint32Array.BYTES_PER_ELEMENT;
+    this.readbackBytes = byteLength;
+    this.readback = byteLength > 0 ? this.device.createBuffer({
+      size: Math.max(4, byteLength),
+      usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+    }) : null;
+    this.readbackSignature = [...requestedOutputNames].sort().join("\u0000");
+  }
+
+  setRequestedOutputs(requestedOutputNames) {
+    const signature = [...requestedOutputNames].sort().join("\u0000");
+    if (signature !== this.readbackSignature) this.configureReadback(requestedOutputNames);
+  }
+
+  bufferForBinding(binding, sourceIndex) {
+    if (binding.role === "state-read") return this.stateBuffers.get(binding.slot)[sourceIndex];
+    if (binding.role === "state-write") return this.stateBuffers.get(binding.slot)[1 - sourceIndex];
+    return this.fixedBuffers.get(binding.binding);
+  }
+
+  outputBuffer(index, output) {
+    if (this.stateBuffers.has(output.slot)) return this.stateBuffers.get(output.slot)[index];
+    const binding = this.manifest.bindings.find(
+      (candidate) => candidate.role === "output" && candidate.slot === output.slot,
+    );
+    if (!binding) throw new Error(`compute output ${output.name} has no physical buffer`);
+    return this.fixedBuffers.get(binding.binding);
+  }
+
+  applyInputs(command) {
+    for (const input of command.inputs) {
+      const target = this.inputBindings.get(input.name);
+      if (!target) throw new Error(`Mech wrote undeclared GPU input ${input.name}`);
+      if (input.values.length !== target.binding.elements) {
+        throw new Error(
+          `Mech wrote ${input.values.length} values to ${input.name}; expected ${target.binding.elements}`,
+        );
+      }
+      this.device.queue.writeBuffer(target.buffer, 0, input.values);
+      this.metrics.cpuToGpuInputBytes += input.values.byteLength;
+    }
+  }
+
+  submit(command, activeBuffer) {
+    if (this.disposed) throw new Error("the WebGPU compute device is disposed");
+    this.applyInputs(command);
+    if (this.integrity) {
+      this.device.queue.writeBuffer(
+        this.fixedBuffers.get(this.integrity.binding),
+        0,
+        new Uint32Array([0, 0xffffffff]),
+      );
+    }
+    const outputIndex = 1 - activeBuffer;
+    const encoder = this.device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(this.pipeline);
+    pass.setBindGroup(0, this.bindGroups[activeBuffer]);
+    pass.dispatchWorkgroups(Math.ceil(
+      this.manifest.dispatchElements / this.manifest.workgroupSize,
+    ));
+    pass.end();
+    for (const item of this.readbackPlan) {
+      encoder.copyBufferToBuffer(
+        this.outputBuffer(outputIndex, item.output), 0,
+        this.readback, item.offset, item.bytes,
+      );
+    }
+    if (this.integrity) {
+      encoder.copyBufferToBuffer(
+        this.fixedBuffers.get(this.integrity.binding), 0,
+        this.readback, this.integrityOffset,
+        this.integrity.elements * Uint32Array.BYTES_PER_ELEMENT,
+      );
+    }
+    this.device.queue.submit([encoder.finish()]);
+    return { outputIndex };
+  }
+
+  async finish() {
+    if (!this.readback) {
+      await this.device.queue.onSubmittedWorkDone();
+      this.publishMetrics();
+      return { outputs: [], integrity: null };
+    }
+    await this.readback.mapAsync(GPUMapMode.READ, 0, this.readbackBytes);
+    try {
+      const mapped = this.readback.getMappedRange(0, this.readbackBytes);
+      if (this.integrity) {
+        const words = new Uint32Array(mapped, this.integrityOffset, this.integrity.elements);
+        if (words[0] !== 0) {
+          const packed = words[1];
+          const code = packed & 0xff;
+          const instance = packed >>> 8;
+          const constraint = (this.manifest.constraints || [])
+            .find((candidate) => candidate.code === code);
+          const result = {
+            outputs: [],
+            integrity: { constraint: constraint?.name || String(code), instance },
+          };
+          this.publishMetrics();
+          return result;
+        }
+      }
+      const outputs = [];
+      for (const item of this.readbackPlan) {
+        const values = Float32Array.from(
+          new Float32Array(mapped, item.offset, item.bytes / Float32Array.BYTES_PER_ELEMENT),
+        );
+        this.metrics.gpuToCpuReadbackBytes += item.bytes;
+        for (const output of item.aliases) outputs.push({ name: output.name, values });
+      }
+      this.publishMetrics();
+      return { outputs, integrity: null };
+    } finally {
+      this.readback.unmap();
+    }
+  }
+
+  publishMetrics() {
+    const root = document.documentElement;
+    root.dataset.mechComputeCpuToGpuInputBytes = String(this.metrics.cpuToGpuInputBytes);
+    root.dataset.mechComputeGpuToCpuReadbackBytes = String(this.metrics.gpuToCpuReadbackBytes);
+    root.dataset.mechComputeLogicalOutputs = String(this.metrics.logicalOutputs);
+    root.dataset.mechComputePhysicalOutputBuffers = String(
+      this.metrics.uniquePhysicalOutputBuffers,
+    );
+  }
+
+  dispose() {
+    if (this.disposed) return;
+    this.disposed = true;
+    for (const buffers of this.stateBuffers.values()) buffers.forEach((buffer) => buffer.destroy());
+    for (const buffer of this.fixedBuffers.values()) buffer.destroy();
+    this.readback?.destroy();
+    this.device.destroy();
+  }
+};

--- a/include/browser-compute.js
+++ b/include/browser-compute.js
@@ -1,4 +1,49 @@
 /* Shared WebGPU resource and completion protocol for Mech browser hosts. */
+globalThis.MechComputeSubmissionLifecycle ||= class MechComputeSubmissionLifecycle {
+  constructor(generation) {
+    this.generation = String(generation);
+    this.phase = "ready";
+    this.submitted = false;
+    this.inFlight = null;
+    this.failure = null;
+  }
+
+  markSubmitted(identity) {
+    if (this.phase === "failed") {
+      throw this.failure;
+    }
+    if (this.inFlight !== null) {
+      throw new Error("a checked document compute dispatch is already in flight");
+    }
+    this.submitted = true;
+    this.inFlight = String(identity);
+    this.phase = "in-flight";
+  }
+
+  markAccepted(identity) {
+    if (this.phase === "failed") {
+      throw this.failure;
+    }
+    if (this.inFlight !== String(identity)) {
+      throw new Error("compute completion does not match the in-flight submission");
+    }
+    this.inFlight = null;
+    this.phase = "ready";
+  }
+
+  markFailed(reason) {
+    if (this.phase !== "failed") {
+      this.failure = reason instanceof Error ? reason : new Error(String(reason));
+      this.phase = "failed";
+    }
+    return this.failure;
+  }
+
+  canAutoFallback() {
+    return !this.submitted;
+  }
+};
+
 globalThis.MechBrowserComputeDevice ||= class MechBrowserComputeDevice {
   static logicalOutputValues(output, physicalValues) {
     const dimensions = (output.sampleDimensions || []).map(Number);
@@ -31,14 +76,15 @@ globalThis.MechBrowserComputeDevice ||= class MechBrowserComputeDevice {
     return logical;
   }
 
-  static requiredLimits(manifest, supported, requestedOutputNames = []) {
-    const requested = new Set(requestedOutputNames);
+  static requiredLimits(manifest, supported) {
     const bindingBytes = manifest.bindings.map((binding) =>
       Math.max(4, Number(binding.elements) * Float32Array.BYTES_PER_ELEMENT));
-    const readbackBytes = manifest.outputs
-      .filter((output) => requested.has(output.name))
+    // Output sampling is selected per turn, after device creation. Reserve
+    // enough address space for the largest legal readback plan up front so a
+    // later sample request cannot exceed the limits admitted for this device.
+    const readbackBytes = (manifest.physicalOutputs || [])
       .reduce(
-        (total, output) => total + Number(output.elementsPerInstance) * Float32Array.BYTES_PER_ELEMENT,
+        (total, output) => total + Number(output.sampleElements) * Float32Array.BYTES_PER_ELEMENT,
         0,
       );
     const integrityBytes = Number(
@@ -68,10 +114,14 @@ globalThis.MechBrowserComputeDevice ||= class MechBrowserComputeDevice {
   }
 
   static async create(manifest, adapter, requestedOutputNames = []) {
+    if (Number(manifest.planVersion) !== 1) {
+      throw new Error(
+        `unsupported GPU execution plan version ${manifest.planVersion}; expected 1`,
+      );
+    }
     const requiredLimits = this.requiredLimits(
       manifest,
       adapter.limits,
-      requestedOutputNames,
     );
     const device = await adapter.requestDevice({ requiredLimits });
     try {
@@ -103,6 +153,7 @@ globalThis.MechBrowserComputeDevice ||= class MechBrowserComputeDevice {
     this.metrics = {
       cpuToGpuInputBytes: 0,
       gpuToCpuReadbackBytes: 0,
+      gpuToCpuOutputBytes: 0,
       logicalOutputs: requestedOutputNames.length,
       uniquePhysicalOutputBuffers: 0,
     };
@@ -148,23 +199,23 @@ globalThis.MechBrowserComputeDevice ||= class MechBrowserComputeDevice {
     this.metrics.logicalOutputs = requestedOutputNames.length;
     this.readback?.destroy();
     const requested = new Set(requestedOutputNames);
-    const physical = new Map();
     this.readbackPlan = [];
     let byteLength = 0;
-    for (const output of this.manifest.outputs) {
-      if (!requested.has(output.name)) continue;
-      const key = String(output.slot);
-      let item = physical.get(key);
-      if (!item) {
-        const bytes = output.elementsPerInstance * Float32Array.BYTES_PER_ELEMENT;
-        item = { output, offset: byteLength, bytes, aliases: [] };
-        physical.set(key, item);
-        this.readbackPlan.push(item);
-        byteLength += bytes;
+    for (const physical of this.manifest.physicalOutputs || []) {
+      const aliases = physical.aliases
+        .filter((name) => requested.has(name))
+        .map((name) => this.manifest.outputs.find((output) => output.name === name));
+      if (!aliases.length) continue;
+      if (aliases.some((output) => !output)) {
+        throw new Error(`GPU physical output ${physical.id} names an unknown logical alias`);
       }
-      item.aliases.push(output);
+      const bytes = physical.sampleElements * Float32Array.BYTES_PER_ELEMENT;
+      this.readbackPlan.push({
+        output: aliases[0], physical, offset: byteLength, bytes, aliases,
+      });
+      byteLength += bytes;
     }
-    this.metrics.uniquePhysicalOutputBuffers = physical.size;
+    this.metrics.uniquePhysicalOutputBuffers = this.readbackPlan.length;
     this.integrityOffset = this.integrity ? byteLength : null;
     if (this.integrity) byteLength += this.integrity.elements * Uint32Array.BYTES_PER_ELEMENT;
     this.readbackBytes = byteLength;
@@ -186,13 +237,12 @@ globalThis.MechBrowserComputeDevice ||= class MechBrowserComputeDevice {
     return this.fixedBuffers.get(binding.binding);
   }
 
-  outputBuffer(index, output) {
-    if (this.stateBuffers.has(output.slot)) return this.stateBuffers.get(output.slot)[index];
-    const binding = this.manifest.bindings.find(
-      (candidate) => candidate.role === "output" && candidate.slot === output.slot,
-    );
-    if (!binding) throw new Error(`compute output ${output.name} has no physical buffer`);
-    return this.fixedBuffers.get(binding.binding);
+  outputBuffer(index, physical) {
+    if (this.stateBuffers.has(physical.slot)) return this.stateBuffers.get(physical.slot)[index];
+    if (!Number.isInteger(physical.binding)) {
+      throw new Error(`compute physical output ${physical.id} has no buffer binding`);
+    }
+    return this.fixedBuffers.get(physical.binding);
   }
 
   applyInputs(command) {
@@ -230,7 +280,7 @@ globalThis.MechBrowserComputeDevice ||= class MechBrowserComputeDevice {
     pass.end();
     for (const item of this.readbackPlan) {
       encoder.copyBufferToBuffer(
-        this.outputBuffer(outputIndex, item.output), 0,
+        this.outputBuffer(outputIndex, item.physical), 0,
         this.readback, item.offset, item.bytes,
       );
     }
@@ -254,6 +304,10 @@ globalThis.MechBrowserComputeDevice ||= class MechBrowserComputeDevice {
     await this.readback.mapAsync(GPUMapMode.READ, 0, this.readbackBytes);
     try {
       const mapped = this.readback.getMappedRange(0, this.readbackBytes);
+      // This is the physical mapped transfer. Count it exactly once per
+      // accepted mapping, including integrity metadata and mappings whose
+      // integrity check rejects the candidate state.
+      this.metrics.gpuToCpuReadbackBytes += this.readbackBytes;
       if (this.integrity) {
         const words = new Uint32Array(mapped, this.integrityOffset, this.integrity.elements);
         if (words[0] !== 0) {
@@ -276,7 +330,7 @@ globalThis.MechBrowserComputeDevice ||= class MechBrowserComputeDevice {
           item.output,
           new Float32Array(mapped, item.offset, item.bytes / Float32Array.BYTES_PER_ELEMENT),
         );
-        this.metrics.gpuToCpuReadbackBytes += item.bytes;
+        this.metrics.gpuToCpuOutputBytes += item.bytes * item.aliases.length;
         for (const output of item.aliases) outputs.push({ name: output.name, values });
       }
       this.publishMetrics();
@@ -290,6 +344,7 @@ globalThis.MechBrowserComputeDevice ||= class MechBrowserComputeDevice {
     const root = document.documentElement;
     root.dataset.mechComputeCpuToGpuInputBytes = String(this.metrics.cpuToGpuInputBytes);
     root.dataset.mechComputeGpuToCpuReadbackBytes = String(this.metrics.gpuToCpuReadbackBytes);
+    root.dataset.mechComputeGpuToCpuOutputBytes = String(this.metrics.gpuToCpuOutputBytes);
     root.dataset.mechComputeLogicalOutputs = String(this.metrics.logicalOutputs);
     root.dataset.mechComputePhysicalOutputBuffers = String(
       this.metrics.uniquePhysicalOutputBuffers,

--- a/include/browser-compute.js
+++ b/include/browser-compute.js
@@ -44,6 +44,29 @@ globalThis.MechComputeSubmissionLifecycle ||= class MechComputeSubmissionLifecyc
   }
 };
 
+globalThis.MechComputeStateResetLedger ||= class MechComputeStateResetLedger {
+  constructor() {
+    this.transitions = new Set();
+    this.count = 0;
+  }
+
+  record(previousGeneration, nextGeneration, previousRevision, nextRevision) {
+    const previous = String(previousRevision || "none");
+    const next = String(nextRevision || "none");
+    if (previous === next) return null;
+    const transition = [
+      String(previousGeneration || "none"),
+      String(nextGeneration || "none"),
+      previous,
+      next,
+    ].join(":");
+    if (this.transitions.has(transition)) return null;
+    this.transitions.add(transition);
+    this.count += 1;
+    return { previousRevision: previous, nextRevision: next, resetCount: this.count };
+  }
+};
+
 globalThis.MechBrowserComputeDevice ||= class MechBrowserComputeDevice {
   static logicalOutputValues(output, physicalValues) {
     const dimensions = (output.sampleDimensions || []).map(Number);
@@ -119,6 +142,9 @@ globalThis.MechBrowserComputeDevice ||= class MechBrowserComputeDevice {
         `unsupported GPU execution plan version ${manifest.planVersion}; expected 1`,
       );
     }
+    if (!/^sha256:[0-9a-f]{64}$/.test(String(manifest.physicalRevision || ""))) {
+      throw new Error("GPU execution plan omitted its stable physical revision");
+    }
     const requiredLimits = this.requiredLimits(
       manifest,
       adapter.limits,
@@ -149,6 +175,17 @@ globalThis.MechBrowserComputeDevice ||= class MechBrowserComputeDevice {
     this.manifest = manifest;
     this.device = device;
     this.pipeline = pipeline;
+    this.physicalRevision = String(manifest.physicalRevision || "");
+    globalThis.__MECH_COMPUTE_RESOURCE_SEQUENCE__ =
+      Number(globalThis.__MECH_COMPUTE_RESOURCE_SEQUENCE__ || 0) + 1;
+    globalThis.__MECH_COMPUTE_PIPELINE_BUILD_COUNT__ =
+      Number(globalThis.__MECH_COMPUTE_PIPELINE_BUILD_COUNT__ || 0) + 1;
+    this.resourceIdentity = String(globalThis.__MECH_COMPUTE_RESOURCE_SEQUENCE__);
+    this.deviceIdentity = `device-${this.resourceIdentity}`;
+    this.pipelineIdentity =
+      `pipeline-${globalThis.__MECH_COMPUTE_PIPELINE_BUILD_COUNT__}`;
+    this.stateIdentity = `state-${this.resourceIdentity}`;
+    this.pipelineBuildCount = globalThis.__MECH_COMPUTE_PIPELINE_BUILD_COUNT__;
     this.disposed = false;
     this.metrics = {
       cpuToGpuInputBytes: 0,
@@ -158,6 +195,18 @@ globalThis.MechBrowserComputeDevice ||= class MechBrowserComputeDevice {
       uniquePhysicalOutputBuffers: 0,
     };
     this.createBuffers(requestedOutputNames);
+  }
+
+  compatibleWith(manifest) {
+    return !this.disposed && this.physicalRevision !== "" &&
+      this.physicalRevision === String(manifest?.physicalRevision || "");
+  }
+
+  adoptManifest(manifest) {
+    if (!this.compatibleWith(manifest)) {
+      throw new Error("cannot adopt an incompatible GPU execution plan");
+    }
+    this.manifest = manifest;
   }
 
   createBuffers(requestedOutputNames) {

--- a/include/document.js
+++ b/include/document.js
@@ -520,6 +520,10 @@ function errorMessage(error) {
   return error instanceof Error ? error.message : String(error);
 }
 
+function isRecoverableResidentTurnError(error) {
+  return error instanceof Error && error.mechRecoverableResidentTurn === true;
+}
+
 function controllerQuery(selector) {
   return state.root
     ? state.root.querySelector(selector)
@@ -4093,6 +4097,11 @@ function frame() {
     }
     state.animationFrame = requestAnimationFrame(frame);
   } catch (error) {
+    if (isRecoverableResidentTurnError(error)) {
+      appendError(error);
+      state.animationFrame = requestAnimationFrame(frame);
+      return;
+    }
     showFatalError(error);
   }
 }

--- a/include/document.js
+++ b/include/document.js
@@ -45,6 +45,8 @@ const state = {
   tocLinkHandlers: new Map(),
   mermaidInitialized: false,
   outputFullscreenController: null,
+  computeBridge: null,
+  computeAdapter: undefined,
 };
 
 const ERROR_PANEL_SELECTOR =
@@ -3813,12 +3815,316 @@ function initializeLayout() {
   window.addEventListener("load", initializeOptionalRenderers, { once: true });
 }
 
+function servedComputeHostConfig() {
+  const authority = window.__MECH_HOST_CONFIG;
+  const hosts = authority?.hosts || authority?.payload?.hosts || [];
+  return hosts.find(host => host?.provider === "compute") || null;
+}
+
+async function probeServedComputeAdapter() {
+  const computeHost = servedComputeHostConfig();
+  if (!computeHost) {
+    return;
+  }
+  const requestedBackend = computeHost.settings?.backend || "auto";
+  state.computeAdapter = requestedBackend === "cpu-scalar" || !navigator.gpu
+    ? null
+    : await navigator.gpu.requestAdapter({ powerPreference: "high-performance" });
+  // Runtime construction is synchronous. Publish the result of the actual
+  // adapter probe so `auto` selects the same backend the bridge can execute,
+  // including browsers that expose navigator.gpu but return no adapter.
+  window.__MECH_GPU_AVAILABLE = Boolean(state.computeAdapter);
+}
+
+class DocumentComputeBridge {
+  static async create(controller) {
+    if (typeof controller.computeManifest !== "function") {
+      return null;
+    }
+    const manifest = controller.computeManifest();
+    if (!manifest) {
+      return null;
+    }
+    const backend = controller.computeBackend();
+    if (backend !== "wgpu") {
+      return new DocumentComputeBridge(controller, manifest, backend, null, null);
+    }
+    if (manifest.kernelKind !== "fixed-shape") {
+      throw new Error(
+        `document compute output sampling requires a fixed-shape kernel, got ${manifest.kernelKind}`,
+      );
+    }
+    const adapter = state.computeAdapter !== undefined
+      ? state.computeAdapter
+      : navigator.gpu
+        ? await navigator.gpu.requestAdapter({ powerPreference: "high-performance" })
+        : null;
+    if (!adapter) {
+      throw new Error("the document selected WebGPU but no compatible adapter is available");
+    }
+    const requiredLimits = {
+      maxStorageBuffersPerShaderStage: manifest.bindings.length,
+      maxComputeWorkgroupsPerDimension: Math.ceil(
+        manifest.dispatchElements / manifest.workgroupSize,
+      ),
+    };
+    for (const [name, required] of Object.entries(requiredLimits)) {
+      if (required > adapter.limits[name]) {
+        throw new Error(
+          `Mech requires ${required} for ${name}, but this adapter supports ${adapter.limits[name]}`,
+        );
+      }
+    }
+    const device = await adapter.requestDevice({ requiredLimits });
+    const module = device.createShaderModule({ code: manifest.wgsl });
+    const compilation = await module.getCompilationInfo();
+    const errors = compilation.messages.filter(message => message.type === "error");
+    if (errors.length) {
+      throw new Error(errors.map(message => message.message).join("\n"));
+    }
+    const pipeline = device.createComputePipeline({
+      layout: "auto",
+      compute: { module, entryPoint: "main" },
+    });
+    const bridge = new DocumentComputeBridge(
+      controller,
+      manifest,
+      backend,
+      device,
+      pipeline,
+    );
+    bridge.createBuffers();
+    return bridge;
+  }
+
+  constructor(controller, manifest, backend, device, pipeline) {
+    this.controller = controller;
+    this.manifest = manifest;
+    this.backend = backend;
+    this.device = device;
+    this.pipeline = pipeline;
+    this.activeBuffer = 0;
+    this.blocked = false;
+    this.failure = null;
+    this.dispatches = 0;
+    document.documentElement.dataset.mechComputeBackend = this.backend;
+    document.documentElement.dataset.mechComputeInstances = String(
+      this.manifest.dispatchElements,
+    );
+  }
+
+  createBuffers() {
+    this.stateBuffers = new Map();
+    for (const state of this.manifest.states) {
+      const buffers = [0, 1].map(() => this.device.createBuffer({
+        size: state.elements * Float32Array.BYTES_PER_ELEMENT,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
+      }));
+      this.device.queue.writeBuffer(buffers[0], 0, state.initialValues);
+      this.stateBuffers.set(state.slot, buffers);
+    }
+    this.fixedBuffers = new Map();
+    this.inputBindings = new Map();
+    for (const binding of this.manifest.bindings) {
+      if (binding.role === "state-read" || binding.role === "state-write") {
+        continue;
+      }
+      const buffer = this.device.createBuffer({
+        size: Math.max(4, binding.elements * 4),
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
+      });
+      if (binding.initialValues) {
+        this.device.queue.writeBuffer(buffer, 0, binding.initialValues);
+      }
+      this.fixedBuffers.set(binding.binding, buffer);
+      if (binding.role === "input") {
+        this.inputBindings.set(binding.name, { binding, buffer });
+      }
+    }
+    this.bindGroups = [0, 1].map(sourceIndex => this.device.createBindGroup({
+      layout: this.pipeline.getBindGroupLayout(0),
+      entries: this.manifest.bindings.map(binding => ({
+        binding: binding.binding,
+        resource: { buffer: this.bufferForBinding(binding, sourceIndex) },
+      })),
+    }));
+    this.readbackPlan = [];
+    let byteLength = 0;
+    for (const output of this.manifest.outputs) {
+      const bytes = output.elementsPerInstance * 4;
+      this.readbackPlan.push({ output, offset: byteLength, bytes });
+      byteLength += bytes;
+    }
+    this.integrity = this.manifest.bindings.find(
+      binding => binding.role === "integrity-fault",
+    );
+    this.integrityOffset = this.integrity ? byteLength : null;
+    if (this.integrity) {
+      byteLength += this.integrity.elements * 4;
+    }
+    this.readbackBytes = Math.max(4, byteLength);
+    this.readback = this.device.createBuffer({
+      size: this.readbackBytes,
+      usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+    });
+  }
+
+  bufferForBinding(binding, sourceIndex) {
+    if (binding.role === "state-read") {
+      return this.stateBuffers.get(binding.slot)[sourceIndex];
+    }
+    if (binding.role === "state-write") {
+      return this.stateBuffers.get(binding.slot)[1 - sourceIndex];
+    }
+    return this.fixedBuffers.get(binding.binding);
+  }
+
+  outputBuffer(index, output) {
+    if (this.stateBuffers.has(output.slot)) {
+      return this.stateBuffers.get(output.slot)[index];
+    }
+    const binding = this.manifest.bindings.find(
+      candidate => candidate.role === "output" && candidate.slot === output.slot,
+    );
+    if (!binding) {
+      throw new Error(`compute output ${output.name} has no physical buffer`);
+    }
+    return this.fixedBuffers.get(binding.binding);
+  }
+
+  applyInputs(command) {
+    for (const input of command.inputs) {
+      const target = this.inputBindings.get(input.name);
+      if (!target) {
+        throw new Error(`Mech wrote undeclared GPU input ${input.name}`);
+      }
+      if (input.values.length !== target.binding.elements) {
+        throw new Error(
+          `Mech wrote ${input.values.length} values to ${input.name}; expected ${target.binding.elements}`,
+        );
+      }
+      this.device.queue.writeBuffer(target.buffer, 0, input.values);
+    }
+  }
+
+  submit(command) {
+    if (!command?.dispatch || this.backend !== "wgpu") {
+      return;
+    }
+    if (this.blocked) {
+      throw new Error("a checked document compute dispatch is already in flight");
+    }
+    if (
+      command.acknowledgementRequired !== true ||
+      !Number.isSafeInteger(command.dispatchId) ||
+      command.dispatchId <= 0
+    ) {
+      throw new Error("the document compute command has no valid completion identity");
+    }
+    this.applyInputs(command);
+    if (this.integrity) {
+      this.device.queue.writeBuffer(
+        this.fixedBuffers.get(this.integrity.binding),
+        0,
+        new Uint32Array([0, 0xffffffff]),
+      );
+    }
+    const outputIndex = 1 - this.activeBuffer;
+    const encoder = this.device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(this.pipeline);
+    pass.setBindGroup(0, this.bindGroups[this.activeBuffer]);
+    pass.dispatchWorkgroups(
+      Math.ceil(this.manifest.dispatchElements / this.manifest.workgroupSize),
+    );
+    pass.end();
+    for (const item of this.readbackPlan) {
+      encoder.copyBufferToBuffer(
+        this.outputBuffer(outputIndex, item.output),
+        0,
+        this.readback,
+        item.offset,
+        item.bytes,
+      );
+    }
+    if (this.integrity) {
+      encoder.copyBufferToBuffer(
+        this.fixedBuffers.get(this.integrity.binding),
+        0,
+        this.readback,
+        this.integrityOffset,
+        this.integrity.elements * 4,
+      );
+    }
+    this.device.queue.submit([encoder.finish()]);
+    this.blocked = true;
+    this.finish(command.dispatchId, outputIndex);
+  }
+
+  async finish(dispatchId, outputIndex) {
+    try {
+      await this.device.queue.onSubmittedWorkDone();
+      await this.readback.mapAsync(GPUMapMode.READ, 0, this.readbackBytes);
+      const mapped = this.readback.getMappedRange(0, this.readbackBytes);
+      if (this.integrity) {
+        const words = new Uint32Array(
+          mapped,
+          this.integrityOffset,
+          this.integrity.elements,
+        );
+        if (words[0] !== 0) {
+          const packed = words[1];
+          const code = packed & 0xff;
+          const instance = packed >>> 8;
+          const constraint = (this.manifest.constraints || [])
+            .find(candidate => candidate.code === code);
+          throw new Error(
+            `GPU integrity constraint ${constraint?.name || code} failed at batch instance ${instance}`,
+          );
+        }
+      }
+      const outputs = this.readbackPlan.map(({ output, offset, bytes }) => ({
+        name: output.name,
+        values: Float32Array.from(new Float32Array(mapped, offset, bytes / 4)),
+      }));
+      this.readback.unmap();
+      this.activeBuffer = outputIndex;
+      this.dispatches += 1;
+      this.controller.completeComputeCommand(dispatchId, outputs);
+      document.documentElement.dataset.mechComputeDispatches = String(this.dispatches);
+    } catch (error) {
+      if (this.readback.mapState === "mapped") {
+        this.readback.unmap();
+      }
+      try {
+        this.controller.rejectComputeCommand(
+          dispatchId,
+          error instanceof Error ? error.message : String(error),
+        );
+      } catch (rejectionError) {
+        this.failure = rejectionError;
+      }
+      this.failure ||= error;
+    } finally {
+      this.blocked = false;
+    }
+  }
+}
+
 function frame() {
   if (!state.running || !state.document) {
     return;
   }
   try {
+    if (state.computeBridge?.failure) {
+      throw state.computeBridge.failure;
+    }
+    if (state.computeBridge?.blocked) {
+      state.animationFrame = requestAnimationFrame(frame);
+      return;
+    }
     const result = state.document.frame(8);
+    state.computeBridge?.submit(result.computeCommand);
     if (result.events?.length) {
       consumeReplResponse(result);
     }
@@ -3857,6 +4163,9 @@ async function main() {
   state.initialEncoded = await loadEncodedDocument();
   const documentSources =
     embeddedDocumentSources || await loadDocumentSourceMap();
+  if (documentSources?.config) {
+    await probeServedComputeAdapter();
+  }
   if (documentSources?.config) {
     if (
       !Object.prototype.hasOwnProperty.call(window, "__MECH_HOST_CONFIG") ||
@@ -3919,6 +4228,7 @@ async function main() {
       "the browser WASM build does not include the document-backed resident REPL host",
     );
   }
+  state.computeBridge = await DocumentComputeBridge.create(state.document);
   state.repl = {
     invoke: source => state.document.replInvoke(source),
     continueStep: (count, requestId) => state.document.replContinueStep(count, requestId),

--- a/include/document.js
+++ b/include/document.js
@@ -3831,9 +3831,16 @@ async function probeServedComputeAdapter() {
     return;
   }
   const requestedBackend = computeHost.settings?.backend || "auto";
-  state.computeAdapter = requestedBackend === "cpu-scalar" || !navigator.gpu
-    ? null
-    : await navigator.gpu.requestAdapter({ powerPreference: "high-performance" });
+  try {
+    state.computeAdapter = requestedBackend === "cpu-scalar" || !navigator.gpu
+      ? null
+      : await navigator.gpu.requestAdapter({ powerPreference: "high-performance" });
+  } catch (error) {
+    if (requestedBackend !== "auto") {
+      throw error;
+    }
+    state.computeAdapter = null;
+  }
   // Runtime construction is synchronous. Publish the result of the actual
   // adapter probe so `auto` selects the same backend the bridge can execute,
   // including browsers that expose navigator.gpu but return no adapter.
@@ -3888,9 +3895,13 @@ class DocumentComputeBridge {
       if (!Number.isSafeInteger(required) || required <= 0) {
         throw new Error(`Mech computed an invalid ${name} requirement: ${required}`);
       }
-      if (required > adapter.limits[name]) {
+      const supported = Number(adapter.limits[name]);
+      if (!Number.isFinite(supported) || supported <= 0) {
+        throw new Error(`this WebGPU adapter does not report the required ${name} limit`);
+      }
+      if (required > supported) {
         throw new Error(
-          `Mech requires ${required} for ${name}, but this adapter supports ${adapter.limits[name]}`,
+          `Mech requires ${required} for ${name}, but this adapter supports ${supported}`,
         );
       }
     }

--- a/include/document.js
+++ b/include/document.js
@@ -3986,18 +3986,18 @@ class DocumentComputeBridge {
       throw new Error("the document compute command has no valid completion identity");
     }
     this.resource.setRequestedOutputs(command.requestedOutputs || []);
-    const { outputIndex } = this.resource.submit(command, this.activeBuffer);
+    const { outputIndex, completion } = this.resource.submit(command, this.activeBuffer);
     // queue.submit() has succeeded at this point. Record that fact before any
     // promise continuation can observe device loss; this generation may no
     // longer be rebuilt on scalar compute automatically.
     this.lifecycle.markSubmitted(command.dispatchToken);
     this.blocked = true;
-    this.finish(command.dispatchToken, outputIndex);
+    this.finish(command.dispatchToken, outputIndex, completion);
   }
 
-  async finish(dispatchToken, outputIndex) {
+  async finish(dispatchToken, outputIndex, completion) {
     try {
-      const { outputs, integrity } = await this.resource.finish();
+      const { outputs, integrity } = await this.resource.finish(completion);
       if (integrity) {
         if (this.isCurrent()) {
           this.controller.rejectIntegrityComputeCommand(

--- a/include/document.js
+++ b/include/document.js
@@ -60,6 +60,11 @@ const OUTPUT_PANEL_SELECTOR =
 const DOCUMENT_LAYOUT_STORAGE_VERSION = 1;
 const KIND_ANNOTATION_MAX_CHARACTERS = 96;
 
+function setComputeBridgeLifecycle(lifecycle) {
+  state.computeBridgeLifecycle = lifecycle;
+  document.documentElement.dataset.mechComputeLifecycle = lifecycle;
+}
+
 function documentLayoutStorageKey() {
   return `mech:document-layout:v${DOCUMENT_LAYOUT_STORAGE_VERSION}:${location.origin}${location.pathname}${location.search}`;
 }
@@ -740,7 +745,7 @@ function invalidateCooperativeOwnership() {
 function stopRuntime() {
   dismissInlineInspectors({ restoreFocus: false });
   state.running = false;
-  state.computeBridgeLifecycle = "stopped";
+  setComputeBridgeLifecycle("stopped");
   state.computeBridgeBuildId += 1;
   cancelFrame();
   state.computeBridge?.retire();
@@ -3839,11 +3844,13 @@ async function probeServedComputeAdapter() {
     return;
   }
   const requestedBackend = computeHost.settings?.backend || "auto";
+  document.documentElement.dataset.mechComputeAdapterStatus = "requesting";
   try {
     state.computeAdapter = requestedBackend === "cpu-scalar" || !navigator.gpu
       ? null
       : await navigator.gpu.requestAdapter({ powerPreference: "high-performance" });
   } catch (error) {
+    document.documentElement.dataset.mechComputeAdapterStatus = "failed";
     if (requestedBackend !== "auto") {
       throw error;
     }
@@ -3853,6 +3860,9 @@ async function probeServedComputeAdapter() {
   // adapter probe so `auto` selects the same backend the bridge can execute,
   // including browsers that expose navigator.gpu but return no adapter.
   window.__MECH_GPU_AVAILABLE = Boolean(state.computeAdapter);
+  document.documentElement.dataset.mechComputeAdapterStatus = state.computeAdapter
+    ? "ready"
+    : "unavailable";
 }
 
 class DocumentComputeBridge {
@@ -3876,7 +3886,15 @@ class DocumentComputeBridge {
     if (!adapter) {
       throw new Error("the document selected WebGPU but no compatible adapter is available");
     }
-    const resource = await globalThis.MechBrowserComputeDevice.create(manifest, adapter, []);
+    document.documentElement.dataset.mechComputeDeviceStatus = "requesting";
+    let resource;
+    try {
+      resource = await globalThis.MechBrowserComputeDevice.create(manifest, adapter, []);
+    } catch (error) {
+      document.documentElement.dataset.mechComputeDeviceStatus = "failed";
+      throw error;
+    }
+    document.documentElement.dataset.mechComputeDeviceStatus = "ready";
     return new DocumentComputeBridge(controller, manifest, backend, resource);
   }
 
@@ -4023,7 +4041,7 @@ function refreshDocumentComputeBridge() {
   state.computeBridge = null;
   const buildId = ++state.computeBridgeBuildId;
   const controller = state.document;
-  state.computeBridgeLifecycle = "building";
+  setComputeBridgeLifecycle("building");
   const refresh = createDocumentComputeBridgeWithFallback(controller)
     .then(next => {
       const currentGeneration = typeof controller?.computeGeneration === "function"
@@ -4042,11 +4060,11 @@ function refreshDocumentComputeBridge() {
       state.computeBridgeGeneration = typeof controller?.computeGeneration === "function"
         ? controller.computeGeneration()
         : generation;
-      state.computeBridgeLifecycle = "ready";
+      setComputeBridgeLifecycle("ready");
     })
     .catch(error => {
       if (buildId === state.computeBridgeBuildId) {
-        state.computeBridgeLifecycle = "fatal";
+        setComputeBridgeLifecycle("fatal");
         showFatalError(error);
       }
     })
@@ -4083,12 +4101,15 @@ function frame() {
       }
       throw failure;
     }
-    if (state.computeBridge?.blocked) {
-      state.animationFrame = requestAnimationFrame(frame);
-      return;
-    }
     const result = state.document.frame(8);
-    state.computeBridge?.submit(result.computeCommand);
+    if (state.computeBridge?.blocked && result.computeCommand?.dispatch) {
+      throw new Error(
+        "the resident coordinator queued another compute turn while the previous turn is in flight",
+      );
+    }
+    if (!state.computeBridge?.blocked) {
+      state.computeBridge?.submit(result.computeCommand);
+    }
     if (result.events?.length) {
       consumeReplResponse(result);
     }
@@ -4182,7 +4203,7 @@ async function createDocumentComputeBridgeWithFallback(controller = state.docume
         { cause: error },
       );
     }
-    state.computeBridgeLifecycle = "falling-back";
+    setComputeBridgeLifecycle("falling-back");
     controller.fallbackComputeToCpu();
     const bridge = await DocumentComputeBridge.create(controller);
     if (bridge?.backend === "wgpu") {
@@ -4227,14 +4248,14 @@ async function main() {
       "the browser WASM build does not include the document-backed resident REPL host",
     );
   }
-  state.computeBridgeLifecycle = "building";
+  setComputeBridgeLifecycle("building");
   const initialBuildId = ++state.computeBridgeBuildId;
   state.computeBridge = await createDocumentComputeBridgeWithFallback(state.document);
   if (initialBuildId !== state.computeBridgeBuildId) {
     state.computeBridge?.retire();
     return;
   }
-  state.computeBridgeLifecycle = "ready";
+  setComputeBridgeLifecycle("ready");
   state.computeBridgeGeneration = typeof state.document.computeGeneration === "function"
     ? state.document.computeGeneration()
     : "0";

--- a/include/document.js
+++ b/include/document.js
@@ -1094,9 +1094,10 @@ function prepareVarPlaceholders() {
 function setKindAnnotation(element, kind) {
   const complete = String(kind || "");
   const elided = complete.length > KIND_ANNOTATION_MAX_CHARACTERS;
-  element.textContent = elided
-    ? `${complete.slice(0, KIND_ANNOTATION_MAX_CHARACTERS - 1)}…`
-    : complete;
+  // Keep the complete Kind in the DOM so keyboard, touch, copy, and assistive
+  // technology all observe the same semantic value. CSS owns visual elision;
+  // title remains only a mouse convenience rather than the accessible source.
+  element.textContent = complete;
   if (elided) {
     element.title = complete;
     element.dataset.mechKindElided = "true";
@@ -1133,6 +1134,9 @@ function createOutputEntry(address, rendered) {
   body.className = "mech-document-output-html mech-output-value";
   body.dataset.mechSource = "";
   body.innerHTML = rendered.blockHtml;
+  if (body.querySelector(".mech-repl-scene, canvas")) {
+    body.dataset.mechOutputFill = "true";
+  }
   row.append(heading, body);
   return row;
 }
@@ -1318,6 +1322,7 @@ function outputContentElement(content) {
   }
   const representations = data.representations?.representations || data.representations || [];
   if (content?.kind === "scene") {
+    body.dataset.mechOutputFill = "true";
     const sceneRepresentation = representations.find(
       entry => entry.media_type === "application/vnd.mech.scene+json",
     );
@@ -3437,10 +3442,18 @@ function initializeOutputFullscreen() {
     if (pane.requestFullscreen) {
       try {
         await pane.requestFullscreen();
+        if (buttonState === "idle") {
+          if (document.fullscreenElement === pane) {
+            await document.exitFullscreen();
+          }
+          return;
+        }
         buttonState = document.fullscreenElement === pane ? "native" : "fallback";
       } catch (error) {
-        buttonState = "fallback";
-        appendError(error);
+        if (buttonState !== "idle") {
+          buttonState = "fallback";
+          appendError(error);
+        }
       }
     } else {
       buttonState = "fallback";

--- a/include/document.js
+++ b/include/document.js
@@ -48,6 +48,8 @@ const state = {
   computeBridge: null,
   computeBridgeRefresh: null,
   computeBridgeGeneration: null,
+  computeBridgeBuildId: 0,
+  computeBridgeLifecycle: "absent",
   computeAdapter: undefined,
 };
 
@@ -734,6 +736,8 @@ function invalidateCooperativeOwnership() {
 function stopRuntime() {
   dismissInlineInspectors({ restoreFocus: false });
   state.running = false;
+  state.computeBridgeLifecycle = "stopped";
+  state.computeBridgeBuildId += 1;
   cancelFrame();
   state.computeBridge?.retire();
   state.computeBridge = null;
@@ -3858,12 +3862,7 @@ class DocumentComputeBridge {
     }
     const backend = controller.computeBackend();
     if (backend !== "wgpu") {
-      return new DocumentComputeBridge(controller, manifest, backend, null, null);
-    }
-    if (manifest.kernelKind !== "fixed-shape") {
-      throw new Error(
-        `document compute output sampling requires a fixed-shape kernel, got ${manifest.kernelKind}`,
-      );
+      return new DocumentComputeBridge(controller, manifest, backend, null);
     }
     const adapter = state.computeAdapter !== undefined
       ? state.computeAdapter
@@ -3873,66 +3872,17 @@ class DocumentComputeBridge {
     if (!adapter) {
       throw new Error("the document selected WebGPU but no compatible adapter is available");
     }
-    const bindingBytes = manifest.bindings.map(binding =>
-      Math.max(4, Number(binding.elements) * 4)
-    );
-    const readbackBytes = Math.max(
-      4,
-      manifest.outputs.reduce(
-        (total, output) => total + Number(output.elementsPerInstance) * 4,
-        0,
-      ) + (manifest.bindings.find(binding => binding.role === "integrity-fault")?.elements || 0) * 4,
-    );
-    const requiredLimits = {
-      maxStorageBuffersPerShaderStage: manifest.bindings.length,
-      maxComputeWorkgroupsPerDimension: Math.ceil(
-        manifest.dispatchElements / manifest.workgroupSize,
-      ),
-      maxStorageBufferBindingSize: Math.max(...bindingBytes, 4),
-      maxBufferSize: Math.max(...bindingBytes, readbackBytes, 4),
-    };
-    for (const [name, required] of Object.entries(requiredLimits)) {
-      if (!Number.isSafeInteger(required) || required <= 0) {
-        throw new Error(`Mech computed an invalid ${name} requirement: ${required}`);
-      }
-      const supported = Number(adapter.limits[name]);
-      if (!Number.isFinite(supported) || supported <= 0) {
-        throw new Error(`this WebGPU adapter does not report the required ${name} limit`);
-      }
-      if (required > supported) {
-        throw new Error(
-          `Mech requires ${required} for ${name}, but this adapter supports ${supported}`,
-        );
-      }
-    }
-    const device = await adapter.requestDevice({ requiredLimits });
-    const module = device.createShaderModule({ code: manifest.wgsl });
-    const compilation = await module.getCompilationInfo();
-    const errors = compilation.messages.filter(message => message.type === "error");
-    if (errors.length) {
-      throw new Error(errors.map(message => message.message).join("\n"));
-    }
-    const pipeline = device.createComputePipeline({
-      layout: "auto",
-      compute: { module, entryPoint: "main" },
-    });
-    const bridge = new DocumentComputeBridge(
-      controller,
-      manifest,
-      backend,
-      device,
-      pipeline,
-    );
-    bridge.createBuffers();
-    return bridge;
+    const resource = await globalThis.MechBrowserComputeDevice.create(manifest, adapter, []);
+    return new DocumentComputeBridge(controller, manifest, backend, resource);
   }
 
-  constructor(controller, manifest, backend, device, pipeline) {
+  constructor(controller, manifest, backend, resource) {
     this.controller = controller;
     this.manifest = manifest;
     this.backend = backend;
-    this.device = device;
-    this.pipeline = pipeline;
+    this.resource = resource;
+    this.device = resource?.device || null;
+    this.pipeline = resource?.pipeline || null;
     this.activeBuffer = 0;
     this.blocked = false;
     this.failure = null;
@@ -3940,7 +3890,14 @@ class DocumentComputeBridge {
     this.retired = false;
     this.generation = typeof controller.computeGeneration === "function"
       ? controller.computeGeneration()
-      : 0;
+      : "0";
+    this.device?.lost.then((info) => {
+      if (this.isCurrent()) {
+        const failure = new Error(`GPU device lost: ${info.message || info.reason || "unknown reason"}`);
+        failure.mechDeviceLost = true;
+        this.failure = failure;
+      }
+    });
     document.documentElement.dataset.mechComputeBackend = this.backend;
     document.documentElement.dataset.mechComputeInstances = String(
       this.manifest.dispatchElements,
@@ -3956,108 +3913,7 @@ class DocumentComputeBridge {
 
   retire() {
     this.retired = true;
-    for (const buffers of this.stateBuffers?.values() || []) {
-      buffers.forEach(buffer => buffer.destroy());
-    }
-    for (const buffer of this.fixedBuffers?.values() || []) {
-      buffer.destroy();
-    }
-    this.readback?.destroy();
-    this.device?.destroy();
-  }
-
-  createBuffers() {
-    this.stateBuffers = new Map();
-    for (const state of this.manifest.states) {
-      const buffers = [0, 1].map(() => this.device.createBuffer({
-        size: state.elements * Float32Array.BYTES_PER_ELEMENT,
-        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
-      }));
-      this.device.queue.writeBuffer(buffers[0], 0, state.initialValues);
-      this.stateBuffers.set(state.slot, buffers);
-    }
-    this.fixedBuffers = new Map();
-    this.inputBindings = new Map();
-    for (const binding of this.manifest.bindings) {
-      if (binding.role === "state-read" || binding.role === "state-write") {
-        continue;
-      }
-      const buffer = this.device.createBuffer({
-        size: Math.max(4, binding.elements * 4),
-        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
-      });
-      if (binding.initialValues) {
-        this.device.queue.writeBuffer(buffer, 0, binding.initialValues);
-      }
-      this.fixedBuffers.set(binding.binding, buffer);
-      if (binding.role === "input") {
-        this.inputBindings.set(binding.name, { binding, buffer });
-      }
-    }
-    this.bindGroups = [0, 1].map(sourceIndex => this.device.createBindGroup({
-      layout: this.pipeline.getBindGroupLayout(0),
-      entries: this.manifest.bindings.map(binding => ({
-        binding: binding.binding,
-        resource: { buffer: this.bufferForBinding(binding, sourceIndex) },
-      })),
-    }));
-    this.readbackPlan = [];
-    let byteLength = 0;
-    for (const output of this.manifest.outputs) {
-      const bytes = output.elementsPerInstance * 4;
-      this.readbackPlan.push({ output, offset: byteLength, bytes });
-      byteLength += bytes;
-    }
-    this.integrity = this.manifest.bindings.find(
-      binding => binding.role === "integrity-fault",
-    );
-    this.integrityOffset = this.integrity ? byteLength : null;
-    if (this.integrity) {
-      byteLength += this.integrity.elements * 4;
-    }
-    this.readbackBytes = Math.max(4, byteLength);
-    this.readback = this.device.createBuffer({
-      size: this.readbackBytes,
-      usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
-    });
-  }
-
-  bufferForBinding(binding, sourceIndex) {
-    if (binding.role === "state-read") {
-      return this.stateBuffers.get(binding.slot)[sourceIndex];
-    }
-    if (binding.role === "state-write") {
-      return this.stateBuffers.get(binding.slot)[1 - sourceIndex];
-    }
-    return this.fixedBuffers.get(binding.binding);
-  }
-
-  outputBuffer(index, output) {
-    if (this.stateBuffers.has(output.slot)) {
-      return this.stateBuffers.get(output.slot)[index];
-    }
-    const binding = this.manifest.bindings.find(
-      candidate => candidate.role === "output" && candidate.slot === output.slot,
-    );
-    if (!binding) {
-      throw new Error(`compute output ${output.name} has no physical buffer`);
-    }
-    return this.fixedBuffers.get(binding.binding);
-  }
-
-  applyInputs(command) {
-    for (const input of command.inputs) {
-      const target = this.inputBindings.get(input.name);
-      if (!target) {
-        throw new Error(`Mech wrote undeclared GPU input ${input.name}`);
-      }
-      if (input.values.length !== target.binding.elements) {
-        throw new Error(
-          `Mech wrote ${input.values.length} values to ${input.name}; expected ${target.binding.elements}`,
-        );
-      }
-      this.device.queue.writeBuffer(target.buffer, 0, input.values);
-    }
+    this.resource?.dispose();
   }
 
   publishCompletion(outputs) {
@@ -4096,99 +3952,46 @@ class DocumentComputeBridge {
     }
     if (
       command.acknowledgementRequired !== true ||
-      !Number.isSafeInteger(command.dispatchId) ||
-      command.dispatchId <= 0
+      typeof command.dispatchToken !== "string" ||
+      !/^[1-9][0-9]*:[1-9][0-9]*$/.test(command.dispatchToken)
     ) {
       throw new Error("the document compute command has no valid completion identity");
     }
-    this.applyInputs(command);
-    if (this.integrity) {
-      this.device.queue.writeBuffer(
-        this.fixedBuffers.get(this.integrity.binding),
-        0,
-        new Uint32Array([0, 0xffffffff]),
-      );
-    }
-    const outputIndex = 1 - this.activeBuffer;
-    const encoder = this.device.createCommandEncoder();
-    const pass = encoder.beginComputePass();
-    pass.setPipeline(this.pipeline);
-    pass.setBindGroup(0, this.bindGroups[this.activeBuffer]);
-    pass.dispatchWorkgroups(
-      Math.ceil(this.manifest.dispatchElements / this.manifest.workgroupSize),
-    );
-    pass.end();
-    for (const item of this.readbackPlan) {
-      encoder.copyBufferToBuffer(
-        this.outputBuffer(outputIndex, item.output),
-        0,
-        this.readback,
-        item.offset,
-        item.bytes,
-      );
-    }
-    if (this.integrity) {
-      encoder.copyBufferToBuffer(
-        this.fixedBuffers.get(this.integrity.binding),
-        0,
-        this.readback,
-        this.integrityOffset,
-        this.integrity.elements * 4,
-      );
-    }
-    this.device.queue.submit([encoder.finish()]);
+    this.resource.setRequestedOutputs(command.requestedOutputs || []);
+    const { outputIndex } = this.resource.submit(command, this.activeBuffer);
     this.blocked = true;
-    this.finish(command.dispatchId, outputIndex);
+    this.finish(command.dispatchToken, outputIndex);
   }
 
-  async finish(dispatchId, outputIndex) {
+  async finish(dispatchToken, outputIndex) {
     try {
-      await this.device.queue.onSubmittedWorkDone();
-      await this.readback.mapAsync(GPUMapMode.READ, 0, this.readbackBytes);
-      const mapped = this.readback.getMappedRange(0, this.readbackBytes);
-      if (this.integrity) {
-        const words = new Uint32Array(
-          mapped,
-          this.integrityOffset,
-          this.integrity.elements,
-        );
-        if (words[0] !== 0) {
-          const packed = words[1];
-          const code = packed & 0xff;
-          const instance = packed >>> 8;
-          const constraint = (this.manifest.constraints || [])
-            .find(candidate => candidate.code === code);
-          this.readback.unmap();
-          if (this.isCurrent()) {
-            this.controller.rejectIntegrityComputeCommand(
-              dispatchId,
-              constraint?.name || String(code),
-              instance,
-            );
-          }
-          return;
+      const { outputs, integrity } = await this.resource.finish();
+      if (integrity) {
+        if (this.isCurrent()) {
+          this.controller.rejectIntegrityComputeCommand(
+            dispatchToken,
+            integrity.constraint,
+            integrity.instance,
+          );
         }
+        return;
       }
-      const outputs = this.readbackPlan.map(({ output, offset, bytes }) => ({
-        name: output.name,
-        values: Float32Array.from(new Float32Array(mapped, offset, bytes / 4)),
-      }));
-      this.readback.unmap();
       if (this.isCurrent()) {
-        this.controller.completeComputeCommand(dispatchId, outputs);
+        if (outputs.length) {
+          this.controller.completeComputeCommand(dispatchToken, outputs);
+        } else {
+          this.controller.acknowledgeComputeCommand(dispatchToken);
+        }
         this.activeBuffer = outputIndex;
         this.publishCompletion(outputs);
       }
     } catch (error) {
-      if (this.readback.mapState === "mapped") {
-        this.readback.unmap();
-      }
       try {
         if (!this.isCurrent()) {
           return;
         }
         this.controller.rejectComputeCommand(
-          dispatchId,
+          dispatchToken,
           error instanceof Error ? error.message : String(error),
         );
       } catch (rejectionError) {
@@ -4205,7 +4008,7 @@ function refreshDocumentComputeBridge() {
   const bridge = state.computeBridge;
   const generation = typeof state.document?.computeGeneration === "function"
     ? state.document.computeGeneration()
-    : 0;
+    : "0";
   if (
     state.computeBridgeRefresh ||
     (state.computeBridgeGeneration === generation && (!bridge || bridge.isCurrent()))
@@ -4214,18 +4017,42 @@ function refreshDocumentComputeBridge() {
   }
   bridge?.retire();
   state.computeBridge = null;
-  state.computeBridgeRefresh = DocumentComputeBridge.create(state.document)
+  const buildId = ++state.computeBridgeBuildId;
+  const controller = state.document;
+  state.computeBridgeLifecycle = "building";
+  const refresh = createDocumentComputeBridgeWithFallback(controller)
     .then(next => {
+      const currentGeneration = typeof controller?.computeGeneration === "function"
+        ? controller.computeGeneration()
+        : "0";
+      if (
+        buildId !== state.computeBridgeBuildId ||
+        controller !== state.document ||
+        state.computeBridgeLifecycle === "stopped" ||
+        next?.generation !== currentGeneration
+      ) {
+        next?.retire();
+        return;
+      }
       state.computeBridge = next;
-      state.computeBridgeGeneration = generation;
+      state.computeBridgeGeneration = typeof controller?.computeGeneration === "function"
+        ? controller.computeGeneration()
+        : generation;
+      state.computeBridgeLifecycle = "ready";
     })
-    .catch(showFatalError)
+    .catch(error => {
+      if (buildId === state.computeBridgeBuildId) {
+        state.computeBridgeLifecycle = "fatal";
+        showFatalError(error);
+      }
+    })
     .finally(() => {
-      state.computeBridgeRefresh = null;
-      if (state.running) {
+      if (state.computeBridgeRefresh === refresh) state.computeBridgeRefresh = null;
+      if (state.running && buildId === state.computeBridgeBuildId) {
         state.animationFrame = requestAnimationFrame(frame);
       }
     });
+  state.computeBridgeRefresh = refresh;
   return true;
 }
 
@@ -4238,7 +4065,19 @@ function frame() {
       return;
     }
     if (state.computeBridge?.failure) {
-      throw state.computeBridge.failure;
+      const failure = state.computeBridge.failure;
+      const requestedBackend = servedComputeHostConfig()?.settings?.backend || "auto";
+      if (failure.mechDeviceLost && requestedBackend === "auto") {
+        state.computeBridge.failure = null;
+        state.computeBridge.retire();
+        state.computeBridge = null;
+        state.computeAdapter = null;
+        window.__MECH_GPU_AVAILABLE = false;
+        state.document.fallbackComputeToCpu();
+        refreshDocumentComputeBridge();
+        return;
+      }
+      throw failure;
     }
     if (state.computeBridge?.blocked) {
       state.animationFrame = requestAnimationFrame(frame);
@@ -4318,23 +4157,25 @@ function constructDocumentController(WasmDocument, documentSources) {
   return WasmDocument.fromEncoded(state.initialEncoded);
 }
 
-async function createDocumentComputeBridgeWithFallback(WasmDocument, documentSources) {
+async function createDocumentComputeBridgeWithFallback(controller = state.document) {
   try {
-    return await DocumentComputeBridge.create(state.document);
+    return await DocumentComputeBridge.create(controller);
   } catch (error) {
     const requestedBackend = servedComputeHostConfig()?.settings?.backend || "auto";
-    if (requestedBackend !== "auto" || state.document.computeBackend() !== "wgpu") {
+    if (requestedBackend !== "auto" || controller.computeBackend() !== "wgpu") {
       throw error;
-    }
-    try {
-      state.document.stop();
-    } catch (_stopError) {
-      // The provisional runtime never started; stopping is best-effort.
     }
     state.computeAdapter = null;
     window.__MECH_GPU_AVAILABLE = false;
-    state.document = constructDocumentController(WasmDocument, documentSources);
-    const bridge = await DocumentComputeBridge.create(state.document);
+    if (typeof controller.fallbackComputeToCpu !== "function") {
+      throw new Error(
+        "automatic WebGPU fallback requires a browser runtime that can rebuild the accepted generation",
+        { cause: error },
+      );
+    }
+    state.computeBridgeLifecycle = "falling-back";
+    controller.fallbackComputeToCpu();
+    const bridge = await DocumentComputeBridge.create(controller);
     if (bridge?.backend === "wgpu") {
       throw error;
     }
@@ -4377,13 +4218,17 @@ async function main() {
       "the browser WASM build does not include the document-backed resident REPL host",
     );
   }
-  state.computeBridge = await createDocumentComputeBridgeWithFallback(
-    WasmDocument,
-    documentSources,
-  );
+  state.computeBridgeLifecycle = "building";
+  const initialBuildId = ++state.computeBridgeBuildId;
+  state.computeBridge = await createDocumentComputeBridgeWithFallback(state.document);
+  if (initialBuildId !== state.computeBridgeBuildId) {
+    state.computeBridge?.retire();
+    return;
+  }
+  state.computeBridgeLifecycle = "ready";
   state.computeBridgeGeneration = typeof state.document.computeGeneration === "function"
     ? state.document.computeGeneration()
-    : 0;
+    : "0";
   state.repl = {
     invoke: source => state.document.replInvoke(source),
     continueStep: (count, requestId) => state.document.replContinueStep(count, requestId),

--- a/include/document.js
+++ b/include/document.js
@@ -50,6 +50,7 @@ const state = {
   computeBridgeGeneration: null,
   computeBridgeBuildId: 0,
   computeBridgeLifecycle: "absent",
+  computeResetLedger: null,
   computeAdapter: undefined,
 };
 
@@ -696,6 +697,7 @@ function appendDiagnostic(diagnostic) {
   row.className = `mech-repl-entry mech-repl-diagnostic mech-repl-${severity}`;
   row.dataset.mechDiagnosticId = diagnostic.id || "";
   row.dataset.mechDiagnosticSeverity = severity;
+  row.dataset.mechDiagnosticCode = diagnostic.code || "";
   if (severity === "error" || severity === "fatal") {
     row.classList.add("mech-repl-error");
     row.setAttribute("role", "alert");
@@ -3872,7 +3874,7 @@ async function probeServedComputeAdapter() {
 }
 
 class DocumentComputeBridge {
-  static async create(controller) {
+  static async create(controller, previous = null) {
     if (typeof controller.computeManifest !== "function") {
       return null;
     }
@@ -3888,7 +3890,24 @@ class DocumentComputeBridge {
       document.documentElement.dataset.mechComputeInstances = String(
         manifest.dispatchElements,
       );
+      document.documentElement.dataset.mechComputeRevision =
+        String(manifest.physicalRevision || "");
       return null;
+    }
+    if (previous?.canTransferTo(manifest, backend)) {
+      return new DocumentComputeBridge(
+        controller,
+        manifest,
+        backend,
+        previous.resource,
+        {
+          activeBuffer: previous.activeBuffer,
+          dispatches: previous.dispatches,
+          priorDispatchToken: previous.lastDispatchToken,
+          ownsResource: false,
+          adoptionSource: previous,
+        },
+      );
     }
     const adapter = state.computeAdapter !== undefined
       ? state.computeAdapter
@@ -3910,18 +3929,23 @@ class DocumentComputeBridge {
     return new DocumentComputeBridge(controller, manifest, backend, resource);
   }
 
-  constructor(controller, manifest, backend, resource) {
+  constructor(controller, manifest, backend, resource, options = {}) {
     this.controller = controller;
     this.manifest = manifest;
     this.backend = backend;
     this.resource = resource;
     this.device = resource?.device || null;
     this.pipeline = resource?.pipeline || null;
-    this.activeBuffer = 0;
+    this.activeBuffer = options.activeBuffer ?? 0;
     this.blocked = false;
     this.failure = null;
-    this.dispatches = 0;
+    this.dispatches = options.dispatches ?? 0;
+    this.lastDispatchToken = null;
+    this.priorDispatchToken = options.priorDispatchToken || null;
     this.retired = false;
+    this.ownsResource = options.ownsResource ?? true;
+    this.adoptionSource = options.adoptionSource || null;
+    this.physicalRevision = String(manifest.physicalRevision || "");
     this.generation = typeof controller.computeGeneration === "function"
       ? controller.computeGeneration()
       : "0";
@@ -3937,6 +3961,7 @@ class DocumentComputeBridge {
     document.documentElement.dataset.mechComputeInstances = String(
       this.manifest.dispatchElements,
     );
+    this.publishIdentity();
   }
 
   isCurrent() {
@@ -3946,14 +3971,56 @@ class DocumentComputeBridge {
     );
   }
 
+  canTransferTo(manifest, backend) {
+    return !this.retired && !this.blocked && !this.failure && this.ownsResource &&
+      this.backend === backend && this.resource?.compatibleWith(manifest);
+  }
+
+  adoptCompatibleResource() {
+    const previous = this.adoptionSource;
+    if (!previous || !previous.canTransferTo(this.manifest, this.backend)) {
+      throw new Error("the compatible GPU resource is no longer transferable");
+    }
+    if (
+      this.priorDispatchToken &&
+      typeof this.controller.isComputeCommandTokenCurrent === "function" &&
+      this.controller.isComputeCommandTokenCurrent(this.priorDispatchToken)
+    ) {
+      throw new Error("a stale compute completion token remained valid after generation handoff");
+    }
+    previous.ownsResource = false;
+    previous.retired = true;
+    this.resource.adoptManifest(this.manifest);
+    this.ownsResource = true;
+    this.adoptionSource = null;
+    document.documentElement.dataset.mechComputeStaleCompletionRejected =
+      String(Boolean(this.priorDispatchToken));
+    this.publishIdentity();
+  }
+
+  publishIdentity() {
+    const root = document.documentElement;
+    root.dataset.mechComputeGeneration = String(this.generation);
+    root.dataset.mechComputeRevision = this.physicalRevision;
+    root.dataset.mechComputeActiveBuffer = String(this.activeBuffer);
+    root.dataset.mechComputeResourceIdentity = this.resource?.resourceIdentity || "";
+    root.dataset.mechComputeDeviceIdentity = this.resource?.deviceIdentity || "";
+    root.dataset.mechComputePipelineIdentity = this.resource?.pipelineIdentity || "";
+    root.dataset.mechComputeStateIdentity = this.resource?.stateIdentity || "";
+    root.dataset.mechComputePipelineBuildCount =
+      String(this.resource?.pipelineBuildCount ?? 0);
+  }
+
   retire() {
     this.retired = true;
-    this.resource?.dispose();
+    if (this.ownsResource) this.resource?.dispose();
+    this.ownsResource = false;
   }
 
   publishCompletion(outputs) {
     this.dispatches += 1;
     document.documentElement.dataset.mechComputeDispatches = String(this.dispatches);
+    this.publishIdentity();
     window.dispatchEvent(new CustomEvent("mech:compute-complete", {
       detail: {
         backend: this.backend,
@@ -3991,7 +4058,16 @@ class DocumentComputeBridge {
     // promise continuation can observe device loss; this generation may no
     // longer be rebuilt on scalar compute automatically.
     this.lifecycle.markSubmitted(command.dispatchToken);
+    this.lastDispatchToken = command.dispatchToken;
     this.blocked = true;
+    window.dispatchEvent(new CustomEvent("mech:compute-submit", {
+      detail: {
+        dispatchToken: command.dispatchToken,
+        generation: this.generation,
+        revision: this.physicalRevision,
+        resourceIdentity: this.resource?.resourceIdentity || "",
+      },
+    }));
     this.finish(command.dispatchToken, outputIndex, completion);
   }
 
@@ -4020,6 +4096,7 @@ class DocumentComputeBridge {
         }
         this.lifecycle.markAccepted(dispatchToken);
         this.activeBuffer = outputIndex;
+        this.publishIdentity();
         this.publishCompletion(outputs);
       }
     } catch (error) {
@@ -4052,12 +4129,16 @@ function refreshDocumentComputeBridge() {
   ) {
     return Boolean(state.computeBridgeRefresh);
   }
-  bridge?.retire();
-  state.computeBridge = null;
+  // Runtime preparation rejects source replacement while Rust still owns a
+  // queued/claimed command. Keep this browser-side guard as the ownership
+  // backstop so an asynchronous refresh can never retire pending GPU state.
+  if (bridge?.blocked) {
+    return true;
+  }
   const buildId = ++state.computeBridgeBuildId;
   const controller = state.document;
   setComputeBridgeLifecycle("building");
-  const refresh = createDocumentComputeBridgeWithFallback(controller)
+  const refresh = createDocumentComputeBridgeWithFallback(controller, bridge)
     .then(next => {
       const currentGeneration = typeof controller?.computeGeneration === "function"
         ? controller.computeGeneration()
@@ -4066,16 +4147,48 @@ function refreshDocumentComputeBridge() {
         buildId !== state.computeBridgeBuildId ||
         controller !== state.document ||
         state.computeBridgeLifecycle === "stopped" ||
-        next?.generation !== currentGeneration
+        (next && next.generation !== currentGeneration)
       ) {
         next?.retire();
         return;
+      }
+      const reused = Boolean(next?.adoptionSource === bridge);
+      if (reused) {
+        next.adoptCompatibleResource();
+      } else {
+        bridge?.retire();
       }
       state.computeBridge = next;
       state.computeBridgeGeneration = typeof controller?.computeGeneration === "function"
         ? controller.computeGeneration()
         : generation;
+      document.documentElement.dataset.mechComputeGeneration =
+        String(state.computeBridgeGeneration);
       setComputeBridgeLifecycle("ready");
+      if (bridge && !reused) {
+        const previousRevision = bridge.physicalRevision || "none";
+        const nextRevision = next?.physicalRevision ||
+          String(controller.computeManifest?.()?.physicalRevision || "none");
+        state.computeResetLedger ||= new globalThis.MechComputeStateResetLedger();
+        const reset = state.computeResetLedger.record(
+          bridge.generation,
+          state.computeBridgeGeneration,
+          previousRevision,
+          nextRevision,
+        );
+        if (reset) {
+          document.documentElement.dataset.mechComputeStateResets =
+            String(reset.resetCount);
+          if (typeof controller.reportComputeStateReset === "function") {
+            consumeReplResponse(
+              controller.reportComputeStateReset(previousRevision, nextRevision),
+            );
+          }
+          window.dispatchEvent(new CustomEvent("mech:compute-state-reset", {
+            detail: reset,
+          }));
+        }
+      }
     })
     .catch(error => {
       if (buildId === state.computeBridgeBuildId) {
@@ -4206,9 +4319,12 @@ function constructDocumentController(WasmDocument, documentSources) {
   return WasmDocument.fromEncoded(state.initialEncoded);
 }
 
-async function createDocumentComputeBridgeWithFallback(controller = state.document) {
+async function createDocumentComputeBridgeWithFallback(
+  controller = state.document,
+  previous = null,
+) {
   try {
-    return await DocumentComputeBridge.create(controller);
+    return await DocumentComputeBridge.create(controller, previous);
   } catch (error) {
     const requestedBackend = servedComputeHostConfig()?.settings?.backend || "auto";
     if (requestedBackend !== "auto" || controller.computeBackend() !== "wgpu") {
@@ -4278,6 +4394,8 @@ async function main() {
   state.computeBridgeGeneration = typeof state.document.computeGeneration === "function"
     ? state.document.computeGeneration()
     : "0";
+  document.documentElement.dataset.mechComputeGeneration =
+    String(state.computeBridgeGeneration);
   state.repl = {
     invoke: source => state.document.replInvoke(source),
     continueStep: (count, requestId) => state.document.replContinueStep(count, requestId),

--- a/include/document.js
+++ b/include/document.js
@@ -4060,8 +4060,32 @@ class DocumentComputeBridge {
     }
   }
 
+  publishCompletion(outputs) {
+    this.dispatches += 1;
+    document.documentElement.dataset.mechComputeDispatches = String(this.dispatches);
+    window.dispatchEvent(new CustomEvent("mech:compute-complete", {
+      detail: {
+        backend: this.backend,
+        completedTurns: this.dispatches,
+        outputs: (outputs || []).map(output => ({
+          name: output.name,
+          values: output.values instanceof Float32Array
+            ? output.values
+            : Float32Array.from(output.values || []),
+        })),
+      },
+    }));
+  }
+
   submit(command) {
-    if (!command?.dispatch || this.backend !== "wgpu") {
+    if (!command?.dispatch) {
+      return;
+    }
+    if (this.backend !== "wgpu") {
+      if (command.acknowledgementRequired === true) {
+        throw new Error("a synchronous browser compute command unexpectedly requires acknowledgement");
+      }
+      this.publishCompletion(command.outputs);
       return;
     }
     if (!this.isCurrent()) {
@@ -4153,8 +4177,7 @@ class DocumentComputeBridge {
       if (this.isCurrent()) {
         this.controller.completeComputeCommand(dispatchId, outputs);
         this.activeBuffer = outputIndex;
-        this.dispatches += 1;
-        document.documentElement.dataset.mechComputeDispatches = String(this.dispatches);
+        this.publishCompletion(outputs);
       }
     } catch (error) {
       if (this.readback.mapState === "mapped") {

--- a/include/document.js
+++ b/include/document.js
@@ -46,6 +46,8 @@ const state = {
   mermaidInitialized: false,
   outputFullscreenController: null,
   computeBridge: null,
+  computeBridgeRefresh: null,
+  computeBridgeGeneration: null,
   computeAdapter: undefined,
 };
 
@@ -733,6 +735,8 @@ function stopRuntime() {
   dismissInlineInspectors({ restoreFocus: false });
   state.running = false;
   cancelFrame();
+  state.computeBridge?.retire();
+  state.computeBridge = null;
   invalidateCooperativeOwnership();
   if (!state.document) {
     return;
@@ -3862,13 +3866,28 @@ class DocumentComputeBridge {
     if (!adapter) {
       throw new Error("the document selected WebGPU but no compatible adapter is available");
     }
+    const bindingBytes = manifest.bindings.map(binding =>
+      Math.max(4, Number(binding.elements) * 4)
+    );
+    const readbackBytes = Math.max(
+      4,
+      manifest.outputs.reduce(
+        (total, output) => total + Number(output.elementsPerInstance) * 4,
+        0,
+      ) + (manifest.bindings.find(binding => binding.role === "integrity-fault")?.elements || 0) * 4,
+    );
     const requiredLimits = {
       maxStorageBuffersPerShaderStage: manifest.bindings.length,
       maxComputeWorkgroupsPerDimension: Math.ceil(
         manifest.dispatchElements / manifest.workgroupSize,
       ),
+      maxStorageBufferBindingSize: Math.max(...bindingBytes, 4),
+      maxBufferSize: Math.max(...bindingBytes, readbackBytes, 4),
     };
     for (const [name, required] of Object.entries(requiredLimits)) {
+      if (!Number.isSafeInteger(required) || required <= 0) {
+        throw new Error(`Mech computed an invalid ${name} requirement: ${required}`);
+      }
       if (required > adapter.limits[name]) {
         throw new Error(
           `Mech requires ${required} for ${name}, but this adapter supports ${adapter.limits[name]}`,
@@ -3907,10 +3926,33 @@ class DocumentComputeBridge {
     this.blocked = false;
     this.failure = null;
     this.dispatches = 0;
+    this.retired = false;
+    this.generation = typeof controller.computeGeneration === "function"
+      ? controller.computeGeneration()
+      : 0;
     document.documentElement.dataset.mechComputeBackend = this.backend;
     document.documentElement.dataset.mechComputeInstances = String(
       this.manifest.dispatchElements,
     );
+  }
+
+  isCurrent() {
+    return !this.retired && (
+      typeof this.controller.computeGeneration !== "function" ||
+      this.controller.computeGeneration() === this.generation
+    );
+  }
+
+  retire() {
+    this.retired = true;
+    for (const buffers of this.stateBuffers?.values() || []) {
+      buffers.forEach(buffer => buffer.destroy());
+    }
+    for (const buffer of this.fixedBuffers?.values() || []) {
+      buffer.destroy();
+    }
+    this.readback?.destroy();
+    this.device?.destroy();
   }
 
   createBuffers() {
@@ -4011,6 +4053,9 @@ class DocumentComputeBridge {
     if (!command?.dispatch || this.backend !== "wgpu") {
       return;
     }
+    if (!this.isCurrent()) {
+      throw new Error("a retired document compute bridge received a dispatch");
+    }
     if (this.blocked) {
       throw new Error("a checked document compute dispatch is already in flight");
     }
@@ -4078,9 +4123,15 @@ class DocumentComputeBridge {
           const instance = packed >>> 8;
           const constraint = (this.manifest.constraints || [])
             .find(candidate => candidate.code === code);
-          throw new Error(
-            `GPU integrity constraint ${constraint?.name || code} failed at batch instance ${instance}`,
-          );
+          this.readback.unmap();
+          if (this.isCurrent()) {
+            this.controller.rejectIntegrityComputeCommand(
+              dispatchId,
+              constraint?.name || String(code),
+              instance,
+            );
+          }
+          return;
         }
       }
       const outputs = this.readbackPlan.map(({ output, offset, bytes }) => ({
@@ -4088,15 +4139,20 @@ class DocumentComputeBridge {
         values: Float32Array.from(new Float32Array(mapped, offset, bytes / 4)),
       }));
       this.readback.unmap();
-      this.activeBuffer = outputIndex;
-      this.dispatches += 1;
-      this.controller.completeComputeCommand(dispatchId, outputs);
-      document.documentElement.dataset.mechComputeDispatches = String(this.dispatches);
+      if (this.isCurrent()) {
+        this.controller.completeComputeCommand(dispatchId, outputs);
+        this.activeBuffer = outputIndex;
+        this.dispatches += 1;
+        document.documentElement.dataset.mechComputeDispatches = String(this.dispatches);
+      }
     } catch (error) {
       if (this.readback.mapState === "mapped") {
         this.readback.unmap();
       }
       try {
+        if (!this.isCurrent()) {
+          return;
+        }
         this.controller.rejectComputeCommand(
           dispatchId,
           error instanceof Error ? error.message : String(error),
@@ -4111,11 +4167,42 @@ class DocumentComputeBridge {
   }
 }
 
+function refreshDocumentComputeBridge() {
+  const bridge = state.computeBridge;
+  const generation = typeof state.document?.computeGeneration === "function"
+    ? state.document.computeGeneration()
+    : 0;
+  if (
+    state.computeBridgeRefresh ||
+    (state.computeBridgeGeneration === generation && (!bridge || bridge.isCurrent()))
+  ) {
+    return Boolean(state.computeBridgeRefresh);
+  }
+  bridge?.retire();
+  state.computeBridge = null;
+  state.computeBridgeRefresh = DocumentComputeBridge.create(state.document)
+    .then(next => {
+      state.computeBridge = next;
+      state.computeBridgeGeneration = generation;
+    })
+    .catch(showFatalError)
+    .finally(() => {
+      state.computeBridgeRefresh = null;
+      if (state.running) {
+        state.animationFrame = requestAnimationFrame(frame);
+      }
+    });
+  return true;
+}
+
 function frame() {
   if (!state.running || !state.document) {
     return;
   }
   try {
+    if (refreshDocumentComputeBridge()) {
+      return;
+    }
     if (state.computeBridge?.failure) {
       throw state.computeBridge.failure;
     }
@@ -4134,6 +4221,90 @@ function frame() {
     state.animationFrame = requestAnimationFrame(frame);
   } catch (error) {
     showFatalError(error);
+  }
+}
+
+function constructDocumentController(WasmDocument, documentSources) {
+  if (documentSources?.config) {
+    if (
+      !Object.prototype.hasOwnProperty.call(window, "__MECH_HOST_CONFIG") ||
+      (documentSources.version === 2
+        ? typeof WasmDocument.fromServedEncodedWithBundle !== "function"
+        : typeof WasmDocument.fromServedEncoded !== "function")
+    ) {
+      throw new Error(
+        "configured source documents require a browser WASM build with served project authority",
+      );
+    }
+    return documentSources.version === 2
+      ? WasmDocument.fromServedEncodedWithBundle(
+          state.initialEncoded,
+          documentSources.rootSpecifier,
+          documentSources.config,
+          documentSources.sources,
+          documentSources.resolutions,
+        )
+      : WasmDocument.fromServedEncoded(
+          state.initialEncoded,
+          documentSources.rootSpecifier,
+          documentSources.config,
+          documentSources.sources,
+        );
+  }
+  if (documentSources) {
+    if (
+      documentSources.version === 2 &&
+      typeof WasmDocument.fromEncodedWithBundle !== "function"
+    ) {
+      throw new Error(
+        "source document bundles require a browser WASM build with explicit source resolution",
+      );
+    }
+    if (
+      documentSources.version !== 2 &&
+      typeof WasmDocument.fromEncodedWithSources !== "function"
+    ) {
+      throw new Error(
+        "source documents with imports require a browser WASM build with document source resolution",
+      );
+    }
+    return documentSources.version === 2
+      ? WasmDocument.fromEncodedWithBundle(
+          state.initialEncoded,
+          documentSources.rootSpecifier,
+          documentSources.sources,
+          documentSources.resolutions,
+        )
+      : WasmDocument.fromEncodedWithSources(
+          state.initialEncoded,
+          documentSources.rootSpecifier,
+          documentSources.sources,
+        );
+  }
+  return WasmDocument.fromEncoded(state.initialEncoded);
+}
+
+async function createDocumentComputeBridgeWithFallback(WasmDocument, documentSources) {
+  try {
+    return await DocumentComputeBridge.create(state.document);
+  } catch (error) {
+    const requestedBackend = servedComputeHostConfig()?.settings?.backend || "auto";
+    if (requestedBackend !== "auto" || state.document.computeBackend() !== "wgpu") {
+      throw error;
+    }
+    try {
+      state.document.stop();
+    } catch (_stopError) {
+      // The provisional runtime never started; stopping is best-effort.
+    }
+    state.computeAdapter = null;
+    window.__MECH_GPU_AVAILABLE = false;
+    state.document = constructDocumentController(WasmDocument, documentSources);
+    const bridge = await DocumentComputeBridge.create(state.document);
+    if (bridge?.backend === "wgpu") {
+      throw error;
+    }
+    return bridge;
   }
 }
 
@@ -4166,69 +4337,19 @@ async function main() {
   if (documentSources?.config) {
     await probeServedComputeAdapter();
   }
-  if (documentSources?.config) {
-    if (
-      !Object.prototype.hasOwnProperty.call(window, "__MECH_HOST_CONFIG") ||
-      (documentSources.version === 2
-        ? typeof WasmDocument.fromServedEncodedWithBundle !== "function"
-        : typeof WasmDocument.fromServedEncoded !== "function")
-    ) {
-      throw new Error(
-        "configured source documents require a browser WASM build with served project authority",
-      );
-    }
-    state.document = documentSources.version === 2
-      ? WasmDocument.fromServedEncodedWithBundle(
-          state.initialEncoded,
-          documentSources.rootSpecifier,
-          documentSources.config,
-          documentSources.sources,
-          documentSources.resolutions,
-        )
-      : WasmDocument.fromServedEncoded(
-          state.initialEncoded,
-          documentSources.rootSpecifier,
-          documentSources.config,
-          documentSources.sources,
-        );
-  } else if (documentSources) {
-    if (
-      documentSources.version === 2 &&
-      typeof WasmDocument.fromEncodedWithBundle !== "function"
-    ) {
-      throw new Error(
-        "source document bundles require a browser WASM build with explicit source resolution",
-      );
-    }
-    if (
-      documentSources.version !== 2 &&
-      typeof WasmDocument.fromEncodedWithSources !== "function"
-    ) {
-      throw new Error(
-        "source documents with imports require a browser WASM build with document source resolution",
-      );
-    }
-    state.document = documentSources.version === 2
-      ? WasmDocument.fromEncodedWithBundle(
-          state.initialEncoded,
-          documentSources.rootSpecifier,
-          documentSources.sources,
-          documentSources.resolutions,
-        )
-      : WasmDocument.fromEncodedWithSources(
-          state.initialEncoded,
-          documentSources.rootSpecifier,
-          documentSources.sources,
-        );
-  } else {
-    state.document = WasmDocument.fromEncoded(state.initialEncoded);
-  }
+  state.document = constructDocumentController(WasmDocument, documentSources);
   if (typeof state.document.replInvoke !== "function") {
     throw new Error(
       "the browser WASM build does not include the document-backed resident REPL host",
     );
   }
-  state.computeBridge = await DocumentComputeBridge.create(state.document);
+  state.computeBridge = await createDocumentComputeBridgeWithFallback(
+    WasmDocument,
+    documentSources,
+  );
+  state.computeBridgeGeneration = typeof state.document.computeGeneration === "function"
+    ? state.document.computeGeneration()
+    : 0;
   state.repl = {
     invoke: source => state.document.replInvoke(source),
     continueStep: (count, requestId) => state.document.replContinueStep(count, requestId),

--- a/include/document.js
+++ b/include/document.js
@@ -52,6 +52,8 @@ const state = {
   computeBridgeLifecycle: "absent",
   computeResetLedger: null,
   computeAdapter: undefined,
+  scenePointerSession: null,
+  scenePointerTimestamp: null,
 };
 
 const ERROR_PANEL_SELECTOR =
@@ -1327,6 +1329,7 @@ function outputContentElement(content) {
         const svg = document.createElementNS(namespace, "svg");
         svg.classList.add("mech-repl-scene");
         svg.dataset.mechRichScene = "true";
+        svg.dataset.mechScenePointerSurface = "true";
         svg.setAttribute("viewBox", `0 0 ${scene.width} ${scene.height}`);
         svg.setAttribute("width", String(scene.width));
         svg.setAttribute("height", String(scene.height));
@@ -2007,6 +2010,20 @@ function renderValues() {
 // compute presentation buffer or route scalar compute through JavaScript.
 globalThis.__MECH_RENDERED_DOCUMENT_VALUE__ = (name) =>
   state.document?.renderedDocumentValue?.(String(name)) || null;
+
+// Complete-source reflection is the stable handoff used by the document
+// editor. It deliberately goes through the resident session instead of
+// mutating the browser bridge or its GPU resources directly.
+globalThis.__MECH_ACCEPTED_REPL_SOURCE__ = () =>
+  state.document?.replSource?.() || "";
+globalThis.__MECH_REPLACE_ACCEPTED_REPL_SOURCE__ = (source) => {
+  if (typeof state.document?.replReplaceSource !== "function") {
+    throw new Error("the document runtime does not expose transactional source replacement");
+  }
+  const response = state.document.replReplaceSource(String(source));
+  consumeReplResponse(response);
+  return state.document.replSource();
+};
 
 function transcript() {
   return state.console?.transcript || null;
@@ -3788,6 +3805,90 @@ function initializePageStyleProbe() {
   return probe;
 }
 
+function initializeScenePointerInput() {
+  if (state.root?.dataset.mechScenePointerBound === "true") return;
+  state.root.dataset.mechScenePointerBound = "true";
+
+  const pointerSample = (event, svg) => {
+    const viewBox = svg.viewBox?.baseVal;
+    const transform = svg.getScreenCTM?.();
+    if (
+      viewBox && viewBox.width > 0 && viewBox.height > 0 && transform &&
+      typeof DOMPoint === "function"
+    ) {
+      try {
+        const point = new DOMPoint(event.clientX, event.clientY)
+          .matrixTransform(transform.inverse());
+        return {
+          x: Math.max(-1, Math.min(1, ((point.x - viewBox.x) / viewBox.width) * 2 - 1)),
+          y: Math.max(-1, Math.min(1, 1 - ((point.y - viewBox.y) / viewBox.height) * 2)),
+        };
+      } catch (_error) {
+        // Fall through to the rectangular mapping for older SVG engines.
+      }
+    }
+    const rect = svg.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return null;
+    return {
+      x: Math.max(-1, Math.min(1, ((event.clientX - rect.left) / rect.width) * 2 - 1)),
+      y: Math.max(-1, Math.min(1, 1 - ((event.clientY - rect.top) / rect.height) * 2)),
+    };
+  };
+  const sceneInstance = svg => {
+    const displayId = svg.closest("[data-mech-display-id]")?.dataset.mechDisplayId || "";
+    return displayId.startsWith("scene-") ? displayId.slice("scene-".length) : "";
+  };
+  const submit = (instance, point, pressed, timestamp) => {
+    if (!instance || !point || typeof state.document?.scenePointerInput !== "function") {
+      return false;
+    }
+    const previous = state.scenePointerTimestamp;
+    const deltaSeconds = previous === null
+      ? 0
+      : Math.max(0, Math.min(1, (timestamp - previous) / 1000));
+    state.scenePointerTimestamp = timestamp;
+    state.document.scenePointerInput(
+      instance,
+      point.x,
+      point.y,
+      pressed,
+      deltaSeconds,
+    );
+    const submissions = Number(state.root.dataset.mechScenePointerSubmissions || 0) + 1;
+    state.root.dataset.mechScenePointerSubmissions = String(submissions);
+    state.root.dataset.mechScenePointerInstance = instance;
+    state.root.dataset.mechScenePointerPosition = `${point.x},${point.y}`;
+    state.root.dataset.mechScenePointerPressed = String(pressed);
+    return true;
+  };
+  // Output presentation and fullscreen modes may place the drop-in REPL host
+  // outside `.mech-root`. Delegate from the document so the same scene input
+  // contract survives those layout moves.
+  document.addEventListener("pointerdown", event => {
+    if (event.button !== 0 || !(event.target instanceof Element)) return;
+    const svg = event.target.closest("svg[data-mech-scene-pointer-surface]");
+    if (!svg) return;
+    const point = pointerSample(event, svg);
+    const instance = sceneInstance(svg);
+    if (!submit(instance, point, true, event.timeStamp)) return;
+    state.scenePointerSession = { instance, point };
+    event.preventDefault();
+    event.stopPropagation();
+  });
+  window.addEventListener("pointerup", event => {
+    const session = state.scenePointerSession;
+    if (!session) return;
+    state.scenePointerSession = null;
+    submit(session.instance, session.point, false, event.timeStamp);
+  });
+  window.addEventListener("pointercancel", event => {
+    const session = state.scenePointerSession;
+    if (!session) return;
+    state.scenePointerSession = null;
+    submit(session.instance, session.point, false, event.timeStamp);
+  });
+}
+
 function initializeLayout() {
   window.addEventListener("mech:output", event => {
     if (event instanceof CustomEvent && event.detail) {
@@ -3833,6 +3934,7 @@ function initializeLayout() {
   initializeWorkspaceResizers();
   initializeFullscreen();
   initializeOutputFullscreen();
+  initializeScenePointerInput();
   initializeBreadcrumb();
   window.addEventListener("mech:document-layout-refresh", initializeToc);
   initializeToc();
@@ -3909,11 +4011,17 @@ class DocumentComputeBridge {
         },
       );
     }
-    const adapter = state.computeAdapter !== undefined
-      ? state.computeAdapter
-      : navigator.gpu
-        ? await navigator.gpu.requestAdapter({ powerPreference: "high-performance" })
-        : null;
+    // A GPUAdapter may be consumed after requestDevice (notably by Dawn's
+    // deterministic test adapter). Physical-generation replacement therefore
+    // acquires a fresh adapter while the old resource remains live; compatible
+    // generations take the transfer path above and allocate neither one.
+    const adapter = previous && navigator.gpu
+      ? await navigator.gpu.requestAdapter({ powerPreference: "high-performance" })
+      : state.computeAdapter !== undefined
+        ? state.computeAdapter
+        : navigator.gpu
+          ? await navigator.gpu.requestAdapter({ powerPreference: "high-performance" })
+          : null;
     if (!adapter) {
       throw new Error("the document selected WebGPU but no compatible adapter is available");
     }
@@ -3981,21 +4089,34 @@ class DocumentComputeBridge {
     if (!previous || !previous.canTransferTo(this.manifest, this.backend)) {
       throw new Error("the compatible GPU resource is no longer transferable");
     }
-    if (
-      this.priorDispatchToken &&
-      typeof this.controller.isComputeCommandTokenCurrent === "function" &&
-      this.controller.isComputeCommandTokenCurrent(this.priorDispatchToken)
-    ) {
-      throw new Error("a stale compute completion token remained valid after generation handoff");
-    }
     previous.ownsResource = false;
     previous.retired = true;
     this.resource.adoptManifest(this.manifest);
     this.ownsResource = true;
     this.adoptionSource = null;
     document.documentElement.dataset.mechComputeStaleCompletionRejected =
-      String(Boolean(this.priorDispatchToken));
+      this.priorDispatchToken ? "pending" : "not-applicable";
     this.publishIdentity();
+  }
+
+  verifyPriorCompletionRejectedDuringActiveDispatch(dispatchToken) {
+    if (!this.priorDispatchToken) return;
+    let rejected = false;
+    try {
+      this.controller.acknowledgeComputeCommand(this.priorDispatchToken);
+    } catch (_error) {
+      rejected = true;
+    }
+    const currentIntact =
+      typeof this.controller.isComputeCommandTokenCurrent === "function" &&
+      this.controller.isComputeCommandTokenCurrent(dispatchToken);
+    if (!rejected || !currentIntact) {
+      throw new Error(
+        "a stale completion collided with the replacement generation active dispatch",
+      );
+    }
+    this.priorDispatchToken = null;
+    document.documentElement.dataset.mechComputeStaleCompletionRejected = "true";
   }
 
   publishIdentity() {
@@ -4009,6 +4130,7 @@ class DocumentComputeBridge {
     root.dataset.mechComputeStateIdentity = this.resource?.stateIdentity || "";
     root.dataset.mechComputePipelineBuildCount =
       String(this.resource?.pipelineBuildCount ?? 0);
+    root.dataset.mechComputeDispatches = String(this.dispatches);
   }
 
   retire() {
@@ -4060,6 +4182,10 @@ class DocumentComputeBridge {
     this.lifecycle.markSubmitted(command.dispatchToken);
     this.lastDispatchToken = command.dispatchToken;
     this.blocked = true;
+    // Exercise generation identity against an actually claimed replacement
+    // command. If an old `:1` token can alias the new generation's active
+    // `:1`, this check fails before the new command can be published.
+    this.verifyPriorCompletionRejectedDuringActiveDispatch(command.dispatchToken);
     window.dispatchEvent(new CustomEvent("mech:compute-submit", {
       detail: {
         dispatchToken: command.dispatchToken,
@@ -4153,9 +4279,11 @@ function refreshDocumentComputeBridge() {
         return;
       }
       const reused = Boolean(next?.adoptionSource === bridge);
+      let retiredResource = null;
       if (reused) {
         next.adoptCompatibleResource();
       } else {
+        retiredResource = bridge?.resource || null;
         bridge?.retire();
       }
       state.computeBridge = next;
@@ -4185,7 +4313,11 @@ function refreshDocumentComputeBridge() {
             );
           }
           window.dispatchEvent(new CustomEvent("mech:compute-state-reset", {
-            detail: reset,
+            detail: {
+              ...reset,
+              retiredResourceIdentity: retiredResource?.resourceIdentity || "",
+              retiredResourceDisposed: retiredResource?.disposed === true,
+            },
           }));
         }
       }
@@ -4326,8 +4458,13 @@ async function createDocumentComputeBridgeWithFallback(
   try {
     return await DocumentComputeBridge.create(controller, previous);
   } catch (error) {
+    document.documentElement.dataset.mechComputeBridgeCreateError =
+      error instanceof Error ? error.message : String(error);
     const requestedBackend = servedComputeHostConfig()?.settings?.backend || "auto";
-    if (requestedBackend !== "auto" || controller.computeBackend() !== "wgpu") {
+    if (
+      requestedBackend !== "auto" || controller.computeBackend() !== "wgpu" ||
+      (previous && !previous.lifecycle.canAutoFallback())
+    ) {
       throw error;
     }
     state.computeAdapter = null;

--- a/include/document.js
+++ b/include/document.js
@@ -50,7 +50,7 @@ const state = {
   computeBridgeGeneration: null,
   computeBridgeBuildId: 0,
   computeBridgeLifecycle: "absent",
-  computeResetLedger: null,
+  computeResetTracker: null,
   computeAdapter: undefined,
   scenePointerSession: null,
   scenePointerTimestamp: null,
@@ -3948,6 +3948,19 @@ function servedComputeHostConfig() {
   return hosts.find(host => host?.provider === "compute") || null;
 }
 
+function documentComputeIdentity(controller, bridge = null) {
+  const manifest = typeof controller?.computeManifest === "function"
+    ? controller.computeManifest()
+    : null;
+  return {
+    present: Boolean(manifest),
+    generation: typeof controller?.computeGeneration === "function"
+      ? controller.computeGeneration()
+      : "0",
+    revision: bridge?.physicalRevision || manifest?.physicalRevision || "none",
+  };
+}
+
 async function probeServedComputeAdapter() {
   const computeHost = servedComputeHostConfig();
   if (!computeHost) {
@@ -4293,33 +4306,29 @@ function refreshDocumentComputeBridge() {
       document.documentElement.dataset.mechComputeGeneration =
         String(state.computeBridgeGeneration);
       setComputeBridgeLifecycle("ready");
-      if (bridge && !reused) {
-        const previousRevision = bridge.physicalRevision || "none";
-        const nextRevision = next?.physicalRevision ||
-          String(controller.computeManifest?.()?.physicalRevision || "none");
-        state.computeResetLedger ||= new globalThis.MechComputeStateResetLedger();
-        const reset = state.computeResetLedger.record(
-          bridge.generation,
-          state.computeBridgeGeneration,
-          previousRevision,
-          nextRevision,
-        );
-        if (reset) {
-          document.documentElement.dataset.mechComputeStateResets =
-            String(reset.resetCount);
-          if (typeof controller.reportComputeStateReset === "function") {
-            consumeReplResponse(
-              controller.reportComputeStateReset(previousRevision, nextRevision),
-            );
-          }
-          window.dispatchEvent(new CustomEvent("mech:compute-state-reset", {
-            detail: {
-              ...reset,
-              retiredResourceIdentity: retiredResource?.resourceIdentity || "",
-              retiredResourceDisposed: retiredResource?.disposed === true,
-            },
-          }));
+      state.computeResetTracker ||=
+        new globalThis.MechComputeStateResetTracker();
+      const reset = state.computeResetTracker.advance(
+        documentComputeIdentity(controller, next),
+      );
+      if (reset) {
+        document.documentElement.dataset.mechComputeStateResets =
+          String(reset.resetCount);
+        if (typeof controller.reportComputeStateReset === "function") {
+          consumeReplResponse(
+            controller.reportComputeStateReset(
+              reset.previousRevision,
+              reset.nextRevision,
+            ),
+          );
         }
+        window.dispatchEvent(new CustomEvent("mech:compute-state-reset", {
+          detail: {
+            ...reset,
+            retiredResourceIdentity: retiredResource?.resourceIdentity || "",
+            retiredResourceDisposed: retiredResource?.disposed === true,
+          },
+        }));
       }
     })
     .catch(error => {
@@ -4533,6 +4542,10 @@ async function main() {
     : "0";
   document.documentElement.dataset.mechComputeGeneration =
     String(state.computeBridgeGeneration);
+  state.computeResetTracker ||= new globalThis.MechComputeStateResetTracker();
+  state.computeResetTracker.advance(
+    documentComputeIdentity(state.document, state.computeBridge),
+  );
   state.repl = {
     invoke: source => state.document.replInvoke(source),
     continueStep: (count, requestId) => state.document.replContinueStep(count, requestId),

--- a/include/document.js
+++ b/include/document.js
@@ -2000,6 +2000,12 @@ function renderValues() {
   dispatch("mech:document-rendered");
 }
 
+// A read-only reflection seam for browser conformance harnesses and embedders.
+// It observes an ordinary retained resident symbol; it does not allocate a
+// compute presentation buffer or route scalar compute through JavaScript.
+globalThis.__MECH_RENDERED_DOCUMENT_VALUE__ = (name) =>
+  state.document?.renderedDocumentValue?.(String(name)) || null;
+
 function transcript() {
   return state.console?.transcript || null;
 }
@@ -3876,7 +3882,13 @@ class DocumentComputeBridge {
     }
     const backend = controller.computeBackend();
     if (backend !== "wgpu") {
-      return new DocumentComputeBridge(controller, manifest, backend, null);
+      // Resident scalar compute completes inside the runtime. It has no
+      // browser transport, command queue, or full-output presentation bridge.
+      document.documentElement.dataset.mechComputeBackend = backend;
+      document.documentElement.dataset.mechComputeInstances = String(
+        manifest.dispatchElements,
+      );
+      return null;
     }
     const adapter = state.computeAdapter !== undefined
       ? state.computeAdapter
@@ -3913,11 +3925,12 @@ class DocumentComputeBridge {
     this.generation = typeof controller.computeGeneration === "function"
       ? controller.computeGeneration()
       : "0";
+    this.lifecycle = new globalThis.MechComputeSubmissionLifecycle(this.generation);
     this.device?.lost.then((info) => {
       if (this.isCurrent()) {
         const failure = new Error(`GPU device lost: ${info.message || info.reason || "unknown reason"}`);
         failure.mechDeviceLost = true;
-        this.failure = failure;
+        this.failure = this.lifecycle.markFailed(failure);
       }
     });
     document.documentElement.dataset.mechComputeBackend = this.backend;
@@ -3959,13 +3972,6 @@ class DocumentComputeBridge {
     if (!command?.dispatch) {
       return;
     }
-    if (this.backend !== "wgpu") {
-      if (command.acknowledgementRequired === true) {
-        throw new Error("a synchronous browser compute command unexpectedly requires acknowledgement");
-      }
-      this.publishCompletion(command.outputs);
-      return;
-    }
     if (!this.isCurrent()) {
       throw new Error("a retired document compute bridge received a dispatch");
     }
@@ -3981,6 +3987,10 @@ class DocumentComputeBridge {
     }
     this.resource.setRequestedOutputs(command.requestedOutputs || []);
     const { outputIndex } = this.resource.submit(command, this.activeBuffer);
+    // queue.submit() has succeeded at this point. Record that fact before any
+    // promise continuation can observe device loss; this generation may no
+    // longer be rebuilt on scalar compute automatically.
+    this.lifecycle.markSubmitted(command.dispatchToken);
     this.blocked = true;
     this.finish(command.dispatchToken, outputIndex);
   }
@@ -3995,6 +4005,10 @@ class DocumentComputeBridge {
             integrity.constraint,
             integrity.instance,
           );
+          // Integrity rejection is a matching terminal completion: the
+          // candidate state was not published, but the host is reusable for
+          // the next independent turn.
+          this.lifecycle.markAccepted(dispatchToken);
         }
         return;
       }
@@ -4004,6 +4018,7 @@ class DocumentComputeBridge {
         } else {
           this.controller.acknowledgeComputeCommand(dispatchToken);
         }
+        this.lifecycle.markAccepted(dispatchToken);
         this.activeBuffer = outputIndex;
         this.publishCompletion(outputs);
       }
@@ -4019,7 +4034,7 @@ class DocumentComputeBridge {
       } catch (rejectionError) {
         this.failure = rejectionError;
       }
-      this.failure ||= error;
+      this.failure = this.lifecycle.markFailed(this.failure || error);
     } finally {
       this.blocked = false;
     }
@@ -4089,7 +4104,11 @@ function frame() {
     if (state.computeBridge?.failure) {
       const failure = state.computeBridge.failure;
       const requestedBackend = servedComputeHostConfig()?.settings?.backend || "auto";
-      if (failure.mechDeviceLost && requestedBackend === "auto") {
+      if (
+        failure.mechDeviceLost &&
+        requestedBackend === "auto" &&
+        state.computeBridge.lifecycle.canAutoFallback()
+      ) {
         state.computeBridge.failure = null;
         state.computeBridge.retire();
         state.computeBridge = null;
@@ -4101,15 +4120,15 @@ function frame() {
       }
       throw failure;
     }
+    if (state.computeBridge?.blocked) {
+      // The resident compute host is in its single InFlight phase. Leave
+      // timer and pointer packets queued (or coalesced by their configured
+      // policy) until the matching completion has been accepted.
+      state.animationFrame = requestAnimationFrame(frame);
+      return;
+    }
     const result = state.document.frame(8);
-    if (state.computeBridge?.blocked && result.computeCommand?.dispatch) {
-      throw new Error(
-        "the resident coordinator queued another compute turn while the previous turn is in flight",
-      );
-    }
-    if (!state.computeBridge?.blocked) {
-      state.computeBridge?.submit(result.computeCommand);
-    }
+    state.computeBridge?.submit(result.computeCommand);
     if (result.events?.length) {
       consumeReplResponse(result);
     }

--- a/include/mech-repl.css
+++ b/include/mech-repl.css
@@ -300,7 +300,7 @@ body.console-fullscreen [data-mech-console-pane] {
 [data-mech-repl-host][data-mech-output-fullscreen-active="true"] [data-mech-output-panel],
 [data-mech-repl-host][data-mech-presentation="output"]:not([data-mech-presentation-view="workspace"]) [data-mech-output-panel] {
   height: 100%;
-  overflow: hidden;
+  overflow: auto;
   padding: 0;
 }
 
@@ -318,11 +318,28 @@ body.console-fullscreen [data-mech-console-pane] {
   .mech-repl-output-scene,
   .mech-repl-scene
 ) {
-  height: 100%;
   max-height: none;
   max-width: none;
   min-height: 0;
   width: 100%;
+}
+
+/* A presentation surface fills the viewport only when its content explicitly
+ * owns that geometry. Ordinary values and streams retain the panel's single
+ * scroll surface, while scenes/canvases can use every available pixel. */
+[data-mech-repl-host][data-mech-output-fullscreen-active="true"] [data-mech-output-panel] :is(
+  .mech-output-region,
+  .mech-repl-output-entry,
+  .mech-repl-output-content
+):has([data-mech-output-fill="true"]),
+[data-mech-repl-host][data-mech-presentation="output"]:not([data-mech-presentation-view="workspace"]) [data-mech-output-panel] :is(
+  .mech-output-region,
+  .mech-repl-output-entry,
+  .mech-repl-output-content
+):has([data-mech-output-fill="true"]),
+[data-mech-repl-host][data-mech-output-fullscreen-active="true"] [data-mech-output-panel] [data-mech-output-fill="true"],
+[data-mech-repl-host][data-mech-presentation="output"]:not([data-mech-presentation-view="workspace"]) [data-mech-output-panel] [data-mech-output-fill="true"] {
+  height: 100%;
 }
 
 [data-mech-repl-host][data-mech-output-fullscreen-active="true"] [data-mech-output-panel] .mech-repl-output-entry,
@@ -913,6 +930,11 @@ body.is-resizing[data-mech-resize-axis="row"] [data-mech-console-pane] * {
   white-space: pre-wrap;
 }
 
+:is([data-mech-repl], [data-mech-output-panel], [data-mech-errors-panel], [data-mech-repl-popup]) .mech-repl-output-text:not(.mech-repl-logo) {
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
 [data-mech-output-panel] .mech-document-output-html {
   max-width: none;
   min-width: 100%;
@@ -1044,6 +1066,18 @@ body.is-resizing[data-mech-resize-axis="row"] [data-mech-console-pane] * {
     max-width: 100vw;
     width: min(94vw, 520px) !important;
     z-index: 900;
+  }
+
+  /* Presentation ownership outranks the compact drawer at this breakpoint,
+   * including when the Fullscreen API falls back to the CSS viewport. */
+  [data-mech-repl-host][data-mech-output-fullscreen-active="true"][data-mech-console-open="true"] [data-mech-console-pane],
+  [data-mech-repl-host][data-mech-presentation="output"]:not([data-mech-presentation-view="workspace"]) [data-mech-console-pane] {
+    bottom: 0;
+    height: 100dvh !important;
+    max-width: none;
+    right: 0;
+    top: 0;
+    width: 100vw !important;
   }
 
   [data-mech-repl-host][data-mech-console-open="false"] [data-mech-console-pane],

--- a/include/mech-repl.css
+++ b/include/mech-repl.css
@@ -341,6 +341,11 @@ body.console-fullscreen [data-mech-console-pane] {
   object-fit: contain;
 }
 
+.mech-repl-scene[data-mech-scene-pointer-surface="true"] {
+  cursor: pointer;
+  touch-action: none;
+}
+
 [data-mech-console-pane] .console-topbar {
   align-items: center;
   border-bottom: 1px solid var(--mech-repl-border);

--- a/include/mechdown.css
+++ b/include/mechdown.css
@@ -107,6 +107,14 @@
   margin: 0 0 14px -20px;
 }
 
+[data-mechdown] .mech-section-annotations {
+  color: var(--mechdown-purple);
+  font-size: 0.42em;
+  font-weight: 650;
+  letter-spacing: 0.08em;
+  line-height: 1.2;
+}
+
 [data-mechdown] .mechdown-section > h3 {
   counter-increment: mechdown-subsection;
   counter-reset: mechdown-subsubsection mechdown-h5 mechdown-h6;

--- a/include/project.js
+++ b/include/project.js
@@ -722,13 +722,29 @@ function installComputeSmokeTest(target) {
       const state = globalThis.__MECH_GPU_RUNTIME__;
       if (target.dispatchPending) pendingObservations += 1;
       if (performance.now() > deadline) {
-        fail('timed out waiting for compute frames and pointer transaction');
+        fail(`timed out waiting for compute convergence: ${JSON.stringify({
+          runtimeReady: Boolean(state),
+          itemCount: state?.itemCount,
+          dispatched: state?.dispatched,
+          totalDispatches: state?.totalDispatches,
+          dispatchPending: target.dispatchPending,
+          delayedCompletions,
+          pendingObservations,
+          maxCompletionsInFlight,
+          pressedAt,
+          lastInputs: state?.lastInputs,
+          pageErrors,
+        })}`);
         return;
       }
-      if (!state || state.itemCount !== 1_000_000 || !state.dispatched) {
+      if (!state || state.itemCount !== 1_000_000) {
         return;
       }
-      if (pressedAt === 0 && state.totalDispatches >= 3) {
+      // Submit one baseline turn, then change the input while that turn owns
+      // the single command slot. The next submitted turn must carry the
+      // pointer transaction, which proves both completion-backed progress and
+      // queued input delivery without coupling the canary to GPU throughput.
+      if (pressedAt === 0 && state.totalDispatches >= 1) {
         const rect = target.canvas.getBoundingClientRect();
         target.canvas.dispatchEvent(new PointerEvent('pointerdown', {
           bubbles: true,
@@ -740,12 +756,12 @@ function installComputeSmokeTest(target) {
         pressedAt = state.totalDispatches;
         return;
       }
-      if (pressedAt === 0 || state.totalDispatches < pressedAt + 3) {
+      if (pressedAt === 0 || state.totalDispatches < pressedAt + 1) {
         return;
       }
       if (
         target.backend === 'wgpu' &&
-        (delayedCompletions < 3 || pendingObservations < 3 || maxCompletionsInFlight !== 1)
+        (delayedCompletions < 2 || pendingObservations < 2 || maxCompletionsInFlight !== 1)
       ) {
         return;
       }
@@ -774,7 +790,7 @@ function installComputeSmokeTest(target) {
       root.dataset.mechGpuSmokeReadbackBytes =
         root.dataset.mechComputeGpuToCpuReadbackBytes || "0";
       root.dataset.mechComputeBackend = state.backend;
-      root.dataset.mechGpuSmokeStateAdvanced = String(state.totalDispatches >= 6);
+      root.dataset.mechGpuSmokeStateAdvanced = String(state.totalDispatches >= 2);
       running = false;
       target.stop();
       root.dataset.mechGpuSmokeDisposed = String(

--- a/include/project.js
+++ b/include/project.js
@@ -737,10 +737,31 @@ function installComputeSmokeTest(target) {
   }
   let pointerQueuedAt = null;
   const fail = (message) => {
+    if (root.dataset.mechGpuSmoke !== 'running') {
+      return;
+    }
     root.dataset.mechGpuSmoke = 'failed';
     root.dataset.mechGpuSmokeError = message;
     clearInterval(timer);
   };
+  target.device?.lost.then((info) => {
+    fail(`browser WebGPU device lost before compute completion: ${JSON.stringify({
+      reason: info.reason,
+      message: info.message,
+      adapter: target.adapter?.info ? {
+        vendor: target.adapter.info.vendor,
+        architecture: target.adapter.info.architecture,
+        device: target.adapter.info.device,
+        description: target.adapter.info.description,
+      } : null,
+      totalDispatches: target.totalDispatches,
+      dispatchPending: target.dispatchPending,
+      delayedCompletions,
+      pendingObservations,
+      pageErrors,
+      firstPageError,
+    })}`);
+  });
   const timer = setInterval(async () => {
     try {
       const state = globalThis.__MECH_GPU_RUNTIME__;

--- a/include/project.js
+++ b/include/project.js
@@ -218,6 +218,8 @@ class BrowserComputeProject {
     this.lastFrameTime = 0;
     this.lastInputs = {};
     this.totalDispatches = 0;
+    this.acceptedDispatches = 0;
+    this.lastAcceptedDispatchToken = null;
     this.bridgeFailure = null;
     this.dispatchPending = false;
     this.pointerListeners = [];
@@ -539,6 +541,10 @@ class BrowserComputeProject {
           } else {
             this.controller.acknowledgeComputeCommand(dispatchToken);
           }
+          // A successful return is the resident host acknowledgement boundary,
+          // not merely completion of the browser GPU promise.
+          this.acceptedDispatches += 1;
+          this.lastAcceptedDispatchToken = dispatchToken;
           if (!integrity) this.activeBuffer = outputIndex;
         } catch (error) {
           this.bridgeFailure = this.rejectWgpuCommand(dispatchToken, error);
@@ -628,6 +634,8 @@ class BrowserComputeProject {
       itemCount: this.itemCount,
       displayedCount: this.renderItemCount,
       totalDispatches: this.totalDispatches,
+      acceptedDispatches: this.acceptedDispatches,
+      lastAcceptedDispatchToken: this.lastAcceptedDispatchToken,
       lastInputs: this.lastInputs,
       backend: this.backend,
     };
@@ -794,6 +802,10 @@ function installComputeSmokeTest(target) {
       if (!state || state.itemCount !== expectedItemCount) {
         return;
       }
+      if (target.bridgeFailure) {
+        fail(`resident compute acknowledgement failed: ${describeError(target.bridgeFailure)}`);
+        return;
+      }
       // Change the input only while a submitted baseline turn owns the single
       // command slot. Recording the owning dispatch before delivering the
       // event makes this an explicit queued-input proof rather than an
@@ -811,6 +823,9 @@ function installComputeSmokeTest(target) {
         return;
       }
       if (pointerQueuedAt === null || state.totalDispatches < pointerQueuedAt + 1) {
+        return;
+      }
+      if (target.acceptedDispatches < pointerQueuedAt + 1) {
         return;
       }
       if (
@@ -839,6 +854,9 @@ function installComputeSmokeTest(target) {
       root.dataset.mechGpuSmokeDispatches = String(state.totalDispatches);
       root.dataset.mechGpuSmokeInputs = JSON.stringify(state.lastInputs);
       root.dataset.mechGpuSmokeDelayedCompletions = String(delayedCompletions);
+      root.dataset.mechGpuSmokeAcceptedDispatches = String(target.acceptedDispatches);
+      root.dataset.mechGpuSmokeLastAcceptedDispatchToken =
+        target.lastAcceptedDispatchToken || "missing";
       root.dataset.mechGpuSmokePendingObservations = String(pendingObservations);
       root.dataset.mechGpuSmokeMaxCompletionsInFlight = String(maxCompletionsInFlight);
       root.dataset.mechGpuSmokeReadbackBytes =

--- a/include/project.js
+++ b/include/project.js
@@ -674,8 +674,13 @@ class BrowserComputeProject {
 }
 
 function installComputeSmokeTest(target) {
-  if (!new URLSearchParams(window.location.search).has('mech-gpu-smoke')) {
+  const smokeValue = new URLSearchParams(window.location.search).get('mech-gpu-smoke');
+  if (smokeValue === null) {
     return;
+  }
+  const expectedItemCount = Number(smokeValue);
+  if (!Number.isSafeInteger(expectedItemCount) || expectedItemCount <= 0) {
+    throw new Error(`invalid particle smoke item count ${smokeValue}`);
   }
   const root = document.documentElement;
   root.dataset.mechGpuSmoke = 'running';
@@ -737,7 +742,7 @@ function installComputeSmokeTest(target) {
         })}`);
         return;
       }
-      if (!state || state.itemCount !== 1_000_000) {
+      if (!state || state.itemCount !== expectedItemCount) {
         return;
       }
       // Submit one baseline turn, then change the input while that turn owns

--- a/include/project.js
+++ b/include/project.js
@@ -691,14 +691,29 @@ function installComputeSmokeTest(target) {
   let maxCompletionsInFlight = 0;
   let pendingObservations = 0;
   let pageErrors = 0;
+  let firstPageError = null;
+  const describeError = (value) => {
+    if (value instanceof Error) return value.stack || value.message;
+    if (typeof value === 'string') return value;
+    try {
+      return JSON.stringify(value);
+    } catch (_error) {
+      return String(value);
+    }
+  };
+  const rememberPageError = (value) => {
+    pageErrors += 1;
+    if (firstPageError === null) firstPageError = describeError(value);
+  };
   const originalConsoleError = console.error;
   console.error = (...args) => {
-    pageErrors += 1;
+    rememberPageError(args.map(describeError).join(' '));
     originalConsoleError.apply(console, args);
   };
-  const recordPageError = () => { pageErrors += 1; };
-  window.addEventListener('error', recordPageError);
-  window.addEventListener('unhandledrejection', recordPageError);
+  const recordWindowError = (event) => rememberPageError(event.error || event.message);
+  const recordRejection = (event) => rememberPageError(event.reason);
+  window.addEventListener('error', recordWindowError);
+  window.addEventListener('unhandledrejection', recordRejection);
   if (target.backend === 'wgpu') {
     const finish = target.computeResource.finish.bind(target.computeResource);
     target.computeResource.finish = async (completion) => {
@@ -743,6 +758,15 @@ function installComputeSmokeTest(target) {
           pointerQueuedAt,
           lastInputs: state?.lastInputs,
           pageErrors,
+          firstPageError,
+          adapter: target.adapter?.info ? {
+            vendor: target.adapter.info.vendor,
+            architecture: target.adapter.info.architecture,
+            device: target.adapter.info.device,
+            description: target.adapter.info.description,
+          } : null,
+          status: target.status?.textContent,
+          stopped: target.stopped,
         })}`);
         return;
       }
@@ -806,8 +830,8 @@ function installComputeSmokeTest(target) {
         target.stopped === true && target.computeResource?.disposed === true,
       );
       root.dataset.mechGpuSmokePageErrors = String(pageErrors);
-      window.removeEventListener('error', recordPageError);
-      window.removeEventListener('unhandledrejection', recordPageError);
+      window.removeEventListener('error', recordWindowError);
+      window.removeEventListener('unhandledrejection', recordRejection);
       console.error = originalConsoleError;
       clearInterval(timer);
     } catch (error) {

--- a/include/project.js
+++ b/include/project.js
@@ -232,6 +232,8 @@ class BrowserComputeProject {
     this.lastInputs = {};
     this.totalDispatches = 0;
     this.bridgeFailure = null;
+    this.readbackBuffers = [];
+    this.fixedDispatchPending = false;
   }
 
   async start() {
@@ -284,7 +286,9 @@ class BrowserComputeProject {
     if (
       this.backend === 'wgpu' &&
       (typeof this.controller.acknowledgeComputeCommand !== 'function' ||
-        typeof this.controller.rejectComputeCommand !== 'function')
+        typeof this.controller.rejectComputeCommand !== 'function' ||
+        (this.manifest.kernelKind === 'fixed-shape' &&
+          typeof this.controller.completeComputeCommand !== 'function'))
     ) {
       throw new Error('WASM build-profile mismatch: the WebGPU command acknowledgement API is unavailable');
     }
@@ -395,7 +399,7 @@ class BrowserComputeProject {
     for (const state of this.manifest.states) {
       const buffers = [0, 1].map(() => this.device.createBuffer({
         size: state.elements * Float32Array.BYTES_PER_ELEMENT,
-        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
       }));
       this.device.queue.writeBuffer(buffers[0], 0, state.initialValues);
       if (this.backend === 'wgpu') {
@@ -412,7 +416,7 @@ class BrowserComputeProject {
       }
       const buffer = this.device.createBuffer({
         size: Math.max(4, binding.elements * Float32Array.BYTES_PER_ELEMENT),
-        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
       });
       if (binding.initialValues && this.backend === 'wgpu') {
         this.device.queue.writeBuffer(buffer, 0, binding.initialValues);
@@ -456,17 +460,106 @@ class BrowserComputeProject {
     return this.fixedBuffers.get(binding.binding);
   }
 
-  outputBuffer(index) {
-    if (this.stateBuffers.has(this.output.slot)) {
-      return this.stateBuffers.get(this.output.slot)[index];
+  outputBuffer(index, output = this.output) {
+    if (this.stateBuffers.has(output.slot)) {
+      return this.stateBuffers.get(output.slot)[index];
     }
     const binding = this.manifest.bindings.find(
-      (candidate) => candidate.role === 'output' && candidate.slot === this.output.slot,
+      (candidate) => candidate.role === 'output' && candidate.slot === output.slot,
     );
     if (!binding) {
-      throw new Error(`compute output ${this.output.name} has no physical buffer`);
+      throw new Error(`compute output ${output.name} has no physical buffer`);
     }
     return this.fixedBuffers.get(binding.binding);
+  }
+
+  acquireReadbackBuffer(size) {
+    let entry = this.readbackBuffers.find((candidate) => !candidate.busy && candidate.size >= size);
+    if (!entry) {
+      entry = {
+        buffer: this.device.createBuffer({
+          size: Math.max(4, size),
+          usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+        }),
+        size: Math.max(4, size),
+        busy: false,
+      };
+      this.readbackBuffers.push(entry);
+    }
+    entry.busy = true;
+    return entry;
+  }
+
+  prepareFixedReadback(encoder, outputIndex) {
+    if (this.manifest.kernelKind !== 'fixed-shape') {
+      return null;
+    }
+    const outputs = [];
+    let byteLength = 0;
+    for (const output of this.manifest.outputs) {
+      const bytes = output.elementsPerInstance * Float32Array.BYTES_PER_ELEMENT;
+      outputs.push({ output, offset: byteLength, bytes });
+      byteLength += bytes;
+    }
+    const integrity = this.manifest.bindings.find(
+      (binding) => binding.role === 'integrity-fault',
+    );
+    const integrityOffset = integrity ? byteLength : null;
+    if (integrity) {
+      byteLength += integrity.elements * Uint32Array.BYTES_PER_ELEMENT;
+    }
+    const staging = this.acquireReadbackBuffer(byteLength);
+    for (const item of outputs) {
+      encoder.copyBufferToBuffer(
+        this.outputBuffer(outputIndex, item.output),
+        0,
+        staging.buffer,
+        item.offset,
+        item.bytes,
+      );
+    }
+    if (integrity) {
+      const source = this.fixedBuffers.get(integrity.binding);
+      encoder.copyBufferToBuffer(
+        source,
+        0,
+        staging.buffer,
+        integrityOffset,
+        integrity.elements * Uint32Array.BYTES_PER_ELEMENT,
+      );
+    }
+    return { staging, outputs, integrity, integrityOffset, byteLength };
+  }
+
+  async completedFixedOutputs(readback) {
+    await readback.staging.buffer.mapAsync(GPUMapMode.READ, 0, readback.byteLength);
+    try {
+      const mapped = readback.staging.buffer.getMappedRange(0, readback.byteLength);
+      if (readback.integrity) {
+        const words = new Uint32Array(
+          mapped,
+          readback.integrityOffset,
+          readback.integrity.elements,
+        );
+        if (words[0] !== 0) {
+          const packed = words[1];
+          const code = packed & 0xff;
+          const instance = packed >>> 8;
+          const constraint = (this.manifest.constraints || [])
+            .find((candidate) => candidate.code === code);
+          throw new Error(
+            `GPU integrity constraint ${constraint?.name || code} failed at batch instance ${instance}`,
+          );
+        }
+      }
+      return readback.outputs.map(({ output, offset, bytes }) => ({
+        name: output.name,
+        values: Float32Array.from(new Float32Array(mapped, offset, bytes / 4)),
+      }));
+    } finally {
+      readback.staging.buffer.unmap();
+      readback.staging.busy = false;
+    }
   }
 
   resize() {
@@ -540,7 +633,18 @@ class BrowserComputeProject {
     this.resize();
     const encoder = this.device.createCommandEncoder();
     let renderedBuffer = this.activeBuffer;
+    let readback = null;
     if (dispatch && this.backend === 'wgpu') {
+      const integrity = this.manifest.bindings.find(
+        (binding) => binding.role === 'integrity-fault',
+      );
+      if (integrity) {
+        this.device.queue.writeBuffer(
+          this.fixedBuffers.get(integrity.binding),
+          0,
+          new Uint32Array([0, 0xffffffff]),
+        );
+      }
       const compute = encoder.beginComputePass();
       compute.setPipeline(this.computePipeline);
       compute.setBindGroup(0, this.computeBindGroups[this.activeBuffer]);
@@ -549,7 +653,9 @@ class BrowserComputeProject {
       );
       compute.end();
       renderedBuffer = 1 - this.activeBuffer;
+      readback = this.prepareFixedReadback(encoder, renderedBuffer);
     }
+    const displayBuffer = readback ? this.activeBuffer : renderedBuffer;
     const render = encoder.beginRenderPass({
       colorAttachments: [{
         view: this.context.getCurrentTexture().createView(),
@@ -559,11 +665,11 @@ class BrowserComputeProject {
       }],
     });
     render.setPipeline(this.renderPipeline);
-    render.setBindGroup(0, this.renderBindGroups[renderedBuffer]);
+    render.setBindGroup(0, this.renderBindGroups[displayBuffer]);
     render.draw(6, this.renderItemCount);
     render.end();
     this.device.queue.submit([encoder.finish()]);
-    return renderedBuffer;
+    return { renderedBuffer, readback };
   }
 
   rejectWgpuCommand(dispatchId, error) {
@@ -579,7 +685,7 @@ class BrowserComputeProject {
     return failure;
   }
 
-  trackWgpuCompletion(dispatchId) {
+  trackWgpuCompletion(dispatchId, readback, outputIndex) {
     let completion;
     try {
       completion = this.device.queue.onSubmittedWorkDone();
@@ -587,15 +693,24 @@ class BrowserComputeProject {
       throw this.rejectWgpuCommand(dispatchId, error);
     }
     completion.then(
-      () => {
+      async () => {
         try {
-          this.controller.acknowledgeComputeCommand(dispatchId);
+          if (readback) {
+            const outputs = await this.completedFixedOutputs(readback);
+            this.activeBuffer = outputIndex;
+            this.controller.completeComputeCommand(dispatchId, outputs);
+          } else {
+            this.controller.acknowledgeComputeCommand(dispatchId);
+          }
         } catch (error) {
-          this.bridgeFailure = error instanceof Error ? error : new Error(String(error));
+          this.bridgeFailure = this.rejectWgpuCommand(dispatchId, error);
+        } finally {
+          this.fixedDispatchPending = false;
         }
       },
       (error) => {
         this.bridgeFailure = this.rejectWgpuCommand(dispatchId, error);
+        this.fixedDispatchPending = false;
       },
     );
   }
@@ -613,13 +728,18 @@ class BrowserComputeProject {
       ? 1 / 60
       : Math.max(0.001, Math.min(0.05, (timestamp - this.lastFrameTime) / 1000));
     this.lastFrameTime = timestamp;
-    const command = this.controller.frame(
-      this.pointer.x,
-      this.pointer.y,
-      this.pointer.pressed,
-      deltaSeconds,
-      maxInputsPerFrame,
-    );
+    const fixedDispatchBlocked = this.backend === 'wgpu' &&
+      this.manifest.kernelKind === 'fixed-shape' &&
+      this.fixedDispatchPending;
+    const command = fixedDispatchBlocked
+      ? null
+      : this.controller.frame(
+          this.pointer.x,
+          this.pointer.y,
+          this.pointer.pressed,
+          deltaSeconds,
+          maxInputsPerFrame,
+        );
     const dispatch = command?.dispatch === true;
     let wgpuDispatchId = null;
     if (dispatch && this.backend === 'wgpu') {
@@ -632,9 +752,9 @@ class BrowserComputeProject {
       }
       wgpuDispatchId = command.dispatchId;
     }
-    let renderedBuffer;
+    let submission;
     try {
-      renderedBuffer = this.submitFrame(command, dispatch);
+      submission = this.submitFrame(command, dispatch);
     } catch (error) {
       if (wgpuDispatchId !== null) {
         throw this.rejectWgpuCommand(wgpuDispatchId, error);
@@ -642,8 +762,16 @@ class BrowserComputeProject {
       throw error;
     }
     if (wgpuDispatchId !== null) {
-      this.activeBuffer = renderedBuffer;
-      this.trackWgpuCompletion(wgpuDispatchId);
+      if (submission.readback) {
+        this.fixedDispatchPending = true;
+      } else {
+        this.activeBuffer = submission.renderedBuffer;
+      }
+      this.trackWgpuCompletion(
+        wgpuDispatchId,
+        submission.readback,
+        submission.renderedBuffer,
+      );
     }
     if (dispatch) {
       this.totalDispatches += 1;

--- a/include/project.js
+++ b/include/project.js
@@ -483,16 +483,17 @@ class BrowserComputeProject {
     this.resize();
     const encoder = this.device.createCommandEncoder();
     let renderedBuffer = this.activeBuffer;
-    let readback = null;
+    let computeCompletion = null;
     if (dispatch && this.backend === 'wgpu') {
       this.lastInputs = Object.fromEntries(
         command.inputs.map((input) => [input.name, Array.from(input.values)]),
       );
       this.computeResource.setRequestedOutputs(command.requestedOutputs || []);
-      renderedBuffer = this.computeResource.submit(command, this.activeBuffer).outputIndex;
-      readback = true;
+      const submission = this.computeResource.submit(command, this.activeBuffer);
+      renderedBuffer = submission.outputIndex;
+      computeCompletion = submission.completion;
     }
-    const displayBuffer = readback ? this.activeBuffer : renderedBuffer;
+    const displayBuffer = computeCompletion ? this.activeBuffer : renderedBuffer;
     const render = encoder.beginRenderPass({
       colorAttachments: [{
         view: this.context.getCurrentTexture().createView(),
@@ -506,7 +507,7 @@ class BrowserComputeProject {
     render.draw(6, this.renderItemCount);
     render.end();
     this.device.queue.submit([encoder.finish()]);
-    return { renderedBuffer, readback };
+    return { renderedBuffer, computeCompletion };
   }
 
   rejectWgpuCommand(dispatchToken, error) {
@@ -522,8 +523,8 @@ class BrowserComputeProject {
     return failure;
   }
 
-  trackWgpuCompletion(dispatchToken, readback, outputIndex) {
-    this.computeResource.finish().then(
+  trackWgpuCompletion(dispatchToken, completion, outputIndex) {
+    this.computeResource.finish(completion).then(
       ({ outputs, integrity }) => {
         if (this.stopped) return;
         try {
@@ -600,7 +601,7 @@ class BrowserComputeProject {
       this.dispatchPending = true;
       this.trackWgpuCompletion(
         wgpuDispatchToken,
-        submission.readback,
+        submission.computeCompletion,
         submission.renderedBuffer,
       );
     }
@@ -700,17 +701,20 @@ function installComputeSmokeTest(target) {
   window.addEventListener('unhandledrejection', recordPageError);
   if (target.backend === 'wgpu') {
     const finish = target.computeResource.finish.bind(target.computeResource);
-    target.computeResource.finish = async () => {
+    target.computeResource.finish = async (completion) => {
       completionsInFlight += 1;
       maxCompletionsInFlight = Math.max(maxCompletionsInFlight, completionsInFlight);
       try {
+        // Attach to the exact compute completion immediately, before delaying
+        // publication, so a fast rejection cannot become unhandled.
+        const result = finish(completion);
         // Exercise more than one animation frame while the elementwise GPU
         // dispatch owns the command slot. A second dispatch during this delay
         // would either raise maxCompletionsInFlight or trip Rust backpressure.
         await new Promise(resolve => setTimeout(resolve, 75));
-        const result = await finish();
+        const completed = await result;
         delayedCompletions += 1;
-        return result;
+        return completed;
       } finally {
         completionsInFlight -= 1;
       }

--- a/include/project.js
+++ b/include/project.js
@@ -684,6 +684,15 @@ function installComputeSmokeTest(target) {
   let completionsInFlight = 0;
   let maxCompletionsInFlight = 0;
   let pendingObservations = 0;
+  let pageErrors = 0;
+  const originalConsoleError = console.error;
+  console.error = (...args) => {
+    pageErrors += 1;
+    originalConsoleError.apply(console, args);
+  };
+  const recordPageError = () => { pageErrors += 1; };
+  window.addEventListener('error', recordPageError);
+  window.addEventListener('unhandledrejection', recordPageError);
   if (target.backend === 'wgpu') {
     const finish = target.computeResource.finish.bind(target.computeResource);
     target.computeResource.finish = async () => {
@@ -765,6 +774,16 @@ function installComputeSmokeTest(target) {
       root.dataset.mechGpuSmokeReadbackBytes =
         root.dataset.mechComputeGpuToCpuReadbackBytes || "0";
       root.dataset.mechComputeBackend = state.backend;
+      root.dataset.mechGpuSmokeStateAdvanced = String(state.totalDispatches >= 6);
+      running = false;
+      target.stop();
+      root.dataset.mechGpuSmokeDisposed = String(
+        target.stopped === true && target.computeResource?.disposed === true,
+      );
+      root.dataset.mechGpuSmokePageErrors = String(pageErrors);
+      window.removeEventListener('error', recordPageError);
+      window.removeEventListener('unhandledrejection', recordPageError);
+      console.error = originalConsoleError;
       clearInterval(timer);
     } catch (error) {
       fail(error instanceof Error ? error.message : String(error));

--- a/include/project.js
+++ b/include/project.js
@@ -716,7 +716,7 @@ function installComputeSmokeTest(target) {
       }
     };
   }
-  let pressedAt = 0;
+  let pointerQueuedAt = null;
   const fail = (message) => {
     root.dataset.mechGpuSmoke = 'failed';
     root.dataset.mechGpuSmokeError = message;
@@ -736,7 +736,7 @@ function installComputeSmokeTest(target) {
           delayedCompletions,
           pendingObservations,
           maxCompletionsInFlight,
-          pressedAt,
+          pointerQueuedAt,
           lastInputs: state?.lastInputs,
           pageErrors,
         })}`);
@@ -745,12 +745,13 @@ function installComputeSmokeTest(target) {
       if (!state || state.itemCount !== expectedItemCount) {
         return;
       }
-      // Submit one baseline turn, then change the input while that turn owns
-      // the single command slot. The next submitted turn must carry the
-      // pointer transaction, which proves both completion-backed progress and
-      // queued input delivery without coupling the canary to GPU throughput.
-      if (pressedAt === 0 && state.totalDispatches >= 1) {
+      // Change the input only while a submitted baseline turn owns the single
+      // command slot. Recording the owning dispatch before delivering the
+      // event makes this an explicit queued-input proof rather than an
+      // inference from animation-frame timing.
+      if (pointerQueuedAt === null && target.dispatchPending && state.totalDispatches >= 1) {
         const rect = target.canvas.getBoundingClientRect();
+        pointerQueuedAt = state.totalDispatches;
         target.canvas.dispatchEvent(new PointerEvent('pointerdown', {
           bubbles: true,
           pointerId: 1,
@@ -758,10 +759,9 @@ function installComputeSmokeTest(target) {
           clientX: rect.left + rect.width * 0.75,
           clientY: rect.top + rect.height * 0.25,
         }));
-        pressedAt = state.totalDispatches;
         return;
       }
-      if (pressedAt === 0 || state.totalDispatches < pressedAt + 1) {
+      if (pointerQueuedAt === null || state.totalDispatches < pointerQueuedAt + 1) {
         return;
       }
       if (

--- a/include/project.js
+++ b/include/project.js
@@ -154,24 +154,11 @@ fn fragment_main(input: VertexOutput) -> @location(0) vec4f {
 `;
 
 export function requiredWgpuLimits(manifest, adapterLimits) {
-  const requiredLimits = {
-    maxStorageBuffersPerShaderStage: manifest.bindings.length,
-    maxComputeWorkgroupsPerDimension: Math.ceil(
-      manifest.dispatchElements / manifest.workgroupSize,
-    ),
-  };
-  for (const [limit, required] of Object.entries(requiredLimits)) {
-    const available = adapterLimits[limit];
-    if (!Number.isInteger(required) || required <= 0) {
-      throw new Error(`Mech generated invalid WebGPU limit ${limit}: ${required}`);
-    }
-    if (required > available) {
-      throw new Error(
-        `Mech requires ${required} for ${limit}, but this adapter supports ${available}`,
-      );
-    }
-  }
-  return requiredLimits;
+  return globalThis.MechBrowserComputeDevice.requiredLimits(
+    manifest,
+    adapterLimits,
+    manifest.outputs.map((output) => output.name),
+  );
 }
 
 class BrowserComputeProject {
@@ -232,8 +219,8 @@ class BrowserComputeProject {
     this.lastInputs = {};
     this.totalDispatches = 0;
     this.bridgeFailure = null;
-    this.readbackBuffers = [];
-    this.fixedDispatchPending = false;
+    this.dispatchPending = false;
+    this.pointerListeners = [];
   }
 
   async start() {
@@ -264,12 +251,10 @@ class BrowserComputeProject {
     this.renderItemCount = Math.ceil(this.itemCount / this.sampleStride);
     this.setStatus(`Preparing ${this.backend.toUpperCase()} compute`, '');
 
-    const requiredLimits = this.backend === 'wgpu'
-      ? requiredWgpuLimits(this.manifest, this.adapter.limits)
+    this.computeResource = this.backend === 'wgpu'
+      ? await globalThis.MechBrowserComputeDevice.create(this.manifest, this.adapter, [])
       : null;
-    this.device = await this.adapter.requestDevice(this.backend === 'wgpu'
-      ? { requiredLimits }
-      : {});
+    this.device = this.computeResource?.device || await this.adapter.requestDevice({});
     this.device.lost.then((info) => {
       this.stopped = true;
       this.setStatus(`GPU device lost: ${info.message}`, 'error');
@@ -339,8 +324,7 @@ class BrowserComputeProject {
       this.pointer.x = Math.max(-1, Math.min(1, ((event.clientX - rect.left) / rect.width) * 2 - 1));
       this.pointer.y = Math.max(-1, Math.min(1, 1 - ((event.clientY - rect.top) / rect.height) * 2));
     };
-    this.canvas.addEventListener('pointermove', update);
-    this.canvas.addEventListener('pointerdown', (event) => {
+    const press = (event) => {
       update(event);
       this.pointer.pressed = true;
       try {
@@ -350,7 +334,7 @@ class BrowserComputeProject {
           throw error;
         }
       }
-    });
+    };
     const release = (event) => {
       update(event);
       this.pointer.pressed = false;
@@ -358,23 +342,19 @@ class BrowserComputeProject {
         this.canvas.releasePointerCapture(event.pointerId);
       }
     };
-    this.canvas.addEventListener('pointerup', release);
-    this.canvas.addEventListener('pointercancel', release);
+    for (const [name, listener] of [
+      ['pointermove', update],
+      ['pointerdown', press],
+      ['pointerup', release],
+      ['pointercancel', release],
+    ]) {
+      this.canvas.addEventListener(name, listener);
+      this.pointerListeners.push([name, listener]);
+    }
   }
 
   async createPipelines() {
-    if (this.backend === 'wgpu') {
-      const computeModule = this.device.createShaderModule({ code: this.manifest.wgsl });
-      const compilation = await computeModule.getCompilationInfo();
-      const errors = compilation.messages.filter((message) => message.type === 'error');
-      if (errors.length > 0) {
-        throw new Error(errors.map((message) => message.message).join('\n'));
-      }
-      this.computePipeline = this.device.createComputePipeline({
-        layout: 'auto',
-        compute: { module: computeModule, entryPoint: 'main' },
-      });
-    }
+    if (this.computeResource) this.computePipeline = this.computeResource.pipeline;
     const renderModule = this.device.createShaderModule({ code: pointRendererShader });
     this.renderPipeline = this.device.createRenderPipeline({
       layout: 'auto',
@@ -395,48 +375,33 @@ class BrowserComputeProject {
   }
 
   createBuffers() {
-    this.stateBuffers = new Map();
-    for (const state of this.manifest.states) {
-      const buffers = [0, 1].map(() => this.device.createBuffer({
-        size: state.elements * Float32Array.BYTES_PER_ELEMENT,
-        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
-      }));
-      this.device.queue.writeBuffer(buffers[0], 0, state.initialValues);
-      if (this.backend === 'wgpu') {
-        state.initialValues = null;
+    if (this.computeResource) {
+      this.stateBuffers = this.computeResource.stateBuffers;
+      this.fixedBuffers = this.computeResource.fixedBuffers;
+      this.inputBindings = this.computeResource.inputBindings;
+      this.computeBindGroups = this.computeResource.bindGroups;
+    } else {
+      this.stateBuffers = new Map();
+      for (const state of this.manifest.states) {
+        const buffers = [0, 1].map(() => this.device.createBuffer({
+          size: Math.max(4, state.elements * Float32Array.BYTES_PER_ELEMENT),
+          usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
+        }));
+        this.device.queue.writeBuffer(buffers[0], 0, state.initialValues);
+        this.stateBuffers.set(state.slot, buffers);
       }
-      this.stateBuffers.set(state.slot, buffers);
+      this.fixedBuffers = new Map();
+      this.inputBindings = new Map();
+      for (const binding of this.manifest.bindings) {
+        if (binding.role === 'state-read' || binding.role === 'state-write') continue;
+        const buffer = this.device.createBuffer({
+          size: Math.max(4, binding.elements * Float32Array.BYTES_PER_ELEMENT),
+          usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
+        });
+        this.fixedBuffers.set(binding.binding, buffer);
+      }
+      this.computeBindGroups = [];
     }
-
-    this.fixedBuffers = new Map();
-    this.inputBindings = new Map();
-    for (const binding of this.manifest.bindings) {
-      if (binding.role === 'state-read' || binding.role === 'state-write') {
-        continue;
-      }
-      const buffer = this.device.createBuffer({
-        size: Math.max(4, binding.elements * Float32Array.BYTES_PER_ELEMENT),
-        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
-      });
-      if (binding.initialValues && this.backend === 'wgpu') {
-        this.device.queue.writeBuffer(buffer, 0, binding.initialValues);
-        binding.initialValues = null;
-      }
-      this.fixedBuffers.set(binding.binding, buffer);
-      if (binding.role === 'input') {
-        this.inputBindings.set(binding.name, { binding, buffer });
-      }
-    }
-
-    this.computeBindGroups = this.backend === 'wgpu'
-      ? [0, 1].map((sourceIndex) => this.device.createBindGroup({
-        layout: this.computePipeline.getBindGroupLayout(0),
-        entries: this.manifest.bindings.map((binding) => ({
-          binding: binding.binding,
-          resource: { buffer: this.bufferForBinding(binding, sourceIndex) },
-        })),
-      }))
-      : [];
     this.renderUniform = this.device.createBuffer({
       size: 32,
       usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
@@ -473,95 +438,6 @@ class BrowserComputeProject {
     return this.fixedBuffers.get(binding.binding);
   }
 
-  acquireReadbackBuffer(size) {
-    let entry = this.readbackBuffers.find((candidate) => !candidate.busy && candidate.size >= size);
-    if (!entry) {
-      entry = {
-        buffer: this.device.createBuffer({
-          size: Math.max(4, size),
-          usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
-        }),
-        size: Math.max(4, size),
-        busy: false,
-      };
-      this.readbackBuffers.push(entry);
-    }
-    entry.busy = true;
-    return entry;
-  }
-
-  prepareFixedReadback(encoder, outputIndex) {
-    if (this.manifest.kernelKind !== 'fixed-shape') {
-      return null;
-    }
-    const outputs = [];
-    let byteLength = 0;
-    for (const output of this.manifest.outputs) {
-      const bytes = output.elementsPerInstance * Float32Array.BYTES_PER_ELEMENT;
-      outputs.push({ output, offset: byteLength, bytes });
-      byteLength += bytes;
-    }
-    const integrity = this.manifest.bindings.find(
-      (binding) => binding.role === 'integrity-fault',
-    );
-    const integrityOffset = integrity ? byteLength : null;
-    if (integrity) {
-      byteLength += integrity.elements * Uint32Array.BYTES_PER_ELEMENT;
-    }
-    const staging = this.acquireReadbackBuffer(byteLength);
-    for (const item of outputs) {
-      encoder.copyBufferToBuffer(
-        this.outputBuffer(outputIndex, item.output),
-        0,
-        staging.buffer,
-        item.offset,
-        item.bytes,
-      );
-    }
-    if (integrity) {
-      const source = this.fixedBuffers.get(integrity.binding);
-      encoder.copyBufferToBuffer(
-        source,
-        0,
-        staging.buffer,
-        integrityOffset,
-        integrity.elements * Uint32Array.BYTES_PER_ELEMENT,
-      );
-    }
-    return { staging, outputs, integrity, integrityOffset, byteLength };
-  }
-
-  async completedFixedOutputs(readback) {
-    await readback.staging.buffer.mapAsync(GPUMapMode.READ, 0, readback.byteLength);
-    try {
-      const mapped = readback.staging.buffer.getMappedRange(0, readback.byteLength);
-      if (readback.integrity) {
-        const words = new Uint32Array(
-          mapped,
-          readback.integrityOffset,
-          readback.integrity.elements,
-        );
-        if (words[0] !== 0) {
-          const packed = words[1];
-          const code = packed & 0xff;
-          const instance = packed >>> 8;
-          const constraint = (this.manifest.constraints || [])
-            .find((candidate) => candidate.code === code);
-          throw new Error(
-            `GPU integrity constraint ${constraint?.name || code} failed at batch instance ${instance}`,
-          );
-        }
-      }
-      return readback.outputs.map(({ output, offset, bytes }) => ({
-        name: output.name,
-        values: Float32Array.from(new Float32Array(mapped, offset, bytes / 4)),
-      }));
-    } finally {
-      readback.staging.buffer.unmap();
-      readback.staging.busy = false;
-    }
-  }
-
   resize() {
     const ratio = Math.min(window.devicePixelRatio || 1, 2);
     const width = Math.max(1, Math.floor(this.canvas.clientWidth * ratio));
@@ -592,38 +468,12 @@ class BrowserComputeProject {
     );
   }
 
-  applyGpuCommand(command) {
-    if (!command?.dispatch) {
-      return false;
-    }
-    for (const input of command.inputs) {
-      const target = this.inputBindings.get(input.name);
-      if (!target) {
-        throw new Error(`Mech CPU graph wrote undeclared GPU input ${input.name}`);
-      }
-      if (input.values.length !== target.binding.elements) {
-        throw new Error(
-          `Mech CPU graph wrote ${input.values.length} values to ${input.name}; ` +
-          `the GPU region requires ${target.binding.elements}`,
-        );
-      }
-      this.device.queue.writeBuffer(target.buffer, 0, input.values);
-    }
-    this.lastInputs = Object.fromEntries(
-      command.inputs.map((input) => [input.name, Array.from(input.values)]),
-    );
-    return true;
-  }
-
   uploadCpuOutput() {
     const positions = this.controller.cpuOutput(this.output.name);
     this.device.queue.writeBuffer(this.outputBuffer(0), 0, positions);
   }
 
   submitFrame(command, dispatch) {
-    if (dispatch && this.backend === 'wgpu') {
-      this.applyGpuCommand(command);
-    }
     if (dispatch && this.backend.startsWith('cpu-')) {
       this.lastInputs = Object.fromEntries(
         command.inputs.map((input) => [input.name, Array.from(input.values)]),
@@ -635,25 +485,12 @@ class BrowserComputeProject {
     let renderedBuffer = this.activeBuffer;
     let readback = null;
     if (dispatch && this.backend === 'wgpu') {
-      const integrity = this.manifest.bindings.find(
-        (binding) => binding.role === 'integrity-fault',
+      this.lastInputs = Object.fromEntries(
+        command.inputs.map((input) => [input.name, Array.from(input.values)]),
       );
-      if (integrity) {
-        this.device.queue.writeBuffer(
-          this.fixedBuffers.get(integrity.binding),
-          0,
-          new Uint32Array([0, 0xffffffff]),
-        );
-      }
-      const compute = encoder.beginComputePass();
-      compute.setPipeline(this.computePipeline);
-      compute.setBindGroup(0, this.computeBindGroups[this.activeBuffer]);
-      compute.dispatchWorkgroups(
-        Math.ceil(this.manifest.dispatchElements / this.manifest.workgroupSize),
-      );
-      compute.end();
-      renderedBuffer = 1 - this.activeBuffer;
-      readback = this.prepareFixedReadback(encoder, renderedBuffer);
+      this.computeResource.setRequestedOutputs(command.requestedOutputs || []);
+      renderedBuffer = this.computeResource.submit(command, this.activeBuffer).outputIndex;
+      readback = true;
     }
     const displayBuffer = readback ? this.activeBuffer : renderedBuffer;
     const render = encoder.beginRenderPass({
@@ -672,45 +509,46 @@ class BrowserComputeProject {
     return { renderedBuffer, readback };
   }
 
-  rejectWgpuCommand(dispatchId, error) {
+  rejectWgpuCommand(dispatchToken, error) {
     const failure = error instanceof Error ? error : new Error(String(error));
     try {
-      this.controller.rejectComputeCommand(dispatchId, failure.message);
+      this.controller.rejectComputeCommand(dispatchToken, failure.message);
     } catch (rejectionError) {
       const detail = rejectionError instanceof Error
         ? rejectionError.message
         : String(rejectionError);
-      return new Error(`${failure.message}; rejecting dispatch ${dispatchId} also failed: ${detail}`);
+      return new Error(`${failure.message}; rejecting dispatch ${dispatchToken} also failed: ${detail}`);
     }
     return failure;
   }
 
-  trackWgpuCompletion(dispatchId, readback, outputIndex) {
-    let completion;
-    try {
-      completion = this.device.queue.onSubmittedWorkDone();
-    } catch (error) {
-      throw this.rejectWgpuCommand(dispatchId, error);
-    }
-    completion.then(
-      async () => {
+  trackWgpuCompletion(dispatchToken, readback, outputIndex) {
+    this.computeResource.finish().then(
+      ({ outputs, integrity }) => {
+        if (this.stopped) return;
         try {
-          if (readback) {
-            const outputs = await this.completedFixedOutputs(readback);
-            this.activeBuffer = outputIndex;
-            this.controller.completeComputeCommand(dispatchId, outputs);
+          if (integrity) {
+            this.controller.rejectIntegrityComputeCommand(
+              dispatchToken,
+              integrity.constraint,
+              integrity.instance,
+            );
+          } else if (outputs.length) {
+            this.controller.completeComputeCommand(dispatchToken, outputs);
           } else {
-            this.controller.acknowledgeComputeCommand(dispatchId);
+            this.controller.acknowledgeComputeCommand(dispatchToken);
           }
+          if (!integrity) this.activeBuffer = outputIndex;
         } catch (error) {
-          this.bridgeFailure = this.rejectWgpuCommand(dispatchId, error);
+          this.bridgeFailure = this.rejectWgpuCommand(dispatchToken, error);
         } finally {
-          this.fixedDispatchPending = false;
+          this.dispatchPending = false;
         }
       },
       (error) => {
-        this.bridgeFailure = this.rejectWgpuCommand(dispatchId, error);
-        this.fixedDispatchPending = false;
+        if (this.stopped) return;
+        this.bridgeFailure = this.rejectWgpuCommand(dispatchToken, error);
+        this.dispatchPending = false;
       },
     );
   }
@@ -728,10 +566,7 @@ class BrowserComputeProject {
       ? 1 / 60
       : Math.max(0.001, Math.min(0.05, (timestamp - this.lastFrameTime) / 1000));
     this.lastFrameTime = timestamp;
-    const fixedDispatchBlocked = this.backend === 'wgpu' &&
-      this.manifest.kernelKind === 'fixed-shape' &&
-      this.fixedDispatchPending;
-    const command = fixedDispatchBlocked
+    const command = this.backend === 'wgpu' && this.dispatchPending
       ? null
       : this.controller.frame(
           this.pointer.x,
@@ -741,34 +576,30 @@ class BrowserComputeProject {
           maxInputsPerFrame,
         );
     const dispatch = command?.dispatch === true;
-    let wgpuDispatchId = null;
+    let wgpuDispatchToken = null;
     if (dispatch && this.backend === 'wgpu') {
       if (
         command.acknowledgementRequired !== true ||
-        !Number.isSafeInteger(command.dispatchId) ||
-        command.dispatchId <= 0
+        typeof command.dispatchToken !== 'string' ||
+        !/^[1-9][0-9]*:[1-9][0-9]*$/.test(command.dispatchToken)
       ) {
         throw new Error('the WebGPU bridge received a command without a valid acknowledgement identity');
       }
-      wgpuDispatchId = command.dispatchId;
+      wgpuDispatchToken = command.dispatchToken;
     }
     let submission;
     try {
       submission = this.submitFrame(command, dispatch);
     } catch (error) {
-      if (wgpuDispatchId !== null) {
-        throw this.rejectWgpuCommand(wgpuDispatchId, error);
+      if (wgpuDispatchToken !== null) {
+        throw this.rejectWgpuCommand(wgpuDispatchToken, error);
       }
       throw error;
     }
-    if (wgpuDispatchId !== null) {
-      if (submission.readback) {
-        this.fixedDispatchPending = true;
-      } else {
-        this.activeBuffer = submission.renderedBuffer;
-      }
+    if (wgpuDispatchToken !== null) {
+      this.dispatchPending = true;
       this.trackWgpuCompletion(
-        wgpuDispatchId,
+        wgpuDispatchToken,
         submission.readback,
         submission.renderedBuffer,
       );
@@ -803,8 +634,26 @@ class BrowserComputeProject {
   }
 
   stop() {
+    if (this.stopped) return;
     this.stopped = true;
-    this.controller.stop();
+    for (const [name, listener] of this.pointerListeners) {
+      this.canvas?.removeEventListener(name, listener);
+    }
+    this.pointerListeners = [];
+    try {
+      this.controller.stop();
+    } finally {
+      if (this.computeResource) {
+        this.computeResource.dispose();
+      } else {
+        for (const buffers of this.stateBuffers?.values() || []) {
+          buffers.forEach((buffer) => buffer.destroy());
+        }
+        for (const buffer of this.fixedBuffers?.values() || []) buffer.destroy();
+        this.renderUniform?.destroy();
+        this.device?.destroy();
+      }
+    }
   }
 
   setText(selector, value) {
@@ -831,6 +680,28 @@ function installComputeSmokeTest(target) {
   const root = document.documentElement;
   root.dataset.mechGpuSmoke = 'running';
   const deadline = performance.now() + 120_000;
+  let delayedCompletions = 0;
+  let completionsInFlight = 0;
+  let maxCompletionsInFlight = 0;
+  let pendingObservations = 0;
+  if (target.backend === 'wgpu') {
+    const finish = target.computeResource.finish.bind(target.computeResource);
+    target.computeResource.finish = async () => {
+      completionsInFlight += 1;
+      maxCompletionsInFlight = Math.max(maxCompletionsInFlight, completionsInFlight);
+      try {
+        // Exercise more than one animation frame while the elementwise GPU
+        // dispatch owns the command slot. A second dispatch during this delay
+        // would either raise maxCompletionsInFlight or trip Rust backpressure.
+        await new Promise(resolve => setTimeout(resolve, 75));
+        const result = await finish();
+        delayedCompletions += 1;
+        return result;
+      } finally {
+        completionsInFlight -= 1;
+      }
+    };
+  }
   let pressedAt = 0;
   const fail = (message) => {
     root.dataset.mechGpuSmoke = 'failed';
@@ -840,6 +711,7 @@ function installComputeSmokeTest(target) {
   const timer = setInterval(async () => {
     try {
       const state = globalThis.__MECH_GPU_RUNTIME__;
+      if (target.dispatchPending) pendingObservations += 1;
       if (performance.now() > deadline) {
         fail('timed out waiting for compute frames and pointer transaction');
         return;
@@ -862,6 +734,12 @@ function installComputeSmokeTest(target) {
       if (pressedAt === 0 || state.totalDispatches < pressedAt + 3) {
         return;
       }
+      if (
+        target.backend === 'wgpu' &&
+        (delayedCompletions < 3 || pendingObservations < 3 || maxCompletionsInFlight !== 1)
+      ) {
+        return;
+      }
       const strength = state.lastInputs?.['force-strength']?.[0];
       const forcePoint = state.lastInputs?.['force-point'];
       const forceX = forcePoint?.[0];
@@ -881,6 +759,11 @@ function installComputeSmokeTest(target) {
       root.dataset.mechGpuSmoke = 'passed';
       root.dataset.mechGpuSmokeDispatches = String(state.totalDispatches);
       root.dataset.mechGpuSmokeInputs = JSON.stringify(state.lastInputs);
+      root.dataset.mechGpuSmokeDelayedCompletions = String(delayedCompletions);
+      root.dataset.mechGpuSmokePendingObservations = String(pendingObservations);
+      root.dataset.mechGpuSmokeMaxCompletionsInFlight = String(maxCompletionsInFlight);
+      root.dataset.mechGpuSmokeReadbackBytes =
+        root.dataset.mechComputeGpuToCpuReadbackBytes || "0";
       root.dataset.mechComputeBackend = state.backend;
       clearInterval(timer);
     } catch (error) {

--- a/machines/matrix/src/catalog.rs
+++ b/machines/matrix/src/catalog.rs
@@ -375,6 +375,18 @@ macro_rules! export_matrix_transpose_fixed_family {
 }
 
 mech_core::declare_native_runtime_factory! {
+    cfg: all(feature = "solve", feature = "matrixd", feature = "vectord", feature = "f32"),
+    registration: register_matrix_solve_mdvd_f32,
+    installer: install_matrix_solve_mdvd_f32,
+    name: "MatrixSolveMDVD<f32>",
+    factory_type: crate::solve::MatrixSolveMDVD<f32>,
+    contract: RuntimeFunctionContract::linear_solve(RuntimeOutputAliasPolicy::DisallowInputAlias),
+    package: "mech-matrix", crate_name: "mech_matrix",
+    installer_path: "mech_matrix::__mech_native::install_matrix_solve_mdvd_f32",
+    extra_cargo_features: ["solve"],
+}
+
+mech_core::declare_native_runtime_factory! {
     cfg: all(feature = "solve", feature = "matrixd", feature = "vectord", feature = "f64"),
     registration: register_matrix_solve_mdvd_f64,
     installer: install_matrix_solve_mdvd_f64,
@@ -383,6 +395,30 @@ mech_core::declare_native_runtime_factory! {
     contract: RuntimeFunctionContract::linear_solve(RuntimeOutputAliasPolicy::DisallowInputAlias),
     package: "mech-matrix", crate_name: "mech_matrix",
     installer_path: "mech_matrix::__mech_native::install_matrix_solve_mdvd_f64",
+    extra_cargo_features: ["solve"],
+}
+
+mech_core::declare_native_runtime_factory! {
+    cfg: all(feature = "solve", feature = "matrixd", feature = "f32"),
+    registration: register_matrix_solve_mdmd_f32,
+    installer: install_matrix_solve_mdmd_f32,
+    name: "MatrixSolveMDMD<f32>",
+    factory_type: crate::solve::MatrixSolveMDMD<f32>,
+    contract: RuntimeFunctionContract::linear_solve(RuntimeOutputAliasPolicy::DisallowInputAlias),
+    package: "mech-matrix", crate_name: "mech_matrix",
+    installer_path: "mech_matrix::__mech_native::install_matrix_solve_mdmd_f32",
+    extra_cargo_features: ["solve"],
+}
+
+mech_core::declare_native_runtime_factory! {
+    cfg: all(feature = "solve", feature = "matrixd", feature = "f64"),
+    registration: register_matrix_solve_mdmd_f64,
+    installer: install_matrix_solve_mdmd_f64,
+    name: "MatrixSolveMDMD<f64>",
+    factory_type: crate::solve::MatrixSolveMDMD<f64>,
+    contract: RuntimeFunctionContract::linear_solve(RuntimeOutputAliasPolicy::DisallowInputAlias),
+    package: "mech-matrix", crate_name: "mech_matrix",
+    installer_path: "mech_matrix::__mech_native::install_matrix_solve_mdmd_f64",
     extra_cargo_features: ["solve"],
 }
 
@@ -582,9 +618,20 @@ pub fn install_runtime(builder: &mut FunctionCatalogBuilder) -> MResult<()> {
         feature = "solve",
         feature = "matrixd",
         feature = "vectord",
+        feature = "f32"
+    ))]
+    register_matrix_solve_mdvd_f32(builder)?;
+    #[cfg(all(
+        feature = "solve",
+        feature = "matrixd",
+        feature = "vectord",
         feature = "f64"
     ))]
     register_matrix_solve_mdvd_f64(builder)?;
+    #[cfg(all(feature = "solve", feature = "matrixd", feature = "f32"))]
+    register_matrix_solve_mdmd_f32(builder)?;
+    #[cfg(all(feature = "solve", feature = "matrixd", feature = "f64"))]
+    register_matrix_solve_mdmd_f64(builder)?;
     #[cfg(feature = "transpose")]
     install_transpose_runtime(builder)?;
     Ok(())
@@ -624,9 +671,20 @@ pub mod __mech_native {
         feature = "solve",
         feature = "matrixd",
         feature = "vectord",
+        feature = "f32"
+    ))]
+    pub use super::install_matrix_solve_mdvd_f32;
+    #[cfg(all(
+        feature = "solve",
+        feature = "matrixd",
+        feature = "vectord",
         feature = "f64"
     ))]
     pub use super::install_matrix_solve_mdvd_f64;
+    #[cfg(all(feature = "solve", feature = "matrixd", feature = "f32"))]
+    pub use super::install_matrix_solve_mdmd_f32;
+    #[cfg(all(feature = "solve", feature = "matrixd", feature = "f64"))]
+    pub use super::install_matrix_solve_mdmd_f64;
 }
 
 #[cfg(all(test, feature = "source"))]

--- a/machines/matrix/src/solve.rs
+++ b/machines/matrix/src/solve.rs
@@ -186,6 +186,16 @@ macro_rules! impl_solve {
 #[cfg(all(feature = "matrixd", feature = "vectord"))]
 impl_solve!(MatrixSolveMDVD, DMatrix<T>, DVector<T>, DVector<T>);
 
+#[cfg(feature = "matrixd")]
+impl_solve!(MatrixSolveMDMD, DMatrix<T>, DMatrix<T>, DMatrix<T>);
+
+// Keep fixed-shape source mathematical. The semantic compiler sees the
+// ordinary solve operation and compute backends can scalarize it without the
+// program spelling out an inverse or splitting a matrix right-hand side into
+// columns.
+#[cfg(all(feature = "matrix2", feature = "matrix2x3"))]
+impl_solve!(MatrixSolveM2M2x3, Matrix2<T>, Matrix2x3<T>, Matrix2x3<T>);
+
 #[cfg(all(test, feature = "f64", feature = "matrixd", feature = "vectord"))]
 mod tests {
     use super::*;
@@ -209,6 +219,27 @@ mod tests {
         assert_eq!(error.kind_name(), "MatrixSolveSingular");
         assert_eq!(*out.borrow(), previous);
     }
+
+    #[test]
+    fn matrix_right_hand_side_is_solved_in_one_operation() {
+        let lhs = Ref::new(DMatrix::from_row_slice(2, 2, &[4.0, 1.0, 2.0, 3.0]));
+        let rhs = Ref::new(DMatrix::from_row_slice(
+            2,
+            3,
+            &[9.0, 1.0, 5.0, 8.0, 7.0, 2.0],
+        ));
+        let out = Ref::new(DMatrix::zeros(2, 3));
+        let function = MatrixSolveMDMD {
+            lhs: lhs.clone(),
+            rhs: rhs.clone(),
+            out: out.clone(),
+        };
+
+        function.solve_result().unwrap();
+
+        let residual = lhs.borrow().clone() * out.borrow().clone() - rhs.borrow().clone();
+        assert!(residual.norm() < 1.0e-12);
+    }
 }
 
 #[cfg(feature = "source")]
@@ -217,6 +248,30 @@ macro_rules! impl_solve_match_arms {
     match $arg {
       $(
         $(
+          #[cfg(all(feature = $value_string, feature = "matrixd"))]
+          (LegacyValue::$matrix_kind(Matrix::DMatrix(lhs)), LegacyValue::$matrix_kind(Matrix::DMatrix(rhs))) => {
+            let (a_rows, a_cols) = lhs.borrow().shape();
+            let (b_rows, b_cols) = rhs.borrow().shape();
+            if a_rows != a_cols || a_rows != b_rows {
+              return Err(MechError::new(
+                DimensionMismatch { dims: vec![a_rows, a_cols, b_rows, b_cols] },
+                Some("Matrix solve requires a square coefficient matrix whose rows match the right-hand side".to_string())
+              ).with_compiler_loc());
+            }
+            Ok(Box::new(MatrixSolveMDMD {
+              lhs: lhs.clone(),
+              rhs: rhs.clone(),
+              out: Ref::new(DMatrix::from_element(a_rows, b_cols, $target_type::zero())),
+            }))
+          },
+          #[cfg(all(feature = $value_string, feature = "matrix2", feature = "matrix2x3"))]
+          (LegacyValue::$matrix_kind(Matrix::Matrix2(lhs)), LegacyValue::$matrix_kind(Matrix::Matrix2x3(rhs))) => {
+            Ok(Box::new(MatrixSolveM2M2x3 {
+              lhs: lhs.clone(),
+              rhs: rhs.clone(),
+              out: Ref::new(Matrix2x3::from_element($target_type::zero())),
+            }))
+          },
           #[cfg(all(feature = $value_string, feature = "matrixd", feature = "vectord"))]
           (LegacyValue::$matrix_kind(Matrix::DMatrix(lhs)), LegacyValue::$matrix_kind(Matrix::DVector(rhs))) => {
             let (a_rows, a_cols) = lhs.borrow().shape();
@@ -227,10 +282,10 @@ macro_rules! impl_solve_match_arms {
                 Some("Right-hand side must be a vector (1 column)".to_string())
               ).with_compiler_loc());
             }
-            if a_rows != b_rows {
+            if a_rows != a_cols || a_rows != b_rows {
               return Err(MechError::new(
                 DimensionMismatch { dims: vec![a_rows, a_cols, b_rows, b_cols] },
-                Some("Matrix rows must match vector rows".to_string())
+                Some("Matrix solve requires a square coefficient matrix whose rows match the right-hand side".to_string())
               ).with_compiler_loc());
             }
             Ok(Box::new(MatrixSolveMDVD { lhs: lhs.clone(), rhs: rhs.clone(), out: Ref::new(DVector::from_element(a_rows, $target_type::zero())) }))
@@ -241,14 +296,14 @@ macro_rules! impl_solve_match_arms {
             let rhs_shape = rhs.shape();
             return Err(MechError::new(
               DimensionMismatch { dims: vec![lhs_shape[0], lhs_shape[1], rhs_shape[0], rhs_shape[1]] },
-              Some("Matrix multiplication is only implemented for `matrixd` and `vectord` types".to_string())
+              Some("Matrix solve is not implemented for this pair of matrix representations".to_string())
             ).with_compiler_loc());
           }
         )+
       )+
       (arg1,arg2) => Err(MechError::new(
         UnhandledFunctionArgumentKind2 { arg: (arg1.kind(),arg2.kind()), fxn_name: stringify!($fxn).to_string() },
-        Some("Unsupported types for matrix multiplication".to_string())
+        Some("Unsupported types for matrix solve".to_string())
       ).with_compiler_loc()),
     }
   }

--- a/scripts/browser_webgpu_flags.py
+++ b/scripts/browser_webgpu_flags.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 
-def chrome_webgpu_test_flags(*, software_adapter: bool) -> list[str]:
+def chrome_webgpu_test_flags(*, software_adapter: bool, linux: bool = False) -> list[str]:
     """Return WebGPU flags, optionally forcing Chromium's test adapter."""
 
     flags = ["--enable-unsafe-webgpu"]
@@ -15,4 +15,9 @@ def chrome_webgpu_test_flags(*, software_adapter: bool) -> list[str]:
                 "--use-gpu-in-tests",
             ]
         )
+        if linux:
+            # Chromium's Linux WebGPU decoder requires a Vulkan shared
+            # context (or GLES compat). Force the same SwiftShader Vulkan
+            # driver as the selected Dawn fallback adapter on GPU-less CI.
+            flags.extend(["--enable-features=Vulkan", "--use-vulkan=swiftshader"])
     return flags

--- a/scripts/browser_webgpu_flags.py
+++ b/scripts/browser_webgpu_flags.py
@@ -16,8 +16,17 @@ def chrome_webgpu_test_flags(*, software_adapter: bool, linux: bool = False) -> 
             ]
         )
         if linux:
-            # Chromium's Linux WebGPU decoder requires a Vulkan shared
-            # context (or GLES compat). Force the same SwiftShader Vulkan
-            # driver as the selected Dawn fallback adapter on GPU-less CI.
-            flags.extend(["--enable-features=Vulkan", "--use-vulkan=swiftshader"])
+            # Chromium's own Linux WebGPU SwiftShader pixel-test profile keeps
+            # ANGLE, Dawn, and Vulkan on the same software implementation and
+            # avoids creating a presentation surface in a headless process.
+            # Using only the Vulkan switches can destroy Dawn's external
+            # instance while submitted work is still pending.
+            flags.extend(
+                [
+                    "--enable-features=Vulkan",
+                    "--use-angle=swiftshader",
+                    "--use-vulkan=swiftshader",
+                    "--disable-vulkan-surface",
+                ]
+            )
     return flags

--- a/scripts/browser_webgpu_flags.py
+++ b/scripts/browser_webgpu_flags.py
@@ -1,0 +1,18 @@
+"""Canonical Chromium flags for browser WebGPU acceptance tests."""
+
+from __future__ import annotations
+
+
+def chrome_webgpu_test_flags(*, software_adapter: bool) -> list[str]:
+    """Return WebGPU flags, optionally forcing Chromium's test adapter."""
+
+    flags = ["--enable-unsafe-webgpu"]
+    if software_adapter:
+        flags.extend(
+            [
+                "--enable-unsafe-swiftshader",
+                "--use-webgpu-adapter=swiftshader",
+                "--use-gpu-in-tests",
+            ]
+        )
+    return flags

--- a/scripts/check-native-linkage-coverage.py
+++ b/scripts/check-native-linkage-coverage.py
@@ -32,9 +32,9 @@ PREFERRED_OWNER_REPRESENTATIVES = {
     "mech-engine": "VariableDefineF64",
     "mech-math": "AddSS<f64>",
 }
-EXPECTED_FULL_COUNT = 9_028
+EXPECTED_FULL_COUNT = 9_031
 EXPECTED_FULL_SURFACE_SHA256 = (
-    "a759bb071a8ed4975755957a9df5e92b4c20cb90ba60d2469702556ad898ed27"
+    "31add5ab4f7a5b777f4d8d90e711062d1f36a1fdd99684eded79e46a0af1b238"
 )
 OWNERS: dict[str, tuple[Path, str, str]] = {
     "mech-engine": (ROOT / "src/engine/Cargo.toml", "extended-engine", "stdlib"),

--- a/scripts/check-static-distribution-profiles.sh
+++ b/scripts/check-static-distribution-profiles.sh
@@ -296,7 +296,7 @@ if set(profiles) != expected_profiles:
     raise SystemExit(
         "static distribution profile contract failed: deterministic profile set mismatch"
     )
-expected_digest = "16d6ed2ce31a15696398540dc5b0a116836b039f4a27cbc219ce25c828fbea37"
+expected_digest = "29efa79d9ce1c2f10626775a1f3dab7274a42b747856fb3ef10f293bb70bf2e1"
 selected_digest = "a006c5b25aa925939f4973273e2aea9cac2897fbcca32dc25edd6be74631445d"
 runtime_surface = json.loads(runtime_surface_path.read_text(encoding="utf-8"))
 runtime_factories = runtime_surface.get("runtime_factories")
@@ -318,9 +318,9 @@ if actual_digest != expected_digest:
     )
 expected_surface = {
     "selected-runtime": (3, 0, 0, 0, 0, selected_digest, "sha256-canonical-id-tab-name-lf-v1"),
-    "full-runtime": (9028, 0, 0, 0, 0, expected_digest, "sha256-canonical-id-tab-name-lf-v1"),
-    "full-source": (9029, 119, 10, 52, 50, "471a0c091702b82028212f59c3d888a2b12a7cdec828e23cf9839f2e57837ecb", "sha256-canonical-id-tab-name-lf-v1"),
-    "full-compiler": (9029, 119, 10, 52, 50, "471a0c091702b82028212f59c3d888a2b12a7cdec828e23cf9839f2e57837ecb", "sha256-canonical-id-tab-name-lf-v1"),
+    "full-runtime": (9031, 0, 0, 0, 0, expected_digest, "sha256-canonical-id-tab-name-lf-v1"),
+    "full-source": (9032, 119, 10, 52, 50, "427478979de64b5ad5d05a0c7ccda8718b8bfbe8be78bc3213785b6eec6f8daf", "sha256-canonical-id-tab-name-lf-v1"),
+    "full-compiler": (9032, 119, 10, 52, 50, "427478979de64b5ad5d05a0c7ccda8718b8bfbe8be78bc3213785b6eec6f8daf", "sha256-canonical-id-tab-name-lf-v1"),
 }
 surface_keys = (
     "catalog_factory_count", "source_specializer_count", "intrinsic_count",

--- a/scripts/smoke-gpu-particles-browser.py
+++ b/scripts/smoke-gpu-particles-browser.py
@@ -366,7 +366,7 @@ def main() -> None:
                     if marker not in dom:
                         fail(f"delayed completion evidence {name} is missing; artifacts: {work}")
                     value = int(dom.split(marker, 1)[1].split('"', 1)[0])
-                    if value < 3:
+                    if value < 2:
                         fail(f"delayed completion evidence {name} was only {value}; artifacts: {work}")
                 if 'data-mech-gpu-smoke-readback-bytes="0"' not in dom:
                     fail(f"report-only elementwise dispatch copied output data to the CPU; artifacts: {work}")

--- a/scripts/smoke-gpu-particles-browser.py
+++ b/scripts/smoke-gpu-particles-browser.py
@@ -276,7 +276,7 @@ def main() -> None:
         "--particle-count",
         type=int,
         default=1_000_000,
-        help="particle lanes compiled from the checked-in source (CI uses a bounded SwiftShader workload)",
+        help="particle lanes compiled from the checked-in source",
     )
     args = parser.parse_args()
     if args.particle_count <= 0:

--- a/scripts/smoke-gpu-particles-browser.py
+++ b/scripts/smoke-gpu-particles-browser.py
@@ -352,6 +352,19 @@ def main() -> None:
             expected_backend = "wgpu" if args.backend in ("auto", "gpu") else "cpu-scalar"
             if f'data-mech-compute-backend="{expected_backend}"' not in dom:
                 fail(f"page did not select {expected_backend} compute; artifacts: {work}")
+            if expected_backend == "wgpu":
+                marker = 'data-mech-gpu-smoke-max-completions-in-flight="1"'
+                if marker not in dom:
+                    fail(f"delayed GPU completion overlapped another dispatch; artifacts: {work}")
+                for name in ("delayed-completions", "pending-observations"):
+                    marker = f'data-mech-gpu-smoke-{name}="'
+                    if marker not in dom:
+                        fail(f"delayed completion evidence {name} is missing; artifacts: {work}")
+                    value = int(dom.split(marker, 1)[1].split('"', 1)[0])
+                    if value < 3:
+                        fail(f"delayed completion evidence {name} was only {value}; artifacts: {work}")
+                if 'data-mech-gpu-smoke-readback-bytes="0"' not in dom:
+                    fail(f"report-only elementwise dispatch copied output data to the CPU; artifacts: {work}")
             print("Compute particle browser smoke passed")
             print(f"browser: {browser}")
             print(f"backend: {expected_backend}")

--- a/scripts/smoke-gpu-particles-browser.py
+++ b/scripts/smoke-gpu-particles-browser.py
@@ -271,7 +271,12 @@ def main() -> None:
         build()
     verify_package()
     browser = browser_path(args.browser)
-    mech = ROOT / "target" / "release" / ("mech.exe" if os.name == "nt" else "mech")
+    configured_mech = os.environ.get("MECH_BIN")
+    mech = Path(configured_mech) if configured_mech else (
+        ROOT / "target" / "release" / ("mech.exe" if os.name == "nt" else "mech")
+    )
+    if not mech.is_absolute():
+        mech = ROOT / mech
     if not mech.is_file():
         fail("release Mech executable is missing; rerun with --build")
 
@@ -365,6 +370,12 @@ def main() -> None:
                         fail(f"delayed completion evidence {name} was only {value}; artifacts: {work}")
                 if 'data-mech-gpu-smoke-readback-bytes="0"' not in dom:
                     fail(f"report-only elementwise dispatch copied output data to the CPU; artifacts: {work}")
+                if 'data-mech-gpu-smoke-state-advanced="true"' not in dom:
+                    fail(f"completion-backed turns did not advance rendered GPU state; artifacts: {work}")
+                if 'data-mech-gpu-smoke-disposed="true"' not in dom:
+                    fail(f"particle compute resources were not disposed during teardown; artifacts: {work}")
+                if 'data-mech-gpu-smoke-page-errors="0"' not in dom:
+                    fail(f"the particle page reported a console, page, or promise error; artifacts: {work}")
             print("Compute particle browser smoke passed")
             print(f"browser: {browser}")
             print(f"backend: {expected_backend}")

--- a/scripts/smoke-gpu-particles-browser.py
+++ b/scripts/smoke-gpu-particles-browser.py
@@ -21,6 +21,8 @@ import time
 import urllib.request
 import urllib.parse
 
+from browser_webgpu_flags import chrome_webgpu_test_flags
+
 
 ROOT = Path(__file__).resolve().parents[1]
 PACKAGE = ROOT / "src" / "wasm" / "pkg"
@@ -264,6 +266,11 @@ def main() -> None:
     parser.add_argument("--browser", help="path to Chrome or Edge")
     parser.add_argument("--build", action="store_true", help="rebuild WASM and the release server first")
     parser.add_argument("--backend", choices=("auto", "cpu", "gpu"), default="auto")
+    parser.add_argument(
+        "--software-adapter",
+        action="store_true",
+        help="force Chromium's WebGPU SwiftShader test adapter",
+    )
     parser.add_argument("--timeout", type=int, default=180)
     parser.add_argument(
         "--particle-count",
@@ -333,15 +340,16 @@ def main() -> None:
                 str(browser),
                 "--headless=new",
                 f"--remote-debugging-port={debugger_port}",
-                "--enable-unsafe-webgpu",
                 "--ignore-gpu-blocklist",
                 "--no-first-run",
                 "--no-default-browser-check",
                 "--run-all-compositor-stages-before-draw",
                 f"--user-data-dir={work / 'profile'}",
             ]
-            if sys.platform.startswith("linux"):
-                command.extend(["--no-sandbox", "--enable-features=Vulkan", "--use-angle=swiftshader"])
+            software_adapter = args.software_adapter or sys.platform.startswith("linux")
+            command.extend(chrome_webgpu_test_flags(software_adapter=software_adapter))
+            if software_adapter:
+                command.extend(["--no-sandbox", "--disable-dev-shm-usage"])
             command.append("about:blank")
             browser_process = subprocess.Popen(
                 command,

--- a/scripts/smoke-gpu-particles-browser.py
+++ b/scripts/smoke-gpu-particles-browser.py
@@ -412,6 +412,14 @@ def main() -> None:
                     fail(f"report-only elementwise dispatch copied output data to the CPU; artifacts: {work}")
                 if 'data-mech-gpu-smoke-state-advanced="true"' not in dom:
                     fail(f"completion-backed turns did not advance rendered GPU state; artifacts: {work}")
+                marker = 'data-mech-gpu-smoke-accepted-dispatches="'
+                if marker not in dom:
+                    fail(f"resident acknowledgement evidence is missing; artifacts: {work}")
+                accepted = int(dom.split(marker, 1)[1].split('"', 1)[0])
+                if accepted < 2:
+                    fail(f"only {accepted} GPU completions reached the resident host; artifacts: {work}")
+                if 'data-mech-gpu-smoke-last-accepted-dispatch-token="' not in dom:
+                    fail(f"the accepted resident dispatch identity is missing; artifacts: {work}")
                 if 'data-mech-gpu-smoke-disposed="true"' not in dom:
                     fail(f"particle compute resources were not disposed during teardown; artifacts: {work}")
                 if 'data-mech-gpu-smoke-page-errors="0"' not in dom:

--- a/scripts/smoke-gpu-particles-browser.py
+++ b/scripts/smoke-gpu-particles-browser.py
@@ -347,7 +347,10 @@ def main() -> None:
                 f"--user-data-dir={work / 'profile'}",
             ]
             software_adapter = args.software_adapter or sys.platform.startswith("linux")
-            command.extend(chrome_webgpu_test_flags(software_adapter=software_adapter))
+            command.extend(chrome_webgpu_test_flags(
+                software_adapter=software_adapter,
+                linux=sys.platform.startswith("linux"),
+            ))
             if software_adapter:
                 command.extend(["--no-sandbox", "--disable-dev-shm-usage"])
             command.append("about:blank")

--- a/scripts/smoke-gpu-particles-browser.py
+++ b/scripts/smoke-gpu-particles-browser.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run the served million-particle application through a real WebGPU browser."""
+"""Run the served particle application through a real WebGPU browser."""
 
 from __future__ import annotations
 
@@ -265,7 +265,15 @@ def main() -> None:
     parser.add_argument("--build", action="store_true", help="rebuild WASM and the release server first")
     parser.add_argument("--backend", choices=("auto", "cpu", "gpu"), default="auto")
     parser.add_argument("--timeout", type=int, default=180)
+    parser.add_argument(
+        "--particle-count",
+        type=int,
+        default=1_000_000,
+        help="particle lanes compiled from the checked-in source (CI uses a bounded SwiftShader workload)",
+    )
     args = parser.parse_args()
+    if args.particle_count <= 0:
+        fail("--particle-count must be positive")
 
     if args.build:
         build()
@@ -281,15 +289,35 @@ def main() -> None:
         fail("release Mech executable is missing; rerun with --build")
 
     port = free_port()
-    page_url = f"http://127.0.0.1:{port}/?mech-gpu-smoke=1"
+    page_url = f"http://127.0.0.1:{port}/?mech-gpu-smoke={args.particle_count}"
     work = Path(tempfile.mkdtemp(prefix="mech-gpu-smoke-"))
+    project_root = ROOT / "examples/gpu-particles"
+    project_copy: Path | None = None
+    if args.particle_count != 1_000_000:
+        target_root = ROOT / "target"
+        target_root.mkdir(exist_ok=True)
+        project_copy = Path(tempfile.mkdtemp(prefix="gpu-particles-ci-", dir=target_root))
+        shutil.copytree(project_root, project_copy, dirs_exist_ok=True)
+        particle_source = project_copy / "particles.mec"
+        source = particle_source.read_text(encoding="utf-8")
+        declaration = "particle-count := 1000000f32"
+        if source.count(declaration) != 1:
+            fail(
+                "checked-in particle source no longer has one canonical particle-count "
+                f"declaration; artifacts: {work}; project: {project_copy}"
+            )
+        particle_source.write_text(
+            source.replace(declaration, f"particle-count := {args.particle_count}f32"),
+            encoding="utf-8",
+        )
+        project_root = project_copy
     passed = False
     try:
         server_log = (work / "server.log").open("wb")
         browser_log = (work / "browser.log").open("wb")
         server = subprocess.Popen(
             [
-                str(mech), "serve", "examples/gpu-particles", "--port", str(port),
+                str(mech), "serve", str(project_root), "--port", str(port),
                 "--backend", args.backend,
             ],
             cwd=ROOT,
@@ -352,8 +380,9 @@ def main() -> None:
                 marker = 'data-mech-gpu-smoke-error="'
                 detail = dom.split(marker, 1)[1].split('"', 1)[0] if marker in dom else "acceptance marker was not reached"
                 fail(f"{detail}; artifacts: {work}")
-            if "1,000,000" not in dom:
-                fail(f"page did not report one million particles; artifacts: {work}")
+            formatted_count = f"{args.particle_count:,}"
+            if formatted_count not in dom:
+                fail(f"page did not report {formatted_count} particles; artifacts: {work}")
             expected_backend = "wgpu" if args.backend in ("auto", "gpu") else "cpu-scalar"
             if f'data-mech-compute-backend="{expected_backend}"' not in dom:
                 fail(f"page did not select {expected_backend} compute; artifacts: {work}")
@@ -379,7 +408,7 @@ def main() -> None:
             print("Compute particle browser smoke passed")
             print(f"browser: {browser}")
             print(f"backend: {expected_backend}")
-            print("particles: 1,000,000")
+            print(f"particles: {formatted_count}")
             print("compute frames: advanced")
             print("pointer -> Mech CPU transaction -> compute inputs: verified")
             passed = True
@@ -402,8 +431,12 @@ def main() -> None:
     finally:
         if passed:
             shutil.rmtree(work)
+            if project_copy is not None:
+                shutil.rmtree(project_copy)
         else:
             print(f"GPU particle smoke artifacts retained at {work}", file=sys.stderr)
+            if project_copy is not None:
+                print(f"GPU particle smoke project retained at {project_copy}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/smoke-served-resident-ekf-browser.sh
+++ b/scripts/smoke-served-resident-ekf-browser.sh
@@ -563,13 +563,14 @@ import sys
 import time
 
 chrome, page_url, profile, dom_file, chrome_log, compute_backend = sys.argv[1:]
+virtual_time_budget = int(os.environ.get("MECH_BROWSER_VIRTUAL_TIME_BUDGET_MS", "600000"))
 args = [
     chrome,
     "--headless=new",
     "--no-sandbox",
     "--disable-dev-shm-usage",
     "--run-all-compositor-stages-before-draw",
-    "--virtual-time-budget=120000",
+    f"--virtual-time-budget={virtual_time_budget}",
     "--dump-dom",
     f"--user-data-dir={profile}",
     page_url,

--- a/scripts/smoke-served-resident-ekf-browser.sh
+++ b/scripts/smoke-served-resident-ekf-browser.sh
@@ -661,7 +661,10 @@ else:
     # The canary proves the browser WebGPU transport, not host-driver setup.
     # Force Chromium's test adapter so headless macOS and GPU-less Linux CI do
     # not hang while probing an unavailable presentation-capable device.
-    for flag in chrome_webgpu_test_flags(software_adapter=True):
+    for flag in chrome_webgpu_test_flags(
+        software_adapter=True,
+        linux=sys.platform.startswith("linux"),
+    ):
         args.insert(-1, flag)
 
 def read_exact(connection, length):

--- a/scripts/smoke-served-resident-ekf-browser.sh
+++ b/scripts/smoke-served-resident-ekf-browser.sh
@@ -145,6 +145,7 @@ harness = r'''<script>
     let sawCamera = false;
     let maxVisibleCameras = 0;
     let previousVisibleCameraCount;
+    let paritySnapshot;
     const visibleCameraHistory = [];
     let stableCameraGeometry;
     let cameraGeometryStable = true;
@@ -309,12 +310,10 @@ harness = r'''<script>
         sawNoCamera ||= visibleCameraCount === 0;
         sawCamera ||= visibleCameraCount > 0;
         maxVisibleCameras = Math.max(maxVisibleCameras, visibleCameraCount);
-        // WebGPU completion is consumed by the next resident turn, so its
-        // sampled estimate corresponds to the preceding turn's measurement.
-        // The scalar backend completes inside the current turn.
-        const filterVisibleCameraCount = root.dataset.mechComputeBackend === "wgpu"
-          ? previousVisibleCameraCount
-          : visibleCameraCount;
+        // Asynchronous WebGPU completion publishes the originating turn
+        // directly, so its sampled estimate and camera visibility share one
+        // resident snapshot just like the scalar backend.
+        const filterVisibleCameraCount = visibleCameraCount;
         if (filterVisibleCameraCount === 0 && isComputeCompletionFrame) {
           const predictionGap = finitePoint(estimate) && finitePoint(prediction)
             ? Math.hypot(
@@ -322,9 +321,6 @@ harness = r'''<script>
                 Number(estimate.getAttribute("cy")) - Number(prediction.getAttribute("cy")),
               )
             : Number.POSITIVE_INFINITY;
-          // The WGPU sample is consumed asynchronously, one resident output
-          // behind the live ray geometry. At reacquisition boundaries permit
-          // only a subpixel remnant; sustained dead-zone samples coincide.
           const comparisonValid = predictionGap <= 0.25;
           predictionOnlyValid &&= Boolean(comparisonValid);
           if (comparisonValid) predictionOnlyComparisons += 1;
@@ -415,6 +411,17 @@ harness = r'''<script>
       );
       const computeBackend = root.dataset.mechComputeBackend || "";
       const computeInstances = Number(root.dataset.mechComputeInstances || 0);
+      if (
+        paritySnapshot === undefined && observedLapComplete &&
+        finitePoint(truth) && finitePoint(estimate) && covarianceGeometry.finite
+      ) {
+        paritySnapshot = {
+          updates,
+          truth: [Number(truth.getAttribute("cx")), Number(truth.getAttribute("cy"))],
+          estimate: [Number(estimate.getAttribute("cx")), Number(estimate.getAttribute("cy"))],
+          covarianceExtent: covarianceGeometry.extent,
+        };
+      }
 
       root.dataset.mechObservedUpdates = String(updates);
       root.dataset.mechObservedSquareSides = ["east", "north", "west", "south"]
@@ -496,6 +503,16 @@ harness = r'''<script>
         root.dataset.mechEstimatePathPoints = String(estimatePathGeometry.points);
         root.dataset.mechEstimatePathFinite = String(estimatePathGeometry.finite);
         root.dataset.mechTrackingErrorPixels = trackingError.toFixed(4);
+        root.dataset.mechTruthX = truth.getAttribute("cx");
+        root.dataset.mechTruthY = truth.getAttribute("cy");
+        root.dataset.mechEstimateX = estimate.getAttribute("cx");
+        root.dataset.mechEstimateY = estimate.getAttribute("cy");
+        root.dataset.mechParityUpdates = String(paritySnapshot.updates);
+        root.dataset.mechParityTruthX = String(paritySnapshot.truth[0]);
+        root.dataset.mechParityTruthY = String(paritySnapshot.truth[1]);
+        root.dataset.mechParityEstimateX = String(paritySnapshot.estimate[0]);
+        root.dataset.mechParityEstimateY = String(paritySnapshot.estimate[1]);
+        root.dataset.mechParityCovarianceExtent = String(paritySnapshot.covarianceExtent);
         root.dataset.mechSceneVisible = String(sceneVisible);
         root.dataset.mechOutputPresentation = String(outputPresentation);
         root.dataset.mechVerifiedComputeBackend = computeBackend;
@@ -614,6 +631,16 @@ if [[ "$chrome_status" -ne 0 && "$chrome_status" -ne 124 ]] \
   || ! grep -q "data-mech-verified-compute-backend=\"$expected_compute_backend\"" "$dom_file" \
   || ! grep -q 'data-mech-verified-compute-instances="1000"' "$dom_file" \
   || ! grep -q 'data-mech-tracking-error-pixels="[0-9]' "$dom_file" \
+  || ! grep -q 'data-mech-truth-x="[0-9]' "$dom_file" \
+  || ! grep -q 'data-mech-truth-y="[0-9]' "$dom_file" \
+  || ! grep -q 'data-mech-estimate-x="[0-9]' "$dom_file" \
+  || ! grep -q 'data-mech-estimate-y="[0-9]' "$dom_file" \
+  || ! grep -qE 'data-mech-parity-updates="[3-9][0-9][0-9]"' "$dom_file" \
+  || ! grep -q 'data-mech-parity-truth-x="[0-9]' "$dom_file" \
+  || ! grep -q 'data-mech-parity-truth-y="[0-9]' "$dom_file" \
+  || ! grep -q 'data-mech-parity-estimate-x="[0-9]' "$dom_file" \
+  || ! grep -q 'data-mech-parity-estimate-y="[0-9]' "$dom_file" \
+  || ! grep -q 'data-mech-parity-covariance-extent="[0-9]' "$dom_file" \
   || [[ -z "$updates" || "$updates" -lt 376 ]] \
   || grep -qE 'data-mech-(console-error|page-error|timed-out)=' "$dom_file"; then
   echo "Served resident EKF browser smoke test failed" >&2
@@ -649,4 +676,33 @@ turning_samples="$(sed -n 's/.*data-mech-turning-samples="\([0-9][0-9]*\)".*/\1/
 max_heading_step="$(sed -n 's/.*data-mech-max-heading-step="\([0-9.][0-9.]*\)".*/\1/p' "$dom_file" | head -1)"
 max_guide_deviation="$(sed -n 's/.*data-mech-max-guide-deviation="\([0-9.][0-9.]*\)".*/\1/p' "$dom_file" | head -1)"
 covariance_extent="$(sed -n 's/.*data-mech-covariance-extent="\([0-9.][0-9.]*\)".*/\1/p' "$dom_file" | head -1)"
+truth_x="$(sed -n 's/.*data-mech-truth-x="\([0-9.][0-9.]*\)".*/\1/p' "$dom_file" | head -1)"
+truth_y="$(sed -n 's/.*data-mech-truth-y="\([0-9.][0-9.]*\)".*/\1/p' "$dom_file" | head -1)"
+estimate_x="$(sed -n 's/.*data-mech-estimate-x="\([0-9.][0-9.]*\)".*/\1/p' "$dom_file" | head -1)"
+estimate_y="$(sed -n 's/.*data-mech-estimate-y="\([0-9.][0-9.]*\)".*/\1/p' "$dom_file" | head -1)"
+parity_updates="$(sed -n 's/.*data-mech-parity-updates="\([0-9][0-9]*\)".*/\1/p' "$dom_file" | head -1)"
+parity_truth_x="$(sed -n 's/.*data-mech-parity-truth-x="\([0-9.][0-9.]*\)".*/\1/p' "$dom_file" | head -1)"
+parity_truth_y="$(sed -n 's/.*data-mech-parity-truth-y="\([0-9.][0-9.]*\)".*/\1/p' "$dom_file" | head -1)"
+parity_estimate_x="$(sed -n 's/.*data-mech-parity-estimate-x="\([0-9.][0-9.]*\)".*/\1/p' "$dom_file" | head -1)"
+parity_estimate_y="$(sed -n 's/.*data-mech-parity-estimate-y="\([0-9.][0-9.]*\)".*/\1/p' "$dom_file" | head -1)"
+parity_covariance_extent="$(sed -n 's/.*data-mech-parity-covariance-extent="\([0-9.][0-9.]*\)".*/\1/p' "$dom_file" | head -1)"
+if [[ -n "${MECH_EKF_RESULT_FILE:-}" ]]; then
+  python3 - "$MECH_EKF_RESULT_FILE" "$compute_backend" "$parity_updates" \
+    "$parity_truth_x" "$parity_truth_y" "$parity_estimate_x" "$parity_estimate_y" \
+    "$parity_covariance_extent" "$tracking_error_pixels" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+path, backend, updates, truth_x, truth_y, estimate_x, estimate_y, covariance, tracking = sys.argv[1:]
+Path(path).write_text(json.dumps({
+    "backend": backend,
+    "updates": int(updates),
+    "truth": [float(truth_x), float(truth_y)],
+    "estimate": [float(estimate_x), float(estimate_y)],
+    "covariance_extent": float(covariance),
+    "tracking_error": float(tracking),
+}, sort_keys=True))
+PY
+fi
 printf 'EKF_E2E display_updates=%s requested_compute_backend=%s compute_backend=%s compute_instances=1000 cameras=4 max_visible_cameras=1 saw_no_camera=true square_sides=4 lap_complete=true smooth_turning=true turning_samples=%s max_heading_step=%s max_guide_deviation_pixels=%s truth_moved=true covariance_finite=true covariance_extent_pixels=%s paths_finite=true tracking_error_pixels=%s output_presentation=true console_errors=0 page_errors=0\n' "$updates" "$compute_backend" "$expected_compute_backend" "$turning_samples" "$max_heading_step" "$max_guide_deviation" "$covariance_extent" "$tracking_error_pixels"

--- a/scripts/smoke-served-resident-ekf-browser.sh
+++ b/scripts/smoke-served-resident-ekf-browser.sh
@@ -60,6 +60,14 @@ if [[ ! "$filter_count" =~ ^[1-9][0-9]*$ ]]; then
   echo "MECH_EKF_FILTER_COUNT must be a positive integer" >&2
   exit 1
 fi
+continuity_edit="${MECH_EKF_CONTINUITY_EDIT:-true}"
+case "$continuity_edit" in
+  true|false) ;;
+  *)
+    echo "MECH_EKF_CONTINUITY_EDIT must be true or false" >&2
+    exit 1
+    ;;
+esac
 python3 - "$project_dir/localization.mec" "$filter_count" <<'PY'
 from pathlib import Path
 import sys
@@ -121,19 +129,22 @@ if [[ ! -s "$project_dir/index.html" ]]; then
   exit 1
 fi
 
-python3 - "$project_dir/index.html" "$expected_compute_backend" "$filter_count" <<'PY'
+python3 - "$project_dir/index.html" "$expected_compute_backend" "$filter_count" \
+  "$continuity_edit" <<'PY'
 from pathlib import Path
 import sys
 
 path = Path(sys.argv[1])
 compute_backend = sys.argv[2]
 filter_count = sys.argv[3]
+continuity_edit = sys.argv[4]
 html = path.read_text()
 marker = "</head>"
 harness = r'''<script>
     const root = document.documentElement;
     const expectedComputeBackend = "__MECH_EXPECTED_COMPUTE_BACKEND__";
     const expectedComputeInstances = Number("__MECH_EXPECTED_COMPUTE_INSTANCES__");
+    const performContinuityEdit = "__MECH_PERFORM_CONTINUITY_EDIT__" === "true";
     const originalConsoleError = console.error;
     const diagnosticText = (value) => value?.stack || value?.message || String(value);
     console.error = (...args) => {
@@ -154,12 +165,25 @@ harness = r'''<script>
     let continuityNextSample;
     let continuityEditRequested = false;
     let continuityGenerationChanged = false;
-    let continuityResourcePreserved = expectedComputeBackend !== "wgpu";
-    let continuityActiveBufferPreserved = expectedComputeBackend !== "wgpu";
+    let continuityResourcePreserved =
+      expectedComputeBackend !== "wgpu" || !performContinuityEdit;
+    let continuityActiveBufferPreserved =
+      expectedComputeBackend !== "wgpu" || !performContinuityEdit;
     let continuityBefore;
     let busyReplacementAttempted = false;
     let busyReplacementRejected = expectedComputeBackend !== "wgpu";
-    let busyGeneration;
+    let busySourceUntouched = expectedComputeBackend !== "wgpu";
+    let busySymbolAbsent = expectedComputeBackend !== "wgpu";
+    let busyLogicalProgressUnchanged = expectedComputeBackend !== "wgpu";
+    let applicationQualifiedBeforeReset = false;
+    let incompatibleEditRequested = expectedComputeBackend !== "wgpu";
+    let incompatibleGenerationChanged = expectedComputeBackend !== "wgpu";
+    let incompatibleResourcesReplaced = expectedComputeBackend !== "wgpu";
+    let incompatibleOldResourceDisposed = expectedComputeBackend !== "wgpu";
+    let incompatibleStateReset = expectedComputeBackend !== "wgpu";
+    let incompatibleResetDiagnostic = expectedComputeBackend !== "wgpu";
+    let incompatibleBefore;
+    let computeStateResetEvents = 0;
     let displayParityTrackingError;
     let computeReadbackBytes = 0;
     let sampledReadbackEfficient = true;
@@ -172,7 +196,10 @@ harness = r'''<script>
       state: root.dataset.mechComputeStateIdentity || "",
       pipelineBuilds: root.dataset.mechComputePipelineBuildCount || "",
       activeBuffer: root.dataset.mechComputeActiveBuffer || "",
+      dispatches: root.dataset.mechComputeDispatches || "",
     });
+    const acceptedSource = () =>
+      globalThis.__MECH_ACCEPTED_REPL_SOURCE__?.() || "";
     const submitResidentSource = (source) => {
       const input = document.querySelector(".mech-repl-active-prompt .repl-input");
       if (!input || input.disabled || input.readOnly) return false;
@@ -211,8 +238,61 @@ harness = r'''<script>
         Number(root.dataset.mechComputeDispatches || 0) !== busyReplacementTurn
       ) return;
       busyReplacementAttempted = true;
-      busyGeneration = root.dataset.mechComputeGeneration || "";
-      submitResidentSource("busy-replacement-probe := 1");
+      const before = computeIdentity();
+      const logicalTurnBefore = renderedFilterTurn();
+      const sourceBefore = acceptedSource();
+      const submitted = submitResidentSource("busy-replacement-probe := 1");
+      const after = computeIdentity();
+      const logicalTurnAfter = renderedFilterTurn();
+      const sourceAfter = acceptedSource();
+      busySourceUntouched = Boolean(
+        submitted && sourceAfter === sourceBefore &&
+        !sourceAfter.includes("busy-replacement-probe")
+      );
+      busySymbolAbsent =
+        globalThis.__MECH_RENDERED_DOCUMENT_VALUE__?.("busy-replacement-probe") == null;
+      busyLogicalProgressUnchanged = Boolean(
+        after.generation === before.generation &&
+        after.dispatches === before.dispatches &&
+        after.activeBuffer === before.activeBuffer &&
+        logicalTurnAfter === logicalTurnBefore
+      );
+      busyReplacementRejected = Boolean(
+        busySourceUntouched && busySymbolAbsent && busyLogicalProgressUnchanged &&
+        document.querySelector(
+          '[data-mech-diagnostic-code="ComputeSourceReplacementBusy"]',
+        )
+      );
+    });
+    window.addEventListener("mech:compute-state-reset", (event) => {
+      computeStateResetEvents += 1;
+      const after = computeIdentity();
+      incompatibleGenerationChanged = Boolean(
+        incompatibleBefore && after.generation !== incompatibleBefore.generation
+      );
+      incompatibleResourcesReplaced = Boolean(
+        incompatibleBefore && after.revision !== incompatibleBefore.revision &&
+        after.resource !== incompatibleBefore.resource &&
+        after.device !== incompatibleBefore.device &&
+        after.pipeline !== incompatibleBefore.pipeline &&
+        after.state !== incompatibleBefore.state &&
+        Number(after.pipelineBuilds) === Number(incompatibleBefore.pipelineBuilds) + 1
+      );
+      incompatibleOldResourceDisposed = Boolean(
+        incompatibleBefore &&
+        event.detail?.retiredResourceIdentity === incompatibleBefore.resource &&
+        event.detail?.retiredResourceDisposed === true
+      );
+      incompatibleStateReset = Boolean(
+        after.activeBuffer === "0" && after.dispatches === "0"
+      );
+      incompatibleResetDiagnostic = Boolean(
+        computeStateResetEvents === 1 && event.detail?.resetCount === 1 &&
+        Number(root.dataset.mechComputeStateResets || 0) === 1 &&
+        document.querySelectorAll(
+          '[data-mech-diagnostic-code="ComputeStateReset"]',
+        ).length === 1
+      );
     });
     window.addEventListener("mech:compute-complete", (event) => {
       const completedTurns = event.detail?.completedTurns;
@@ -245,13 +325,17 @@ harness = r'''<script>
     });
     window.addEventListener("mech:compute-complete", (event) => {
       const completedTurns = event.detail?.completedTurns;
-      if (completedTurns === continuityEditTurn && !continuityEditRequested) {
+      if (
+        performContinuityEdit && completedTurns === continuityEditTurn &&
+        !continuityEditRequested
+      ) {
         continuityBefore = computeIdentity();
         continuityEditRequested = submitResidentSource("continuity-probe := 1");
         return;
       }
       if (
-        continuityEditRequested && continuityNextSample === undefined &&
+        (continuityEditRequested || !performContinuityEdit) &&
+        continuityNextSample === undefined &&
         completedTurns > continuityEditTurn
       ) {
         const output = event.detail.outputs?.find(candidate => candidate.name === "result.0");
@@ -259,6 +343,24 @@ harness = r'''<script>
         if (values.length === 15 && values.every(Number.isFinite)) {
           continuityNextSample = values;
         }
+      }
+      if (
+        expectedComputeBackend === "wgpu" && applicationQualifiedBeforeReset &&
+        !incompatibleEditRequested
+      ) {
+        const source = acceptedSource();
+        const nextSource = source.replace(
+          `filter-count := ${expectedComputeInstances}.0`,
+          `filter-count := ${expectedComputeInstances + 1}.0`,
+        );
+        if (nextSource === source) {
+          throw new Error(
+            "the incompatible EKF source probe could not change the compute storage shape",
+          );
+        }
+        incompatibleBefore = computeIdentity();
+        const accepted = globalThis.__MECH_REPLACE_ACCEPTED_REPL_SOURCE__?.(nextSource);
+        incompatibleEditRequested = accepted === nextSource;
       }
     });
 
@@ -290,6 +392,42 @@ harness = r'''<script>
     let predictionOnlyFailure;
     let sawInsideCameraRange = false;
     let sawOutsideCameraRange = false;
+    let cameraToggleDisableRequested = false;
+    let cameraToggleDisabled = false;
+    let cameraToggleMeasurementBlocked = false;
+    let cameraToggleEnableRequested = false;
+    let cameraToggleRestored = false;
+    let cameraToggleVisualStateValid = false;
+    let cameraToggleDispatchBeforeDisable = -1;
+    let cameraToggleDispatchBeforeEnable = -1;
+    // Keep the interaction proof outside the turn-121 continuity oracle and
+    // the turn-376 backend parity oracle. That makes the numerical baselines
+    // independent of browser presentation cadence while still exercising a
+    // real disabled measurement on the same resident application run.
+    const cameraToggleDisableTurn = 380;
+    const clickSceneCamera = camera => {
+      const rect = camera?.getBoundingClientRect();
+      if (!rect || rect.width <= 0 || rect.height <= 0) return false;
+      const clientX = rect.left + rect.width / 2;
+      const clientY = rect.top + rect.height / 2;
+      const handled = !camera.dispatchEvent(new PointerEvent("pointerdown", {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        buttons: 1,
+        clientX,
+        clientY,
+      }));
+      window.dispatchEvent(new PointerEvent("pointerup", {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        buttons: 0,
+        clientX,
+        clientY,
+      }));
+      return handled;
+    };
     window.requestAnimationFrame = (callback) => originalSetTimeout(() => {
       if (root.dataset.mechDone === "true" || root.dataset.mechTimedOut === "true") return;
       callback(performance.now());
@@ -315,8 +453,14 @@ harness = r'''<script>
       const title = document.querySelector('[data-mech-scene-id="title"]');
       const cameras = [...document.querySelectorAll('[data-mech-scene-id^="camera-"]')]
         .filter(element => /^camera-[1-4]$/.test(element.dataset.mechSceneId || ""));
+      const disabledCameras = [...document.querySelectorAll(
+        '[data-mech-scene-id^="camera-disabled-"]',
+      )];
       const cameraRanges = [...document.querySelectorAll('[data-mech-scene-id^="camera-range-"]')];
       const cameraRays = [...document.querySelectorAll('[data-mech-scene-id^="ray-"]')];
+      const cameraLabels = [...document.querySelectorAll(
+        '[data-mech-scene-id^="camera-label-"]',
+      )];
       const host = document.querySelector('[data-mech-repl-host]');
       const outputPanel = document.querySelector('[data-mech-console-panel="output"]');
       const errorPanel = document.querySelector('[data-mech-console-panel="errors"]');
@@ -329,21 +473,17 @@ harness = r'''<script>
         : undefined;
       if (
         expectedComputeBackend === "cpu-scalar" &&
+        performContinuityEdit &&
         completedFilterTurn === continuityEditTurn &&
         !continuityEditRequested
       ) {
         continuityBefore = computeIdentity();
         continuityEditRequested = submitResidentSource("continuity-probe := 1");
       }
-      if (busyReplacementAttempted && !busyReplacementRejected) {
-        busyReplacementRejected = Boolean(
-          root.dataset.mechComputeGeneration === busyGeneration &&
-          document.querySelector(
-            '[data-mech-diagnostic-code="ComputeSourceReplacementBusy"]',
-          )
-        );
-      }
-      if (continuityEditRequested && continuityBefore) {
+      if (
+        continuityEditRequested && continuityBefore &&
+        !continuityGenerationChanged
+      ) {
         const after = computeIdentity();
         if (after.generation && after.generation !== continuityBefore.generation) {
           continuityGenerationChanged = true;
@@ -362,7 +502,8 @@ harness = r'''<script>
         }
       }
       if (
-        expectedComputeBackend === "cpu-scalar" && continuityEditRequested &&
+        expectedComputeBackend === "cpu-scalar" &&
+        (continuityEditRequested || !performContinuityEdit) &&
         continuityNextSample === undefined &&
         completedFilterTurn === continuityEditTurn + 1
       ) {
@@ -430,6 +571,9 @@ harness = r'''<script>
       if (truthPoint && updates > 0 && updates !== lastObservedUpdate) {
         lastObservedUpdate = updates;
         const computeDispatches = Number(root.dataset.mechComputeDispatches || 0);
+        const logicalComputeTurn = expectedComputeBackend === "cpu-scalar"
+          ? Number(completedFilterTurn)
+          : computeDispatches;
         const isComputeCompletionFrame = expectedComputeBackend === "cpu-scalar"
           ? Number.isFinite(completedFilterTurn) &&
             completedFilterTurn !== lastObservedCpuFilterTurn
@@ -453,13 +597,12 @@ harness = r'''<script>
           const x = Number(camera?.getAttribute("cx"));
           const y = Number(camera?.getAttribute("cy"));
           const radius = Number(camera?.getAttribute("r"));
-          const opacity = Number(camera?.getAttribute("opacity"));
           const rangeX = Number(range?.getAttribute("cx"));
           const rangeY = Number(range?.getAttribute("cy"));
           const rangeRadius = Number(range?.getAttribute("r"));
           const rayX = Number(ray?.getAttribute("x1"));
           const rayY = Number(ray?.getAttribute("y1"));
-          return {x, y, radius, opacity, rangeX, rangeY, rangeRadius, rayX, rayY};
+          return {x, y, radius, rangeX, rangeY, rangeRadius, rayX, rayY};
         });
         if (stableCameraGeometry === undefined) {
           stableCameraGeometry = currentCameraGeometry;
@@ -470,10 +613,59 @@ harness = r'''<script>
         cameraGeometryStable &&= currentCameraGeometry.length === 4 &&
           currentCameraGeometry.every(sensor =>
             Object.values(sensor).every(Number.isFinite) &&
-            sensor.radius === 9 && sensor.opacity === 1 &&
+            sensor.radius === 9 &&
             sensor.x === sensor.rangeX && sensor.y === sensor.rangeY &&
             sensor.x === sensor.rayX && sensor.y === sensor.rayY
           );
+        const enabledMask = renderedDocumentNumbers("camera-enabled");
+        const cameraToggleStateReadable = enabledMask.length === 4 &&
+          enabledMask.every(value => value === 0 || value === 1);
+        const filterVisibility = renderedFilterVisibility();
+        if (
+          !cameraToggleDisableRequested && logicalComputeTurn === cameraToggleDisableTurn &&
+          cameraToggleStateReadable && enabledMask.every(value => value === 1) &&
+          Number.isFinite(filterVisibility) && filterVisibility > 0
+        ) {
+          cameraToggleDispatchBeforeDisable = logicalComputeTurn;
+          cameraToggleDisableRequested = clickSceneCamera(orderedCameras[0]);
+        }
+        if (
+          cameraToggleDisableRequested && !cameraToggleDisabled &&
+          cameraToggleStateReadable && enabledMask[0] === 0 &&
+          enabledMask.slice(1).every(value => value === 1)
+        ) {
+          const activeOpacity = Number(orderedCameras[0]?.getAttribute("opacity"));
+          const disabledOpacity = Number(indexed(disabledCameras, "camera-disabled-")[0]
+            ?.getAttribute("opacity"));
+          const rangeOpacity = Number(orderedRanges[0]?.getAttribute("opacity"));
+          const rayOpacity = Number(orderedRays[0]?.getAttribute("opacity"));
+          const labelOpacity = Number(indexed(cameraLabels, "camera-label-")[0]
+            ?.getAttribute("opacity"));
+          cameraToggleVisualStateValid = activeOpacity === 0 && disabledOpacity === 1 &&
+            rangeOpacity === 0 && rayOpacity === 0 && labelOpacity === 0.32;
+          cameraToggleDisabled = cameraToggleVisualStateValid;
+        }
+        if (
+          cameraToggleDisabled && !cameraToggleMeasurementBlocked &&
+          logicalComputeTurn > cameraToggleDispatchBeforeDisable && filterVisibility === 0
+        ) {
+          cameraToggleMeasurementBlocked = true;
+          cameraToggleDispatchBeforeEnable = logicalComputeTurn;
+          cameraToggleEnableRequested = clickSceneCamera(orderedCameras[0]);
+        }
+        if (
+          cameraToggleEnableRequested && cameraToggleStateReadable &&
+          enabledMask.every(value => value === 1) &&
+          logicalComputeTurn > cameraToggleDispatchBeforeEnable &&
+          Number.isFinite(filterVisibility) && filterVisibility > 0
+        ) {
+          const activeOpacity = Number(orderedCameras[0]?.getAttribute("opacity"));
+          const disabledOpacity = Number(indexed(disabledCameras, "camera-disabled-")[0]
+            ?.getAttribute("opacity"));
+          const rangeOpacity = Number(orderedRanges[0]?.getAttribute("opacity"));
+          cameraToggleRestored = activeOpacity === 1 && disabledOpacity === 0 &&
+            rangeOpacity === 0.16;
+        }
         let visibleCameraCount = 0;
         for (let index = 0; index < currentCameraGeometry.length; index += 1) {
           const sensor = currentCameraGeometry[index];
@@ -483,7 +675,8 @@ harness = r'''<script>
           const expectedVisibility = Math.max(0, Math.min(1,
             (sensor.rangeRadius - distance) / fadeWidth,
           ));
-          const expectedRayOpacity = 0.4 * expectedVisibility;
+          const cameraEnabled = cameraToggleStateReadable ? enabledMask[index] : 1;
+          const expectedRayOpacity = 0.4 * expectedVisibility * cameraEnabled;
           cameraRangeOracleValid &&= Number.isFinite(rayOpacity) &&
             Math.abs(rayOpacity - expectedRayOpacity) <= 1e-9;
           if (distance >= sensor.rangeRadius) {
@@ -500,7 +693,6 @@ harness = r'''<script>
         // Asynchronous WebGPU completion publishes the originating turn
         // directly, so its sampled estimate and camera visibility share one
         // resident snapshot just like the scalar backend.
-        const filterVisibility = renderedFilterVisibility();
         if (filterVisibility === 0 && isComputeCompletionFrame) {
           const predictionGap = finitePoint(estimate) && finitePoint(prediction)
             ? Math.hypot(
@@ -656,6 +848,10 @@ harness = r'''<script>
         String(busyReplacementAttempted);
       root.dataset.mechObservedBusyReplacementRejected =
         String(busyReplacementRejected);
+      root.dataset.mechObservedBusySourceUntouched = String(busySourceUntouched);
+      root.dataset.mechObservedBusySymbolAbsent = String(busySymbolAbsent);
+      root.dataset.mechObservedBusyLogicalProgressUnchanged =
+        String(busyLogicalProgressUnchanged);
       root.dataset.mechObservedComputeStateResets =
         root.dataset.mechComputeStateResets || "0";
       root.dataset.mechObservedStaleCompletionRejected =
@@ -669,20 +865,71 @@ harness = r'''<script>
       root.dataset.mechObservedErrorText = (errorPanel?.textContent || "").trim().slice(0, 1000);
       root.dataset.mechObservedDisplayIds = [...document.querySelectorAll('[data-mech-display-id]')]
         .map(element => element.dataset.mechDisplayId).join(",");
-      if (
+      root.dataset.mechObservedApplicationQualifiedBeforeReset =
+        String(applicationQualifiedBeforeReset);
+      root.dataset.mechObservedCameraToggleDisableRequested =
+        String(cameraToggleDisableRequested);
+      root.dataset.mechObservedCameraToggleDisabled = String(cameraToggleDisabled);
+      root.dataset.mechObservedCameraToggleMeasurementBlocked =
+        String(cameraToggleMeasurementBlocked);
+      root.dataset.mechObservedCameraToggleEnableRequested =
+        String(cameraToggleEnableRequested);
+      root.dataset.mechObservedCameraToggleRestored = String(cameraToggleRestored);
+      root.dataset.mechObservedCameraEnabled = JSON.stringify(
+        renderedDocumentNumbers("camera-enabled"),
+      );
+      root.dataset.mechObservedScenePointerPulse = JSON.stringify(
+        renderedDocumentNumbers("scene-pointer-pulse"),
+      );
+      root.dataset.mechObservedScenePointerSurface = String(Boolean(
+        scene?.dataset.mechScenePointerSurface,
+      ));
+      root.dataset.mechObservedScenePointerSubmissions =
+        document.querySelector(".mech-root")?.dataset.mechScenePointerSubmissions || "0";
+      root.dataset.mechObservedScenePointerPosition =
+        document.querySelector(".mech-root")?.dataset.mechScenePointerPosition || "";
+      root.dataset.mechObservedCameraOneOpacity =
+        document.querySelector('[data-mech-scene-id="camera-1"]')?.getAttribute("opacity") || "";
+      root.dataset.mechObservedCameraDisabledOneOpacity = document.querySelector(
+        '[data-mech-scene-id="camera-disabled-1"]',
+      )?.getAttribute("opacity") || "";
+      root.dataset.mechObservedIncompatibleEditRequested =
+        String(incompatibleEditRequested);
+      root.dataset.mechObservedIncompatibleGenerationChanged =
+        String(incompatibleGenerationChanged);
+      root.dataset.mechObservedIncompatibleResourcesReplaced =
+        String(incompatibleResourcesReplaced);
+      root.dataset.mechObservedIncompatibleOldResourceDisposed =
+        String(incompatibleOldResourceDisposed);
+      root.dataset.mechObservedIncompatibleStateReset = String(incompatibleStateReset);
+      root.dataset.mechObservedIncompatibleResetDiagnostic =
+        String(incompatibleResetDiagnostic);
+      root.dataset.mechObservedComputeStateResetEvents = String(computeStateResetEvents);
+      const continuityQualified = Boolean(
+        continuityNextSample !== undefined &&
+        (!performContinuityEdit || (
+          continuityEditRequested && continuityGenerationChanged &&
+          continuityResourcePreserved && continuityActiveBufferPreserved
+        ))
+      );
+      const preResetQualified = Boolean(
         updates >= 376 &&
         finitePointContract &&
         cameras.length === 4 && cameraRanges.length === 4 && cameraRays.length === 4 &&
         cameraGeometryStable && cameraRangeOracleValid && predictionOnlyValid &&
         predictionOnlyComparisons > 0 &&
+        cameraToggleDisableRequested && cameraToggleDisabled &&
+        cameraToggleMeasurementBlocked && cameraToggleEnableRequested &&
+        cameraToggleRestored && cameraToggleVisualStateValid &&
+        cameraToggleDispatchBeforeDisable === cameraToggleDisableTurn &&
+        Number(document.querySelector(".mech-root")?.dataset.mechScenePointerSubmissions) === 4 &&
         computeParitySample !== undefined &&
         displayParityTrackingError !== undefined &&
         sampledReadbackEfficient &&
-        continuityEditRequested && continuityGenerationChanged &&
-        continuityResourcePreserved && continuityActiveBufferPreserved &&
-        continuityNextSample !== undefined &&
-        busyReplacementRejected &&
-        (expectedComputeBackend !== "wgpu" ||
+        continuityQualified &&
+        busyReplacementRejected && busySourceUntouched && busySymbolAbsent &&
+        busyLogicalProgressUnchanged &&
+        (expectedComputeBackend !== "wgpu" || !performContinuityEdit ||
           root.dataset.mechComputeStaleCompletionRejected === "true") &&
         Number(root.dataset.mechComputeStateResets || 0) === 0 &&
         sawInsideCameraRange && sawOutsideCameraRange &&
@@ -703,7 +950,22 @@ harness = r'''<script>
         title?.textContent === "Camera EKF Localization" &&
         sceneVisible && outputPresentation &&
         computeBackend === expectedComputeBackend && computeInstances === expectedComputeInstances
-      ) {
+      );
+      if (preResetQualified) applicationQualifiedBeforeReset = true;
+      const incompatibleQualified = Boolean(
+        incompatibleEditRequested && incompatibleGenerationChanged &&
+        incompatibleResourcesReplaced && incompatibleOldResourceDisposed &&
+        incompatibleStateReset &&
+        incompatibleResetDiagnostic &&
+        computeStateResetEvents === (expectedComputeBackend === "wgpu" ? 1 : 0) &&
+        Number(root.dataset.mechComputeStateResets || 0) ===
+          (expectedComputeBackend === "wgpu" ? 1 : 0) &&
+        (expectedComputeBackend !== "wgpu" ||
+          document.querySelectorAll(
+            '[data-mech-diagnostic-code="ComputeStateReset"]',
+          ).length === 1)
+      );
+      if (applicationQualifiedBeforeReset && incompatibleQualified) {
         root.dataset.mechUpdates = String(updates);
         root.dataset.mechCameras = String(cameras.length);
         root.dataset.mechCameraRanges = String(cameraRanges.length);
@@ -711,6 +973,12 @@ harness = r'''<script>
         root.dataset.mechSawCamera = String(sawCamera);
         root.dataset.mechMaxVisibleCameras = String(maxVisibleCameras);
         root.dataset.mechCameraGeometryStable = String(cameraGeometryStable);
+        root.dataset.mechCameraToggleDisabled = String(cameraToggleDisabled);
+        root.dataset.mechCameraToggleMeasurementBlocked =
+          String(cameraToggleMeasurementBlocked);
+        root.dataset.mechCameraToggleRestored = String(cameraToggleRestored);
+        root.dataset.mechCameraTogglePointerSubmissions =
+          document.querySelector(".mech-root")?.dataset.mechScenePointerSubmissions || "0";
         root.dataset.mechCameraRangeOracle = String(cameraRangeOracleValid);
         root.dataset.mechPredictionOnly = String(predictionOnlyValid);
         root.dataset.mechPredictionOnlyComparisons = String(predictionOnlyComparisons);
@@ -753,11 +1021,29 @@ harness = r'''<script>
           String(continuityActiveBufferPreserved);
         root.dataset.mechContinuityNextSample = continuityNextSample.join(",");
         root.dataset.mechBusyReplacementRejected = String(busyReplacementRejected);
+        root.dataset.mechBusySourceUntouched = String(busySourceUntouched);
+        root.dataset.mechBusySymbolAbsent = String(busySymbolAbsent);
+        root.dataset.mechBusyLogicalProgressUnchanged =
+          String(busyLogicalProgressUnchanged);
         root.dataset.mechStaleCompletionRejected =
           root.dataset.mechComputeStaleCompletionRejected || "true";
+        root.dataset.mechIncompatibleGenerationChanged =
+          String(incompatibleGenerationChanged);
+        root.dataset.mechIncompatibleResourcesReplaced =
+          String(incompatibleResourcesReplaced);
+        root.dataset.mechIncompatibleOldResourceDisposed =
+          String(incompatibleOldResourceDisposed);
+        root.dataset.mechIncompatibleStateReset = String(incompatibleStateReset);
+        root.dataset.mechIncompatibleResetDiagnostic =
+          String(incompatibleResetDiagnostic);
         root.dataset.mechComputeStateResetsVerified =
           root.dataset.mechComputeStateResets || "0";
         root.dataset.mechDone = "true";
+        globalThis.__MECH_STOP__?.();
+        return;
+      }
+      if (updates >= 450 && !cameraToggleDisabled) {
+        root.dataset.mechTimedOut = "true";
         globalThis.__MECH_STOP__?.();
         return;
       }
@@ -771,6 +1057,7 @@ if html.count(marker) != 1:
     raise SystemExit("could not find the head boundary in generated EKF HTML")
 harness = harness.replace("__MECH_EXPECTED_COMPUTE_BACKEND__", compute_backend)
 harness = harness.replace("__MECH_EXPECTED_COMPUTE_INSTANCES__", filter_count)
+harness = harness.replace("__MECH_PERFORM_CONTINUITY_EDIT__", continuity_edit)
 path.write_text(html.replace(marker, harness + "\n  " + marker, 1))
 PY
 
@@ -1016,6 +1303,13 @@ chrome_status="$?"
 set -e
 
 updates="$(sed -n 's/.*data-mech-updates="\([0-9][0-9]*\)".*/\1/p' "$dom_file" | head -1)"
+expected_continuity_generation_changed="$continuity_edit"
+expected_compute_state_resets=0
+verified_compute_instances="$filter_count"
+if [[ "$expected_compute_backend" == "wgpu" ]]; then
+  expected_compute_state_resets=1
+  verified_compute_instances="$((filter_count + 1))"
+fi
 if [[ "$chrome_status" -ne 0 && "$chrome_status" -ne 124 ]] \
   || ! grep -q 'data-mech-done="true"' "$dom_file" \
   || ! grep -q 'data-mech-cameras="4"' "$dom_file" \
@@ -1024,6 +1318,10 @@ if [[ "$chrome_status" -ne 0 && "$chrome_status" -ne 124 ]] \
   || ! grep -q 'data-mech-saw-camera="true"' "$dom_file" \
   || ! grep -q 'data-mech-max-visible-cameras="1"' "$dom_file" \
   || ! grep -q 'data-mech-camera-geometry-stable="true"' "$dom_file" \
+  || ! grep -q 'data-mech-camera-toggle-disabled="true"' "$dom_file" \
+  || ! grep -q 'data-mech-camera-toggle-measurement-blocked="true"' "$dom_file" \
+  || ! grep -q 'data-mech-camera-toggle-restored="true"' "$dom_file" \
+  || ! grep -q 'data-mech-camera-toggle-pointer-submissions="4"' "$dom_file" \
   || ! grep -q 'data-mech-camera-range-oracle="true"' "$dom_file" \
   || ! grep -q 'data-mech-prediction-only="true"' "$dom_file" \
   || ! grep -qE 'data-mech-prediction-only-comparisons="[1-9][0-9]*"' "$dom_file" \
@@ -1044,15 +1342,23 @@ if [[ "$chrome_status" -ne 0 && "$chrome_status" -ne 124 ]] \
   || ! grep -q 'data-mech-scene-visible="true"' "$dom_file" \
   || ! grep -q 'data-mech-output-presentation="true"' "$dom_file" \
   || ! grep -q "data-mech-verified-compute-backend=\"$expected_compute_backend\"" "$dom_file" \
-  || ! grep -q "data-mech-verified-compute-instances=\"$filter_count\"" "$dom_file" \
+  || ! grep -q "data-mech-verified-compute-instances=\"$verified_compute_instances\"" "$dom_file" \
   || ! grep -q 'data-mech-sampled-readback-efficient="true"' "$dom_file" \
-  || ! grep -q 'data-mech-continuity-generation-changed="true"' "$dom_file" \
+  || ! grep -q "data-mech-continuity-generation-changed=\"$expected_continuity_generation_changed\"" "$dom_file" \
   || ! grep -q 'data-mech-continuity-resource-preserved="true"' "$dom_file" \
   || ! grep -q 'data-mech-continuity-active-buffer-preserved="true"' "$dom_file" \
   || ! grep -q 'data-mech-continuity-next-sample="[-0-9.,eE+]*"' "$dom_file" \
   || ! grep -q 'data-mech-busy-replacement-rejected="true"' "$dom_file" \
+  || ! grep -q 'data-mech-busy-source-untouched="true"' "$dom_file" \
+  || ! grep -q 'data-mech-busy-symbol-absent="true"' "$dom_file" \
+  || ! grep -q 'data-mech-busy-logical-progress-unchanged="true"' "$dom_file" \
   || ! grep -q 'data-mech-stale-completion-rejected="true"' "$dom_file" \
-  || ! grep -q 'data-mech-compute-state-resets-verified="0"' "$dom_file" \
+  || ! grep -q 'data-mech-incompatible-generation-changed="true"' "$dom_file" \
+  || ! grep -q 'data-mech-incompatible-resources-replaced="true"' "$dom_file" \
+  || ! grep -q 'data-mech-incompatible-old-resource-disposed="true"' "$dom_file" \
+  || ! grep -q 'data-mech-incompatible-state-reset="true"' "$dom_file" \
+  || ! grep -q 'data-mech-incompatible-reset-diagnostic="true"' "$dom_file" \
+  || ! grep -q "data-mech-compute-state-resets-verified=\"$expected_compute_state_resets\"" "$dom_file" \
   || ! grep -q 'data-mech-tracking-error-pixels="[0-9]' "$dom_file" \
   || ! grep -q 'data-mech-truth-x="[0-9]' "$dom_file" \
   || ! grep -q 'data-mech-truth-y="[0-9]' "$dom_file" \
@@ -1129,4 +1435,4 @@ Path(path).write_text(json.dumps({
 }, sort_keys=True))
 PY
 fi
-printf 'EKF_E2E display_updates=%s requested_compute_backend=%s compute_backend=%s compute_instances=%s cameras=4 max_visible_cameras=1 saw_no_camera=true square_sides=4 lap_complete=true smooth_turning=true turning_samples=%s max_heading_step=%s max_guide_deviation_pixels=%s truth_moved=true covariance_finite=true covariance_extent_pixels=%s paths_finite=true tracking_error_pixels=%s output_presentation=true console_errors=0 page_errors=0\n' "$updates" "$compute_backend" "$expected_compute_backend" "$filter_count" "$turning_samples" "$max_heading_step" "$max_guide_deviation" "$covariance_extent" "$tracking_error_pixels"
+printf 'EKF_E2E display_updates=%s requested_compute_backend=%s compute_backend=%s initial_compute_instances=%s verified_compute_instances=%s cameras=4 camera_toggle_disabled=true camera_measurement_blocked=true camera_toggle_restored=true max_visible_cameras=1 saw_no_camera=true square_sides=4 lap_complete=true smooth_turning=true turning_samples=%s max_heading_step=%s max_guide_deviation_pixels=%s truth_moved=true covariance_finite=true covariance_extent_pixels=%s paths_finite=true tracking_error_pixels=%s output_presentation=true console_errors=0 page_errors=0\n' "$updates" "$compute_backend" "$expected_compute_backend" "$filter_count" "$verified_compute_instances" "$turning_samples" "$max_heading_step" "$max_guide_deviation" "$covariance_extent" "$tracking_error_pixels"

--- a/scripts/smoke-served-resident-ekf-browser.sh
+++ b/scripts/smoke-served-resident-ekf-browser.sh
@@ -642,6 +642,8 @@ import time
 import urllib.request
 from urllib.parse import urlparse
 
+from scripts.browser_webgpu_flags import chrome_webgpu_test_flags
+
 chrome, page_url, profile, dom_file, chrome_log, compute_backend = sys.argv[1:]
 args = [
     chrome,
@@ -659,12 +661,7 @@ else:
     # The canary proves the browser WebGPU transport, not host-driver setup.
     # Force Chromium's test adapter so headless macOS and GPU-less Linux CI do
     # not hang while probing an unavailable presentation-capable device.
-    for flag in (
-        "--enable-unsafe-webgpu",
-        "--enable-unsafe-swiftshader",
-        "--use-webgpu-adapter=swiftshader",
-        "--use-gpu-in-tests",
-    ):
+    for flag in chrome_webgpu_test_flags(software_adapter=True):
         args.insert(-1, flag)
 
 def read_exact(connection, length):

--- a/scripts/smoke-served-resident-ekf-browser.sh
+++ b/scripts/smoke-served-resident-ekf-browser.sh
@@ -148,10 +148,72 @@ harness = r'''<script>
     });
 
     const parityComputeTurn = 376;
+    const continuityEditTurn = 120;
+    const busyReplacementTurn = 40;
     let computeParitySample;
+    let continuityNextSample;
+    let continuityEditRequested = false;
+    let continuityGenerationChanged = false;
+    let continuityResourcePreserved = expectedComputeBackend !== "wgpu";
+    let continuityActiveBufferPreserved = expectedComputeBackend !== "wgpu";
+    let continuityBefore;
+    let busyReplacementAttempted = false;
+    let busyReplacementRejected = expectedComputeBackend !== "wgpu";
+    let busyGeneration;
     let displayParityTrackingError;
     let computeReadbackBytes = 0;
     let sampledReadbackEfficient = true;
+    const computeIdentity = () => ({
+      generation: root.dataset.mechComputeGeneration || "",
+      revision: root.dataset.mechComputeRevision || "",
+      resource: root.dataset.mechComputeResourceIdentity || "",
+      device: root.dataset.mechComputeDeviceIdentity || "",
+      pipeline: root.dataset.mechComputePipelineIdentity || "",
+      state: root.dataset.mechComputeStateIdentity || "",
+      pipelineBuilds: root.dataset.mechComputePipelineBuildCount || "",
+      activeBuffer: root.dataset.mechComputeActiveBuffer || "",
+    });
+    const submitResidentSource = (source) => {
+      const input = document.querySelector(".mech-repl-active-prompt .repl-input");
+      if (!input || input.disabled || input.readOnly) return false;
+      input.value = source;
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      input.dispatchEvent(new KeyboardEvent("keydown", {
+        key: "Enter",
+        bubbles: true,
+        cancelable: true,
+      }));
+      return true;
+    };
+    const renderedDocumentNumbers = (name) => {
+      const rendered = globalThis.__MECH_RENDERED_DOCUMENT_VALUE__?.(name);
+      const text = document.createElement("span");
+      text.innerHTML = rendered?.inlineHtml || "";
+      return (text.textContent || "")
+        .match(/[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?/g)
+        ?.map(Number) || [];
+    };
+    const renderedFilterSample = () => {
+      const values = renderedDocumentNumbers("filter-sample");
+      return values.length === 15 && values.every(Number.isFinite) ? values : undefined;
+    };
+    const renderedFilterVisibility = () => {
+      const values = renderedDocumentNumbers("filter-camera-visibility");
+      return values.length === 1 && Number.isFinite(values[0]) ? values[0] : undefined;
+    };
+    const renderedFilterTurn = () => {
+      const values = renderedDocumentNumbers("last-filter-turn");
+      return values.length === 1 && Number.isFinite(values[0]) ? values[0] : undefined;
+    };
+    window.addEventListener("mech:compute-submit", () => {
+      if (
+        expectedComputeBackend !== "wgpu" || busyReplacementAttempted ||
+        Number(root.dataset.mechComputeDispatches || 0) !== busyReplacementTurn
+      ) return;
+      busyReplacementAttempted = true;
+      busyGeneration = root.dataset.mechComputeGeneration || "";
+      submitResidentSource("busy-replacement-probe := 1");
+    });
     window.addEventListener("mech:compute-complete", (event) => {
       const completedTurns = event.detail?.completedTurns;
       root.dataset.mechObservedComputeCompletion = String(completedTurns ?? "missing");
@@ -159,10 +221,10 @@ harness = r'''<script>
         computeReadbackBytes = Number(root.dataset.mechComputeGpuToCpuReadbackBytes || 0);
         const computeOutputBytes = Number(root.dataset.mechComputeGpuToCpuOutputBytes || 0);
         sampledReadbackEfficient &&= Boolean(
-          Number(root.dataset.mechComputeLogicalOutputs || 0) === 1 &&
-          Number(root.dataset.mechComputePhysicalOutputBuffers || 0) === 1 &&
-          computeReadbackBytes === completedTurns * (15 * Float32Array.BYTES_PER_ELEMENT + 8) &&
-          computeOutputBytes === completedTurns * 15 * Float32Array.BYTES_PER_ELEMENT
+          Number(root.dataset.mechComputeLogicalOutputs || 0) === 2 &&
+          Number(root.dataset.mechComputePhysicalOutputBuffers || 0) === 2 &&
+          computeReadbackBytes === completedTurns * (16 * Float32Array.BYTES_PER_ELEMENT + 8) &&
+          computeOutputBytes === completedTurns * 16 * Float32Array.BYTES_PER_ELEMENT
         );
       }
       if (completedTurns !== parityComputeTurn) return;
@@ -181,6 +243,24 @@ harness = r'''<script>
         computeParitySample = values.slice(0, 15);
       }
     });
+    window.addEventListener("mech:compute-complete", (event) => {
+      const completedTurns = event.detail?.completedTurns;
+      if (completedTurns === continuityEditTurn && !continuityEditRequested) {
+        continuityBefore = computeIdentity();
+        continuityEditRequested = submitResidentSource("continuity-probe := 1");
+        return;
+      }
+      if (
+        continuityEditRequested && continuityNextSample === undefined &&
+        completedTurns > continuityEditTurn
+      ) {
+        const output = event.detail.outputs?.find(candidate => candidate.name === "result.0");
+        const values = Array.from(output?.values || []);
+        if (values.length === 15 && values.every(Number.isFinite)) {
+          continuityNextSample = values;
+        }
+      }
+    });
 
     const originalSetTimeout = window.setTimeout.bind(window);
     let harnessFrames = 0;
@@ -189,6 +269,7 @@ harness = r'''<script>
     let previousHeading;
     let lastObservedUpdate = -1;
     let lastObservedComputeDispatch = 0;
+    let lastObservedCpuFilterTurn;
     let departedStart = false;
     const squareSides = new Set();
     let turningSamples = 0;
@@ -243,6 +324,50 @@ harness = r'''<script>
       const tabs = [...document.querySelectorAll('[data-mech-console-tab]')]
         .map(tab => tab.dataset.mechConsoleTab).join(",");
       const updates = Number(display?.dataset.mechDisplayUpdates || 0);
+      const completedFilterTurn = expectedComputeBackend === "cpu-scalar"
+        ? renderedFilterTurn()
+        : undefined;
+      if (
+        expectedComputeBackend === "cpu-scalar" &&
+        completedFilterTurn === continuityEditTurn &&
+        !continuityEditRequested
+      ) {
+        continuityBefore = computeIdentity();
+        continuityEditRequested = submitResidentSource("continuity-probe := 1");
+      }
+      if (busyReplacementAttempted && !busyReplacementRejected) {
+        busyReplacementRejected = Boolean(
+          root.dataset.mechComputeGeneration === busyGeneration &&
+          document.querySelector(
+            '[data-mech-diagnostic-code="ComputeSourceReplacementBusy"]',
+          )
+        );
+      }
+      if (continuityEditRequested && continuityBefore) {
+        const after = computeIdentity();
+        if (after.generation && after.generation !== continuityBefore.generation) {
+          continuityGenerationChanged = true;
+          if (expectedComputeBackend === "wgpu") {
+            continuityResourcePreserved = Boolean(
+              after.revision === continuityBefore.revision &&
+              after.resource === continuityBefore.resource &&
+              after.device === continuityBefore.device &&
+              after.pipeline === continuityBefore.pipeline &&
+              after.state === continuityBefore.state &&
+              after.pipelineBuilds === continuityBefore.pipelineBuilds
+            );
+            continuityActiveBufferPreserved =
+              after.activeBuffer === continuityBefore.activeBuffer;
+          }
+        }
+      }
+      if (
+        expectedComputeBackend === "cpu-scalar" && continuityEditRequested &&
+        continuityNextSample === undefined &&
+        completedFilterTurn === continuityEditTurn + 1
+      ) {
+        continuityNextSample = renderedFilterSample();
+      }
       const finiteCoordinate = (element, attribute) => {
         const raw = element?.getAttribute(attribute);
         return typeof raw === "string" && raw.trim() !== "" && Number.isFinite(Number(raw));
@@ -305,8 +430,13 @@ harness = r'''<script>
       if (truthPoint && updates > 0 && updates !== lastObservedUpdate) {
         lastObservedUpdate = updates;
         const computeDispatches = Number(root.dataset.mechComputeDispatches || 0);
-        const isComputeCompletionFrame = expectedComputeBackend === "cpu-scalar" ||
-          computeDispatches > lastObservedComputeDispatch;
+        const isComputeCompletionFrame = expectedComputeBackend === "cpu-scalar"
+          ? Number.isFinite(completedFilterTurn) &&
+            completedFilterTurn !== lastObservedCpuFilterTurn
+          : computeDispatches > lastObservedComputeDispatch;
+        if (Number.isFinite(completedFilterTurn)) {
+          lastObservedCpuFilterTurn = completedFilterTurn;
+        }
         lastObservedComputeDispatch = computeDispatches;
         if (firstTruth === undefined) firstTruth = truthPoint;
         maxGuideDeviation = Math.max(maxGuideDeviation, distanceToRenderedGuide(truthPoint));
@@ -370,8 +500,8 @@ harness = r'''<script>
         // Asynchronous WebGPU completion publishes the originating turn
         // directly, so its sampled estimate and camera visibility share one
         // resident snapshot just like the scalar backend.
-        const filterVisibleCameraCount = visibleCameraCount;
-        if (filterVisibleCameraCount === 0 && isComputeCompletionFrame) {
+        const filterVisibility = renderedFilterVisibility();
+        if (filterVisibility === 0 && isComputeCompletionFrame) {
           const predictionGap = finitePoint(estimate) && finitePoint(prediction)
             ? Math.hypot(
                 Number(estimate.getAttribute("cx")) - Number(prediction.getAttribute("cx")),
@@ -443,19 +573,11 @@ harness = r'''<script>
         displayParityTrackingError = trackingError;
       }
       if (
-        updates === parityComputeTurn &&
+        completedFilterTurn === parityComputeTurn &&
         expectedComputeBackend === "cpu-scalar" &&
         computeParitySample === undefined
       ) {
-        const rendered = globalThis.__MECH_RENDERED_DOCUMENT_VALUE__?.("filter-sample");
-        const text = document.createElement("span");
-        text.innerHTML = rendered?.inlineHtml || "";
-        const values = (text.textContent || "")
-          .match(/[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?/g)
-          ?.map(Number) || [];
-        if (values.length === 15 && values.every(Number.isFinite)) {
-          computeParitySample = values;
-        }
+        computeParitySample = renderedFilterSample();
       }
       const lineStripCoordinates = (element) => {
         const coordinates = (element?.getAttribute("points") || "")
@@ -521,9 +643,27 @@ harness = r'''<script>
       root.dataset.mechObservedComputeLogicalOutputs = root.dataset.mechComputeLogicalOutputs || "missing";
       root.dataset.mechObservedComputePhysicalOutputBuffers =
         root.dataset.mechComputePhysicalOutputBuffers || "missing";
+      root.dataset.mechObservedContinuityEditRequested = String(continuityEditRequested);
+      root.dataset.mechObservedContinuityGenerationChanged =
+        String(continuityGenerationChanged);
+      root.dataset.mechObservedContinuityResourcePreserved =
+        String(continuityResourcePreserved);
+      root.dataset.mechObservedContinuityActiveBufferPreserved =
+        String(continuityActiveBufferPreserved);
+      root.dataset.mechObservedContinuityNextSample =
+        JSON.stringify(continuityNextSample || null);
+      root.dataset.mechObservedBusyReplacementAttempted =
+        String(busyReplacementAttempted);
+      root.dataset.mechObservedBusyReplacementRejected =
+        String(busyReplacementRejected);
+      root.dataset.mechObservedComputeStateResets =
+        root.dataset.mechComputeStateResets || "0";
+      root.dataset.mechObservedStaleCompletionRejected =
+        root.dataset.mechComputeStaleCompletionRejected ||
+        String(expectedComputeBackend !== "wgpu");
       root.dataset.mechObservedExpectedReadbackBytes = String(
         Number(root.dataset.mechObservedComputeCompletion || 0) *
-          15 * Float32Array.BYTES_PER_ELEMENT
+          16 * Float32Array.BYTES_PER_ELEMENT
       );
       root.dataset.mechObservedOutputPresentation = String(outputPresentation);
       root.dataset.mechObservedErrorText = (errorPanel?.textContent || "").trim().slice(0, 1000);
@@ -538,6 +678,13 @@ harness = r'''<script>
         computeParitySample !== undefined &&
         displayParityTrackingError !== undefined &&
         sampledReadbackEfficient &&
+        continuityEditRequested && continuityGenerationChanged &&
+        continuityResourcePreserved && continuityActiveBufferPreserved &&
+        continuityNextSample !== undefined &&
+        busyReplacementRejected &&
+        (expectedComputeBackend !== "wgpu" ||
+          root.dataset.mechComputeStaleCompletionRejected === "true") &&
+        Number(root.dataset.mechComputeStateResets || 0) === 0 &&
         sawInsideCameraRange && sawOutsideCameraRange &&
         sawNoCamera && sawCamera && maxVisibleCameras === 1 &&
         finitePoint(truth) && finitePoint(estimate) && finitePoint(prediction) &&
@@ -598,6 +745,18 @@ harness = r'''<script>
         root.dataset.mechVerifiedComputeInstances = String(computeInstances);
         root.dataset.mechSampledReadbackEfficient = String(sampledReadbackEfficient);
         root.dataset.mechGpuToCpuReadbackBytes = String(computeReadbackBytes);
+        root.dataset.mechContinuityGenerationChanged =
+          String(continuityGenerationChanged);
+        root.dataset.mechContinuityResourcePreserved =
+          String(continuityResourcePreserved);
+        root.dataset.mechContinuityActiveBufferPreserved =
+          String(continuityActiveBufferPreserved);
+        root.dataset.mechContinuityNextSample = continuityNextSample.join(",");
+        root.dataset.mechBusyReplacementRejected = String(busyReplacementRejected);
+        root.dataset.mechStaleCompletionRejected =
+          root.dataset.mechComputeStaleCompletionRejected || "true";
+        root.dataset.mechComputeStateResetsVerified =
+          root.dataset.mechComputeStateResets || "0";
         root.dataset.mechDone = "true";
         globalThis.__MECH_STOP__?.();
         return;
@@ -887,6 +1046,13 @@ if [[ "$chrome_status" -ne 0 && "$chrome_status" -ne 124 ]] \
   || ! grep -q "data-mech-verified-compute-backend=\"$expected_compute_backend\"" "$dom_file" \
   || ! grep -q "data-mech-verified-compute-instances=\"$filter_count\"" "$dom_file" \
   || ! grep -q 'data-mech-sampled-readback-efficient="true"' "$dom_file" \
+  || ! grep -q 'data-mech-continuity-generation-changed="true"' "$dom_file" \
+  || ! grep -q 'data-mech-continuity-resource-preserved="true"' "$dom_file" \
+  || ! grep -q 'data-mech-continuity-active-buffer-preserved="true"' "$dom_file" \
+  || ! grep -q 'data-mech-continuity-next-sample="[-0-9.,eE+]*"' "$dom_file" \
+  || ! grep -q 'data-mech-busy-replacement-rejected="true"' "$dom_file" \
+  || ! grep -q 'data-mech-stale-completion-rejected="true"' "$dom_file" \
+  || ! grep -q 'data-mech-compute-state-resets-verified="0"' "$dom_file" \
   || ! grep -q 'data-mech-tracking-error-pixels="[0-9]' "$dom_file" \
   || ! grep -q 'data-mech-truth-x="[0-9]' "$dom_file" \
   || ! grep -q 'data-mech-truth-y="[0-9]' "$dom_file" \
@@ -937,21 +1103,28 @@ estimate_x="$(sed -n 's/.*data-mech-estimate-x="\([0-9.][0-9.]*\)".*/\1/p' "$dom
 estimate_y="$(sed -n 's/.*data-mech-estimate-y="\([0-9.][0-9.]*\)".*/\1/p' "$dom_file" | head -1)"
 parity_updates="$(sed -n 's/.*data-mech-parity-updates="\([0-9][0-9]*\)".*/\1/p' "$dom_file" | head -1)"
 parity_output="$(sed -n 's/.*data-mech-parity-output="\([^"]*\)".*/\1/p' "$dom_file" | head -1)"
+continuity_output="$(sed -n 's/.*data-mech-continuity-next-sample="\([^"]*\)".*/\1/p' "$dom_file" | head -1)"
 if [[ -n "${MECH_EKF_RESULT_FILE:-}" ]]; then
   python3 - "$MECH_EKF_RESULT_FILE" "$compute_backend" "$parity_updates" \
-    "$parity_output" "$parity_tracking_error" <<'PY'
+    "$parity_output" "$parity_tracking_error" "$continuity_output" <<'PY'
 import json
 from pathlib import Path
 import sys
 
-path, backend, updates, output, tracking = sys.argv[1:]
+path, backend, updates, output, tracking, continuity_output = sys.argv[1:]
 values = [float(value) for value in output.split(",") if value]
+continuity_values = [float(value) for value in continuity_output.split(",") if value]
 if len(values) != 15:
     raise SystemExit(f"expected 15 EKF checkpoint values, got {len(values)}")
+if len(continuity_values) != 15:
+    raise SystemExit(
+        f"expected 15 EKF continuity checkpoint values, got {len(continuity_values)}"
+    )
 Path(path).write_text(json.dumps({
     "backend": backend,
     "updates": int(updates),
     "output": values,
+    "continuity_output": continuity_values,
     "tracking_error": float(tracking),
 }, sort_keys=True))
 PY

--- a/scripts/smoke-served-resident-ekf-browser.sh
+++ b/scripts/smoke-served-resident-ekf-browser.sh
@@ -149,6 +149,7 @@ harness = r'''<script>
 
     const parityComputeTurn = 376;
     let computeParitySample;
+    let displayParityTrackingError;
     let computeReadbackBytes = 0;
     let sampledReadbackEfficient = true;
     window.addEventListener("mech:compute-complete", (event) => {
@@ -431,6 +432,13 @@ harness = r'''<script>
             Number(estimate.getAttribute("cy")) - Number(truth.getAttribute("cy")),
           )
         : Number.POSITIVE_INFINITY;
+      if (
+        updates === parityComputeTurn &&
+        displayParityTrackingError === undefined &&
+        Number.isFinite(trackingError)
+      ) {
+        displayParityTrackingError = trackingError;
+      }
       const lineStripCoordinates = (element) => {
         const coordinates = (element?.getAttribute("points") || "")
           .trim().split(/[\s,]+/).filter(Boolean).map(Number);
@@ -488,6 +496,8 @@ harness = r'''<script>
       root.dataset.mechObservedPredictionOnlyFailure = JSON.stringify(predictionOnlyFailure || null);
       root.dataset.mechObservedSmoothTurning = String(smoothTurning);
       root.dataset.mechObservedParityCaptured = String(computeParitySample !== undefined);
+      root.dataset.mechObservedParityTrackingCaptured =
+        String(displayParityTrackingError !== undefined);
       root.dataset.mechObservedSampledReadbackEfficient = String(sampledReadbackEfficient);
       root.dataset.mechObservedComputeReadbackBytes = String(computeReadbackBytes);
       root.dataset.mechObservedComputeLogicalOutputs = root.dataset.mechComputeLogicalOutputs || "missing";
@@ -508,6 +518,7 @@ harness = r'''<script>
         cameraGeometryStable && cameraRangeOracleValid && predictionOnlyValid &&
         predictionOnlyComparisons > 0 &&
         computeParitySample !== undefined &&
+        displayParityTrackingError !== undefined &&
         sampledReadbackEfficient &&
         sawInsideCameraRange && sawOutsideCameraRange &&
         sawNoCamera && sawCamera && maxVisibleCameras === 1 &&
@@ -562,6 +573,7 @@ harness = r'''<script>
         root.dataset.mechEstimateY = estimate.getAttribute("cy");
         root.dataset.mechParityUpdates = String(parityComputeTurn);
         root.dataset.mechParityOutput = computeParitySample.join(",");
+        root.dataset.mechParityTrackingError = displayParityTrackingError.toFixed(4);
         root.dataset.mechSceneVisible = String(sceneVisible);
         root.dataset.mechOutputPresentation = String(outputPresentation);
         root.dataset.mechVerifiedComputeBackend = computeBackend;
@@ -864,6 +876,7 @@ if [[ "$chrome_status" -ne 0 && "$chrome_status" -ne 124 ]] \
   || ! grep -q 'data-mech-estimate-y="[0-9]' "$dom_file" \
   || ! grep -qE 'data-mech-parity-updates="[3-9][0-9][0-9]"' "$dom_file" \
   || ! grep -q 'data-mech-parity-output="[-0-9.,eE+]*"' "$dom_file" \
+  || ! grep -q 'data-mech-parity-tracking-error="[0-9]' "$dom_file" \
   || [[ -z "$updates" || "$updates" -lt 376 ]] \
   || grep -qE 'data-mech-(console-error|page-error|timed-out)=' "$dom_file"; then
   echo "Served resident EKF browser smoke test failed" >&2
@@ -895,6 +908,7 @@ PY
 fi
 
 tracking_error_pixels="$(sed -n 's/.*data-mech-tracking-error-pixels="\([0-9.][0-9.]*\)".*/\1/p' "$dom_file" | head -1)"
+parity_tracking_error="$(sed -n 's/.*data-mech-parity-tracking-error="\([0-9.][0-9.]*\)".*/\1/p' "$dom_file" | head -1)"
 turning_samples="$(sed -n 's/.*data-mech-turning-samples="\([0-9][0-9]*\)".*/\1/p' "$dom_file" | head -1)"
 max_heading_step="$(sed -n 's/.*data-mech-max-heading-step="\([0-9.][0-9.]*\)".*/\1/p' "$dom_file" | head -1)"
 max_guide_deviation="$(sed -n 's/.*data-mech-max-guide-deviation="\([0-9.][0-9.]*\)".*/\1/p' "$dom_file" | head -1)"
@@ -907,7 +921,7 @@ parity_updates="$(sed -n 's/.*data-mech-parity-updates="\([0-9][0-9]*\)".*/\1/p'
 parity_output="$(sed -n 's/.*data-mech-parity-output="\([^"]*\)".*/\1/p' "$dom_file" | head -1)"
 if [[ -n "${MECH_EKF_RESULT_FILE:-}" ]]; then
   python3 - "$MECH_EKF_RESULT_FILE" "$compute_backend" "$parity_updates" \
-    "$parity_output" "$tracking_error_pixels" <<'PY'
+    "$parity_output" "$parity_tracking_error" <<'PY'
 import json
 from pathlib import Path
 import sys

--- a/scripts/smoke-served-resident-ekf-browser.sh
+++ b/scripts/smoke-served-resident-ekf-browser.sh
@@ -127,6 +127,29 @@ harness = r'''<script>
       root.dataset.mechPageError = diagnosticText(event.reason);
     });
 
+    const parityComputeTurn = 376;
+    let computeParitySample;
+    window.addEventListener("mech:compute-complete", (event) => {
+      root.dataset.mechObservedComputeCompletion = String(
+        event.detail?.completedTurns ?? "missing",
+      );
+      if (event.detail?.completedTurns !== parityComputeTurn) return;
+      root.dataset.mechObservedParityOutputs = (event.detail.outputs || [])
+        .map(output => `${output.name}:${output.values?.length ?? "missing"}`)
+        .join(",");
+      const output = event.detail.outputs?.find(candidate => candidate.name === "result.0");
+      const values = Array.from(output?.values || []);
+      // Both backends publish the first 15-value lane used by the document;
+      // the full 1,000-filter batch stays backend-local on every turn.
+      if (
+        event.detail?.backend === expectedComputeBackend &&
+        values.length === 15 &&
+        values.every(Number.isFinite)
+      ) {
+        computeParitySample = values.slice(0, 15);
+      }
+    });
+
     const originalSetTimeout = window.setTimeout.bind(window);
     let harnessFrames = 0;
     let firstTruth;
@@ -145,7 +168,6 @@ harness = r'''<script>
     let sawCamera = false;
     let maxVisibleCameras = 0;
     let previousVisibleCameraCount;
-    let paritySnapshot;
     const visibleCameraHistory = [];
     let stableCameraGeometry;
     let cameraGeometryStable = true;
@@ -411,18 +433,6 @@ harness = r'''<script>
       );
       const computeBackend = root.dataset.mechComputeBackend || "";
       const computeInstances = Number(root.dataset.mechComputeInstances || 0);
-      if (
-        paritySnapshot === undefined && observedLapComplete &&
-        finitePoint(truth) && finitePoint(estimate) && covarianceGeometry.finite
-      ) {
-        paritySnapshot = {
-          updates,
-          truth: [Number(truth.getAttribute("cx")), Number(truth.getAttribute("cy"))],
-          estimate: [Number(estimate.getAttribute("cx")), Number(estimate.getAttribute("cy"))],
-          covarianceExtent: covarianceGeometry.extent,
-        };
-      }
-
       root.dataset.mechObservedUpdates = String(updates);
       root.dataset.mechObservedSquareSides = ["east", "north", "west", "south"]
         .filter(side => squareSides.has(side)).join(",");
@@ -446,6 +456,7 @@ harness = r'''<script>
       root.dataset.mechObservedFinitePointContract = String(finitePointContract);
       root.dataset.mechObservedPredictionOnlyFailure = JSON.stringify(predictionOnlyFailure || null);
       root.dataset.mechObservedSmoothTurning = String(smoothTurning);
+      root.dataset.mechObservedParityCaptured = String(computeParitySample !== undefined);
       root.dataset.mechObservedOutputPresentation = String(outputPresentation);
       root.dataset.mechObservedErrorText = (errorPanel?.textContent || "").trim().slice(0, 1000);
       root.dataset.mechObservedDisplayIds = [...document.querySelectorAll('[data-mech-display-id]')]
@@ -456,6 +467,7 @@ harness = r'''<script>
         cameras.length === 4 && cameraRanges.length === 4 && cameraRays.length === 4 &&
         cameraGeometryStable && cameraRangeOracleValid && predictionOnlyValid &&
         predictionOnlyComparisons > 0 &&
+        computeParitySample !== undefined &&
         sawInsideCameraRange && sawOutsideCameraRange &&
         sawNoCamera && sawCamera && maxVisibleCameras === 1 &&
         finitePoint(truth) && finitePoint(estimate) && finitePoint(prediction) &&
@@ -507,12 +519,8 @@ harness = r'''<script>
         root.dataset.mechTruthY = truth.getAttribute("cy");
         root.dataset.mechEstimateX = estimate.getAttribute("cx");
         root.dataset.mechEstimateY = estimate.getAttribute("cy");
-        root.dataset.mechParityUpdates = String(paritySnapshot.updates);
-        root.dataset.mechParityTruthX = String(paritySnapshot.truth[0]);
-        root.dataset.mechParityTruthY = String(paritySnapshot.truth[1]);
-        root.dataset.mechParityEstimateX = String(paritySnapshot.estimate[0]);
-        root.dataset.mechParityEstimateY = String(paritySnapshot.estimate[1]);
-        root.dataset.mechParityCovarianceExtent = String(paritySnapshot.covarianceExtent);
+        root.dataset.mechParityUpdates = String(parityComputeTurn);
+        root.dataset.mechParityOutput = computeParitySample.join(",");
         root.dataset.mechSceneVisible = String(sceneVisible);
         root.dataset.mechOutputPresentation = String(outputPresentation);
         root.dataset.mechVerifiedComputeBackend = computeBackend;
@@ -636,11 +644,7 @@ if [[ "$chrome_status" -ne 0 && "$chrome_status" -ne 124 ]] \
   || ! grep -q 'data-mech-estimate-x="[0-9]' "$dom_file" \
   || ! grep -q 'data-mech-estimate-y="[0-9]' "$dom_file" \
   || ! grep -qE 'data-mech-parity-updates="[3-9][0-9][0-9]"' "$dom_file" \
-  || ! grep -q 'data-mech-parity-truth-x="[0-9]' "$dom_file" \
-  || ! grep -q 'data-mech-parity-truth-y="[0-9]' "$dom_file" \
-  || ! grep -q 'data-mech-parity-estimate-x="[0-9]' "$dom_file" \
-  || ! grep -q 'data-mech-parity-estimate-y="[0-9]' "$dom_file" \
-  || ! grep -q 'data-mech-parity-covariance-extent="[0-9]' "$dom_file" \
+  || ! grep -q 'data-mech-parity-output="[-0-9.,eE+]*"' "$dom_file" \
   || [[ -z "$updates" || "$updates" -lt 376 ]] \
   || grep -qE 'data-mech-(console-error|page-error|timed-out)=' "$dom_file"; then
   echo "Served resident EKF browser smoke test failed" >&2
@@ -651,12 +655,12 @@ import re
 import sys
 
 line = Path(sys.argv[1]).read_text(errors="replace").split("<head>", 1)[0]
+for match in re.finditer(r'(data-mech-observed-[a-z0-9-]+)="([^"]*)"', line):
+    print(f"{match.group(1)}: {unescape(match.group(2))}")
 for name in (
     "data-mech-document-error",
     "data-mech-console-error",
     "data-mech-page-error",
-    "data-mech-observed-error-text",
-    "data-mech-observed-prediction-only-failure",
 ):
     match = re.search(rf'{name}="([^"]*)"', line)
     if match:
@@ -681,26 +685,22 @@ truth_y="$(sed -n 's/.*data-mech-truth-y="\([0-9.][0-9.]*\)".*/\1/p' "$dom_file"
 estimate_x="$(sed -n 's/.*data-mech-estimate-x="\([0-9.][0-9.]*\)".*/\1/p' "$dom_file" | head -1)"
 estimate_y="$(sed -n 's/.*data-mech-estimate-y="\([0-9.][0-9.]*\)".*/\1/p' "$dom_file" | head -1)"
 parity_updates="$(sed -n 's/.*data-mech-parity-updates="\([0-9][0-9]*\)".*/\1/p' "$dom_file" | head -1)"
-parity_truth_x="$(sed -n 's/.*data-mech-parity-truth-x="\([0-9.][0-9.]*\)".*/\1/p' "$dom_file" | head -1)"
-parity_truth_y="$(sed -n 's/.*data-mech-parity-truth-y="\([0-9.][0-9.]*\)".*/\1/p' "$dom_file" | head -1)"
-parity_estimate_x="$(sed -n 's/.*data-mech-parity-estimate-x="\([0-9.][0-9.]*\)".*/\1/p' "$dom_file" | head -1)"
-parity_estimate_y="$(sed -n 's/.*data-mech-parity-estimate-y="\([0-9.][0-9.]*\)".*/\1/p' "$dom_file" | head -1)"
-parity_covariance_extent="$(sed -n 's/.*data-mech-parity-covariance-extent="\([0-9.][0-9.]*\)".*/\1/p' "$dom_file" | head -1)"
+parity_output="$(sed -n 's/.*data-mech-parity-output="\([^"]*\)".*/\1/p' "$dom_file" | head -1)"
 if [[ -n "${MECH_EKF_RESULT_FILE:-}" ]]; then
   python3 - "$MECH_EKF_RESULT_FILE" "$compute_backend" "$parity_updates" \
-    "$parity_truth_x" "$parity_truth_y" "$parity_estimate_x" "$parity_estimate_y" \
-    "$parity_covariance_extent" "$tracking_error_pixels" <<'PY'
+    "$parity_output" "$tracking_error_pixels" <<'PY'
 import json
 from pathlib import Path
 import sys
 
-path, backend, updates, truth_x, truth_y, estimate_x, estimate_y, covariance, tracking = sys.argv[1:]
+path, backend, updates, output, tracking = sys.argv[1:]
+values = [float(value) for value in output.split(",") if value]
+if len(values) != 15:
+    raise SystemExit(f"expected 15 EKF checkpoint values, got {len(values)}")
 Path(path).write_text(json.dumps({
     "backend": backend,
     "updates": int(updates),
-    "truth": [float(truth_x), float(truth_y)],
-    "estimate": [float(estimate_x), float(estimate_y)],
-    "covariance_extent": float(covariance),
+    "output": values,
     "tracking_error": float(tracking),
 }, sort_keys=True))
 PY

--- a/scripts/smoke-served-resident-ekf-browser.sh
+++ b/scripts/smoke-served-resident-ekf-browser.sh
@@ -188,8 +188,15 @@ harness = r'''<script>
     let sawOutsideCameraRange = false;
     window.requestAnimationFrame = (callback) => originalSetTimeout(() => {
       if (root.dataset.mechDone === "true" || root.dataset.mechTimedOut === "true") return;
-      harnessFrames += 1;
       callback(performance.now());
+
+      // Adapter discovery and pipeline creation are asynchronous. Chrome's
+      // virtual-time budget can advance thousands of unrelated layout frames
+      // while WebGPU initialization is still legitimately pending, especially
+      // with a software adapter in CI. Start the simulation-frame budget only
+      // after the document runtime is ready; the outer process deadline still
+      // catches an initialization that actually hangs.
+      if (root.dataset.mechDocumentStatus === "ready") harnessFrames += 1;
 
       const display = document.querySelector('[data-mech-display-id="scene-localization"]');
       const scene = document.querySelector('[data-mech-rich-scene="true"]');
@@ -579,7 +586,11 @@ import sys
 import time
 
 chrome, page_url, profile, dom_file, chrome_log, compute_backend = sys.argv[1:]
-virtual_time_budget = int(os.environ.get("MECH_BROWSER_VIRTUAL_TIME_BUDGET_MS", "600000"))
+default_virtual_time_budget = "3600000" if compute_backend == "wgpu" else "600000"
+virtual_time_budget = int(os.environ.get(
+    "MECH_BROWSER_VIRTUAL_TIME_BUDGET_MS",
+    default_virtual_time_budget,
+))
 args = [
     chrome,
     "--headless=new",

--- a/scripts/smoke-served-resident-ekf-browser.sh
+++ b/scripts/smoke-served-resident-ekf-browser.sh
@@ -640,6 +640,13 @@ harness = r'''<script>
           cameraToggleDispatchBeforeDisable = logicalComputeTurn;
           cameraToggleDisableGesture = pressSceneCamera(orderedCameras[0]);
           cameraToggleDisableRequested = Boolean(cameraToggleDisableGesture);
+          // Deliver release before the next runtime frame. This is the common
+          // quick-click path where ingress coalesces the activation payload
+          // with the final released level.
+          if (cameraToggleDisableRequested) {
+            cameraToggleDisableReleased = releaseSceneCamera(cameraToggleDisableGesture);
+            cameraToggleDispatchAfterDisableRelease = logicalComputeTurn;
+          }
         }
         if (
           cameraToggleDisableRequested && !cameraToggleDisabled &&
@@ -656,12 +663,6 @@ harness = r'''<script>
           cameraToggleVisualStateValid = activeOpacity === 0 && disabledOpacity === 1 &&
             rangeOpacity === 0 && rayOpacity === 0 && labelOpacity === 0.32;
           cameraToggleDisabled = cameraToggleVisualStateValid;
-        }
-        if (
-          cameraToggleDisabled && !cameraToggleDisableReleased
-        ) {
-          cameraToggleDisableReleased = releaseSceneCamera(cameraToggleDisableGesture);
-          cameraToggleDispatchAfterDisableRelease = logicalComputeTurn;
         }
         const pointerPressed = renderedDocumentNumbers("scene-pointer-pressed");
         const pointerPulse = renderedDocumentNumbers("scene-pointer-pulse");

--- a/scripts/smoke-served-resident-ekf-browser.sh
+++ b/scripts/smoke-served-resident-ekf-browser.sh
@@ -586,7 +586,11 @@ import sys
 import time
 
 chrome, page_url, profile, dom_file, chrome_log, compute_backend = sys.argv[1:]
-default_virtual_time_budget = "3600000" if compute_backend == "wgpu" else "600000"
+# Chrome can consume accelerated virtual time while adapter discovery, large
+# WASM compilation, and software-WebGPU pipeline creation wait on real work.
+# Keep the WebGPU ceiling beyond the independent 90-second real-time watchdog;
+# a successful proof stops its timers and lets --dump-dom exit immediately.
+default_virtual_time_budget = "60000000" if compute_backend == "wgpu" else "600000"
 virtual_time_budget = int(os.environ.get(
     "MECH_BROWSER_VIRTUAL_TIME_BUDGET_MS",
     default_virtual_time_budget,

--- a/scripts/smoke-served-resident-ekf-browser.sh
+++ b/scripts/smoke-served-resident-ekf-browser.sh
@@ -55,6 +55,28 @@ trap cleanup EXIT
 cp examples/ekf/mech.mcfg "$project_dir/mech.mcfg"
 cp examples/ekf/localization.mec "$project_dir/localization.mec"
 
+compute_backend="${MECH_EKF_COMPUTE_BACKEND:-cpu-scalar}"
+case "$compute_backend" in
+  cpu-scalar|wgpu) expected_compute_backend="$compute_backend" ;;
+  auto) expected_compute_backend="cpu-scalar" ;;
+  *)
+    echo "MECH_EKF_COMPUTE_BACKEND must be auto, cpu-scalar, or wgpu" >&2
+    exit 1
+    ;;
+esac
+python3 - "$project_dir/mech.mcfg" "$compute_backend" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+backend = sys.argv[2]
+source = path.read_text()
+needle = 'backend: "auto"'
+if source.count(needle) != 1:
+    raise SystemExit("could not select the EKF browser smoke compute backend")
+path.write_text(source.replace(needle, f'backend: "{backend}"', 1))
+PY
+
 port="$(python3 - <<'PY'
 import socket
 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
@@ -81,15 +103,17 @@ if [[ ! -s "$project_dir/index.html" ]]; then
   exit 1
 fi
 
-python3 - "$project_dir/index.html" <<'PY'
+python3 - "$project_dir/index.html" "$expected_compute_backend" <<'PY'
 from pathlib import Path
 import sys
 
 path = Path(sys.argv[1])
+compute_backend = sys.argv[2]
 html = path.read_text()
 marker = "</head>"
 harness = r'''<script>
     const root = document.documentElement;
+    const expectedComputeBackend = "__MECH_EXPECTED_COMPUTE_BACKEND__";
     const originalConsoleError = console.error;
     const diagnosticText = (value) => value?.stack || value?.message || String(value);
     console.error = (...args) => {
@@ -109,6 +133,7 @@ harness = r'''<script>
     let previousTruth;
     let previousHeading;
     let lastObservedUpdate = -1;
+    let lastObservedComputeDispatch = 0;
     let departedStart = false;
     const squareSides = new Set();
     let turningSamples = 0;
@@ -119,11 +144,14 @@ harness = r'''<script>
     let sawNoCamera = false;
     let sawCamera = false;
     let maxVisibleCameras = 0;
+    let previousVisibleCameraCount;
+    const visibleCameraHistory = [];
     let stableCameraGeometry;
     let cameraGeometryStable = true;
     let cameraRangeOracleValid = true;
     let predictionOnlyValid = true;
     let predictionOnlyComparisons = 0;
+    let predictionOnlyFailure;
     let sawInsideCameraRange = false;
     let sawOutsideCameraRange = false;
     window.requestAnimationFrame = (callback) => originalSetTimeout(() => {
@@ -214,6 +242,14 @@ harness = r'''<script>
       }
       if (truthPoint && updates > 0 && updates !== lastObservedUpdate) {
         lastObservedUpdate = updates;
+        const computeDispatches = Number(root.dataset.mechComputeDispatches || 0);
+        const isComputeCompletionFrame = root.dataset.mechComputeBackend === "wgpu"
+          ? computeDispatches > lastObservedComputeDispatch
+          : Boolean(
+              previousTruth &&
+              Math.hypot(truthPoint.x - previousTruth.x, truthPoint.y - previousTruth.y) <= 1e-9
+            );
+        lastObservedComputeDispatch = computeDispatches;
         if (firstTruth === undefined) firstTruth = truthPoint;
         maxGuideDeviation = Math.max(maxGuideDeviation, distanceToRenderedGuide(truthPoint));
         const indexed = (elements, prefix) => [...elements].sort((left, right) =>
@@ -273,13 +309,41 @@ harness = r'''<script>
         sawNoCamera ||= visibleCameraCount === 0;
         sawCamera ||= visibleCameraCount > 0;
         maxVisibleCameras = Math.max(maxVisibleCameras, visibleCameraCount);
-        if (visibleCameraCount === 0) {
-          const comparisonValid = finitePoint(estimate) && finitePoint(prediction) &&
-            Number(estimate.getAttribute("cx")) === Number(prediction.getAttribute("cx")) &&
-            Number(estimate.getAttribute("cy")) === Number(prediction.getAttribute("cy"));
+        // WebGPU completion is consumed by the next resident turn, so its
+        // sampled estimate corresponds to the preceding turn's measurement.
+        // The scalar backend completes inside the current turn.
+        const filterVisibleCameraCount = root.dataset.mechComputeBackend === "wgpu"
+          ? previousVisibleCameraCount
+          : visibleCameraCount;
+        if (filterVisibleCameraCount === 0 && isComputeCompletionFrame) {
+          const predictionGap = finitePoint(estimate) && finitePoint(prediction)
+            ? Math.hypot(
+                Number(estimate.getAttribute("cx")) - Number(prediction.getAttribute("cx")),
+                Number(estimate.getAttribute("cy")) - Number(prediction.getAttribute("cy")),
+              )
+            : Number.POSITIVE_INFINITY;
+          // The WGPU sample is consumed asynchronously, one resident output
+          // behind the live ray geometry. At reacquisition boundaries permit
+          // only a subpixel remnant; sustained dead-zone samples coincide.
+          const comparisonValid = predictionGap <= 0.25;
           predictionOnlyValid &&= Boolean(comparisonValid);
           if (comparisonValid) predictionOnlyComparisons += 1;
+          if (!comparisonValid && predictionOnlyFailure === undefined) {
+            predictionOnlyFailure = {
+              estimateX: estimate?.getAttribute("cx"),
+              estimateY: estimate?.getAttribute("cy"),
+              predictionX: prediction?.getAttribute("cx"),
+              predictionY: prediction?.getAttribute("cy"),
+              currentVisibleCameraCount: visibleCameraCount,
+              previousVisibleCameraCount,
+              visibleCameraHistory: visibleCameraHistory.slice(-8),
+              computeDispatches,
+              predictionGap,
+            };
+          }
         }
+        previousVisibleCameraCount = visibleCameraCount;
+        visibleCameraHistory.push(visibleCameraCount);
       }
       if (truthPoint && previousTruth && updates === lastObservedUpdate) {
         const dx = truthPoint.x - previousTruth.x;
@@ -349,6 +413,8 @@ harness = r'''<script>
         outputPanel?.hidden === false &&
         tabs === "output,console,errors"
       );
+      const computeBackend = root.dataset.mechComputeBackend || "";
+      const computeInstances = Number(root.dataset.mechComputeInstances || 0);
 
       root.dataset.mechObservedUpdates = String(updates);
       root.dataset.mechObservedSquareSides = ["east", "north", "west", "south"]
@@ -371,6 +437,7 @@ harness = r'''<script>
       root.dataset.mechObservedPredictionOnly = String(predictionOnlyValid);
       root.dataset.mechObservedPredictionOnlyComparisons = String(predictionOnlyComparisons);
       root.dataset.mechObservedFinitePointContract = String(finitePointContract);
+      root.dataset.mechObservedPredictionOnlyFailure = JSON.stringify(predictionOnlyFailure || null);
       root.dataset.mechObservedSmoothTurning = String(smoothTurning);
       root.dataset.mechObservedOutputPresentation = String(outputPresentation);
       root.dataset.mechObservedErrorText = (errorPanel?.textContent || "").trim().slice(0, 1000);
@@ -398,7 +465,8 @@ harness = r'''<script>
         estimatePathGeometry.finite && estimatePathGeometry.points >= 376 &&
         estimatePathGeometry.extent > 100 &&
         title?.textContent === "Camera EKF Localization" &&
-        sceneVisible && outputPresentation
+        sceneVisible && outputPresentation &&
+        computeBackend === expectedComputeBackend && computeInstances === 1000
       ) {
         root.dataset.mechUpdates = String(updates);
         root.dataset.mechCameras = String(cameras.length);
@@ -430,6 +498,8 @@ harness = r'''<script>
         root.dataset.mechTrackingErrorPixels = trackingError.toFixed(4);
         root.dataset.mechSceneVisible = String(sceneVisible);
         root.dataset.mechOutputPresentation = String(outputPresentation);
+        root.dataset.mechVerifiedComputeBackend = computeBackend;
+        root.dataset.mechVerifiedComputeInstances = String(computeInstances);
         root.dataset.mechDone = "true";
         globalThis.__MECH_STOP__?.();
         return;
@@ -442,6 +512,7 @@ harness = r'''<script>
   </script>'''
 if html.count(marker) != 1:
     raise SystemExit("could not find the head boundary in generated EKF HTML")
+harness = harness.replace("__MECH_EXPECTED_COMPUTE_BACKEND__", compute_backend)
 path.write_text(html.replace(marker, harness + "\n  " + marker, 1))
 PY
 
@@ -458,7 +529,7 @@ if ! grep -q 'root.dataset.mechDone' "$browser_dir/preflight.html"; then
 fi
 
 set +e
-python3 - "$chrome_bin" "$page_url" "$chrome_profile" "$dom_file" "$chrome_log" <<'PY'
+python3 - "$chrome_bin" "$page_url" "$chrome_profile" "$dom_file" "$chrome_log" "$compute_backend" <<'PY'
 import os
 from pathlib import Path
 import signal
@@ -466,12 +537,11 @@ import subprocess
 import sys
 import time
 
-chrome, page_url, profile, dom_file, chrome_log = sys.argv[1:]
+chrome, page_url, profile, dom_file, chrome_log, compute_backend = sys.argv[1:]
 args = [
     chrome,
     "--headless=new",
     "--no-sandbox",
-    "--disable-gpu",
     "--disable-dev-shm-usage",
     "--run-all-compositor-stages-before-draw",
     "--virtual-time-budget=120000",
@@ -479,6 +549,10 @@ args = [
     f"--user-data-dir={profile}",
     page_url,
 ]
+if compute_backend != "wgpu":
+    args.insert(-1, "--disable-gpu")
+else:
+    args.insert(-1, "--enable-unsafe-webgpu")
 with Path(dom_file).open("wb") as stdout, Path(chrome_log).open("wb") as stderr:
     process = subprocess.Popen(args, stdout=stdout, stderr=stderr, start_new_session=True)
     deadline = time.monotonic() + 90
@@ -537,10 +611,30 @@ if [[ "$chrome_status" -ne 0 && "$chrome_status" -ne 124 ]] \
   || ! grep -q 'data-mech-estimate-path-finite="true"' "$dom_file" \
   || ! grep -q 'data-mech-scene-visible="true"' "$dom_file" \
   || ! grep -q 'data-mech-output-presentation="true"' "$dom_file" \
+  || ! grep -q "data-mech-verified-compute-backend=\"$expected_compute_backend\"" "$dom_file" \
+  || ! grep -q 'data-mech-verified-compute-instances="1000"' "$dom_file" \
   || ! grep -q 'data-mech-tracking-error-pixels="[0-9]' "$dom_file" \
   || [[ -z "$updates" || "$updates" -lt 376 ]] \
   || grep -qE 'data-mech-(console-error|page-error|timed-out)=' "$dom_file"; then
   echo "Served resident EKF browser smoke test failed" >&2
+  python3 - "$dom_file" <<'PY' >&2 || true
+from html import unescape
+from pathlib import Path
+import re
+import sys
+
+line = Path(sys.argv[1]).read_text(errors="replace").split("<head>", 1)[0]
+for name in (
+    "data-mech-document-error",
+    "data-mech-console-error",
+    "data-mech-page-error",
+    "data-mech-observed-error-text",
+    "data-mech-observed-prediction-only-failure",
+):
+    match = re.search(rf'{name}="([^"]*)"', line)
+    if match:
+        print(f"{name}: {unescape(match.group(1))}")
+PY
   echo "Server log:" >&2
   sed -n '1,240p' "$server_log" >&2 || true
   echo "Chrome stderr:" >&2
@@ -555,4 +649,4 @@ turning_samples="$(sed -n 's/.*data-mech-turning-samples="\([0-9][0-9]*\)".*/\1/
 max_heading_step="$(sed -n 's/.*data-mech-max-heading-step="\([0-9.][0-9.]*\)".*/\1/p' "$dom_file" | head -1)"
 max_guide_deviation="$(sed -n 's/.*data-mech-max-guide-deviation="\([0-9.][0-9.]*\)".*/\1/p' "$dom_file" | head -1)"
 covariance_extent="$(sed -n 's/.*data-mech-covariance-extent="\([0-9.][0-9.]*\)".*/\1/p' "$dom_file" | head -1)"
-printf 'EKF_E2E display_updates=%s cameras=4 max_visible_cameras=1 saw_no_camera=true square_sides=4 lap_complete=true smooth_turning=true turning_samples=%s max_heading_step=%s max_guide_deviation_pixels=%s truth_moved=true covariance_finite=true covariance_extent_pixels=%s paths_finite=true tracking_error_pixels=%s output_presentation=true console_errors=0 page_errors=0\n' "$updates" "$turning_samples" "$max_heading_step" "$max_guide_deviation" "$covariance_extent" "$tracking_error_pixels"
+printf 'EKF_E2E display_updates=%s requested_compute_backend=%s compute_backend=%s compute_instances=1000 cameras=4 max_visible_cameras=1 saw_no_camera=true square_sides=4 lap_complete=true smooth_turning=true turning_samples=%s max_heading_step=%s max_guide_deviation_pixels=%s truth_moved=true covariance_finite=true covariance_extent_pixels=%s paths_finite=true tracking_error_pixels=%s output_presentation=true console_errors=0 page_errors=0\n' "$updates" "$compute_backend" "$expected_compute_backend" "$turning_samples" "$max_heading_step" "$max_guide_deviation" "$covariance_extent" "$tracking_error_pixels"

--- a/scripts/smoke-served-resident-ekf-browser.sh
+++ b/scripts/smoke-served-resident-ekf-browser.sh
@@ -129,11 +129,20 @@ harness = r'''<script>
 
     const parityComputeTurn = 376;
     let computeParitySample;
+    let computeReadbackBytes = 0;
+    let sampledReadbackEfficient = true;
     window.addEventListener("mech:compute-complete", (event) => {
-      root.dataset.mechObservedComputeCompletion = String(
-        event.detail?.completedTurns ?? "missing",
-      );
-      if (event.detail?.completedTurns !== parityComputeTurn) return;
+      const completedTurns = event.detail?.completedTurns;
+      root.dataset.mechObservedComputeCompletion = String(completedTurns ?? "missing");
+      if (expectedComputeBackend === "wgpu") {
+        computeReadbackBytes = Number(root.dataset.mechComputeGpuToCpuReadbackBytes || 0);
+        sampledReadbackEfficient &&= Boolean(
+          Number(root.dataset.mechComputeLogicalOutputs || 0) === 1 &&
+          Number(root.dataset.mechComputePhysicalOutputBuffers || 0) === 1 &&
+          computeReadbackBytes === completedTurns * 15 * Float32Array.BYTES_PER_ELEMENT
+        );
+      }
+      if (completedTurns !== parityComputeTurn) return;
       root.dataset.mechObservedParityOutputs = (event.detail.outputs || [])
         .map(output => `${output.name}:${output.values?.length ?? "missing"}`)
         .join(",");
@@ -266,12 +275,7 @@ harness = r'''<script>
       if (truthPoint && updates > 0 && updates !== lastObservedUpdate) {
         lastObservedUpdate = updates;
         const computeDispatches = Number(root.dataset.mechComputeDispatches || 0);
-        const isComputeCompletionFrame = root.dataset.mechComputeBackend === "wgpu"
-          ? computeDispatches > lastObservedComputeDispatch
-          : Boolean(
-              previousTruth &&
-              Math.hypot(truthPoint.x - previousTruth.x, truthPoint.y - previousTruth.y) <= 1e-9
-            );
+        const isComputeCompletionFrame = computeDispatches > lastObservedComputeDispatch;
         lastObservedComputeDispatch = computeDispatches;
         if (firstTruth === undefined) firstTruth = truthPoint;
         maxGuideDeviation = Math.max(maxGuideDeviation, distanceToRenderedGuide(truthPoint));
@@ -457,6 +461,15 @@ harness = r'''<script>
       root.dataset.mechObservedPredictionOnlyFailure = JSON.stringify(predictionOnlyFailure || null);
       root.dataset.mechObservedSmoothTurning = String(smoothTurning);
       root.dataset.mechObservedParityCaptured = String(computeParitySample !== undefined);
+      root.dataset.mechObservedSampledReadbackEfficient = String(sampledReadbackEfficient);
+      root.dataset.mechObservedComputeReadbackBytes = String(computeReadbackBytes);
+      root.dataset.mechObservedComputeLogicalOutputs = root.dataset.mechComputeLogicalOutputs || "missing";
+      root.dataset.mechObservedComputePhysicalOutputBuffers =
+        root.dataset.mechComputePhysicalOutputBuffers || "missing";
+      root.dataset.mechObservedExpectedReadbackBytes = String(
+        Number(root.dataset.mechObservedComputeCompletion || 0) *
+          15 * Float32Array.BYTES_PER_ELEMENT
+      );
       root.dataset.mechObservedOutputPresentation = String(outputPresentation);
       root.dataset.mechObservedErrorText = (errorPanel?.textContent || "").trim().slice(0, 1000);
       root.dataset.mechObservedDisplayIds = [...document.querySelectorAll('[data-mech-display-id]')]
@@ -468,6 +481,7 @@ harness = r'''<script>
         cameraGeometryStable && cameraRangeOracleValid && predictionOnlyValid &&
         predictionOnlyComparisons > 0 &&
         computeParitySample !== undefined &&
+        sampledReadbackEfficient &&
         sawInsideCameraRange && sawOutsideCameraRange &&
         sawNoCamera && sawCamera && maxVisibleCameras === 1 &&
         finitePoint(truth) && finitePoint(estimate) && finitePoint(prediction) &&
@@ -525,6 +539,8 @@ harness = r'''<script>
         root.dataset.mechOutputPresentation = String(outputPresentation);
         root.dataset.mechVerifiedComputeBackend = computeBackend;
         root.dataset.mechVerifiedComputeInstances = String(computeInstances);
+        root.dataset.mechSampledReadbackEfficient = String(sampledReadbackEfficient);
+        root.dataset.mechGpuToCpuReadbackBytes = String(computeReadbackBytes);
         root.dataset.mechDone = "true";
         globalThis.__MECH_STOP__?.();
         return;
@@ -639,6 +655,7 @@ if [[ "$chrome_status" -ne 0 && "$chrome_status" -ne 124 ]] \
   || ! grep -q 'data-mech-output-presentation="true"' "$dom_file" \
   || ! grep -q "data-mech-verified-compute-backend=\"$expected_compute_backend\"" "$dom_file" \
   || ! grep -q 'data-mech-verified-compute-instances="1000"' "$dom_file" \
+  || ! grep -q 'data-mech-sampled-readback-efficient="true"' "$dom_file" \
   || ! grep -q 'data-mech-tracking-error-pixels="[0-9]' "$dom_file" \
   || ! grep -q 'data-mech-truth-x="[0-9]' "$dom_file" \
   || ! grep -q 'data-mech-truth-y="[0-9]' "$dom_file" \

--- a/scripts/smoke-served-resident-ekf-browser.sh
+++ b/scripts/smoke-served-resident-ekf-browser.sh
@@ -588,9 +588,11 @@ import time
 chrome, page_url, profile, dom_file, chrome_log, compute_backend = sys.argv[1:]
 # Chrome can consume accelerated virtual time while adapter discovery, large
 # WASM compilation, and software-WebGPU pipeline creation wait on real work.
-# Keep the WebGPU ceiling beyond the independent 90-second real-time watchdog;
-# a successful proof stops its timers and lets --dump-dom exit immediately.
-default_virtual_time_budget = "60000000" if compute_backend == "wgpu" else "600000"
+# Chrome can advance virtual time more than four thousand times faster than wall
+# time while a software WebGPU adapter is initializing. Keep this ceiling far
+# beyond the independent 90-second real-time watchdog; a successful proof stops
+# its timers and lets --dump-dom exit immediately.
+default_virtual_time_budget = "2000000000" if compute_backend == "wgpu" else "600000"
 virtual_time_budget = int(os.environ.get(
     "MECH_BROWSER_VIRTUAL_TIME_BUDGET_MS",
     default_virtual_time_budget,

--- a/scripts/smoke-served-resident-ekf-browser.sh
+++ b/scripts/smoke-served-resident-ekf-browser.sh
@@ -157,10 +157,12 @@ harness = r'''<script>
       root.dataset.mechObservedComputeCompletion = String(completedTurns ?? "missing");
       if (expectedComputeBackend === "wgpu") {
         computeReadbackBytes = Number(root.dataset.mechComputeGpuToCpuReadbackBytes || 0);
+        const computeOutputBytes = Number(root.dataset.mechComputeGpuToCpuOutputBytes || 0);
         sampledReadbackEfficient &&= Boolean(
           Number(root.dataset.mechComputeLogicalOutputs || 0) === 1 &&
           Number(root.dataset.mechComputePhysicalOutputBuffers || 0) === 1 &&
-          computeReadbackBytes === completedTurns * 15 * Float32Array.BYTES_PER_ELEMENT
+          computeReadbackBytes === completedTurns * (15 * Float32Array.BYTES_PER_ELEMENT + 8) &&
+          computeOutputBytes === completedTurns * 15 * Float32Array.BYTES_PER_ELEMENT
         );
       }
       if (completedTurns !== parityComputeTurn) return;
@@ -303,7 +305,8 @@ harness = r'''<script>
       if (truthPoint && updates > 0 && updates !== lastObservedUpdate) {
         lastObservedUpdate = updates;
         const computeDispatches = Number(root.dataset.mechComputeDispatches || 0);
-        const isComputeCompletionFrame = computeDispatches > lastObservedComputeDispatch;
+        const isComputeCompletionFrame = expectedComputeBackend === "cpu-scalar" ||
+          computeDispatches > lastObservedComputeDispatch;
         lastObservedComputeDispatch = computeDispatches;
         if (firstTruth === undefined) firstTruth = truthPoint;
         maxGuideDeviation = Math.max(maxGuideDeviation, distanceToRenderedGuide(truthPoint));
@@ -438,6 +441,21 @@ harness = r'''<script>
         Number.isFinite(trackingError)
       ) {
         displayParityTrackingError = trackingError;
+      }
+      if (
+        updates === parityComputeTurn &&
+        expectedComputeBackend === "cpu-scalar" &&
+        computeParitySample === undefined
+      ) {
+        const rendered = globalThis.__MECH_RENDERED_DOCUMENT_VALUE__?.("filter-sample");
+        const text = document.createElement("span");
+        text.innerHTML = rendered?.inlineHtml || "";
+        const values = (text.textContent || "")
+          .match(/[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?/g)
+          ?.map(Number) || [];
+        if (values.length === 15 && values.every(Number.isFinite)) {
+          computeParitySample = values;
+        }
       }
       const lineStripCoordinates = (element) => {
         const coordinates = (element?.getAttribute("points") || "")

--- a/scripts/smoke-served-resident-ekf-browser.sh
+++ b/scripts/smoke-served-resident-ekf-browser.sh
@@ -55,6 +55,24 @@ trap cleanup EXIT
 cp examples/ekf/mech.mcfg "$project_dir/mech.mcfg"
 cp examples/ekf/localization.mec "$project_dir/localization.mec"
 
+filter_count="${MECH_EKF_FILTER_COUNT:-1000}"
+if [[ ! "$filter_count" =~ ^[1-9][0-9]*$ ]]; then
+  echo "MECH_EKF_FILTER_COUNT must be a positive integer" >&2
+  exit 1
+fi
+python3 - "$project_dir/localization.mec" "$filter_count" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+filter_count = sys.argv[2]
+source = path.read_text()
+needle = "  filter-count := 1000.0"
+if source.count(needle) != 1:
+    raise SystemExit("could not select the EKF browser smoke filter count")
+path.write_text(source.replace(needle, f"  filter-count := {filter_count}.0", 1))
+PY
+
 compute_backend="${MECH_EKF_COMPUTE_BACKEND:-cpu-scalar}"
 case "$compute_backend" in
   cpu-scalar|wgpu) expected_compute_backend="$compute_backend" ;;
@@ -103,17 +121,19 @@ if [[ ! -s "$project_dir/index.html" ]]; then
   exit 1
 fi
 
-python3 - "$project_dir/index.html" "$expected_compute_backend" <<'PY'
+python3 - "$project_dir/index.html" "$expected_compute_backend" "$filter_count" <<'PY'
 from pathlib import Path
 import sys
 
 path = Path(sys.argv[1])
 compute_backend = sys.argv[2]
+filter_count = sys.argv[3]
 html = path.read_text()
 marker = "</head>"
 harness = r'''<script>
     const root = document.documentElement;
     const expectedComputeBackend = "__MECH_EXPECTED_COMPUTE_BACKEND__";
+    const expectedComputeInstances = Number("__MECH_EXPECTED_COMPUTE_INSTANCES__");
     const originalConsoleError = console.error;
     const diagnosticText = (value) => value?.stack || value?.message || String(value);
     console.error = (...args) => {
@@ -506,7 +526,7 @@ harness = r'''<script>
         estimatePathGeometry.extent > 100 &&
         title?.textContent === "Camera EKF Localization" &&
         sceneVisible && outputPresentation &&
-        computeBackend === expectedComputeBackend && computeInstances === 1000
+        computeBackend === expectedComputeBackend && computeInstances === expectedComputeInstances
       ) {
         root.dataset.mechUpdates = String(updates);
         root.dataset.mechCameras = String(cameras.length);
@@ -561,6 +581,7 @@ harness = r'''<script>
 if html.count(marker) != 1:
     raise SystemExit("could not find the head boundary in generated EKF HTML")
 harness = harness.replace("__MECH_EXPECTED_COMPUTE_BACKEND__", compute_backend)
+harness = harness.replace("__MECH_EXPECTED_COMPUTE_INSTANCES__", filter_count)
 path.write_text(html.replace(marker, harness + "\n  " + marker, 1))
 PY
 
@@ -578,66 +599,229 @@ fi
 
 set +e
 python3 - "$chrome_bin" "$page_url" "$chrome_profile" "$dom_file" "$chrome_log" "$compute_backend" <<'PY'
+import base64
+import json
 import os
 from pathlib import Path
 import signal
+import socket
+import struct
 import subprocess
 import sys
 import time
+import urllib.request
+from urllib.parse import urlparse
 
 chrome, page_url, profile, dom_file, chrome_log, compute_backend = sys.argv[1:]
-# Chrome can consume accelerated virtual time while adapter discovery, large
-# WASM compilation, and software-WebGPU pipeline creation wait on real work.
-# Chrome can advance virtual time more than four thousand times faster than wall
-# time while a software WebGPU adapter is initializing. Keep this ceiling far
-# beyond the independent 90-second real-time watchdog; a successful proof stops
-# its timers and lets --dump-dom exit immediately.
-default_virtual_time_budget = "2000000000" if compute_backend == "wgpu" else "600000"
-virtual_time_budget = int(os.environ.get(
-    "MECH_BROWSER_VIRTUAL_TIME_BUDGET_MS",
-    default_virtual_time_budget,
-))
 args = [
     chrome,
     "--headless=new",
     "--no-sandbox",
     "--disable-dev-shm-usage",
-    "--run-all-compositor-stages-before-draw",
-    f"--virtual-time-budget={virtual_time_budget}",
-    "--dump-dom",
+    "--remote-debugging-port=0",
+    "--remote-allow-origins=*",
     f"--user-data-dir={profile}",
     page_url,
 ]
 if compute_backend != "wgpu":
     args.insert(-1, "--disable-gpu")
 else:
-    args.insert(-1, "--enable-unsafe-webgpu")
-with Path(dom_file).open("wb") as stdout, Path(chrome_log).open("wb") as stderr:
-    process = subprocess.Popen(args, stdout=stdout, stderr=stderr, start_new_session=True)
-    deadline = time.monotonic() + 90
+    # The canary proves the browser WebGPU transport, not host-driver setup.
+    # Force Chromium's test adapter so headless macOS and GPU-less Linux CI do
+    # not hang while probing an unavailable presentation-capable device.
+    for flag in (
+        "--enable-unsafe-webgpu",
+        "--enable-unsafe-swiftshader",
+        "--use-webgpu-adapter=swiftshader",
+        "--use-gpu-in-tests",
+    ):
+        args.insert(-1, flag)
+
+def read_exact(connection, length):
+    chunks = []
+    remaining = length
+    while remaining:
+        chunk = connection.recv(remaining)
+        if not chunk:
+            raise RuntimeError("Chrome closed the debugging socket")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+def send_frame(connection, payload, opcode=1):
+    payload = payload if isinstance(payload, bytes) else payload.encode()
+    mask = os.urandom(4)
+    length = len(payload)
+    header = bytearray([0x80 | opcode])
+    if length < 126:
+        header.append(0x80 | length)
+    elif length <= 0xffff:
+        header.append(0x80 | 126)
+        header.extend(struct.pack("!H", length))
+    else:
+        header.append(0x80 | 127)
+        header.extend(struct.pack("!Q", length))
+    header.extend(mask)
+    header.extend(byte ^ mask[index % 4] for index, byte in enumerate(payload))
+    connection.sendall(header)
+
+def receive_message(connection):
+    fragments = []
+    message_opcode = None
     while True:
-        return_code = process.poll()
-        if return_code is not None:
-            raise SystemExit(return_code)
+        first, second = read_exact(connection, 2)
+        final = bool(first & 0x80)
+        opcode = first & 0x0f
+        length = second & 0x7f
+        if length == 126:
+            length = struct.unpack("!H", read_exact(connection, 2))[0]
+        elif length == 127:
+            length = struct.unpack("!Q", read_exact(connection, 8))[0]
+        mask = read_exact(connection, 4) if second & 0x80 else None
+        payload = read_exact(connection, length)
+        if mask:
+            payload = bytes(byte ^ mask[index % 4] for index, byte in enumerate(payload))
+        if opcode == 8:
+            raise RuntimeError("Chrome closed the debugging websocket")
+        if opcode == 9:
+            send_frame(connection, payload, opcode=10)
+            continue
+        if opcode in (1, 2):
+            message_opcode = opcode
+            fragments = [payload]
+        elif opcode == 0:
+            fragments.append(payload)
+        else:
+            continue
+        if final:
+            joined = b"".join(fragments)
+            return joined.decode() if message_opcode == 1 else joined
+
+def connect_debugger(process, deadline):
+    active_port = Path(profile) / "DevToolsActivePort"
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(f"Chrome exited during debugger startup ({process.returncode})")
         try:
-            dom_bytes = Path(dom_file).read_bytes()
-            proof_emitted = (
-                b'data-mech-done="true"' in dom_bytes
-                or b'data-mech-timed-out="true"' in dom_bytes
-                or b'data-mech-console-error=' in dom_bytes
-                or b'data-mech-page-error=' in dom_bytes
+            port = int(active_port.read_text().splitlines()[0])
+            targets = json.load(urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/json/list", timeout=1,
+            ))
+            target = next(
+                (candidate for candidate in targets if candidate.get("type") == "page"),
+                None,
             )
+            if target:
+                endpoint = urlparse(target["webSocketDebuggerUrl"])
+                connection = socket.create_connection((endpoint.hostname, endpoint.port), timeout=2)
+                key = base64.b64encode(os.urandom(16)).decode()
+                request = (
+                    f"GET {endpoint.path} HTTP/1.1\r\n"
+                    f"Host: {endpoint.hostname}:{endpoint.port}\r\n"
+                    "Upgrade: websocket\r\n"
+                    "Connection: Upgrade\r\n"
+                    f"Sec-WebSocket-Key: {key}\r\n"
+                    "Sec-WebSocket-Version: 13\r\n\r\n"
+                )
+                connection.sendall(request.encode())
+                response = b""
+                while b"\r\n\r\n" not in response:
+                    response += connection.recv(4096)
+                if not response.startswith(b"HTTP/1.1 101"):
+                    raise RuntimeError(f"debugging websocket rejected the upgrade: {response[:200]!r}")
+                connection.settimeout(5)
+                return connection
+        except (OSError, ValueError, StopIteration, urllib.error.URLError):
+            pass
+        time.sleep(0.1)
+    raise RuntimeError("Chrome did not expose its debugging target")
+
+next_command_id = 0
+def command(connection, method, params=None):
+    global next_command_id
+    next_command_id += 1
+    command_id = next_command_id
+    send_frame(connection, json.dumps({
+        "id": command_id,
+        "method": method,
+        "params": params or {},
+    }))
+    while True:
+        message = json.loads(receive_message(connection))
+        if message.get("id") == command_id:
+            if "error" in message:
+                raise RuntimeError(f"Chrome debugging command failed: {message['error']}")
+            return message.get("result", {})
+
+def evaluate(connection, expression):
+    result = command(connection, "Runtime.evaluate", {
+        "expression": expression,
+        "returnByValue": True,
+        "awaitPromise": True,
+    })
+    if "exceptionDetails" in result:
+        raise RuntimeError(f"browser evaluation failed: {result['exceptionDetails']}")
+    return result.get("result", {}).get("value")
+
+def stop(process):
+    if process.poll() is None:
+        os.killpg(process.pid, signal.SIGKILL)
+        process.wait()
+
+deadline = time.monotonic() + 90
+milestones = {}
+connection = None
+with Path(chrome_log).open("wb") as stderr:
+    process = subprocess.Popen(
+        args,
+        stdout=subprocess.DEVNULL,
+        stderr=stderr,
+        start_new_session=True,
+    )
+try:
+    connection = connect_debugger(process, deadline)
+    command(connection, "Runtime.enable")
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(f"Chrome exited while running the canary ({process.returncode})")
+        snapshot = evaluate(connection, r'''(() => {
+          const root = document.documentElement;
+          const data = root?.dataset || {};
+          return {
+            readyState: document.readyState,
+            documentStatus: data.mechDocumentStatus || "",
+            adapterStatus: data.mechComputeAdapterStatus || "",
+            deviceStatus: data.mechComputeDeviceStatus || "",
+            computeLifecycle: data.mechComputeLifecycle || "",
+            computeBackend: data.mechComputeBackend || "",
+            computeDispatches: data.mechComputeDispatches || "0",
+            done: data.mechDone === "true",
+            timedOut: data.mechTimedOut === "true",
+            consoleError: data.mechConsoleError || "",
+            pageError: data.mechPageError || "",
+          };
+        })()''') or {}
+        milestones = snapshot
+        if any((
+            snapshot.get("done"),
+            snapshot.get("timedOut"),
+            snapshot.get("consoleError"),
+            snapshot.get("pageError"),
+        )):
+            break
+        time.sleep(0.1)
+    html = evaluate(connection, "document.documentElement.outerHTML") or ""
+    Path(dom_file).write_text(html)
+finally:
+    if connection is not None:
+        try:
+            connection.close()
         except OSError:
-            proof_emitted = False
-        if proof_emitted:
-            os.killpg(process.pid, signal.SIGKILL)
-            process.wait()
-            raise SystemExit(124)
-        if time.monotonic() >= deadline:
-            os.killpg(process.pid, signal.SIGKILL)
-            process.wait()
-            raise SystemExit(124)
-        time.sleep(0.25)
+            pass
+    stop(process)
+    with Path(chrome_log).open("ab") as log:
+        log.write(("\nMech browser milestones: " + json.dumps(milestones, sort_keys=True) + "\n").encode())
+raise SystemExit(124)
 PY
 chrome_status="$?"
 set -e
@@ -671,7 +855,7 @@ if [[ "$chrome_status" -ne 0 && "$chrome_status" -ne 124 ]] \
   || ! grep -q 'data-mech-scene-visible="true"' "$dom_file" \
   || ! grep -q 'data-mech-output-presentation="true"' "$dom_file" \
   || ! grep -q "data-mech-verified-compute-backend=\"$expected_compute_backend\"" "$dom_file" \
-  || ! grep -q 'data-mech-verified-compute-instances="1000"' "$dom_file" \
+  || ! grep -q "data-mech-verified-compute-instances=\"$filter_count\"" "$dom_file" \
   || ! grep -q 'data-mech-sampled-readback-efficient="true"' "$dom_file" \
   || ! grep -q 'data-mech-tracking-error-pixels="[0-9]' "$dom_file" \
   || ! grep -q 'data-mech-truth-x="[0-9]' "$dom_file" \
@@ -740,4 +924,4 @@ Path(path).write_text(json.dumps({
 }, sort_keys=True))
 PY
 fi
-printf 'EKF_E2E display_updates=%s requested_compute_backend=%s compute_backend=%s compute_instances=1000 cameras=4 max_visible_cameras=1 saw_no_camera=true square_sides=4 lap_complete=true smooth_turning=true turning_samples=%s max_heading_step=%s max_guide_deviation_pixels=%s truth_moved=true covariance_finite=true covariance_extent_pixels=%s paths_finite=true tracking_error_pixels=%s output_presentation=true console_errors=0 page_errors=0\n' "$updates" "$compute_backend" "$expected_compute_backend" "$turning_samples" "$max_heading_step" "$max_guide_deviation" "$covariance_extent" "$tracking_error_pixels"
+printf 'EKF_E2E display_updates=%s requested_compute_backend=%s compute_backend=%s compute_instances=%s cameras=4 max_visible_cameras=1 saw_no_camera=true square_sides=4 lap_complete=true smooth_turning=true turning_samples=%s max_heading_step=%s max_guide_deviation_pixels=%s truth_moved=true covariance_finite=true covariance_extent_pixels=%s paths_finite=true tracking_error_pixels=%s output_presentation=true console_errors=0 page_errors=0\n' "$updates" "$compute_backend" "$expected_compute_backend" "$filter_count" "$turning_samples" "$max_heading_step" "$max_guide_deviation" "$covariance_extent" "$tracking_error_pixels"

--- a/scripts/smoke-served-resident-ekf-browser.sh
+++ b/scripts/smoke-served-resident-ekf-browser.sh
@@ -394,20 +394,27 @@ harness = r'''<script>
     let sawOutsideCameraRange = false;
     let cameraToggleDisableRequested = false;
     let cameraToggleDisabled = false;
+    let cameraToggleDisableReleased = false;
+    let cameraToggleDisableRetained = false;
     let cameraToggleMeasurementBlocked = false;
     let cameraToggleEnableRequested = false;
+    let cameraToggleEnableReleased = false;
     let cameraToggleRestored = false;
     let cameraToggleVisualStateValid = false;
     let cameraToggleDispatchBeforeDisable = -1;
+    let cameraToggleDispatchAfterDisableRelease = -1;
     let cameraToggleDispatchBeforeEnable = -1;
+    let cameraToggleDispatchAfterEnableRelease = -1;
+    let cameraToggleDisableGesture;
+    let cameraToggleEnableGesture;
     // Keep the interaction proof outside the turn-121 continuity oracle and
     // the turn-376 backend parity oracle. That makes the numerical baselines
     // independent of browser presentation cadence while still exercising a
     // real disabled measurement on the same resident application run.
     const cameraToggleDisableTurn = 380;
-    const clickSceneCamera = camera => {
+    const pressSceneCamera = camera => {
       const rect = camera?.getBoundingClientRect();
-      if (!rect || rect.width <= 0 || rect.height <= 0) return false;
+      if (!rect || rect.width <= 0 || rect.height <= 0) return null;
       const clientX = rect.left + rect.width / 2;
       const clientY = rect.top + rect.height / 2;
       const handled = !camera.dispatchEvent(new PointerEvent("pointerdown", {
@@ -418,15 +425,19 @@ harness = r'''<script>
         clientX,
         clientY,
       }));
+      return handled ? {clientX, clientY} : null;
+    };
+    const releaseSceneCamera = gesture => {
+      if (!gesture) return false;
       window.dispatchEvent(new PointerEvent("pointerup", {
         bubbles: true,
         cancelable: true,
         button: 0,
         buttons: 0,
-        clientX,
-        clientY,
+        clientX: gesture.clientX,
+        clientY: gesture.clientY,
       }));
-      return handled;
+      return true;
     };
     window.requestAnimationFrame = (callback) => originalSetTimeout(() => {
       if (root.dataset.mechDone === "true" || root.dataset.mechTimedOut === "true") return;
@@ -627,7 +638,8 @@ harness = r'''<script>
           Number.isFinite(filterVisibility) && filterVisibility > 0
         ) {
           cameraToggleDispatchBeforeDisable = logicalComputeTurn;
-          cameraToggleDisableRequested = clickSceneCamera(orderedCameras[0]);
+          cameraToggleDisableGesture = pressSceneCamera(orderedCameras[0]);
+          cameraToggleDisableRequested = Boolean(cameraToggleDisableGesture);
         }
         if (
           cameraToggleDisableRequested && !cameraToggleDisabled &&
@@ -646,17 +658,48 @@ harness = r'''<script>
           cameraToggleDisabled = cameraToggleVisualStateValid;
         }
         if (
-          cameraToggleDisabled && !cameraToggleMeasurementBlocked &&
+          cameraToggleDisabled && !cameraToggleDisableReleased
+        ) {
+          cameraToggleDisableReleased = releaseSceneCamera(cameraToggleDisableGesture);
+          cameraToggleDispatchAfterDisableRelease = logicalComputeTurn;
+        }
+        const pointerPressed = renderedDocumentNumbers("scene-pointer-pressed");
+        const pointerPulse = renderedDocumentNumbers("scene-pointer-pulse");
+        if (
+          cameraToggleDisableReleased && !cameraToggleDisableRetained &&
+          cameraToggleStateReadable && enabledMask[0] === 0 &&
+          enabledMask.slice(1).every(value => value === 1) &&
+          pointerPressed.length === 1 && pointerPressed[0] === 0 &&
+          pointerPulse.length === 1 && pointerPulse[0] === 1 &&
+          logicalComputeTurn > cameraToggleDispatchAfterDisableRelease
+        ) {
+          cameraToggleDisableRetained = true;
+        }
+        if (
+          cameraToggleDisableRetained && !cameraToggleMeasurementBlocked &&
           logicalComputeTurn > cameraToggleDispatchBeforeDisable && filterVisibility === 0
         ) {
           cameraToggleMeasurementBlocked = true;
           cameraToggleDispatchBeforeEnable = logicalComputeTurn;
-          cameraToggleEnableRequested = clickSceneCamera(orderedCameras[0]);
+          cameraToggleEnableGesture = pressSceneCamera(orderedCameras[0]);
+          cameraToggleEnableRequested = Boolean(cameraToggleEnableGesture);
         }
         if (
-          cameraToggleEnableRequested && cameraToggleStateReadable &&
+          cameraToggleEnableRequested && !cameraToggleEnableReleased &&
+          cameraToggleStateReadable &&
           enabledMask.every(value => value === 1) &&
           logicalComputeTurn > cameraToggleDispatchBeforeEnable &&
+          Number.isFinite(filterVisibility) && filterVisibility > 0
+        ) {
+          cameraToggleEnableReleased = releaseSceneCamera(cameraToggleEnableGesture);
+          cameraToggleDispatchAfterEnableRelease = logicalComputeTurn;
+        }
+        if (
+          cameraToggleEnableReleased && cameraToggleStateReadable &&
+          enabledMask.every(value => value === 1) &&
+          pointerPressed.length === 1 && pointerPressed[0] === 0 &&
+          pointerPulse.length === 1 && pointerPulse[0] === 2 &&
+          logicalComputeTurn > cameraToggleDispatchAfterEnableRelease &&
           Number.isFinite(filterVisibility) && filterVisibility > 0
         ) {
           const activeOpacity = Number(orderedCameras[0]?.getAttribute("opacity"));
@@ -870,6 +913,10 @@ harness = r'''<script>
       root.dataset.mechObservedCameraToggleDisableRequested =
         String(cameraToggleDisableRequested);
       root.dataset.mechObservedCameraToggleDisabled = String(cameraToggleDisabled);
+      root.dataset.mechObservedCameraToggleDisableReleased =
+        String(cameraToggleDisableReleased);
+      root.dataset.mechObservedCameraToggleDisableRetained =
+        String(cameraToggleDisableRetained);
       root.dataset.mechObservedCameraToggleMeasurementBlocked =
         String(cameraToggleMeasurementBlocked);
       root.dataset.mechObservedCameraToggleEnableRequested =
@@ -919,8 +966,9 @@ harness = r'''<script>
         cameraGeometryStable && cameraRangeOracleValid && predictionOnlyValid &&
         predictionOnlyComparisons > 0 &&
         cameraToggleDisableRequested && cameraToggleDisabled &&
+        cameraToggleDisableReleased && cameraToggleDisableRetained &&
         cameraToggleMeasurementBlocked && cameraToggleEnableRequested &&
-        cameraToggleRestored && cameraToggleVisualStateValid &&
+        cameraToggleEnableReleased && cameraToggleRestored && cameraToggleVisualStateValid &&
         cameraToggleDispatchBeforeDisable === cameraToggleDisableTurn &&
         Number(document.querySelector(".mech-root")?.dataset.mechScenePointerSubmissions) === 4 &&
         computeParitySample !== undefined &&
@@ -974,6 +1022,8 @@ harness = r'''<script>
         root.dataset.mechMaxVisibleCameras = String(maxVisibleCameras);
         root.dataset.mechCameraGeometryStable = String(cameraGeometryStable);
         root.dataset.mechCameraToggleDisabled = String(cameraToggleDisabled);
+        root.dataset.mechCameraToggleDisableRetained =
+          String(cameraToggleDisableRetained);
         root.dataset.mechCameraToggleMeasurementBlocked =
           String(cameraToggleMeasurementBlocked);
         root.dataset.mechCameraToggleRestored = String(cameraToggleRestored);
@@ -1319,6 +1369,7 @@ if [[ "$chrome_status" -ne 0 && "$chrome_status" -ne 124 ]] \
   || ! grep -q 'data-mech-max-visible-cameras="1"' "$dom_file" \
   || ! grep -q 'data-mech-camera-geometry-stable="true"' "$dom_file" \
   || ! grep -q 'data-mech-camera-toggle-disabled="true"' "$dom_file" \
+  || ! grep -q 'data-mech-camera-toggle-disable-retained="true"' "$dom_file" \
   || ! grep -q 'data-mech-camera-toggle-measurement-blocked="true"' "$dom_file" \
   || ! grep -q 'data-mech-camera-toggle-restored="true"' "$dom_file" \
   || ! grep -q 'data-mech-camera-toggle-pointer-submissions="4"' "$dom_file" \

--- a/scripts/smoke-served-rich-document-browser.sh
+++ b/scripts/smoke-served-rich-document-browser.sh
@@ -953,6 +953,41 @@ def assert_output_fullscreen_control():
     if not all(fullscreen.values()):
         fail(f"output fullscreen did not remain an independent output-only surface: {fullscreen!r}")
 
+    evaluate("""
+(() => {
+  window.dispatchEvent(new CustomEvent('mech:output', { detail: {
+    stream: 'stdout', operation: 'create', display_id: 'fullscreen-long-text',
+    content: {kind: 'text', data: {text: Array.from(
+      {length: 240}, (_, index) => `text output line ${index + 1}`).join('\\n')}},
+  }}));
+})()
+""")
+    wait_for(
+        "document.querySelector('[data-mech-display-id=\"fullscreen-long-text\"]') !== null",
+        "long textual output in output fullscreen",
+    )
+    text_scroll = evaluate_json("""
+(() => {
+  const panel = document.querySelector('[data-mech-output-panel]');
+  const style = panel && getComputedStyle(panel);
+  return panel ? {
+    overflow: style.overflowY,
+    scrollable: panel.scrollHeight > panel.clientHeight,
+  } : null;
+})()
+""")
+    if (
+        text_scroll is None or
+        text_scroll["overflow"] not in {"auto", "scroll"} or
+        not text_scroll["scrollable"]
+    ):
+        fail(f"fullscreen textual output did not retain the panel scroll surface: {text_scroll!r}")
+    evaluate("""
+window.dispatchEvent(new CustomEvent('mech:output', { detail: {
+  stream: 'stdout', operation: 'remove', display_id: 'fullscreen-long-text',
+}}))
+""")
+
     captured = evaluate_json("""
 (() => {
   const input = document.querySelector('.repl-input');
@@ -971,6 +1006,108 @@ def assert_output_fullscreen_control():
         "document.querySelector(\"[data-mech-console-tab='output']\")?.getAttribute('aria-selected') === 'true' && "
         "getComputedStyle(document.querySelector('.content-shell, .content, #left-pane')).display !== 'none'",
         "backtick revealing the editor with Output selected",
+    )
+
+    evaluate("""
+(() => {
+  const pane = document.querySelector('[data-mech-console-pane]');
+  const toggle = document.querySelector('button[data-mech-output-fullscreen]');
+  const pending = {native: false, exitCalls: 0, resolve: null};
+  window.__mechPendingOutputFullscreen = pending;
+  Object.defineProperty(document, 'fullscreenElement', {
+    configurable: true,
+    get: () => pending.native ? pane : null,
+  });
+  Object.defineProperty(document, 'exitFullscreen', {
+    configurable: true,
+    value: async () => {
+      pending.exitCalls += 1;
+      pending.native = false;
+      document.dispatchEvent(new Event('fullscreenchange'));
+    },
+  });
+  Object.defineProperty(pane, 'requestFullscreen', {
+    configurable: true,
+    value: () => new Promise(resolve => {
+      pending.resolve = () => {
+        pending.native = true;
+        document.dispatchEvent(new Event('fullscreenchange'));
+        resolve();
+      };
+    }),
+  });
+  toggle.click();
+})()
+""")
+    wait_for(
+        "document.querySelector('[data-mech-repl-host]')?.dataset.mechOutputFullscreenActive === 'true' && "
+        "typeof window.__mechPendingOutputFullscreen?.resolve === 'function'",
+        "a pending output fullscreen request",
+    )
+    evaluate("document.querySelector('button[data-mech-output-fullscreen]')?.click()")
+    wait_for(
+        "document.querySelector('[data-mech-repl-host]')?.dataset.mechOutputFullscreenActive === 'false'",
+        "canceling a pending output fullscreen request",
+    )
+    evaluate("window.__mechPendingOutputFullscreen.resolve()")
+    wait_for(
+        "window.__mechPendingOutputFullscreen?.exitCalls === 1 && "
+        "document.fullscreenElement === null && "
+        "document.querySelector('[data-mech-repl-host]')?.dataset.mechOutputFullscreenActive === 'false' && "
+        "!document.querySelector('[data-mech-console-pane]')?.classList.contains('is-fullscreen')",
+        "the stale fullscreen completion being relinquished",
+    )
+    evaluate("""
+(() => {
+  const pane = document.querySelector('[data-mech-console-pane]');
+  delete pane.requestFullscreen;
+  delete document.exitFullscreen;
+  delete document.fullscreenElement;
+  delete window.__mechPendingOutputFullscreen;
+})()
+""")
+
+    devtools.call(
+        "Emulation.setDeviceMetricsOverride",
+        {"width": 700, "height": 700, "deviceScaleFactor": 1, "mobile": False},
+        session_id,
+    )
+    evaluate("""
+(() => {
+  const pane = document.querySelector('[data-mech-console-pane]');
+  Object.defineProperty(pane, 'requestFullscreen', {
+    configurable: true,
+    value: undefined,
+  });
+  document.querySelector('button[data-mech-output-fullscreen]')?.click();
+})()
+""")
+    wait_for(
+        "document.querySelector('[data-mech-repl-host]')?.dataset.mechOutputFullscreenActive === 'true'",
+        "compact output fullscreen fallback",
+    )
+    compact_fallback = evaluate_json("""
+(() => {
+  const pane = document.querySelector('[data-mech-console-pane]');
+  const rect = pane?.getBoundingClientRect();
+  return rect ? {
+    fillsWidth: rect.left <= 1 && rect.right >= innerWidth - 1,
+    fillsHeight: rect.top <= 1 && rect.bottom >= innerHeight - 1,
+  } : null;
+})()
+""")
+    if compact_fallback is None or not all(compact_fallback.values()):
+        fail(f"compact output fullscreen fallback remained a drawer: {compact_fallback!r}")
+    evaluate("document.querySelector('button[data-mech-output-fullscreen]')?.click()")
+    wait_for(
+        "document.querySelector('[data-mech-repl-host]')?.dataset.mechOutputFullscreenActive === 'false'",
+        "compact output fullscreen fallback exit",
+    )
+    evaluate("delete document.querySelector('[data-mech-console-pane]').requestFullscreen")
+    devtools.call(
+        "Emulation.setDeviceMetricsOverride",
+        {"width": 1680, "height": 900, "deviceScaleFactor": 1, "mobile": False},
+        session_id,
     )
     evaluate("document.querySelector(\"[data-mech-console-tab='console']\")?.click()")
 
@@ -1030,8 +1167,10 @@ def assert_fullscreen_accessibility():
     kindElided: (() => {
       const kind = document.querySelector(
         '[data-mech-display-id="unread-output"] [data-mech-kind-elided="true"]');
-      return Boolean(kind) && kind.textContent.length <= 96 &&
-        kind.textContent.endsWith('…') && (kind.title || '').length > 96;
+      const style = kind && getComputedStyle(kind);
+      return Boolean(kind) && kind.textContent === kind.title &&
+        kind.textContent.length > 96 && style.overflow === 'hidden' &&
+        style.textOverflow === 'ellipsis' && style.maxWidth !== 'none';
     })(),
   };
 })()

--- a/scripts/test-browser-compute-lifecycle.mjs
+++ b/scripts/test-browser-compute-lifecycle.mjs
@@ -119,7 +119,7 @@ function fakeDeviceFor(bytes) {
 const rejectedBytes = new ArrayBuffer(68);
 new Uint32Array(rejectedBytes, 60, 2).set([1, (7 << 8) | 1]);
 const rejectedDevice = fakeDeviceFor(rejectedBytes);
-const rejected = await rejectedDevice.finish();
+const rejected = await rejectedDevice.finish(Promise.resolve());
 assert.deepEqual(rejected, {
   outputs: [],
   integrity: { constraint: "finite-estimate!", instance: 7 },
@@ -130,14 +130,20 @@ assert.equal(rejectedDevice.metrics.gpuToCpuOutputBytes, 0);
 const acceptedBytes = new ArrayBuffer(68);
 new Float32Array(acceptedBytes, 0, 15).set(Array.from({ length: 15 }, (_, index) => index));
 const acceptedDevice = fakeDeviceFor(acceptedBytes);
-const acceptedResult = await acceptedDevice.finish();
+const acceptedResult = await acceptedDevice.finish(Promise.resolve());
 assert.equal(acceptedResult.outputs.length, 2);
 assert.equal(acceptedDevice.metrics.gpuToCpuReadbackBytes, 68);
 assert.equal(acceptedDevice.metrics.gpuToCpuOutputBytes, 120);
 
 const reportOnly = Object.create(Device.prototype);
 reportOnly.readback = null;
-reportOnly.device = { queue: { async onSubmittedWorkDone() {} } };
+reportOnly.device = {
+  queue: {
+    async onSubmittedWorkDone() {
+      throw new Error("finish must not widen completion to later queue work");
+    },
+  },
+};
 reportOnly.metrics = {
   cpuToGpuInputBytes: 0,
   gpuToCpuReadbackBytes: 0,
@@ -146,7 +152,14 @@ reportOnly.metrics = {
   uniquePhysicalOutputBuffers: 0,
 };
 reportOnly.publishMetrics = () => {};
-assert.deepEqual(await reportOnly.finish(), { outputs: [], integrity: null });
+assert.deepEqual(
+  await reportOnly.finish(Promise.resolve()),
+  { outputs: [], integrity: null },
+);
 assert.equal(reportOnly.metrics.gpuToCpuReadbackBytes, 0);
+await assert.rejects(
+  () => reportOnly.finish(),
+  /exact submission promise/,
+);
 
 console.log("browser compute submission lifecycle tests passed");

--- a/scripts/test-browser-compute-lifecycle.mjs
+++ b/scripts/test-browser-compute-lifecycle.mjs
@@ -5,6 +5,7 @@ await import("../include/browser-compute.js");
 
 const Lifecycle = globalThis.MechComputeSubmissionLifecycle;
 const ResetLedger = globalThis.MechComputeStateResetLedger;
+const ResetTracker = globalThis.MechComputeStateResetTracker;
 const Device = globalThis.MechBrowserComputeDevice;
 
 const resets = new ResetLedger();
@@ -21,6 +22,39 @@ assert.equal(
   resets.record(2, 3, "sha256:old", "sha256:new"),
   null,
   "one physical plan transition must publish exactly one reset",
+);
+
+const scalarResets = new ResetTracker();
+assert.equal(
+  scalarResets.advance({
+    present: true,
+    generation: 1,
+    revision: "sha256:scalar-old",
+  }),
+  null,
+  "the first scalar generation seeds reset tracking",
+);
+assert.deepEqual(
+  scalarResets.advance({
+    present: true,
+    generation: 2,
+    revision: "sha256:scalar-new",
+  }),
+  {
+    previousRevision: "sha256:scalar-old",
+    nextRevision: "sha256:scalar-new",
+    resetCount: 1,
+  },
+  "scalar physical replacement must report the same reset as WebGPU",
+);
+assert.equal(
+  scalarResets.advance({
+    present: true,
+    generation: 3,
+    revision: "sha256:scalar-new",
+  }),
+  null,
+  "a compatible scalar replacement must preserve state without a reset",
 );
 
 const beforeSubmission = new Lifecycle(7);

--- a/scripts/test-browser-compute-lifecycle.mjs
+++ b/scripts/test-browser-compute-lifecycle.mjs
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+
+globalThis.GPUMapMode = { READ: 1 };
+await import("../include/browser-compute.js");
+
+const Lifecycle = globalThis.MechComputeSubmissionLifecycle;
+const Device = globalThis.MechBrowserComputeDevice;
+
+const beforeSubmission = new Lifecycle(7);
+assert.equal(beforeSubmission.canAutoFallback(), true);
+const constructionFailure = new Error("device lost before submission");
+assert.equal(beforeSubmission.markFailed(constructionFailure), constructionFailure);
+assert.equal(beforeSubmission.canAutoFallback(), true);
+
+const inFlight = new Lifecycle(8);
+inFlight.markSubmitted("8:1");
+assert.equal(inFlight.canAutoFallback(), false);
+const loss = new Error("device lost after submission");
+assert.equal(inFlight.markFailed(loss), loss);
+assert.equal(inFlight.canAutoFallback(), false);
+assert.throws(() => inFlight.markAccepted("8:1"), loss);
+
+const accepted = new Lifecycle(9);
+accepted.markSubmitted("9:1");
+accepted.markAccepted("9:1");
+assert.equal(accepted.canAutoFallback(), false);
+const acceptedLoss = accepted.markFailed(new Error("device lost after acceptance"));
+assert.match(acceptedLoss.message, /after acceptance/);
+assert.equal(accepted.canAutoFallback(), false);
+
+const identity = new Lifecycle(10);
+identity.markSubmitted("10:2");
+assert.throws(
+  () => identity.markAccepted("10:1"),
+  /does not match the in-flight submission/,
+);
+identity.markAccepted("10:2");
+
+const firstFailure = new Lifecycle(11);
+const first = firstFailure.markFailed(new Error("first"));
+assert.equal(firstFailure.markFailed(new Error("second")), first);
+assert.equal(firstFailure.failure.message, "first");
+
+const manifest = {
+  bindings: [
+    { elements: 15, role: "state-write" },
+    { elements: 2, role: "integrity-fault" },
+  ],
+  outputs: [
+    {
+      name: "estimate",
+      sampleDimensions: [15],
+      physicalLayout: "row-major",
+    },
+    {
+      name: "estimate-alias",
+      sampleDimensions: [15],
+      physicalLayout: "row-major",
+    },
+  ],
+  physicalOutputs: [{
+    id: 0,
+    aliases: ["estimate", "estimate-alias"],
+    sampleElements: 15,
+  }],
+  constraints: [{ code: 1, name: "finite-estimate!" }],
+  dispatchElements: 1,
+  workgroupSize: 64,
+};
+const supported = {
+  maxStorageBuffersPerShaderStage: 8,
+  maxComputeWorkgroupsPerDimension: 65535,
+  maxStorageBufferBindingSize: 1024,
+  maxBufferSize: 1024,
+};
+assert.equal(
+  Device.requiredLimits(manifest, supported, ["estimate", "estimate-alias"]).maxBufferSize,
+  68,
+  "logical aliases must not multiply the physical readback allocation",
+);
+assert.equal(
+  Device.requiredLimits(manifest, supported, []).maxBufferSize,
+  68,
+  "late-bound sampling must be admitted when the WebGPU device is created",
+);
+
+function fakeReadback(bytes) {
+  return {
+    async mapAsync() {},
+    getMappedRange() { return bytes; },
+    unmap() {},
+  };
+}
+
+function fakeDeviceFor(bytes) {
+  const device = Object.create(Device.prototype);
+  device.readback = fakeReadback(bytes);
+  device.readbackBytes = bytes.byteLength;
+  device.metrics = {
+    cpuToGpuInputBytes: 0,
+    gpuToCpuReadbackBytes: 0,
+    gpuToCpuOutputBytes: 0,
+    logicalOutputs: 2,
+    uniquePhysicalOutputBuffers: 1,
+  };
+  device.integrity = { elements: 2 };
+  device.integrityOffset = 60;
+  device.manifest = manifest;
+  device.readbackPlan = [{
+    output: manifest.outputs[0],
+    aliases: manifest.outputs,
+    offset: 0,
+    bytes: 60,
+  }];
+  device.publishMetrics = () => {};
+  return device;
+}
+
+const rejectedBytes = new ArrayBuffer(68);
+new Uint32Array(rejectedBytes, 60, 2).set([1, (7 << 8) | 1]);
+const rejectedDevice = fakeDeviceFor(rejectedBytes);
+const rejected = await rejectedDevice.finish();
+assert.deepEqual(rejected, {
+  outputs: [],
+  integrity: { constraint: "finite-estimate!", instance: 7 },
+});
+assert.equal(rejectedDevice.metrics.gpuToCpuReadbackBytes, 68);
+assert.equal(rejectedDevice.metrics.gpuToCpuOutputBytes, 0);
+
+const acceptedBytes = new ArrayBuffer(68);
+new Float32Array(acceptedBytes, 0, 15).set(Array.from({ length: 15 }, (_, index) => index));
+const acceptedDevice = fakeDeviceFor(acceptedBytes);
+const acceptedResult = await acceptedDevice.finish();
+assert.equal(acceptedResult.outputs.length, 2);
+assert.equal(acceptedDevice.metrics.gpuToCpuReadbackBytes, 68);
+assert.equal(acceptedDevice.metrics.gpuToCpuOutputBytes, 120);
+
+const reportOnly = Object.create(Device.prototype);
+reportOnly.readback = null;
+reportOnly.device = { queue: { async onSubmittedWorkDone() {} } };
+reportOnly.metrics = {
+  cpuToGpuInputBytes: 0,
+  gpuToCpuReadbackBytes: 0,
+  gpuToCpuOutputBytes: 0,
+  logicalOutputs: 0,
+  uniquePhysicalOutputBuffers: 0,
+};
+reportOnly.publishMetrics = () => {};
+assert.deepEqual(await reportOnly.finish(), { outputs: [], integrity: null });
+assert.equal(reportOnly.metrics.gpuToCpuReadbackBytes, 0);
+
+console.log("browser compute submission lifecycle tests passed");

--- a/scripts/test-browser-compute-lifecycle.mjs
+++ b/scripts/test-browser-compute-lifecycle.mjs
@@ -4,7 +4,24 @@ globalThis.GPUMapMode = { READ: 1 };
 await import("../include/browser-compute.js");
 
 const Lifecycle = globalThis.MechComputeSubmissionLifecycle;
+const ResetLedger = globalThis.MechComputeStateResetLedger;
 const Device = globalThis.MechBrowserComputeDevice;
+
+const resets = new ResetLedger();
+assert.equal(resets.record(1, 2, "sha256:same", "sha256:same"), null);
+assert.deepEqual(
+  resets.record(2, 3, "sha256:old", "sha256:new"),
+  {
+    previousRevision: "sha256:old",
+    nextRevision: "sha256:new",
+    resetCount: 1,
+  },
+);
+assert.equal(
+  resets.record(2, 3, "sha256:old", "sha256:new"),
+  null,
+  "one physical plan transition must publish exactly one reset",
+);
 
 const beforeSubmission = new Lifecycle(7);
 assert.equal(beforeSubmission.canAutoFallback(), true);
@@ -42,6 +59,7 @@ assert.equal(firstFailure.markFailed(new Error("second")), first);
 assert.equal(firstFailure.failure.message, "first");
 
 const manifest = {
+  physicalRevision: "sha256:stable-plan",
   bindings: [
     { elements: 15, role: "state-write" },
     { elements: 2, role: "integrity-fault" },
@@ -67,6 +85,19 @@ const manifest = {
   dispatchElements: 1,
   workgroupSize: 64,
 };
+
+const reusable = Object.create(Device.prototype);
+reusable.disposed = false;
+reusable.physicalRevision = manifest.physicalRevision;
+reusable.manifest = manifest;
+assert.equal(reusable.compatibleWith({ ...manifest }), true);
+assert.equal(
+  reusable.compatibleWith({ ...manifest, physicalRevision: "sha256:changed-plan" }),
+  false,
+);
+const replacementManifest = { ...manifest };
+reusable.adoptManifest(replacementManifest);
+assert.equal(reusable.manifest, replacementManifest);
 const supported = {
   maxStorageBuffersPerShaderStage: 8,
   maxComputeWorkgroupsPerDimension: 65535,

--- a/src/cli/compute.rs
+++ b/src/cli/compute.rs
@@ -1,8 +1,11 @@
-use mech_compute::{BackendRequest, ComputePlatform};
+use std::collections::BTreeMap;
+
+use mech_compute::{BackendRequest, ComputePlatform, ComputeValue};
 use mech_core::{MResult, MechError, MechErrorKind};
 use mech_engine::ProgramArtifact;
 use mech_gpu::{
-    ComputeHostFactory, lower_elementwise_compute_program, native_compute_backend_registry,
+    ComputeHostFactory, ComputeLowerer, lower_elementwise_compute_program,
+    native_compute_backend_registry,
 };
 use mech_runtime::{FileSourceResolver, RuntimeHostFactory, SourceRequest};
 
@@ -97,15 +100,29 @@ fn compile_compute_application(
     .build_compiler()?;
     let mixed = compile(&mut compiler)?;
 
-    let program = lower_elementwise_compute_program(&mixed.compute.artifact).map_err(|error| {
-        compute_cli_error(
-            "lower_compute_region",
-            format!(
-                "region `{}` is not supported by the native compute backends:\n{error}",
-                mixed.compute.declaration.name
-            ),
-        )
-    })?;
+    let mut activation_values =
+        initializer_values(&mixed.compute.interface, &mixed.compute.initializers)?;
+    activation_values.extend(
+        mixed
+            .activation_inputs
+            .iter()
+            .map(|(name, value)| (name.clone(), value_elements(value))),
+    );
+    let program = match lower_elementwise_compute_program(&mixed.compute.artifact) {
+        Ok(program) => program,
+        Err(elementwise_failure) => ComputeLowerer
+            .compile_broadcast(&mixed.compute.artifact, &activation_values)
+            .map(|kernel| kernel.compute_program().clone())
+            .map_err(|fixed_failure| {
+                compute_cli_error(
+                    "lower_compute_region",
+                    format!(
+                        "region `{}` is not supported by the native compute backends; elementwise: {elementwise_failure}; fixed-shape: {fixed_failure}",
+                        mixed.compute.declaration.name,
+                    ),
+                )
+            })?,
+    };
     let mut factory = ComputeHostFactory::new(
         mixed.compute.declaration.name.clone(),
         mixed.compute.declaration.placement,
@@ -128,6 +145,35 @@ fn compile_compute_application(
         coordinator: mixed.coordinator.into_artifact(),
         factory: Box::new(factory),
     })
+}
+
+fn initializer_values(
+    interface: &mech_compute::ComputeRegionInterface,
+    initializers: &mech_compute::ComputeInitializerSet,
+) -> MResult<BTreeMap<String, Vec<f32>>> {
+    interface
+        .inputs
+        .iter()
+        .map(|port| {
+            let value = initializers.get(port.id).ok_or_else(|| {
+                compute_cli_error(
+                    "lower_compute_region",
+                    format!("compute input `{}` has no initializer", port.name),
+                )
+            })?;
+            let value = port.normalize_value(value.clone()).map_err(|failure| {
+                compute_cli_error("lower_compute_region", failure.to_string())
+            })?;
+            Ok((port.name.to_string(), value_elements(&value)))
+        })
+        .collect()
+}
+
+fn value_elements(value: &ComputeValue) -> Vec<f32> {
+    match value {
+        ComputeValue::ScalarF32(value) => vec![*value],
+        ComputeValue::TensorF32 { values, .. } => values.to_vec(),
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/cli/compute.rs
+++ b/src/cli/compute.rs
@@ -130,7 +130,8 @@ fn compile_compute_application(
         mixed.compute.initializers,
         native_compute_backend_registry(),
         ComputePlatform::Native,
-    )?;
+    )?
+    .with_retained_outputs(mixed.retained_outputs)?;
     if let Some(request) = plan.backend_override.as_deref() {
         factory =
             factory.with_backend_override(BackendRequest::parse(request).map_err(|error| {

--- a/src/cli/resources.rs
+++ b/src/cli/resources.rs
@@ -12,10 +12,18 @@ pub(crate) static MECHWASM: &[u8] = include_bytes!("../../src/wasm/pkg/mech_wasm
 pub(crate) static MECHJS: &[u8] = include_bytes!("../../src/wasm/pkg/mech_wasm.js");
 
 #[cfg(has_file_project_js)]
-pub(crate) static PROJECTJS: &str = include_str!("../../include/project.js");
+pub(crate) static PROJECTJS: &str = concat!(
+    include_str!("../../include/browser-compute.js"),
+    "\n",
+    include_str!("../../include/project.js")
+);
 
 #[cfg(has_file_document_js)]
-pub(crate) static DOCUMENTJS: &str = include_str!("../../include/document.js");
+pub(crate) static DOCUMENTJS: &str = concat!(
+    include_str!("../../include/browser-compute.js"),
+    "\n",
+    include_str!("../../include/document.js")
+);
 
 #[cfg(has_file_shim)]
 pub(crate) static SHIMHTML: &str = include_str!("../../include/index.html");

--- a/src/compute/src/ir.rs
+++ b/src/compute/src/ir.rs
@@ -30,6 +30,7 @@ impl BinaryOperation {
 pub enum UnaryOperation {
     Sin,
     Cos,
+    Sqrt,
 }
 
 impl UnaryOperation {
@@ -37,6 +38,7 @@ impl UnaryOperation {
         match self {
             Self::Sin => input.sin(),
             Self::Cos => input.cos(),
+            Self::Sqrt => input.sqrt(),
         }
     }
 }
@@ -184,6 +186,9 @@ pub fn elementwise_lowering(operation: &OperationReference) -> Option<Elementwis
         ))),
         "math/cos" => Some(ElementwiseLowering::Apply(ElementwiseOperation::Unary(
             UnaryOperation::Cos,
+        ))),
+        "math/sqrt" => Some(ElementwiseLowering::Apply(ElementwiseOperation::Unary(
+            UnaryOperation::Sqrt,
         ))),
         "math/atan2" => Some(ElementwiseLowering::Apply(ElementwiseOperation::Atan2)),
         "matrix/horzcat" => Some(ElementwiseLowering::Apply(ElementwiseOperation::Identity)),

--- a/src/compute/src/ir.rs
+++ b/src/compute/src/ir.rs
@@ -31,6 +31,7 @@ pub enum UnaryOperation {
     Sin,
     Cos,
     Sqrt,
+    Ceil,
 }
 
 impl UnaryOperation {
@@ -39,6 +40,7 @@ impl UnaryOperation {
             Self::Sin => input.sin(),
             Self::Cos => input.cos(),
             Self::Sqrt => input.sqrt(),
+            Self::Ceil => input.ceil(),
         }
     }
 }
@@ -190,6 +192,9 @@ pub fn elementwise_lowering(operation: &OperationReference) -> Option<Elementwis
         "math/sqrt" => Some(ElementwiseLowering::Apply(ElementwiseOperation::Unary(
             UnaryOperation::Sqrt,
         ))),
+        "math/ceil" => Some(ElementwiseLowering::Apply(ElementwiseOperation::Unary(
+            UnaryOperation::Ceil,
+        ))),
         "math/atan2" => Some(ElementwiseLowering::Apply(ElementwiseOperation::Atan2)),
         "matrix/horzcat" => Some(ElementwiseLowering::Apply(ElementwiseOperation::Identity)),
         "matrix/vertcat" => Some(ElementwiseLowering::Concat2),
@@ -285,6 +290,12 @@ mod tests {
             Some(ElementwiseLowering::Concat2)
         );
         assert_eq!(
+            elementwise_lowering(&operation("math/ceil")),
+            Some(ElementwiseLowering::Apply(ElementwiseOperation::Unary(
+                UnaryOperation::Ceil
+            )))
+        );
+        assert_eq!(
             elementwise_lowering(&operation("runtime/MulMDS<f32>")),
             None
         );
@@ -294,6 +305,9 @@ mod tests {
     fn elementwise_ir_has_backend_independent_scalar_semantics() {
         let multiply = ElementwiseOperation::Binary(BinaryOperation::Multiply);
         assert_eq!(multiply.apply(&[6.0, 7.0]), 42.0);
+        let ceil = ElementwiseOperation::Unary(UnaryOperation::Ceil);
+        assert_eq!(ceil.apply(&[0.25]), 1.0);
+        assert_eq!(ceil.apply(&[0.0]), 0.0);
         let concatenation = ElementwiseInstruction::Concat2 {
             left: ArtifactSource::Slot(CellSlotId::new(0)),
             right: ArtifactSource::Slot(CellSlotId::new(1)),

--- a/src/compute/src/port.rs
+++ b/src/compute/src/port.rs
@@ -114,6 +114,95 @@ impl ComputePort {
             }),
         }
     }
+
+    /// Normalizes either one inner value or an outer batch of inner values.
+    ///
+    /// The source language only owns ordinary scalar and matrix values, so a
+    /// coordinator may express a scalar batch as a row/column matrix rather
+    /// than a rank-one tensor. Batch admission therefore follows element
+    /// count, while the returned compute value has the canonical
+    /// `[instances, ..inner_dimensions]` row-major shape.
+    pub fn normalize_broadcast_value(
+        &self,
+        value: ComputeValue,
+        expected_instances: Option<u32>,
+    ) -> Result<(ComputeValue, u32), ComputeValueError> {
+        if let Ok(value) = self.normalize_value(value.clone()) {
+            return Ok((value, 1));
+        }
+
+        let ComputeValue::TensorF32 {
+            dimensions,
+            layout,
+            values,
+        } = value
+        else {
+            return self.normalize_value(value).map(|value| (value, 1));
+        };
+        let inner_elements = self.elements()?;
+        if inner_elements == 0 || values.is_empty() || values.len() % inner_elements != 0 {
+            return Err(ComputeValueError::ElementCountMismatch {
+                port: self.name.clone(),
+                expected: inner_elements,
+                actual: values.len(),
+            });
+        }
+        let instances = values.len() / inner_elements;
+        if let Some(expected) = expected_instances
+            && instances != 1
+            && instances != expected as usize
+        {
+            let mut expected_dimensions = Vec::from(self.dimensions.as_ref());
+            expected_dimensions.insert(0, u64::from(expected));
+            return Err(ComputeValueError::DimensionMismatch {
+                port: self.name.clone(),
+                expected: expected_dimensions.into_boxed_slice(),
+                actual: dimensions,
+            });
+        }
+        let instances =
+            u32::try_from(instances).map_err(|_| ComputeValueError::ElementCountMismatch {
+                port: self.name.clone(),
+                expected: usize::try_from(u32::MAX).unwrap_or(usize::MAX),
+                actual: values.len(),
+            })?;
+        let values = match layout {
+            TensorLayout::RowMajor => values,
+            TensorLayout::ColumnMajor => {
+                Arc::from(column_major_to_row_major(&dimensions, values.as_ref())?)
+            }
+            TensorLayout::Scalar => {
+                return Err(ComputeValueError::LayoutMismatch {
+                    port: self.name.clone(),
+                    expected: TensorLayout::RowMajor,
+                    actual: TensorLayout::Scalar,
+                });
+            }
+        };
+        if instances == 1 {
+            if self.dimensions.is_empty() {
+                return Ok((ComputeValue::ScalarF32(values[0]), 1));
+            }
+            return Ok((
+                ComputeValue::TensorF32 {
+                    dimensions: self.dimensions.clone(),
+                    layout: TensorLayout::RowMajor,
+                    values,
+                },
+                1,
+            ));
+        }
+        let mut canonical_dimensions = Vec::from(self.dimensions.as_ref());
+        canonical_dimensions.insert(0, u64::from(instances));
+        Ok((
+            ComputeValue::TensorF32 {
+                dimensions: canonical_dimensions.into_boxed_slice(),
+                layout: TensorLayout::RowMajor,
+                values,
+            },
+            instances,
+        ))
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/compute/src/port.rs
+++ b/src/compute/src/port.rs
@@ -33,6 +33,19 @@ pub enum TensorLayout {
     ColumnMajor,
 }
 
+/// The single host-to-compute numeric narrowing boundary.
+///
+/// Existing non-finite values retain IEEE semantics. A finite f64 that would
+/// become an infinity is rejected rather than silently changing meaning.
+pub fn narrow_compute_f64(value: f64) -> Result<f32, f64> {
+    let narrowed = value as f32;
+    if value.is_finite() && !narrowed.is_finite() {
+        Err(value)
+    } else {
+        Ok(narrowed)
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ComputePort {
     pub id: ComputePortId,
@@ -118,10 +131,11 @@ impl ComputePort {
     /// Normalizes either one inner value or an outer batch of inner values.
     ///
     /// The source language only owns ordinary scalar and matrix values, so a
-    /// coordinator may express a scalar batch as a row/column matrix rather
-    /// than a rank-one tensor. Batch admission therefore follows element
-    /// count, while the returned compute value has the canonical
-    /// `[instances, ..inner_dimensions]` row-major shape.
+    /// coordinator may express a scalar batch as a row/column matrix and a
+    /// matrix batch as one row of flattened inner elements per instance. The
+    /// outer lane axis is nevertheless structural: values with the same total
+    /// element count but a transposed or unrelated shape are rejected before
+    /// storage is relabeled as `[instances, ..inner_dimensions]`.
     pub fn normalize_broadcast_value(
         &self,
         value: ComputeValue,
@@ -157,6 +171,34 @@ impl ComputePort {
             return Err(ComputeValueError::DimensionMismatch {
                 port: self.name.clone(),
                 expected: expected_dimensions.into_boxed_slice(),
+                actual: dimensions,
+            });
+        }
+        let mut canonical_dimensions = Vec::from(self.dimensions.as_ref());
+        canonical_dimensions.insert(0, instances as u64);
+        let shape_is_canonical = dimensions.as_ref() == canonical_dimensions.as_slice();
+        let shape_is_matrix_projection = !self.dimensions.is_empty()
+            && dimensions.as_ref() == [instances as u64, inner_elements as u64];
+        let shape_is_scalar_batch = self.dimensions.is_empty()
+            && matches!(
+                dimensions.as_ref(),
+                [extent] if *extent == instances as u64
+            );
+        let shape_is_scalar_row_or_column = self.dimensions.is_empty()
+            && matches!(
+                dimensions.as_ref(),
+                [rows, columns]
+                    if (*rows == instances as u64 && *columns == 1)
+                        || (*rows == 1 && *columns == instances as u64)
+            );
+        if !shape_is_canonical
+            && !shape_is_matrix_projection
+            && !shape_is_scalar_batch
+            && !shape_is_scalar_row_or_column
+        {
+            return Err(ComputeValueError::DimensionMismatch {
+                port: self.name.clone(),
+                expected: canonical_dimensions.into_boxed_slice(),
                 actual: dimensions,
             });
         }
@@ -617,6 +659,150 @@ fn dimensions_elements(dimensions: &[u64]) -> Result<usize, ComputeValueError> {
             .checked_mul(extent)
             .ok_or(ComputeValueError::ElementCountOverflow)
     })
+}
+
+#[cfg(test)]
+mod broadcast_tests {
+    use super::*;
+
+    fn matrix_port() -> ComputePort {
+        ComputePort {
+            id: ComputePortId::new(0),
+            name: "control".into(),
+            slot: CellSlotId::new(0),
+            schema: SchemaId::new(0),
+            element: ComputeElementType::F32,
+            dimensions: vec![3, 1].into_boxed_slice(),
+        }
+    }
+
+    #[test]
+    fn matrix_batch_requires_the_outer_lane_axis() {
+        let port = matrix_port();
+        let (value, instances) = port
+            .normalize_broadcast_value(
+                ComputeValue::TensorF32 {
+                    dimensions: vec![2, 3].into_boxed_slice(),
+                    layout: TensorLayout::ColumnMajor,
+                    values: Arc::from([1.0, 4.0, 2.0, 5.0, 3.0, 6.0]),
+                },
+                Some(2),
+            )
+            .unwrap();
+        assert_eq!(instances, 2);
+        assert_eq!(
+            value,
+            ComputeValue::TensorF32 {
+                dimensions: vec![2, 3, 1].into_boxed_slice(),
+                layout: TensorLayout::RowMajor,
+                values: Arc::from([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+            }
+        );
+
+        let transposed = port.normalize_broadcast_value(
+            ComputeValue::TensorF32 {
+                dimensions: vec![3, 2].into_boxed_slice(),
+                layout: TensorLayout::RowMajor,
+                values: Arc::from([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+            },
+            Some(2),
+        );
+        assert!(matches!(
+            transposed,
+            Err(ComputeValueError::DimensionMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn canonical_ranked_batch_is_not_reinterpreted() {
+        let port = matrix_port();
+        let values: Arc<[f32]> = Arc::from([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let (value, instances) = port
+            .normalize_broadcast_value(
+                ComputeValue::TensorF32 {
+                    dimensions: vec![2, 3, 1].into_boxed_slice(),
+                    layout: TensorLayout::RowMajor,
+                    values: Arc::clone(&values),
+                },
+                Some(2),
+            )
+            .unwrap();
+        assert_eq!(instances, 2);
+        assert_eq!(
+            value,
+            ComputeValue::TensorF32 {
+                dimensions: vec![2, 3, 1].into_boxed_slice(),
+                layout: TensorLayout::RowMajor,
+                values,
+            }
+        );
+    }
+
+    #[test]
+    fn thousand_lane_matrix_shapes_are_unambiguous() {
+        let port = matrix_port();
+        let values = Arc::<[f32]>::from(vec![0.0; 3_000]);
+        for layout in [TensorLayout::RowMajor, TensorLayout::ColumnMajor] {
+            let (_, instances) = port
+                .normalize_broadcast_value(
+                    ComputeValue::TensorF32 {
+                        dimensions: vec![1_000, 3].into_boxed_slice(),
+                        layout,
+                        values: Arc::clone(&values),
+                    },
+                    Some(1_000),
+                )
+                .unwrap();
+            assert_eq!(instances, 1_000);
+        }
+        for dimensions in [vec![3, 1_000], vec![30, 100], vec![1_000, 2]] {
+            assert!(
+                port.normalize_broadcast_value(
+                    ComputeValue::TensorF32 {
+                        dimensions: dimensions.into_boxed_slice(),
+                        layout: TensorLayout::RowMajor,
+                        values: Arc::clone(&values),
+                    },
+                    Some(1_000),
+                )
+                .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn single_matrix_and_scalar_batches_keep_their_declared_axes() {
+        let matrix = matrix_port();
+        let (_, instances) = matrix
+            .normalize_broadcast_value(
+                ComputeValue::TensorF32 {
+                    dimensions: vec![3, 1].into_boxed_slice(),
+                    layout: TensorLayout::ColumnMajor,
+                    values: Arc::from([1.0, 2.0, 3.0]),
+                },
+                Some(1_000),
+            )
+            .unwrap();
+        assert_eq!(instances, 1);
+
+        let scalar = ComputePort {
+            dimensions: Box::new([]),
+            ..matrix_port()
+        };
+        for dimensions in [vec![1_000], vec![1_000, 1], vec![1, 1_000]] {
+            let (_, instances) = scalar
+                .normalize_broadcast_value(
+                    ComputeValue::TensorF32 {
+                        dimensions: dimensions.into_boxed_slice(),
+                        layout: TensorLayout::RowMajor,
+                        values: Arc::from(vec![1.0; 1_000]),
+                    },
+                    Some(1_000),
+                )
+                .unwrap();
+            assert_eq!(instances, 1_000);
+        }
+    }
 }
 
 fn slot_produced_by_nodes(

--- a/src/compute/src/program.rs
+++ b/src/compute/src/program.rs
@@ -87,6 +87,20 @@ impl ComputeProgram {
         &self,
         update: ComputeInputUpdate,
     ) -> Result<ComputeInputUpdate, ComputeInputError> {
-        self.interface.normalize_input_update(update)
+        let port = self
+            .interface
+            .input(update.port)
+            .ok_or(ComputeInputError::UnknownInputPort { port: update.port })?;
+        let value = if let Some(storage) = self.fixed_shape_storage() {
+            port.normalize_broadcast_value(update.value, Some(storage.instances))
+                .map(|(value, _)| value)
+        } else {
+            port.normalize_value(update.value)
+        }
+        .map_err(ComputeInputError::InvalidValue)?;
+        Ok(ComputeInputUpdate {
+            port: update.port,
+            value,
+        })
     }
 }

--- a/src/compute/src/registry.rs
+++ b/src/compute/src/registry.rs
@@ -170,10 +170,12 @@ pub struct ComputeDispatchRequest {
 #[derive(Clone, Debug, PartialEq)]
 pub enum ComputeCompletionOutcome {
     Completed {
+        attempted_turn: u128,
         report: ComputeDispatchReport,
         snapshot: ComputeOutputSnapshot,
     },
     IntegrityRejected {
+        attempted_turn: u128,
         report: ComputeDispatchReport,
     },
     TransportFailed {

--- a/src/compute/src/registry.rs
+++ b/src/compute/src/registry.rs
@@ -128,6 +128,12 @@ pub enum ComputeOutputSelection {
     #[default]
     All,
     Ports(BTreeSet<ComputePortId>),
+    /// Read only the first outer batch lane for the selected logical ports.
+    ///
+    /// Fixed-shape accelerators must honor this at the physical readback
+    /// boundary rather than transferring the full resident batch and slicing
+    /// it on the host. Non-batched programs treat samples like selected ports.
+    Samples(BTreeSet<ComputePortId>),
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -137,7 +143,7 @@ pub struct ComputeOutputSnapshot {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ComputeFaultEvidence {
-    pub attempted_turn: u64,
+    pub attempted_turn: u128,
     pub constraint: Box<str>,
     pub detail: Box<str>,
 }
@@ -148,6 +154,32 @@ pub struct ComputeDispatchReport {
     pub dispatch_milliseconds: f64,
     pub fault_count: u64,
     pub last_fault: Option<ComputeFaultEvidence>,
+}
+
+/// Resident-host context that accompanies one backend dispatch.
+///
+/// Synchronous backends may ignore it. Asynchronous backends must retain it
+/// with the command so completion can publish exactly the outputs requested by
+/// the coordinator and can report the Mech turn which actually failed.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ComputeDispatchRequest {
+    pub outputs: BTreeSet<ComputePortId>,
+    pub logical_turn: u128,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ComputeCompletionOutcome {
+    Completed {
+        report: ComputeDispatchReport,
+        snapshot: ComputeOutputSnapshot,
+    },
+    IntegrityRejected {
+        report: ComputeDispatchReport,
+    },
+    TransportFailed {
+        attempted_turn: u128,
+        reason: Box<str>,
+    },
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -168,6 +200,17 @@ pub struct ComputeExecutionError {
     pub backend: BackendId,
     pub operation: &'static str,
     pub detail: Box<str>,
+    /// The backend accepted and may have mutated resident state before this
+    /// failure was reported. Callers must stop the session rather than retry
+    /// the same completion identity against an already-advanced state.
+    pub state_advanced: bool,
+}
+
+impl ComputeExecutionError {
+    pub fn after_state_advance(mut self) -> Self {
+        self.state_advanced = true;
+        self
+    }
 }
 
 pub trait ComputeBackendFactory {
@@ -179,27 +222,13 @@ pub trait ComputeBackendFactory {
         &self,
         program: &ComputeProgram,
     ) -> Result<Box<dyn ComputeExecutable>, ComputeBackendError>;
-
-    /// Connects an asynchronous backend to the resident host that owns its
-    /// published outputs. Synchronous backends use the default no-op because
-    /// their dispatch report and output snapshot are returned together.
-    fn bind_completion_target(
-        &self,
-        _target: Arc<dyn ComputeCompletionTarget>,
-    ) -> Result<(), ComputeBackendError> {
-        Ok(())
-    }
 }
 
 /// Atomic publication boundary for backends whose work completes after
 /// `ComputeSession::dispatch` returns. Implementations must validate and stage
 /// a whole snapshot before changing resident-visible state.
 pub trait ComputeCompletionTarget {
-    fn complete(
-        &self,
-        report: ComputeDispatchReport,
-        snapshot: ComputeOutputSnapshot,
-    ) -> Result<(), ComputeExecutionError>;
+    fn complete(&self, outcome: ComputeCompletionOutcome) -> Result<(), ComputeExecutionError>;
 }
 
 pub trait ComputeExecutable {
@@ -210,6 +239,17 @@ pub trait ComputeExecutable {
 }
 
 pub trait ComputeSession {
+    /// Connects this specific asynchronous session to the resident host that
+    /// owns its published outputs. The binding belongs to the session rather
+    /// than the reusable backend factory so one factory cannot cross-wire two
+    /// independently compiled or restarted runtimes.
+    fn bind_completion_target(
+        &mut self,
+        _target: Arc<dyn ComputeCompletionTarget>,
+    ) -> Result<(), ComputeBackendError> {
+        Ok(())
+    }
+
     fn update_inputs(
         &mut self,
         updates: &[ComputeInputUpdate],
@@ -219,6 +259,14 @@ pub trait ComputeSession {
         &mut self,
         turns: NonZeroU32,
     ) -> Result<ComputeDispatchReport, ComputeExecutionError>;
+
+    fn dispatch_requested(
+        &mut self,
+        turns: NonZeroU32,
+        _request: &ComputeDispatchRequest,
+    ) -> Result<ComputeDispatchReport, ComputeExecutionError> {
+        self.dispatch(turns)
+    }
 
     fn read_outputs(
         &mut self,

--- a/src/compute/src/registry.rs
+++ b/src/compute/src/registry.rs
@@ -179,6 +179,27 @@ pub trait ComputeBackendFactory {
         &self,
         program: &ComputeProgram,
     ) -> Result<Box<dyn ComputeExecutable>, ComputeBackendError>;
+
+    /// Connects an asynchronous backend to the resident host that owns its
+    /// published outputs. Synchronous backends use the default no-op because
+    /// their dispatch report and output snapshot are returned together.
+    fn bind_completion_target(
+        &self,
+        _target: Arc<dyn ComputeCompletionTarget>,
+    ) -> Result<(), ComputeBackendError> {
+        Ok(())
+    }
+}
+
+/// Atomic publication boundary for backends whose work completes after
+/// `ComputeSession::dispatch` returns. Implementations must validate and stage
+/// a whole snapshot before changing resident-visible state.
+pub trait ComputeCompletionTarget {
+    fn complete(
+        &self,
+        report: ComputeDispatchReport,
+        snapshot: ComputeOutputSnapshot,
+    ) -> Result<(), ComputeExecutionError>;
 }
 
 pub trait ComputeExecutable {

--- a/src/engine/src/program/compiler_planning.rs
+++ b/src/engine/src/program/compiler_planning.rs
@@ -275,6 +275,22 @@ impl CompilerPlanningProgram {
         self.interpreter.interpret_with_services(tree, services)
     }
 
+    /// Plans source for an executable artifact, retaining user-function call
+    /// graphs in the caller plan so artifact lowering can inline their ordinary
+    /// operations and preserve dependencies on caller-owned inputs.
+    ///
+    /// Interactive evaluation keeps the normal call-local plan boundary; only
+    /// compilation needs the expanded graph after the function frame returns.
+    pub fn plan_artifact_tree_with_services(
+        &mut self,
+        tree: &mech_core::Program,
+        services: &mut dyn MechExecutionServices,
+    ) -> MResult<LegacyValue> {
+        let _persistent_user_function_plan =
+            crate::function::PersistentUserFunctionPlanScope::enter(&self.interpreter);
+        self.interpreter.interpret_with_services(tree, services)
+    }
+
     #[cfg(test)]
     pub(crate) fn plan_source_for_test(&mut self, source: &str) -> MResult<LegacyValue> {
         let tree = mech_syntax::parser::parse(source.trim())?;

--- a/src/runtime/src/input.rs
+++ b/src/runtime/src/input.rs
@@ -302,11 +302,21 @@ pub struct RuntimeHostInputUpdate {
 #[derive(Clone, Debug, PartialEq)]
 pub struct RuntimeHostInput {
     pub updates: Vec<RuntimeHostInputUpdate>,
+    coalescing_group: Option<RuntimeHostInputCoalescingGroup>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RuntimeHostInputCoalescingGroup {
+    scope: String,
+    sequence: u64,
 }
 
 impl RuntimeHostInput {
     pub fn new(updates: Vec<RuntimeHostInputUpdate>) -> MResult<Self> {
-        let input = Self { updates };
+        let input = Self {
+            updates,
+            coalescing_group: None,
+        };
         input.validate()?;
         Ok(input)
     }
@@ -314,7 +324,33 @@ impl RuntimeHostInput {
     pub fn single(source: RuntimeHostInputSource, value: RuntimeHostInputValue) -> Self {
         Self {
             updates: vec![RuntimeHostInputUpdate { source, value }],
+            coalescing_group: None,
         }
+    }
+
+    /// Keep packets with the same group eligible for latest-value coalescing,
+    /// while preserving a resident-turn boundary between different groups.
+    /// Drivers use this for event gestures whose state packets may collapse
+    /// together, but whose distinct activations must never collapse together.
+    /// The group is scoped to the packet's resource base URI so equal sequence
+    /// numbers from independent host instances cannot merge.
+    pub fn with_coalescing_group(mut self, group: u64) -> Self {
+        let scope = self
+            .updates
+            .first()
+            .expect("validated host inputs contain at least one update")
+            .source
+            .base_uri()
+            .to_owned();
+        self.coalescing_group = Some(RuntimeHostInputCoalescingGroup {
+            scope,
+            sequence: group,
+        });
+        self
+    }
+
+    pub(crate) fn coalescing_group(&self) -> Option<&RuntimeHostInputCoalescingGroup> {
+        self.coalescing_group.as_ref()
     }
 
     pub fn validate(&self) -> MResult<()> {
@@ -330,6 +366,16 @@ impl RuntimeHostInput {
                 return Err(input_error(
                     "RuntimeHostInputDuplicateSource",
                     "host input packet contains duplicate sources",
+                ));
+            }
+            if self
+                .coalescing_group
+                .as_ref()
+                .is_some_and(|group| group.scope != update.source.base_uri())
+            {
+                return Err(input_error(
+                    "RuntimeHostInputCoalescingScopeInvalid",
+                    "coalesced host input packets must stay within one resource base URI",
                 ));
             }
         }

--- a/src/runtime/src/interactive.rs
+++ b/src/runtime/src/interactive.rs
@@ -396,6 +396,22 @@ impl<F: ResidentReplRuntimeFactory> ResidentReplSession<F> {
         self.replace_source_preserving(candidate_source, &std::collections::BTreeSet::new())
     }
 
+    /// Rebuild the currently accepted program through the normal candidate
+    /// handoff while preserving compatible resident state.
+    ///
+    /// Hosts use this when an execution backend becomes unavailable after the
+    /// source generation was accepted. Rebuilding the accepted tree avoids
+    /// falling back to an initial document snapshot and keeps the replacement
+    /// on the same source/state generation.
+    pub fn rebuild_runtime_preserving_state(&mut self) -> MResult<RuntimeValueSnapshot> {
+        let source = self.source.clone();
+        let unchanged = std::collections::BTreeSet::new();
+        match self.source_tree.clone() {
+            Some(tree) => self.replace_source_tree_preserving(source, tree, &unchanged),
+            None => self.replace_source_preserving(source, &unchanged),
+        }
+    }
+
     fn replace_source_preserving(
         &mut self,
         candidate_source: String,

--- a/src/runtime/src/runtime/program/compiler.rs
+++ b/src/runtime/src/runtime/program/compiler.rs
@@ -89,6 +89,10 @@ pub struct MixedProgramCompilation {
     /// infer the outer broadcast extent; the inner compute interface remains
     /// the schema for one independent instance.
     pub activation_inputs: BTreeMap<String, ComputeValue>,
+    /// Concrete sampled outputs admitted by the coordinator's declared read
+    /// capability. These form the demand-retention contract across compatible
+    /// compute-host generations; undeclared outputs remain GPU-resident.
+    pub retained_outputs: BTreeSet<String>,
 }
 
 #[cfg(feature = "compute")]
@@ -585,6 +589,7 @@ impl<'a> ProgramCompilerView<'a> {
     fn compile_mixed_tree(&self, tree: &Program) -> MResult<MixedProgramCompilation> {
         let partition = partition_mixed_program(tree)?;
         let external_input_names = source_declared_compute_inputs(tree)?;
+        let retained_outputs = source_declared_compute_outputs(tree)?;
         let (compute, initial_inputs) = self.compile_tree_artifact_with_input_initializers(
             &partition.compute,
             &BTreeMap::new(),
@@ -603,6 +608,7 @@ impl<'a> ProgramCompilerView<'a> {
             coordinator,
             compute,
             activation_inputs,
+            retained_outputs,
         })
     }
 
@@ -619,6 +625,7 @@ impl<'a> ProgramCompilerView<'a> {
         let tree = declaration_tree(&modules[&root].source.source)?;
         let partition = partition_mixed_program(&tree)?;
         let external_input_names = source_declared_compute_inputs(&tree)?;
+        let retained_outputs = source_declared_compute_outputs(&tree)?;
         let (compute, initial_inputs, _) = self.compile_resolved_tree_artifact(
             &root,
             &modules,
@@ -640,6 +647,7 @@ impl<'a> ProgramCompilerView<'a> {
             coordinator,
             compute,
             activation_inputs,
+            retained_outputs,
         })
     }
 
@@ -1464,6 +1472,31 @@ fn source_declared_compute_inputs(tree: &Program) -> MResult<BTreeSet<String>> {
         .filter_map(|capability| match capability.scope {
             SourceContextCapabilityScope::Path(path) => (!path.contains('*'))
                 .then(|| path.strip_prefix("input/").map(str::to_owned))
+                .flatten(),
+            SourceContextCapabilityScope::Wildcard => None,
+        })
+        .collect())
+}
+
+#[cfg(feature = "compute")]
+fn source_declared_compute_outputs(tree: &Program) -> MResult<BTreeSet<String>> {
+    let index = SourceIndex::from_program(tree);
+    index.validate_address_targets()?;
+    Ok(index
+        .all_contexts()
+        .into_iter()
+        .filter(|context| {
+            matches!(
+                &context.base,
+                SourceContextBase::ResourceUri(uri)
+                    if uri.starts_with("compute://") && uri.ends_with("/kernel")
+            )
+        })
+        .flat_map(|context| context.capabilities)
+        .filter(|capability| capability.operation == "read")
+        .filter_map(|capability| match capability.scope {
+            SourceContextCapabilityScope::Path(path) => (!path.contains('*'))
+                .then(|| path.strip_prefix("sample/").map(str::to_owned))
                 .flatten(),
             SourceContextCapabilityScope::Wildcard => None,
         })

--- a/src/runtime/src/runtime/program/compiler.rs
+++ b/src/runtime/src/runtime/program/compiler.rs
@@ -467,7 +467,7 @@ impl<'a> ProgramCompilerView<'a> {
             compute_activation_inputs: BTreeMap::new(),
         };
         let result = program
-            .plan_tree_with_services(&sanitize_tree(tree.clone())?, &mut services)
+            .plan_artifact_tree_with_services(&sanitize_tree(tree.clone())?, &mut services)
             .map_err(classify_source_planning)?;
         publish_document_and_root_outputs(&mut program, &document_output_ids, &result)?;
         if matches!(
@@ -541,7 +541,7 @@ impl<'a> ProgramCompilerView<'a> {
             compute_activation_inputs: BTreeMap::new(),
         };
         let result = program
-            .plan_tree_with_services(&sanitize_tree(tree.clone())?, &mut services)
+            .plan_artifact_tree_with_services(&sanitize_tree(tree.clone())?, &mut services)
             .map_err(classify_source_planning)?;
         #[cfg(feature = "compute")]
         let activation_inputs = std::mem::take(&mut services.compute_activation_inputs);
@@ -1259,7 +1259,7 @@ impl<'a> ProgramCompilerView<'a> {
             compute_activation_inputs: BTreeMap::new(),
         };
         let result = program
-            .plan_tree_with_services(&tree, &mut services)
+            .plan_artifact_tree_with_services(&tree, &mut services)
             .map_err(classify_source_planning)?;
         #[cfg(feature = "compute")]
         compute_activation_inputs.append(&mut services.compute_activation_inputs);

--- a/src/runtime/src/runtime/program/compiler.rs
+++ b/src/runtime/src/runtime/program/compiler.rs
@@ -503,6 +503,7 @@ impl<'a> ProgramCompilerView<'a> {
             inputs,
             external_input_names,
             None,
+            false,
         )
         .map(|(product, inputs, _)| (product, inputs))
     }
@@ -513,6 +514,7 @@ impl<'a> ProgramCompilerView<'a> {
         inputs: &BTreeMap<String, RuntimeHostInputValue>,
         external_input_names: &BTreeSet<String>,
         compute_interface: Option<&ComputeRegionInterface>,
+        retain_root_symbols: bool,
     ) -> MResult<(
         ProgramArtifactCompilationProduct,
         BTreeMap<String, RuntimeHostInputValue>,
@@ -546,6 +548,9 @@ impl<'a> ProgramCompilerView<'a> {
         #[cfg(not(feature = "compute"))]
         let activation_inputs = BTreeMap::new();
         publish_document_and_root_outputs(&mut program, &document_output_ids, &result)?;
+        if retain_root_symbols {
+            program.publish_compiler_root_symbols();
+        }
         let input_names = external_input_names
             .iter()
             .map(String::as_str)
@@ -592,6 +597,7 @@ impl<'a> ProgramCompilerView<'a> {
                 &BTreeMap::new(),
                 &BTreeSet::new(),
                 Some(&compute.interface),
+                true,
             )?;
         Ok(MixedProgramCompilation {
             coordinator,
@@ -619,6 +625,7 @@ impl<'a> ProgramCompilerView<'a> {
             partition.compute,
             &external_input_names,
             None,
+            false,
         )?;
         let compute = assemble_compute_region(compute, initial_inputs, &partition.name)?;
         let (coordinator, _, activation_inputs) = self.compile_resolved_tree_artifact(
@@ -627,6 +634,7 @@ impl<'a> ProgramCompilerView<'a> {
             partition.coordinator,
             &BTreeSet::new(),
             Some(&compute.interface),
+            true,
         )?;
         Ok(MixedProgramCompilation {
             coordinator,
@@ -643,6 +651,7 @@ impl<'a> ProgramCompilerView<'a> {
         tree: Program,
         external_input_names: &BTreeSet<String>,
         compute_interface: Option<&ComputeRegionInterface>,
+        retain_root_symbols: bool,
     ) -> MResult<(
         ProgramArtifactCompilationProduct,
         BTreeMap<String, RuntimeHostInputValue>,
@@ -678,6 +687,9 @@ impl<'a> ProgramCompilerView<'a> {
                 .get(root)
                 .expect("the requested root was executed"),
         );
+        if retain_root_symbols {
+            program.publish_compiler_root_symbols();
+        }
         let input_names = external_input_names
             .iter()
             .map(String::as_str)

--- a/src/runtime/src/runtime/program/compiler.rs
+++ b/src/runtime/src/runtime/program/compiler.rs
@@ -49,6 +49,8 @@ use super::{ResidentRouteFailure, ResidentRouteFailureClass, route_failure, unsu
 
 #[cfg(not(feature = "compute"))]
 type ComputeRegionInterface = ();
+#[cfg(not(feature = "compute"))]
+type ComputeValue = ();
 
 #[derive(Clone, Copy)]
 enum ProgramBytecodeEncoding {
@@ -82,6 +84,11 @@ pub struct ProgramCompiler {
 pub struct MixedProgramCompilation {
     pub coordinator: ProgramArtifactCompilationProduct,
     pub compute: ComputeRegionCompilation,
+    /// Declaration-time values sent across the compute boundary by the
+    /// coordinator. Fixed-shape backends use these ordinary Mech arrays to
+    /// infer the outer broadcast extent; the inner compute interface remains
+    /// the schema for one independent instance.
+    pub activation_inputs: BTreeMap<String, ComputeValue>,
 }
 
 #[cfg(feature = "compute")]
@@ -456,6 +463,8 @@ impl<'a> ProgramCompilerView<'a> {
             providers: self.resources,
             resource_send_operations: &operations,
             compute_interface: None,
+            #[cfg(feature = "compute")]
+            compute_activation_inputs: BTreeMap::new(),
         };
         let result = program
             .plan_tree_with_services(&sanitize_tree(tree.clone())?, &mut services)
@@ -495,6 +504,7 @@ impl<'a> ProgramCompilerView<'a> {
             external_input_names,
             None,
         )
+        .map(|(product, inputs, _)| (product, inputs))
     }
 
     fn compile_tree_artifact_with_input_initializers_and_compute(
@@ -506,6 +516,7 @@ impl<'a> ProgramCompilerView<'a> {
     ) -> MResult<(
         ProgramArtifactCompilationProduct,
         BTreeMap<String, RuntimeHostInputValue>,
+        BTreeMap<String, ComputeValue>,
     )> {
         let mut program = self.new_program();
         for (name, value) in inputs {
@@ -524,10 +535,16 @@ impl<'a> ProgramCompilerView<'a> {
             providers: self.resources,
             resource_send_operations: &operations,
             compute_interface,
+            #[cfg(feature = "compute")]
+            compute_activation_inputs: BTreeMap::new(),
         };
         let result = program
             .plan_tree_with_services(&sanitize_tree(tree.clone())?, &mut services)
             .map_err(classify_source_planning)?;
+        #[cfg(feature = "compute")]
+        let activation_inputs = std::mem::take(&mut services.compute_activation_inputs);
+        #[cfg(not(feature = "compute"))]
+        let activation_inputs = BTreeMap::new();
         publish_document_and_root_outputs(&mut program, &document_output_ids, &result)?;
         let input_names = external_input_names
             .iter()
@@ -556,7 +573,7 @@ impl<'a> ProgramCompilerView<'a> {
                     format!("resident ProgramArtifact finalization failed: {error:?}"),
                 )
             })?;
-        Ok((product, initial_inputs))
+        Ok((product, initial_inputs, activation_inputs))
     }
 
     #[cfg(feature = "compute")]
@@ -569,17 +586,17 @@ impl<'a> ProgramCompilerView<'a> {
             &external_input_names,
         )?;
         let compute = assemble_compute_region(compute, initial_inputs, &partition.name)?;
-        let coordinator = self
+        let (coordinator, _, activation_inputs) = self
             .compile_tree_artifact_with_input_initializers_and_compute(
                 &partition.coordinator,
                 &BTreeMap::new(),
                 &BTreeSet::new(),
                 Some(&compute.interface),
-            )?
-            .0;
+            )?;
         Ok(MixedProgramCompilation {
             coordinator,
             compute,
+            activation_inputs,
         })
     }
 
@@ -596,7 +613,7 @@ impl<'a> ProgramCompilerView<'a> {
         let tree = declaration_tree(&modules[&root].source.source)?;
         let partition = partition_mixed_program(&tree)?;
         let external_input_names = source_declared_compute_inputs(&tree)?;
-        let (compute, initial_inputs) = self.compile_resolved_tree_artifact(
+        let (compute, initial_inputs, _) = self.compile_resolved_tree_artifact(
             &root,
             &modules,
             partition.compute,
@@ -604,7 +621,7 @@ impl<'a> ProgramCompilerView<'a> {
             None,
         )?;
         let compute = assemble_compute_region(compute, initial_inputs, &partition.name)?;
-        let (coordinator, _) = self.compile_resolved_tree_artifact(
+        let (coordinator, _, activation_inputs) = self.compile_resolved_tree_artifact(
             &root,
             &modules,
             partition.coordinator,
@@ -614,6 +631,7 @@ impl<'a> ProgramCompilerView<'a> {
         Ok(MixedProgramCompilation {
             coordinator,
             compute,
+            activation_inputs,
         })
     }
 
@@ -628,6 +646,7 @@ impl<'a> ProgramCompilerView<'a> {
     ) -> MResult<(
         ProgramArtifactCompilationProduct,
         BTreeMap<String, RuntimeHostInputValue>,
+        BTreeMap<String, ComputeValue>,
     )> {
         let mut modules = resolved_modules.clone();
         replace_root_tree(
@@ -640,6 +659,7 @@ impl<'a> ProgramCompilerView<'a> {
         let mut instances = HashMap::new();
         let mut active = Vec::new();
         let mut root_program = Some(self.new_program());
+        let mut activation_inputs = BTreeMap::new();
         self.execute_module(
             root,
             &modules,
@@ -647,6 +667,7 @@ impl<'a> ProgramCompilerView<'a> {
             &mut active,
             Some(&mut root_program),
             compute_interface,
+            &mut activation_inputs,
         )?;
         let program = root_program
             .as_mut()
@@ -689,7 +710,7 @@ impl<'a> ProgramCompilerView<'a> {
                     format!("resident ProgramArtifact finalization failed: {error:?}"),
                 )
             })?;
-        Ok((product, initial_inputs))
+        Ok((product, initial_inputs, activation_inputs))
     }
 
     fn evaluate_static_tree_symbols(
@@ -714,6 +735,8 @@ impl<'a> ProgramCompilerView<'a> {
             providers: self.resources,
             resource_send_operations: &operations,
             compute_interface: None,
+            #[cfg(feature = "compute")]
+            compute_activation_inputs: BTreeMap::new(),
         };
         program
             .plan_tree_with_services(&sanitize_tree(tree.clone())?, &mut services)
@@ -858,6 +881,8 @@ impl<'a> ProgramCompilerView<'a> {
         let mut instances = HashMap::new();
         let mut active = Vec::new();
         let mut root_program = Some(self.new_program());
+        #[cfg(feature = "compute")]
+        let mut compute_activation_inputs = BTreeMap::new();
         self.execute_module(
             &root,
             &modules,
@@ -865,6 +890,8 @@ impl<'a> ProgramCompilerView<'a> {
             &mut active,
             Some(&mut root_program),
             None,
+            #[cfg(feature = "compute")]
+            &mut compute_activation_inputs,
         )?;
         let program = root_program
             .as_mut()
@@ -912,6 +939,8 @@ impl<'a> ProgramCompilerView<'a> {
         let mut instances = HashMap::new();
         let mut active = Vec::new();
         let mut root_program = Some(self.new_program());
+        #[cfg(feature = "compute")]
+        let mut compute_activation_inputs = BTreeMap::new();
         for root in plan_order {
             self.execute_module(
                 &root,
@@ -920,6 +949,8 @@ impl<'a> ProgramCompilerView<'a> {
                 &mut active,
                 Some(&mut root_program),
                 None,
+                #[cfg(feature = "compute")]
+                &mut compute_activation_inputs,
             )?;
         }
         let program = root_program
@@ -1162,6 +1193,7 @@ impl<'a> ProgramCompilerView<'a> {
         active: &mut Vec<String>,
         root_program: Option<&mut Option<CompilerPlanningProgram>>,
         compute_interface: Option<&ComputeRegionInterface>,
+        #[cfg(feature = "compute")] compute_activation_inputs: &mut BTreeMap<String, ComputeValue>,
     ) -> MResult<()> {
         if instances.contains_key(canonical_uri) {
             return Ok(());
@@ -1189,6 +1221,8 @@ impl<'a> ProgramCompilerView<'a> {
                 active,
                 None,
                 compute_interface,
+                #[cfg(feature = "compute")]
+                compute_activation_inputs,
             )?;
         }
 
@@ -1209,10 +1243,14 @@ impl<'a> ProgramCompilerView<'a> {
             providers: self.resources,
             resource_send_operations: &resource_send_operations,
             compute_interface,
+            #[cfg(feature = "compute")]
+            compute_activation_inputs: BTreeMap::new(),
         };
         let result = program
             .plan_tree_with_services(&tree, &mut services)
             .map_err(classify_source_planning)?;
+        #[cfg(feature = "compute")]
+        compute_activation_inputs.append(&mut services.compute_activation_inputs);
         let document_output_ids = root_document_output_ids(&tree);
         let document_outputs = program.compiler_document_output_values(&document_output_ids)?;
 
@@ -1499,6 +1537,9 @@ fn compute_initializers(
         })?;
         let value = match value {
             RuntimeHostInputValue::F32(value) => ComputeValue::ScalarF32(value),
+            RuntimeHostInputValue::F64(value) => {
+                ComputeValue::ScalarF32(narrow_compute_input_f64(port.name.as_ref(), value)?)
+            }
             RuntimeHostInputValue::F32Matrix {
                 rows,
                 columns,
@@ -1507,6 +1548,19 @@ fn compute_initializers(
                 dimensions: vec![rows as u64, columns as u64].into_boxed_slice(),
                 layout: TensorLayout::ColumnMajor,
                 values: Arc::from(values),
+            },
+            RuntimeHostInputValue::F64Matrix {
+                rows,
+                columns,
+                values,
+            } => ComputeValue::TensorF32 {
+                dimensions: vec![rows as u64, columns as u64].into_boxed_slice(),
+                layout: TensorLayout::ColumnMajor,
+                values: values
+                    .into_iter()
+                    .map(|value| narrow_compute_input_f64(port.name.as_ref(), value))
+                    .collect::<MResult<Vec<_>>>()?
+                    .into(),
             },
             value => {
                 return Err(MechError::new(
@@ -1545,6 +1599,23 @@ fn compute_initializers(
         ));
     }
     Ok(ComputeInitializerSet::new(initializers))
+}
+
+#[cfg(feature = "compute")]
+fn narrow_compute_input_f64(port: &str, value: f64) -> MResult<f32> {
+    let narrowed = value as f32;
+    if value.is_finite() && !narrowed.is_finite() {
+        return Err(MechError::new(
+            RuntimeInvalidOperationError {
+                operation: "compile_mixed_program",
+                reason: format!(
+                    "compute input `{port}` contains f64 value {value} outside the f32 range"
+                ),
+            },
+            None,
+        ));
+    }
+    Ok(narrowed)
 }
 
 /// Preserve caller order for independent roots while promoting any requested
@@ -1964,6 +2035,8 @@ struct CompilerPlanningServices<'a> {
     providers: &'a RuntimeResourceRegistry,
     resource_send_operations: &'a [CompiledResourceSendOperation],
     compute_interface: Option<&'a ComputeRegionInterface>,
+    #[cfg(feature = "compute")]
+    compute_activation_inputs: BTreeMap<String, ComputeValue>,
 }
 
 struct CompilerExternalContractResolver<'a> {
@@ -2046,7 +2119,10 @@ impl MechExecutionServices for CompilerPlanningServices<'_> {
             .compute_interface
             .filter(|_| is_compute_kernel_base(&key.base_uri))
         {
-            return plan_compute_write(interface, &key, intent, value);
+            if let Some((name, value)) = plan_compute_write(interface, &key, intent, value)? {
+                self.compute_activation_inputs.insert(name, value);
+            }
+            return Ok(());
         }
         self.providers.plan_write(RuntimeResourceWriteRequest {
             base_uri: key.base_uri,
@@ -2072,11 +2148,10 @@ impl CompilerPlanningServices<'_> {
     fn plan_read(&self, request: &ExecutionResourceRequest) -> MResult<LegacyValue> {
         let key = RuntimeResourceKey::new(&request.base_uri, &request.path)?;
         #[cfg(feature = "compute")]
-        if self
-            .compute_interface
-            .is_some_and(|_| is_compute_kernel_base(&key.base_uri))
+        if is_compute_kernel_base(&key.base_uri)
+            && let Some(interface) = self.compute_interface
         {
-            return plan_compute_read(&key);
+            return plan_compute_read(interface, &key);
         }
         self.providers.plan_read(RuntimeResourceReadRequest {
             base_uri: key.base_uri,
@@ -2092,7 +2167,44 @@ fn is_compute_kernel_base(base_uri: &str) -> bool {
         .is_some_and(|instance| !instance.is_empty() && instance.ends_with("/kernel"))
 }
 
-fn plan_compute_read(key: &RuntimeResourceKey) -> MResult<LegacyValue> {
+#[cfg(feature = "compute")]
+fn plan_compute_read(
+    interface: &ComputeRegionInterface,
+    key: &RuntimeResourceKey,
+) -> MResult<LegacyValue> {
+    if let Some(name) = key.path.strip_prefix("sample/") {
+        let port = interface
+            .outputs
+            .iter()
+            .find(|port| port.name.as_ref() == name)
+            .ok_or_else(|| {
+                compute_planning_error(format!("unknown sampled compute output `{name}`"))
+            })?;
+        let elements = port.elements().map_err(|error| {
+            compute_planning_error(format!(
+                "sampled compute output `{name}` has an invalid shape: {error}"
+            ))
+        })?;
+        return match port.dimensions.as_ref() {
+            [] => RuntimeHostInputValue::F64(0.0).into_mech_value(),
+            [columns] => RuntimeHostInputValue::F64Matrix {
+                rows: 1,
+                columns: *columns as usize,
+                values: vec![0.0; elements],
+            }
+            .into_mech_value(),
+            [rows, columns] => RuntimeHostInputValue::F64Matrix {
+                rows: *rows as usize,
+                columns: *columns as usize,
+                values: vec![0.0; elements],
+            }
+            .into_mech_value(),
+            dimensions => Err(compute_planning_error(format!(
+                "sampled compute output `{name}` has unsupported rank {}",
+                dimensions.len(),
+            ))),
+        };
+    }
     match key.path.as_str() {
         "backend" | "last-fault" => RuntimeHostInputValue::String(String::new()).into_mech_value(),
         "turns" | "dispatch-ms" | "fault-count" => {
@@ -2110,14 +2222,14 @@ fn plan_compute_write(
     key: &RuntimeResourceKey,
     intent: RuntimeResourceWriteIntent,
     value: &LegacyValue,
-) -> MResult<()> {
+) -> MResult<Option<(String, ComputeValue)>> {
     if intent != RuntimeResourceWriteIntent::Send {
         return Err(compute_planning_error(
             "compute inputs and turns are effects; use <-",
         ));
     }
     if key.path == "turn" {
-        return Ok(());
+        return Ok(None);
     }
     let name = key.path.strip_prefix("input/").ok_or_else(|| {
         compute_planning_error(format!("unknown compute input path `{}`", key.path))
@@ -2128,6 +2240,9 @@ fn plan_compute_write(
     let value =
         RuntimeHostInputValue::from_numeric_mech_value(value).and_then(|value| match value {
             RuntimeHostInputValue::F32(value) => Ok(ComputeValue::ScalarF32(value)),
+            RuntimeHostInputValue::F64(value) => Ok(ComputeValue::ScalarF32(
+                narrow_compute_input_f64(port.name.as_ref(), value)?,
+            )),
             RuntimeHostInputValue::F32Matrix {
                 rows,
                 columns,
@@ -2137,15 +2252,30 @@ fn plan_compute_write(
                 layout: TensorLayout::ColumnMajor,
                 values: Arc::from(values),
             }),
+            RuntimeHostInputValue::F64Matrix {
+                rows,
+                columns,
+                values,
+            } => Ok(ComputeValue::TensorF32 {
+                dimensions: vec![rows as u64, columns as u64].into_boxed_slice(),
+                layout: TensorLayout::ColumnMajor,
+                values: values
+                    .into_iter()
+                    .map(|value| narrow_compute_input_f64(port.name.as_ref(), value))
+                    .collect::<MResult<Vec<_>>>()?
+                    .into(),
+            }),
             value => Err(compute_planning_error(format!(
                 "compute input `{}` requires fixed-shape f32 data, found `{value:?}`",
                 port.name
             ))),
         })?;
-    port.normalize_value(value).map_err(|error| {
-        compute_planning_error(format!("compute input `{}` is invalid: {error}", port.name))
-    })?;
-    Ok(())
+    let (value, _) = port
+        .normalize_broadcast_value(value, None)
+        .map_err(|error| {
+            compute_planning_error(format!("compute input `{}` is invalid: {error}", port.name))
+        })?;
+    Ok(Some((name.to_owned(), value)))
 }
 
 fn compute_planning_error(message: impl Into<String>) -> MechError {

--- a/src/runtime/src/runtime/program/compiler.rs
+++ b/src/runtime/src/runtime/program/compiler.rs
@@ -1603,9 +1603,8 @@ fn compute_initializers(
 
 #[cfg(feature = "compute")]
 fn narrow_compute_input_f64(port: &str, value: f64) -> MResult<f32> {
-    let narrowed = value as f32;
-    if value.is_finite() && !narrowed.is_finite() {
-        return Err(MechError::new(
+    mech_compute::narrow_compute_f64(value).map_err(|value| {
+        MechError::new(
             RuntimeInvalidOperationError {
                 operation: "compile_mixed_program",
                 reason: format!(
@@ -1613,9 +1612,8 @@ fn narrow_compute_input_f64(port: &str, value: f64) -> MResult<f32> {
                 ),
             },
             None,
-        ));
-    }
-    Ok(narrowed)
+        )
+    })
 }
 
 /// Preserve caller order for independent roots while promoting any requested

--- a/src/runtime/src/runtime/program/external/coordinator.rs
+++ b/src/runtime/src/runtime/program/external/coordinator.rs
@@ -297,6 +297,48 @@ impl ResidentExternalCoordinator {
             .expect("resident instance is present")
     }
 
+    /// Transfers the latest dequeued live-input snapshot across a compatible
+    /// resident replacement. Observation node/slot identities are artifact
+    /// local, so migration matches the stable resource request plus its schema
+    /// and shape, then re-materializes the value against the candidate schema
+    /// table. Incompatible or newly introduced observations remain unseeded and
+    /// will read their provider on first use.
+    pub(crate) fn preserve_compatible_live_inputs_from(
+        &mut self,
+        previous: &ResidentExternalCoordinator,
+    ) -> MResult<()> {
+        let mut previous_matches = vec![false; previous.bound.observations().len()];
+        for (target_ordinal, target) in self.bound.observations().iter().enumerate() {
+            let Some(source_ordinal) = previous.bound.observations().iter().enumerate().position(
+                |(source_ordinal, source)| {
+                    !previous_matches[source_ordinal]
+                        && source.request == target.request
+                        && source.input.schema_key == target.input.schema_key
+                        && source.input.shape == target.input.shape
+                },
+            ) else {
+                continue;
+            };
+            previous_matches[source_ordinal] = true;
+            let Some(value) = previous
+                .latest_live_inputs
+                .get(source_ordinal)
+                .and_then(|value| value.as_ref())
+            else {
+                continue;
+            };
+            let legacy = provider_value_from_canonical(value, previous.artifact.schemas())?;
+            let migrated = captured_value_from_legacy(
+                &legacy,
+                target.input.schema,
+                &target.input.shape,
+                self.artifact.schemas(),
+            )?;
+            self.latest_live_inputs[target_ordinal] = Some(migrated);
+        }
+        Ok(())
+    }
+
     #[cfg(feature = "runtime_bench_gate_d3")]
     #[doc(hidden)]
     pub fn set_next_epoch_for_benchmark(&mut self, next: u64) {

--- a/src/runtime/src/runtime/program/external/coordinator.rs
+++ b/src/runtime/src/runtime/program/external/coordinator.rs
@@ -93,6 +93,11 @@ pub enum ResidentExternalTurnOutcome {
         turn: TurnId,
         receipt_sequence: LedgerSequence,
         phase: TurnFailurePhase,
+        /// The durable rejection evidence written to the turn receipt.
+        ///
+        /// Keeping it on the immediate outcome prevents host-facing callers
+        /// from replacing the actual cause with a count-only summary.
+        failure: TurnFailureRecord,
     },
     PublishedIndeterminate {
         turn: TurnId,
@@ -666,12 +671,13 @@ impl ResidentExternalCoordinator {
 
         match record.header.status {
             TurnRecordStatus::Rejected => {
-                let phase = record
+                let failure = record
                     .header
                     .failure
                     .as_ref()
                     .expect("validated rejected replay receipt")
-                    .phase;
+                    .clone();
+                let phase = failure.phase;
                 if let Some(prepared) = prepared_input {
                     self.append_prepared_input(prepared);
                 }
@@ -685,6 +691,7 @@ impl ResidentExternalCoordinator {
                     turn,
                     receipt_sequence,
                     phase,
+                    failure,
                 })
             }
             TurnRecordStatus::Accepted => self.execute_replay_accepted(
@@ -1565,17 +1572,18 @@ impl ResidentExternalCoordinator {
         error: MechError,
     ) -> MResult<ResidentExternalTurnOutcome> {
         let message = bounded_failure_message(&error);
+        let failure = TurnFailureRecord {
+            phase,
+            kind: error.kind_name(),
+            message,
+        };
         let record = OwnedTurnRecord {
             header: TurnRecordHeader {
                 turn_id: turn,
                 transaction_id: transaction,
                 input_range: evidence.input_range,
                 status: TurnRecordStatus::Rejected,
-                failure: Some(TurnFailureRecord {
-                    phase,
-                    kind: "ResidentExternalTurnRejected".to_owned(),
-                    message,
-                }),
+                failure: Some(failure.clone()),
             },
             body: ResidentTurnReceiptV1 {
                 version: ResidentTurnReceiptV1::VERSION,
@@ -1605,6 +1613,7 @@ impl ResidentExternalCoordinator {
             turn,
             receipt_sequence,
             phase,
+            failure,
         })
     }
 

--- a/src/runtime/src/runtime/program/external/coordinator.rs
+++ b/src/runtime/src/runtime/program/external/coordinator.rs
@@ -1202,7 +1202,12 @@ impl ResidentExternalCoordinator {
                 "replay input identities do not match the next admitted batch",
             );
         }
-        for (fact, observation) in canonical.facts.iter().zip(self.bound.observations()) {
+        for (ordinal, (fact, observation)) in canonical
+            .facts
+            .iter()
+            .zip(self.bound.observations())
+            .enumerate()
+        {
             if fact.requirement != observation.requirement
                 || fact.node != observation.node
                 || fact.slot != observation.input.artifact_slot
@@ -1216,6 +1221,18 @@ impl ResidentExternalCoordinator {
                 return invalid_coordinator(
                     "replay batch differs from the activated observation plan",
                 );
+            }
+            for (previous_fact, previous_observation) in canonical.facts[..ordinal]
+                .iter()
+                .zip(&self.bound.observations()[..ordinal])
+            {
+                if observations_share_snapshot(previous_observation, observation)
+                    && previous_fact.payload_hash != fact.payload_hash
+                {
+                    return invalid_coordinator(
+                        "replay batch contains conflicting snapshots for one source identity",
+                    );
+                }
             }
         }
         Ok(canonical)

--- a/src/runtime/src/runtime/program/external/coordinator.rs
+++ b/src/runtime/src/runtime/program/external/coordinator.rs
@@ -155,6 +155,7 @@ pub struct ResidentExternalCoordinator {
     artifact: Arc<ProgramArtifact>,
     live: bool,
     bound: BoundResidentExternalPlan,
+    latest_live_inputs: Vec<Option<Value>>,
     durability: ResidentDurabilityPolicy,
     health: ResidentExternalHealth,
     published_state_hash: u64,
@@ -250,6 +251,7 @@ impl ResidentExternalCoordinator {
         let plan_generation = instance.plan.plan_generation;
         let layout_generation = instance.plan.layout_generation;
         let publication_authority = RuntimeResidentPublicationAuthority { _private: () };
+        let latest_live_inputs = vec![None; bound.observations().len()];
         Ok(Self {
             instance: Some(instance),
             publication_authority,
@@ -260,6 +262,7 @@ impl ResidentExternalCoordinator {
             artifact,
             live,
             bound,
+            latest_live_inputs,
             durability,
             health: ResidentExternalHealth::Healthy,
             published_state_hash,
@@ -367,9 +370,11 @@ impl ResidentExternalCoordinator {
     }
 
     /// Executes one live turn while using owned ingress values for matching
-    /// observations. Values absent from the update set are captured from their
-    /// bound providers. This keeps host packets as the authority for the event
-    /// they triggered instead of racing a separately updated provider snapshot.
+    /// observations. Values absent from the update set retain the last accepted
+    /// input snapshot; providers seed only observations that have not yet
+    /// appeared in an accepted batch. This keeps queue order authoritative and
+    /// prevents a future provider snapshot from leaking across the dequeue
+    /// boundary.
     pub fn execute_turn_with_host_updates(
         &mut self,
         updates: &[crate::RuntimeHostInputUpdate],
@@ -519,6 +524,7 @@ impl ResidentExternalCoordinator {
                             );
                         }
                         self.advance_input_identity(&prefix)?;
+                        self.remember_live_inputs(&prefix);
                         RejectedTurnEvidence::from_input(&prefix)
                     } else {
                         drop(input_permit);
@@ -549,6 +555,7 @@ impl ResidentExternalCoordinator {
                 );
             }
             self.advance_input_identity(&batch)?;
+            self.remember_live_inputs(&batch);
             Some(batch)
         } else {
             if host_updates.is_some_and(|updates| !updates.is_empty()) {
@@ -1067,25 +1074,37 @@ impl ResidentExternalCoordinator {
                             && update.source.path() == observation.request.path
                     })
                 });
-                let legacy = if let Some(update) = packet_value {
-                    update.value.clone().into_mech_value()?
+                let value = if let Some(update) = packet_value {
+                    let legacy = update.value.clone().into_mech_value()?;
+                    captured_value_from_legacy(
+                        &legacy,
+                        observation.input.schema,
+                        &observation.input.shape,
+                        self.artifact.schemas(),
+                    )?
+                } else if let Some(value) = host_updates.and_then(|_| {
+                    self.latest_live_inputs
+                        .get(ordinal)
+                        .and_then(|value| value.as_ref())
+                }) {
+                    value.clone()
                 } else {
                     let provider_binding =
                         observation.provider_binding.as_ref().ok_or_else(|| {
                             invalid_value("live observation has no provider binding".to_owned())
                         })?;
-                    provider_binding.read(RuntimeResourceReadRequest {
+                    let legacy = provider_binding.read(RuntimeResourceReadRequest {
                         base_uri: observation.request.base_uri.clone(),
                         path: observation.request.path.clone(),
                         context_name: observation.request.context_name.clone(),
-                    })?
+                    })?;
+                    captured_value_from_legacy(
+                        &legacy,
+                        observation.input.schema,
+                        &observation.input.shape,
+                        self.artifact.schemas(),
+                    )?
                 };
-                let value = captured_value_from_legacy(
-                    &legacy,
-                    observation.input.schema,
-                    &observation.input.shape,
-                    self.artifact.schemas(),
-                )?;
                 CapturedInputFact::new(
                     sequence,
                     observation.requirement,
@@ -1774,6 +1793,13 @@ impl ResidentExternalCoordinator {
             .checked_add(1)
             .ok_or_else(sequence_exhausted)?;
         Ok(())
+    }
+
+    fn remember_live_inputs(&mut self, batch: &CapturedInputBatch) {
+        debug_assert!(batch.facts.len() <= self.latest_live_inputs.len());
+        for (latest, fact) in self.latest_live_inputs.iter_mut().zip(batch.facts.iter()) {
+            *latest = Some(fact.value.clone());
+        }
     }
 }
 

--- a/src/runtime/src/runtime/program/external/coordinator.rs
+++ b/src/runtime/src/runtime/program/external/coordinator.rs
@@ -301,30 +301,22 @@ impl ResidentExternalCoordinator {
     /// resident replacement. Observation node/slot identities are artifact
     /// local, so migration matches the stable resource request plus its schema
     /// and shape, then re-materializes the value against the candidate schema
-    /// table. Incompatible or newly introduced observations remain unseeded and
+    /// table. Every compatible candidate observation inherits that same
+    /// authoritative value, including duplicates introduced by the candidate.
+    /// Observations with a newly introduced source identity remain unseeded and
     /// will read their provider on first use.
     pub(crate) fn preserve_compatible_live_inputs_from(
         &mut self,
         previous: &ResidentExternalCoordinator,
     ) -> MResult<()> {
-        let mut previous_matches = vec![false; previous.bound.observations().len()];
         for (target_ordinal, target) in self.bound.observations().iter().enumerate() {
-            let Some(source_ordinal) = previous.bound.observations().iter().enumerate().position(
+            let Some(value) = previous.bound.observations().iter().enumerate().find_map(
                 |(source_ordinal, source)| {
-                    !previous_matches[source_ordinal]
-                        && source.request == target.request
-                        && source.input.schema_key == target.input.schema_key
-                        && source.input.shape == target.input.shape
+                    observations_share_snapshot(source, target)
+                        .then(|| previous.latest_live_inputs.get(source_ordinal)?.as_ref())
+                        .flatten()
                 },
             ) else {
-                continue;
-            };
-            previous_matches[source_ordinal] = true;
-            let Some(value) = previous
-                .latest_live_inputs
-                .get(source_ordinal)
-                .and_then(|value| value.as_ref())
-            else {
                 continue;
             };
             let legacy = provider_value_from_canonical(value, previous.artifact.schemas())?;
@@ -1102,7 +1094,7 @@ impl ResidentExternalCoordinator {
         &self,
         host_updates: Option<&[crate::RuntimeHostInputUpdate]>,
     ) -> Result<CapturedInputBatch, CaptureFailure> {
-        let mut facts = Vec::with_capacity(self.bound.observations().len());
+        let mut facts: Vec<CapturedInputFact> = Vec::with_capacity(self.bound.observations().len());
         for (ordinal, observation) in self.bound.observations().iter().enumerate() {
             let fact = (|| -> MResult<CapturedInputFact> {
                 let sequence_value = self
@@ -1125,10 +1117,27 @@ impl ResidentExternalCoordinator {
                         self.artifact.schemas(),
                     )?
                 } else if let Some(value) = host_updates.and_then(|_| {
-                    self.latest_live_inputs
-                        .get(ordinal)
-                        .and_then(|value| value.as_ref())
+                    self.bound.observations().iter().enumerate().find_map(
+                        |(candidate_ordinal, candidate)| {
+                            observations_share_snapshot(candidate, observation)
+                                .then(|| {
+                                    self.latest_live_inputs
+                                        .get(candidate_ordinal)
+                                        .and_then(|value| value.as_ref())
+                                })
+                                .flatten()
+                        },
+                    )
                 }) {
+                    value.clone()
+                } else if let Some(value) = self.bound.observations()[..ordinal]
+                    .iter()
+                    .enumerate()
+                    .find(|(_, candidate)| observations_share_snapshot(candidate, observation))
+                    .and_then(|(candidate_ordinal, _)| {
+                        facts.get(candidate_ordinal).map(|fact| &fact.value)
+                    })
+                {
                     value.clone()
                 } else {
                     let provider_binding =
@@ -1843,6 +1852,15 @@ impl ResidentExternalCoordinator {
             *latest = Some(fact.value.clone());
         }
     }
+}
+
+fn observations_share_snapshot(
+    left: &super::BoundResidentObservation,
+    right: &super::BoundResidentObservation,
+) -> bool {
+    left.request == right.request
+        && left.input.schema_key == right.input.schema_key
+        && left.input.shape == right.input.shape
 }
 
 #[derive(Clone, Debug)]

--- a/src/runtime/src/runtime/program/external/tests.rs
+++ b/src/runtime/src/runtime/program/external/tests.rs
@@ -1871,7 +1871,7 @@ fn retained_turn_batches_allow_distinct_nodes_to_share_a_requirement() -> MResul
 }
 
 #[test]
-fn shared_observations_record_a_successful_prefix_before_a_later_read_failure() -> MResult<()> {
+fn shared_observations_capture_one_authoritative_provider_snapshot() -> MResult<()> {
     let trace = Arc::new(Mutex::new(ProviderTrace {
         fail_read_at: Some(2),
         ..ProviderTrace::default()
@@ -1895,33 +1895,16 @@ fn shared_observations_record_a_successful_prefix_before_a_later_read_failure() 
     )?;
     assert!(matches!(
         coordinator.execute_turn()?,
-        ResidentExternalTurnOutcome::Rejected {
-            phase: TurnFailurePhase::InputInstallation,
-            ..
-        }
-    ));
-    assert_eq!(trace.lock().unwrap().reads, 2);
-    let (_, prefix) = coordinator.input_facts().next().expect("captured prefix");
-    assert_eq!(prefix.facts.len(), 1);
-    let receipt = coordinator.receipts().next().unwrap().1;
-    assert_eq!(receipt.header.input_range, Some(prefix.range));
-    assert_eq!(receipt.body.input_batch_hash, prefix.batch_hash);
-    trace.lock().unwrap().fail_read_at = None;
-    assert!(matches!(
-        coordinator.execute_turn()?,
         ResidentExternalTurnOutcome::Accepted { .. }
     ));
-    let batches = coordinator
-        .input_facts()
-        .map(|(_, batch)| batch.clone())
-        .collect::<Vec<_>>();
-    let records = coordinator
-        .receipts()
-        .map(|(_, record)| record.clone())
-        .collect::<Vec<_>>();
-    assert_eq!(batches[0].facts.len(), 1);
-    assert_eq!(batches[1].facts.len(), 2);
-    assert_eq!(batches[1].range.first().get(), 2);
+    assert_eq!(trace.lock().unwrap().reads, 1);
+    let batch = coordinator.input_facts().next().unwrap().1.clone();
+    let record = coordinator.receipts().next().unwrap().1.clone();
+    assert_eq!(batch.facts.len(), 2);
+    assert_eq!(
+        batch.facts[0].value.resident_token(),
+        batch.facts[1].value.resident_token()
+    );
     drop(coordinator);
     drop(providers);
 
@@ -1940,18 +1923,7 @@ fn shared_observations_record_a_successful_prefix_before_a_later_read_failure() 
         ResidentExternalLimits::default(),
     )?;
     assert!(matches!(
-        replay.execute_replay_batch(Some(&batches[0]), &records[0])?,
-        ResidentExternalTurnOutcome::Rejected {
-            phase: TurnFailurePhase::InputInstallation,
-            ..
-        }
-    ));
-    assert_eq!(
-        replay.instance().published_epoch(),
-        mech_core::InstanceEpoch::ZERO
-    );
-    assert!(matches!(
-        replay.execute_replay_batch(Some(&batches[1]), &records[1])?,
+        replay.execute_replay_batch(Some(&batch), &record)?,
         ResidentExternalTurnOutcome::Accepted { .. }
     ));
     assert_eq!(replay.instance().published_epoch().get(), 1);

--- a/src/runtime/src/runtime/program/external/tests.rs
+++ b/src/runtime/src/runtime/program/external/tests.rs
@@ -1905,6 +1905,25 @@ fn shared_observations_capture_one_authoritative_provider_snapshot() -> MResult<
         batch.facts[0].value.resident_token(),
         batch.facts[1].value.resident_token()
     );
+    let second = &batch.facts[1];
+    let divergent_value = captured_value_from_legacy(
+        &LegacyValue::MatrixF64(ToMatrix::to_matrix(vec![9.0, 0.01, 5.0, -2.0], 4, 1)),
+        second.value.schema(),
+        &second.shape,
+        artifact.schemas(),
+    )?;
+    let divergent_second = CapturedInputFact::new(
+        second.sequence,
+        second.requirement,
+        second.node,
+        second.slot,
+        second.schema_key,
+        second.shape.clone(),
+        divergent_value,
+        artifact.schemas(),
+    )?;
+    let inconsistent_batch =
+        CapturedInputBatch::new(vec![batch.facts[0].clone(), divergent_second])?;
     drop(coordinator);
     drop(providers);
 
@@ -1922,6 +1941,20 @@ fn shared_observations_capture_one_authoritative_provider_snapshot() -> MResult<
         ResidentDurabilityPolicy::Retained,
         ResidentExternalLimits::default(),
     )?;
+    let error = replay
+        .execute_replay_batch(Some(&inconsistent_batch), &record)
+        .unwrap_err();
+    assert!(
+        error
+            .display_message()
+            .contains("conflicting snapshots for one source identity")
+    );
+    assert_eq!(replay.input_facts().count(), 0);
+    assert_eq!(replay.receipts().count(), 0);
+    assert_eq!(
+        replay.instance().published_epoch(),
+        mech_core::InstanceEpoch::ZERO
+    );
     assert!(matches!(
         replay.execute_replay_batch(Some(&batch), &record)?,
         ResidentExternalTurnOutcome::Accepted { .. }

--- a/src/runtime/src/runtime/program/input.rs
+++ b/src/runtime/src/runtime/program/input.rs
@@ -23,6 +23,35 @@ pub struct ResidentHostTurnFailed {
     pub failures: Vec<String>,
 }
 
+impl ResidentHostTurnFailed {
+    /// A rejected candidate never published state and may be followed by a
+    /// later turn. Outcomes that advanced or indeterminately published state
+    /// require host intervention instead.
+    pub fn is_recoverable(&self) -> bool {
+        self.status == "rejected"
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResidentHostTurnCause {
+    pub phase: crate::TurnFailurePhase,
+    pub kind: String,
+    pub detail: String,
+}
+
+impl MechErrorKind for ResidentHostTurnCause {
+    fn name(&self) -> &str {
+        &self.kind
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "resident turn failed during {:?}: {}",
+            self.phase, self.detail
+        )
+    }
+}
+
 impl MechErrorKind for ResidentHostTurnFailed {
     fn name(&self) -> &str {
         "ResidentHostTurnFailed"
@@ -50,7 +79,7 @@ impl MechErrorKind for ResidentHostTurnFailed {
 pub(crate) fn resident_host_turn_error(
     outcome: &crate::ResidentExternalTurnOutcome,
 ) -> Option<MechError> {
-    let failure = match outcome {
+    let (failure, source) = match outcome {
         crate::ResidentExternalTurnOutcome::Accepted {
             delivery_failures, ..
         } if delivery_failures.is_empty() => return None,
@@ -58,26 +87,42 @@ pub(crate) fn resident_host_turn_error(
             turn,
             delivery_failures,
             ..
-        } => ResidentHostTurnFailed {
-            turn: *turn,
-            status: "accepted-with-delivery-failures",
-            failure_count: delivery_failures.len(),
-            phase: None,
-            failures: delivery_failures
-                .iter()
-                .map(|failure| failure.message.clone())
-                .collect(),
-        },
-        crate::ResidentExternalTurnOutcome::Rejected { turn, phase, .. } => {
+        } => (
+            ResidentHostTurnFailed {
+                turn: *turn,
+                status: "accepted-with-delivery-failures",
+                failure_count: delivery_failures.len(),
+                phase: None,
+                failures: delivery_failures
+                    .iter()
+                    .map(|failure| failure.message.clone())
+                    .collect(),
+            },
+            None,
+        ),
+        crate::ResidentExternalTurnOutcome::Rejected {
+            turn,
+            phase,
+            failure,
+            ..
+        } => (
             ResidentHostTurnFailed {
                 turn: *turn,
                 status: "rejected",
                 failure_count: 1,
                 phase: Some(*phase),
-                failures: Vec::new(),
-            }
-        }
-        crate::ResidentExternalTurnOutcome::PublishedIndeterminate { turn, failures, .. } => {
+                failures: vec![format!("{}: {}", failure.kind, failure.message)],
+            },
+            Some(MechError::new(
+                ResidentHostTurnCause {
+                    phase: failure.phase,
+                    kind: failure.kind.clone(),
+                    detail: failure.message.clone(),
+                },
+                None,
+            )),
+        ),
+        crate::ResidentExternalTurnOutcome::PublishedIndeterminate { turn, failures, .. } => (
             ResidentHostTurnFailed {
                 turn: *turn,
                 status: "published-indeterminate",
@@ -87,10 +132,15 @@ pub(crate) fn resident_host_turn_error(
                     .iter()
                     .map(|failure| failure.message.clone())
                     .collect(),
-            }
-        }
+            },
+            None,
+        ),
     };
-    Some(MechError::new(failure, None))
+    let error = MechError::new(failure, None);
+    Some(match source {
+        Some(source) => error.with_source(source),
+        None => error,
+    })
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/src/runtime/src/runtime/program/input.rs
+++ b/src/runtime/src/runtime/program/input.rs
@@ -173,6 +173,7 @@ impl crate::runtime::MechRuntime {
             ));
         };
         let mut packets = Vec::new();
+        let mut coalescing_group = None::<Option<crate::input::RuntimeHostInputCoalescingGroup>>;
         for _ in 0..max_inputs {
             let packet = {
                 let mut guard = self.host_input_queue.lock().map_err(|_| {
@@ -181,9 +182,22 @@ impl crate::runtime::MechRuntime {
                         "host input queue lock is poisoned",
                     )
                 })?;
-                guard.queue.pop_front()
+                let may_join = guard
+                    .queue
+                    .front()
+                    .map(|packet| {
+                        coalescing_group
+                            .as_ref()
+                            .map(|group| group.as_ref() == packet.coalescing_group())
+                            .unwrap_or(true)
+                    })
+                    .unwrap_or(false);
+                may_join.then(|| guard.queue.pop_front()).flatten()
             };
             let Some(packet) = packet else { break };
+            if coalescing_group.is_none() {
+                coalescing_group = Some(packet.coalescing_group().cloned());
+            }
             packets.push(packet);
         }
 

--- a/src/runtime/src/runtime/program/input.rs
+++ b/src/runtime/src/runtime/program/input.rs
@@ -20,6 +20,7 @@ pub struct ResidentHostTurnFailed {
     pub status: &'static str,
     pub failure_count: usize,
     pub phase: Option<crate::TurnFailurePhase>,
+    pub failures: Vec<String>,
 }
 
 impl MechErrorKind for ResidentHostTurnFailed {
@@ -28,14 +29,20 @@ impl MechErrorKind for ResidentHostTurnFailed {
     }
 
     fn message(&self) -> String {
+        let details = if self.failures.is_empty() {
+            String::new()
+        } else {
+            format!(": {}", self.failures.join("; "))
+        };
         format!(
-            "resident host turn {} completed as {}{} with {} reported failures",
+            "resident host turn {} completed as {}{} with {} reported failures{}",
             self.turn.get(),
             self.status,
             self.phase
                 .map(|phase| format!(" during {phase:?}"))
                 .unwrap_or_default(),
             self.failure_count,
+            details,
         )
     }
 }
@@ -56,6 +63,10 @@ pub(crate) fn resident_host_turn_error(
             status: "accepted-with-delivery-failures",
             failure_count: delivery_failures.len(),
             phase: None,
+            failures: delivery_failures
+                .iter()
+                .map(|failure| failure.message.clone())
+                .collect(),
         },
         crate::ResidentExternalTurnOutcome::Rejected { turn, phase, .. } => {
             ResidentHostTurnFailed {
@@ -63,6 +74,7 @@ pub(crate) fn resident_host_turn_error(
                 status: "rejected",
                 failure_count: 1,
                 phase: Some(*phase),
+                failures: Vec::new(),
             }
         }
         crate::ResidentExternalTurnOutcome::PublishedIndeterminate { turn, failures, .. } => {
@@ -71,6 +83,10 @@ pub(crate) fn resident_host_turn_error(
                 status: "published-indeterminate",
                 failure_count: failures.len(),
                 phase: None,
+                failures: failures
+                    .iter()
+                    .map(|failure| failure.message.clone())
+                    .collect(),
             }
         }
     };

--- a/src/runtime/src/runtime/program/query.rs
+++ b/src/runtime/src/runtime/program/query.rs
@@ -28,38 +28,48 @@ impl MechRuntime {
         };
         let mappings =
             compatible_state_mappings(previous_artifact, candidate_artifact, changed_state_names);
-        if mappings.is_empty() {
-            return Ok(());
-        }
-        let mapped_targets = mappings
-            .iter()
-            .map(|mapping| mapping.target)
-            .collect::<std::collections::BTreeSet<_>>();
-        let projection_refresh_targets = candidate_artifact
-            .outputs()
-            .iter()
-            .map(|output| output.source)
-            .filter(|slot| {
-                !mapped_targets.contains(slot)
-                    && candidate_artifact
-                        .slots()
-                        .get(slot.get() as usize)
-                        .is_some_and(|declaration| declaration.role == SlotRole::Output)
-            })
-            .collect::<std::collections::BTreeSet<_>>();
+        if !mappings.is_empty() {
+            let mapped_targets = mappings
+                .iter()
+                .map(|mapping| mapping.target)
+                .collect::<std::collections::BTreeSet<_>>();
+            let projection_refresh_targets = candidate_artifact
+                .outputs()
+                .iter()
+                .map(|output| output.source)
+                .filter(|slot| {
+                    !mapped_targets.contains(slot)
+                        && candidate_artifact
+                            .slots()
+                            .get(slot.get() as usize)
+                            .is_some_and(|declaration| declaration.role == SlotRole::Output)
+                })
+                .collect::<std::collections::BTreeSet<_>>();
 
-        let candidate_artifact = std::sync::Arc::new(candidate_artifact.clone());
-        let (_, candidate_instance) = self
-            .resident_artifact_and_instance_mut()
-            .expect("candidate artifact was checked above");
-        candidate_instance
-            .migrate_compatible_state_from(previous_instance, &mappings)
-            .map_err(|error| {
-                super::diagnostics::activation_failure_for_artifact(&candidate_artifact, error)
-            })?;
-        candidate_instance
-            .refresh_output_projections(&projection_refresh_targets)
-            .map_err(super::diagnostics::projection_refresh_failure)?;
+            let candidate_artifact = std::sync::Arc::new(candidate_artifact.clone());
+            let (_, candidate_instance) = self
+                .resident_artifact_and_instance_mut()
+                .expect("candidate artifact was checked above");
+            candidate_instance
+                .migrate_compatible_state_from(previous_instance, &mappings)
+                .map_err(|error| {
+                    super::diagnostics::activation_failure_for_artifact(&candidate_artifact, error)
+                })?;
+            candidate_instance
+                .refresh_output_projections(&projection_refresh_targets)
+                .map_err(super::diagnostics::projection_refresh_failure)?;
+        }
+
+        use crate::runtime::program::ActiveProgramExecution;
+        if let (
+            ActiveProgramExecution::ResidentExternal(candidate),
+            ActiveProgramExecution::ResidentExternal(previous),
+        ) = (&mut self.active_program, &previous.active_program)
+        {
+            candidate
+                .coordinator
+                .preserve_compatible_live_inputs_from(&previous.coordinator)?;
+        }
         Ok(())
     }
 

--- a/src/runtime/src/runtime/program/tests.rs
+++ b/src/runtime/src/runtime/program/tests.rs
@@ -3093,6 +3093,60 @@ fn independent_observations_seed_then_retain_the_accepted_host_snapshot() {
 }
 
 #[test]
+fn compatible_replacement_migrates_the_accepted_host_snapshot() {
+    let (mut previous, previous_reads) = independent_external_runtime();
+    previous
+        .ingress()
+        .submit(crate::RuntimeHostInput::single(
+            crate::RuntimeHostInputSource::new("test://clock/fast", "delta-seconds").unwrap(),
+            crate::RuntimeHostInputValue::F64(7.0),
+        ))
+        .unwrap();
+    previous.drain_resident_host_inputs(1).unwrap();
+    assert_eq!(previous_reads.load(Ordering::SeqCst), 1);
+
+    let (mut candidate, candidate_reads) = independent_external_runtime();
+    candidate
+        .preserve_compatible_resident_state_from(&previous, &BTreeSet::new())
+        .unwrap();
+    candidate
+        .ingress()
+        .submit(crate::RuntimeHostInput::single(
+            crate::RuntimeHostInputSource::new("test://clock/slow", "delta-seconds").unwrap(),
+            crate::RuntimeHostInputValue::F64(8.0),
+        ))
+        .unwrap();
+    let outcome = candidate.drain_resident_host_inputs(1).unwrap();
+    assert!(matches!(
+        outcome.turn,
+        Some(crate::ResidentExternalTurnOutcome::Accepted { .. })
+    ));
+    assert_eq!(
+        candidate_reads.load(Ordering::SeqCst),
+        0,
+        "a compatible replacement must not synthesize absent fields from providers"
+    );
+    let ActiveProgramExecution::ResidentExternal(execution) = &candidate.active_program else {
+        unreachable!()
+    };
+    let mut values = execution
+        .coordinator
+        .input_facts()
+        .last()
+        .unwrap()
+        .1
+        .facts
+        .iter()
+        .map(|fact| match fact.value.data() {
+            ValueData::F64(value) => value.to_f64(),
+            _ => panic!("clock observations must remain f64"),
+        })
+        .collect::<Vec<_>>();
+    values.sort_by(f64::total_cmp);
+    assert_eq!(values, vec![7.0, 8.0]);
+}
+
+#[test]
 fn public_host_drain_exposes_the_clean_resident_turn() {
     let (mut runtime, _, _, _) = external_runtime(crate::ResidentDurabilityPolicy::Volatile);
     runtime

--- a/src/runtime/src/runtime/program/tests.rs
+++ b/src/runtime/src/runtime/program/tests.rs
@@ -1125,6 +1125,42 @@ fn mixed_tree_compilation_owns_partitioning_and_typed_initializers() {
 
 #[cfg(feature = "compute")]
 #[test]
+fn mixed_tree_coordinator_retains_interactive_root_symbols() {
+    let tree = mech_syntax::parse(
+        r#"
+visible := 41
+@compute := compute://worker/kernel{:write(input/x), :write(turn)}
+@compute/input/x <- visible
+@compute/turn <- 1
+
+calculation @compute
+-------------------------------------------------------------------------------
+x := 1f32
+result := x + 1f32
+result
+"#,
+    )
+    .unwrap();
+    let mut compiler = RuntimeBuilder::new()
+        .function_catalog(mech_stdlib::source_native_plan_catalog())
+        .build_compiler()
+        .unwrap();
+
+    let mixed = compiler.compile_mixed_tree(&tree).unwrap();
+    let names = mixed
+        .coordinator
+        .artifact()
+        .outputs()
+        .iter()
+        .filter_map(|output| output.interactive_binding.as_ref())
+        .map(|binding| binding.lexical_name.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(names.contains(&"visible"));
+}
+
+#[cfg(feature = "compute")]
+#[test]
 fn mixed_tree_retains_array_activation_as_outer_broadcast_extent() {
     let tree = mech_syntax::parse(
         r#"

--- a/src/runtime/src/runtime/program/tests.rs
+++ b/src/runtime/src/runtime/program/tests.rs
@@ -589,7 +589,9 @@ fn external_runtime(
     (runtime, plans, reads, value_bits)
 }
 
-fn independent_external_runtime() -> (crate::MechRuntime, Arc<AtomicUsize>) {
+fn independent_external_runtime_with_source(
+    source: &str,
+) -> (crate::MechRuntime, Arc<AtomicUsize>) {
     let reads = Arc::new(AtomicUsize::new(0));
     let mut runtime = runtime();
     runtime
@@ -614,8 +616,14 @@ fn independent_external_runtime() -> (crate::MechRuntime, Arc<AtomicUsize>) {
             .unwrap();
     }
     runtime
-        .load_source_program(
-            r#"
+        .load_source_program(source, crate::ResidentDurabilityPolicy::Retained)
+        .unwrap();
+    (runtime, reads)
+}
+
+fn independent_external_runtime() -> (crate::MechRuntime, Arc<AtomicUsize>) {
+    independent_external_runtime_with_source(
+        r#"
 @fast := test://clock/fast{:read(delta-seconds)}
 @slow := test://clock/slow{:read(delta-seconds)}
 fast := @fast/delta-seconds
@@ -624,10 +632,7 @@ slow := @slow/delta-seconds
 state += fast + slow
 output := state
 "#,
-            crate::ResidentDurabilityPolicy::Retained,
-        )
-        .unwrap();
-    (runtime, reads)
+    )
 }
 
 fn unactivated_external_runtime(driver_count: usize) -> crate::MechRuntime {
@@ -3144,6 +3149,72 @@ fn compatible_replacement_migrates_the_accepted_host_snapshot() {
         .collect::<Vec<_>>();
     values.sort_by(f64::total_cmp);
     assert_eq!(values, vec![7.0, 8.0]);
+}
+
+#[test]
+fn compatible_replacement_expands_one_snapshot_to_new_duplicate_consumers() {
+    let (mut previous, previous_reads) = independent_external_runtime();
+    previous
+        .ingress()
+        .submit(crate::RuntimeHostInput::single(
+            crate::RuntimeHostInputSource::new("test://clock/fast", "delta-seconds").unwrap(),
+            crate::RuntimeHostInputValue::F64(7.0),
+        ))
+        .unwrap();
+    previous.drain_resident_host_inputs(1).unwrap();
+    assert_eq!(previous_reads.load(Ordering::SeqCst), 1);
+
+    let (mut candidate, candidate_reads) = independent_external_runtime_with_source(
+        r#"
+@fast := test://clock/fast{:read(delta-seconds)}
+@fast-copy := test://clock/fast{:read(delta-seconds)}
+@slow := test://clock/slow{:read(delta-seconds)}
+fast := @fast/delta-seconds
+fast-copy := @fast-copy/delta-seconds
+slow := @slow/delta-seconds
+~state := 0.0
+state += fast + fast-copy + slow
+output := state
+"#,
+    );
+    candidate
+        .preserve_compatible_resident_state_from(&previous, &BTreeSet::new())
+        .unwrap();
+    candidate
+        .ingress()
+        .submit(crate::RuntimeHostInput::single(
+            crate::RuntimeHostInputSource::new("test://clock/slow", "delta-seconds").unwrap(),
+            crate::RuntimeHostInputValue::F64(8.0),
+        ))
+        .unwrap();
+    let outcome = candidate.drain_resident_host_inputs(1).unwrap();
+    assert!(matches!(
+        outcome.turn,
+        Some(crate::ResidentExternalTurnOutcome::Accepted { .. })
+    ));
+    assert_eq!(
+        candidate_reads.load(Ordering::SeqCst),
+        0,
+        "new duplicate consumers must inherit the accepted source snapshot"
+    );
+    let ActiveProgramExecution::ResidentExternal(execution) = &candidate.active_program else {
+        unreachable!()
+    };
+    let mut values = execution
+        .coordinator
+        .input_facts()
+        .last()
+        .unwrap()
+        .1
+        .facts
+        .iter()
+        .map(|fact| match fact.value.data() {
+            ValueData::F64(value) => value.to_f64(),
+            _ => panic!("clock observations must remain f64"),
+        })
+        .collect::<Vec<_>>();
+    values.sort_by(f64::total_cmp);
+    assert_eq!(values, vec![7.0, 7.0, 8.0]);
 }
 
 #[test]

--- a/src/runtime/src/runtime/program/tests.rs
+++ b/src/runtime/src/runtime/program/tests.rs
@@ -3809,6 +3809,20 @@ fn resident_turn_duration_rejects_before_scene_publication_and_surfaces_publicly
 
     let error = runtime.drain_host_inputs(1).unwrap_err();
     assert_eq!(error.kind_name(), "ResidentHostTurnFailed");
+    assert!(
+        error
+            .kind_as::<super::ResidentHostTurnFailed>()
+            .expect("resident host turn failure kind")
+            .is_recoverable()
+    );
+    assert!(
+        error
+            .kind_message()
+            .contains("ResourceBudgetExceeded: MechError")
+    );
+    let source = error.source.as_ref().expect("rejection cause is preserved");
+    assert_eq!(source.kind_name(), "ResourceBudgetExceeded");
+    assert!(source.kind_message().contains("turn_duration_ms"));
     assert_eq!(scene.lock().unwrap().deliveries, 0);
     assert_eq!(runtime.program_execution_info().resident_rejected_turns, 1);
     let ActiveProgramExecution::ResidentExternal(execution) = &runtime.active_program else {
@@ -3829,6 +3843,21 @@ fn resident_turn_duration_rejects_before_scene_publication_and_surfaces_publicly
             .phase,
         crate::TurnFailurePhase::Execution,
     );
+
+    runtime.config.limits.max_turn_duration_ms = None;
+    runtime
+        .ingress()
+        .submit(crate::RuntimeHostInput::single(
+            crate::RuntimeHostInputSource::new("timer://clock/tick", "tick").unwrap(),
+            crate::RuntimeHostInputValue::F64(2.0),
+        ))
+        .unwrap();
+    let recovered = runtime.drain_host_inputs(1).unwrap();
+    assert_eq!(recovered.len(), 1);
+    assert_eq!(scene.lock().unwrap().deliveries, 1);
+    let info = runtime.program_execution_info();
+    assert_eq!(info.resident_rejected_turns, 1);
+    assert_eq!(info.resident_accepted_turns, 1);
 }
 
 #[test]

--- a/src/runtime/src/runtime/program/tests.rs
+++ b/src/runtime/src/runtime/program/tests.rs
@@ -1130,6 +1130,37 @@ fn mixed_tree_compilation_owns_partitioning_and_typed_initializers() {
 
 #[cfg(feature = "compute")]
 #[test]
+fn mixed_tree_retains_only_explicit_sample_read_capabilities() {
+    let tree = mech_syntax::parse(
+        r#"
+@compute := compute://worker/kernel{:read(sample/result), :write(input/x), :write(turn)}
+@compute/input/x <- 1f32
+@compute/turn <- 1
+
+calculation @compute
+-------------------------------------------------------------------------------
+x := 1f32
+result := x + 2f32
+unused := x + 3f32
+(result, unused)
+"#,
+    )
+    .unwrap();
+    let mut compiler = RuntimeBuilder::new()
+        .function_catalog(mech_stdlib::source_native_plan_catalog())
+        .build_compiler()
+        .unwrap();
+
+    let mixed = compiler.compile_mixed_tree(&tree).unwrap();
+
+    assert_eq!(
+        mixed.retained_outputs,
+        BTreeSet::from(["result".to_owned()])
+    );
+}
+
+#[cfg(feature = "compute")]
+#[test]
 fn mixed_tree_coordinator_retains_interactive_root_symbols() {
     let tree = mech_syntax::parse(
         r#"

--- a/src/runtime/src/runtime/program/tests.rs
+++ b/src/runtime/src/runtime/program/tests.rs
@@ -1125,6 +1125,47 @@ fn mixed_tree_compilation_owns_partitioning_and_typed_initializers() {
 
 #[cfg(feature = "compute")]
 #[test]
+fn mixed_tree_retains_array_activation_as_outer_broadcast_extent() {
+    let tree = mech_syntax::parse(
+        r#"
+@compute := compute://worker/kernel{:write(input/x), :write(turn)}
+lanes := [1f32 2f32 3f32 4f32]
+@compute/input/x <- lanes
+@compute/turn <- 1
+
+calculation @compute
+-------------------------------------------------------------------------------
+x := 0f32
+result := x + 1f32
+result
+"#,
+    )
+    .unwrap();
+    let mut compiler = RuntimeBuilder::new()
+        .function_catalog(mech_stdlib::source_native_plan_catalog())
+        .build_compiler()
+        .unwrap();
+
+    let mixed = compiler.compile_mixed_tree(&tree).unwrap();
+
+    assert_eq!(
+        mixed.activation_inputs["x"],
+        mech_compute::ComputeValue::TensorF32 {
+            dimensions: vec![4].into_boxed_slice(),
+            layout: mech_compute::TensorLayout::RowMajor,
+            values: Arc::from([1.0, 2.0, 3.0, 4.0]),
+        }
+    );
+    let input = mixed.compute.interface.input_named("x").unwrap();
+    assert_eq!(
+        mixed.compute.initializers.get(input.id),
+        Some(&mech_compute::ComputeValue::ScalarF32(0.0)),
+        "the one-lane port initializer must remain distinct from its outer activation batch",
+    );
+}
+
+#[cfg(feature = "compute")]
+#[test]
 fn mixed_tree_normalizes_matrix_initializers_to_canonical_row_major_layout() {
     let tree = mech_syntax::parse(
         r#"

--- a/src/runtime/src/runtime/program/tests.rs
+++ b/src/runtime/src/runtime/program/tests.rs
@@ -2848,6 +2848,34 @@ fn resident_host_packets_coalesce_and_capture_the_latest_packet_value() {
 }
 
 #[test]
+fn resident_host_packet_groups_preserve_activation_boundaries() {
+    let (mut runtime, _, _, _) = external_runtime(crate::ResidentDurabilityPolicy::Retained);
+    let trigger = crate::RuntimeHostInputSource::new("test://clock/tick", "delta-seconds").unwrap();
+    let ingress = runtime.ingress();
+    for (group, value) in [(1, 7.0), (1, 8.0), (2, 9.0), (2, 10.0)] {
+        ingress
+            .submit(
+                crate::RuntimeHostInput::single(
+                    trigger.clone(),
+                    crate::RuntimeHostInputValue::F64(value),
+                )
+                .with_coalescing_group(group),
+            )
+            .unwrap();
+    }
+
+    let first = runtime.drain_resident_host_inputs(64).unwrap();
+    assert_eq!(first.dequeued_packets, 2);
+    assert_eq!(first.coalesced_packets, 1);
+    assert_eq!(runtime.pending_host_input_count().unwrap(), 2);
+
+    let second = runtime.drain_resident_host_inputs(64).unwrap();
+    assert_eq!(second.dequeued_packets, 2);
+    assert_eq!(second.coalesced_packets, 1);
+    assert_eq!(runtime.pending_host_input_count().unwrap(), 0);
+}
+
+#[test]
 fn resident_recurrence_advances_when_a_same_turn_parent_is_unchanged() {
     let (mut runtime, _, _, _) = configured_external_runtime();
     runtime
@@ -2957,7 +2985,7 @@ output := state
 }
 
 #[test]
-fn independent_observations_capture_absent_values_from_the_bound_provider() {
+fn independent_observations_seed_then_retain_the_accepted_host_snapshot() {
     let (mut runtime, reads) = independent_external_runtime();
     runtime
         .ingress()
@@ -2991,6 +3019,77 @@ fn independent_observations_capture_absent_values_from_the_bound_provider() {
         .collect::<Vec<_>>();
     values.sort_by(f64::total_cmp);
     assert_eq!(values, vec![3.0, 7.0]);
+
+    runtime
+        .ingress()
+        .submit(crate::RuntimeHostInput::single(
+            crate::RuntimeHostInputSource::new("test://clock/slow", "delta-seconds").unwrap(),
+            crate::RuntimeHostInputValue::F64(8.0),
+        ))
+        .unwrap();
+    let outcome = runtime.drain_resident_host_inputs(1).unwrap();
+    assert!(matches!(
+        outcome.turn,
+        Some(crate::ResidentExternalTurnOutcome::Accepted { .. })
+    ));
+    assert_eq!(
+        reads.load(Ordering::SeqCst),
+        1,
+        "an unrelated provider snapshot must not overwrite accepted host state"
+    );
+    let ActiveProgramExecution::ResidentExternal(execution) = &runtime.active_program else {
+        unreachable!()
+    };
+    let mut values = execution
+        .coordinator
+        .input_facts()
+        .last()
+        .unwrap()
+        .1
+        .facts
+        .iter()
+        .map(|fact| match fact.value.data() {
+            ValueData::F64(value) => value.to_f64(),
+            _ => panic!("clock observations must remain f64"),
+        })
+        .collect::<Vec<_>>();
+    values.sort_by(f64::total_cmp);
+    assert_eq!(values, vec![7.0, 8.0]);
+
+    let outcome = {
+        let ActiveProgramExecution::ResidentExternal(execution) = &mut runtime.active_program
+        else {
+            unreachable!()
+        };
+        execution.coordinator.execute_turn().unwrap()
+    };
+    assert!(matches!(
+        outcome,
+        crate::ResidentExternalTurnOutcome::Accepted { .. }
+    ));
+    assert_eq!(
+        reads.load(Ordering::SeqCst),
+        3,
+        "provider-driven turns must still refresh every live observation"
+    );
+    let ActiveProgramExecution::ResidentExternal(execution) = &runtime.active_program else {
+        unreachable!()
+    };
+    let mut values = execution
+        .coordinator
+        .input_facts()
+        .last()
+        .unwrap()
+        .1
+        .facts
+        .iter()
+        .map(|fact| match fact.value.data() {
+            ValueData::F64(value) => value.to_f64(),
+            _ => panic!("clock observations must remain f64"),
+        })
+        .collect::<Vec<_>>();
+    values.sort_by(f64::total_cmp);
+    assert_eq!(values, vec![2.0, 3.0]);
 }
 
 #[test]

--- a/src/runtime/src/runtime/program/tests.rs
+++ b/src/runtime/src/runtime/program/tests.rs
@@ -1260,8 +1260,11 @@ result
 
     let error = compiler.compile_mixed_tree(&tree).unwrap_err();
     let rendered = format!("{error:?}");
-    assert!(rendered.contains("compute boundary planning failed"));
-    assert!(rendered.contains("DimensionMismatch"));
+    assert!(
+        rendered.contains("compute boundary planning failed"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("ElementCountMismatch"), "{rendered}");
 }
 
 #[cfg(feature = "compute")]
@@ -1343,6 +1346,48 @@ result
         mixed.compute.initializers.get(input.id),
         Some(&mech_compute::ComputeValue::ScalarF32(1.0))
     );
+}
+
+#[cfg(feature = "compute")]
+#[test]
+fn mixed_root_inlines_user_function_graphs_into_compute_artifacts() {
+    let mut resolver = InMemorySourceResolver::new();
+    resolver
+        .insert_string(
+            "main.mec",
+            r#"
+@compute := compute://worker/kernel{:write(input/x), :write(turn)}
+@compute/input/x <- [3f32; 4f32]
+@compute/turn <- 1
+
+calculation @compute
+-------------------------------------------------------------------------------
+twice(value<[f32]:2,1>) = result<[f32]:2,1> :=
+  result := value * 2f32.
+
+x := [1f32; 2f32]
+result := twice(x)
+result
+"#,
+        )
+        .unwrap();
+    let mut compiler = RuntimeBuilder::new()
+        .function_catalog(mech_stdlib::source_native_plan_catalog())
+        .source_resolver(resolver)
+        .build_compiler()
+        .unwrap();
+
+    let mixed = compiler
+        .compile_mixed_root(
+            SourceRequest::new("main.mec"),
+            ModuleBuildOptions::new("test", "v0.4", "native", &[], &[]),
+        )
+        .unwrap();
+
+    assert!(mixed.compute.interface.input_named("x").is_some());
+    assert!(mixed.compute.artifact.nodes().iter().any(|node| {
+        node.operation.module_path.as_ref() == ["math"] && node.operation.operation_name == "mul"
+    }));
 }
 
 #[cfg(feature = "compute")]

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1517,7 +1517,11 @@ fn plan_serve_inputs_with_root(
     paths: &[String],
     fixed_root: Option<&Path>,
 ) -> MResult<ServeInputPlan> {
-    let current_dir = std::env::current_dir()?.canonicalize()?;
+    // Resolve user-relative selectors before canonicalization. On Windows,
+    // `canonicalize` returns a verbatim `\\?\` path; joining a subsequently
+    // supplied relative selector onto that namespace can make an existing
+    // directory fail `exists()` and leave the common-root planner empty.
+    let current_dir = std::env::current_dir()?;
     if paths.is_empty() {
         let root = fixed_root
             .map(Path::to_path_buf)
@@ -1681,7 +1685,9 @@ fn relative_specifier(root: &Path, path: &Path) -> Option<String> {
 }
 
 fn log_skipped_serve_inputs(paths: &[String]) -> MResult<()> {
-    let current_dir = std::env::current_dir()?.canonicalize()?;
+    // Keep this resolution identical to `plan_serve_inputs_with_root`: append
+    // relative user input before Windows introduces a verbatim path prefix.
+    let current_dir = std::env::current_dir()?;
     for input in paths {
         let path = Path::new(input);
         let path = if path.is_absolute() {
@@ -3756,6 +3762,29 @@ mod tests {
         assert!(registry.get_route("ROADMAP.mec").is_none());
         assert!(registry.get_route("mech.mcfg").is_none());
         drop(registry);
+        drop(guard);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_relative_project_directory_is_resolved_before_verbatim_canonicalization() {
+        let root = temp_root("windows-relative-project-directory");
+        let project = root.join("examples").join("ekf");
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::write(project.join("localization.mec"), "x := 1\n").unwrap();
+        let guard = CurrentDirGuard::enter(&root);
+
+        let plan = plan_serve_inputs(&["examples/ekf".to_owned()]).unwrap();
+
+        assert_eq!(plan.root, project.canonicalize().unwrap());
+        assert_eq!(
+            plan.folders,
+            vec![RuntimeWorkspaceFolder {
+                specifier: ".".to_owned(),
+                recursive: true,
+            }]
+        );
         drop(guard);
         std::fs::remove_dir_all(root).unwrap();
     }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -754,7 +754,12 @@ impl MechServer {
             full_address,
             stylesheet,
             html_shim,
-            include_str!("../include/project.js").to_string(),
+            concat!(
+                include_str!("../include/browser-compute.js"),
+                "\n",
+                include_str!("../include/project.js")
+            )
+            .to_string(),
             wasm,
             js,
             authority,

--- a/src/stdlib/Cargo.toml
+++ b/src/stdlib/Cargo.toml
@@ -213,6 +213,7 @@ combinatorics_default = ["combinatorics_n_choose_k"]
 
 # Machine-owned leaf operations select the owning crate's concrete runtime
 # implementation and, where syntax has a dedicated branch, its engine marker.
+math_abs = ["mech-math", "mech-math/abs"]
 math_add = ["mech-math", "mech-math/add", "mech-engine/math_add"]
 math_sub = ["mech-math", "mech-math/sub", "mech-engine/math_sub"]
 math_mul = ["mech-math", "mech-math/mul", "mech-engine/math_mul"]

--- a/src/stdlib/Cargo.toml
+++ b/src/stdlib/Cargo.toml
@@ -183,7 +183,7 @@ math_default = [
   "mech-math", "mech-math/math_default",
   "math_add", "math_sub", "math_mul", "math_div", "math_pow", "math_mod",
   "math_neg", "math_add_assign", "math_sub_assign", "math_mul_assign",
-  "math_div_assign", "math_sqrt", "math_acos", "math_acosh", "math_acot",
+  "math_div_assign", "math_sqrt", "math_ceil", "math_acos", "math_acosh", "math_acot",
   "math_acsc", "math_asec", "math_asin", "math_asinh", "math_atan",
   "math_atan2", "math_atanh", "math_cos", "math_cosh", "math_cot",
   "math_csc", "math_sec", "math_sin", "math_sinh", "math_tan", "math_tanh",
@@ -226,6 +226,7 @@ math_sub_assign = ["mech-math", "mech-math/sub_assign", "mech-engine/math_sub_as
 math_mul_assign = ["mech-math", "mech-math/mul_assign", "mech-engine/math_mul_assign"]
 math_div_assign = ["mech-math", "mech-math/div_assign", "mech-engine/math_div_assign"]
 math_sqrt = ["mech-math", "mech-math/sqrt", "mech-engine/math_sqrt"]
+math_ceil = ["mech-math", "mech-math/ceil"]
 math_acos = ["mech-math", "mech-math/acos", "mech-engine/math_acos"]
 math_acosh = ["mech-math", "mech-math/acosh", "mech-engine/math_acosh"]
 math_acot = ["mech-math", "mech-math/acot", "mech-engine/math_acot"]

--- a/src/stdlib/src/catalog.rs
+++ b/src/stdlib/src/catalog.rs
@@ -285,7 +285,7 @@ mod tests {
             .stack_size(64 * 1024 * 1024)
             .spawn(|| {
                 let runtime = runtime_catalog();
-                assert_eq!(runtime.runtime_factory_count(), 9_019);
+                assert_eq!(runtime.runtime_factory_count(), 9_022);
                 let runtime_entries = runtime
                     .runtime_entries()
                     .map(|entry| (entry.id, entry.name.clone()))
@@ -299,7 +299,7 @@ mod tests {
                 );
 
                 let native_plan = native_plan_catalog();
-                assert_eq!(native_plan.runtime_factory_count(), 9_116);
+                assert_eq!(native_plan.runtime_factory_count(), 9_119);
                 assert!(!Arc::ptr_eq(&runtime, &native_plan));
                 let native_plan_entries = native_plan
                     .runtime_entries()

--- a/src/stdlib/tests/profile_contracts.rs
+++ b/src/stdlib/tests/profile_contracts.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
 #[cfg(feature = "full_runtime")]
-const EXPECTED_RUNTIME_FACTORIES: usize = 9_028;
+const EXPECTED_RUNTIME_FACTORIES: usize = 9_031;
 #[cfg(all(feature = "standard_compiler", not(feature = "full_compiler")))]
 const EXPECTED_STANDARD_COMPILER_RUNTIME_FACTORIES: usize = 1_324;
 #[cfg(all(feature = "standard_compiler", not(feature = "full_compiler")))]
@@ -17,10 +17,10 @@ const EXPECTED_STANDARD_SOURCE_SPECIALIZERS: usize = 64;
 const EXPECTED_STANDARD_COMPILER_RUNTIME_SURFACE_DIGEST: &str =
     "ce552cc80163fc113e62240ab077233d46c9304e45580ce31beaf1deb9814724";
 #[cfg(feature = "full_compiler")]
-const EXPECTED_FULL_COMPILER_RUNTIME_FACTORIES: usize = 9_081;
+const EXPECTED_FULL_COMPILER_RUNTIME_FACTORIES: usize = 9_084;
 #[cfg(feature = "full_compiler")]
 const EXPECTED_FULL_COMPILER_RUNTIME_SURFACE_DIGEST: &str =
-    "0228bf738f02fe8bb1ff6dc557d447c5a79e7303ee071769602fbf40f4f90aa7";
+    "fe9127d1ae19599a7a6970250a0ea42a25fe06d5135520e2d6dd9d76631a92d5";
 #[cfg(feature = "full_runtime")]
 const EXPECTED_EXTENDED_RUNTIME_FACTORIES: usize = 120_017;
 #[cfg(feature = "full_source")]
@@ -35,7 +35,7 @@ const EXPECTED_MODULE_EXPORTS: usize = 50;
 const EXPECTED_ALL_EXPORTS: usize = 120;
 #[cfg(feature = "full_runtime")]
 const EXPECTED_RUNTIME_SURFACE_FILE_SHA256: &str =
-    "a759bb071a8ed4975755957a9df5e92b4c20cb90ba60d2469702556ad898ed27";
+    "31add5ab4f7a5b777f4d8d90e711062d1f36a1fdd99684eded79e46a0af1b238";
 #[cfg(feature = "full_runtime")]
 const SOURCE_ONLY_RUNTIME_FACTORY: &str = "HorizontalConcatenateNArgs<f64>";
 #[cfg(feature = "full_runtime")]

--- a/src/stdlib/tests/profile_contracts.rs
+++ b/src/stdlib/tests/profile_contracts.rs
@@ -10,12 +10,12 @@ use sha2::{Digest, Sha256};
 #[cfg(feature = "full_runtime")]
 const EXPECTED_RUNTIME_FACTORIES: usize = 9_028;
 #[cfg(all(feature = "standard_compiler", not(feature = "full_compiler")))]
-const EXPECTED_STANDARD_COMPILER_RUNTIME_FACTORIES: usize = 1_323;
+const EXPECTED_STANDARD_COMPILER_RUNTIME_FACTORIES: usize = 1_324;
 #[cfg(all(feature = "standard_compiler", not(feature = "full_compiler")))]
 const EXPECTED_STANDARD_SOURCE_SPECIALIZERS: usize = 64;
 #[cfg(all(feature = "standard_compiler", not(feature = "full_compiler")))]
 const EXPECTED_STANDARD_COMPILER_RUNTIME_SURFACE_DIGEST: &str =
-    "c345dc16d38ccd9254593cbd0d0d9a203be7413077de169eb7e8387867a8fd24";
+    "ce552cc80163fc113e62240ab077233d46c9304e45580ce31beaf1deb9814724";
 #[cfg(feature = "full_compiler")]
 const EXPECTED_FULL_COMPILER_RUNTIME_FACTORIES: usize = 9_081;
 #[cfg(feature = "full_compiler")]

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -766,6 +766,10 @@ impl Formatter {
     }
 
     pub fn subtitle(&mut self, node: &Subtitle) -> String {
+        self.subtitle_with_annotations(node, None)
+    }
+
+    fn subtitle_with_annotations(&mut self, node: &Subtitle, annotations: Option<&str>) -> String {
         let level = node.level;
         if level == 2 {
             self.h2_num += 1;
@@ -826,15 +830,28 @@ impl Formatter {
         };
 
         if self.html {
+            let annotation_attribute = annotations
+                .map(|annotations| format!(" data-mech-annotations=\"{}\"", annotations))
+                .unwrap_or_default();
+            let annotation_label = annotations
+                .map(|annotations| {
+                    format!(
+                        "<span class=\"mech-section-annotations\">{}</span>",
+                        escape_html_text(annotations),
+                    )
+                })
+                .unwrap_or_default();
             format!(
-                "<h{} id=\"{}\" {} class=\"mech-program-subtitle {}\"><a class=\"mech-program-subtitle-link {}\" href=\"#{}\">{}</a></h{}>",
+                "<h{} id=\"{}\" {} class=\"mech-program-subtitle {}\"{}><a class=\"mech-program-subtitle-link {}\" href=\"#{}\">{}</a>{}</h{}>",
                 level,
                 title_id,
                 section,
                 toc,
+                annotation_attribute,
                 toc,
                 link_id,
                 node.to_string(),
+                annotation_label,
                 level
             )
         } else {
@@ -872,11 +889,7 @@ impl Formatter {
                 title.to_string(),
                 annotations,
             ),
-            (Some(title), false) => format!(
-                "<div class=\"mech-annotated-section-heading\" data-mech-annotations=\"{}\">{}</div>",
-                annotations,
-                self.subtitle(title),
-            ),
+            (Some(title), false) => self.subtitle_with_annotations(title, Some(&annotations)),
             (Some(title), true) => self.subtitle(title),
             (None, _) => "".to_string(),
         };

--- a/src/syntax/src/mechdown.rs
+++ b/src/syntax/src/mechdown.rs
@@ -294,6 +294,14 @@ pub fn annotated_subtitle(input: ParseString) -> ParseResult<(Subtitle, Vec<Sect
             "Expected an annotated section heading",
         )));
     }
+    // A source ordinal is authoring metadata, just as it is for an ordinary
+    // underlined subtitle. Rendering assigns the editorial section counter
+    // from document order, so never retain `5.` as part of the semantic title.
+    let (input, _) = opt(tuple((
+        many1(alt((digit_token, alpha_token))),
+        period,
+        many0(space_tab),
+    )))(input)?;
     let (input, title_tokens) = many1(nom_tuple((is_not(at), text)))(input)?;
     if !title_tokens
         .last()

--- a/src/syntax/tests/compute_regions.rs
+++ b/src/syntax/tests/compute_regions.rs
@@ -24,6 +24,16 @@ fn named_regions_accept_hard_cpu_and_gpu_annotations() {
 }
 
 #[test]
+fn numbered_compute_region_keeps_the_ordinal_out_of_its_name() {
+    let source = format!("5. ekf-batch @cpu\n{}\nx := 1\n", "-".repeat(79),);
+    let program = parser::parse(&source).expect("numbered compute region must parse");
+    let section = &program.body.sections[0];
+
+    assert_eq!(section.subtitle.as_ref().unwrap().to_string(), "ekf-batch");
+    assert_eq!(section.annotations[0].name.as_ref(), "cpu");
+}
+
+#[test]
 fn ordinary_mechdown_section_has_no_annotations() {
     let program = parser::parse(
         "1. Documentation\n-------------------------------------------------------------------------------\n\nText only.\n",

--- a/src/syntax/tests/formatter.rs
+++ b/src/syntax/tests/formatter.rs
@@ -237,6 +237,26 @@ fn formatter_marks_only_heading_owned_sections_for_editorial_numbering() {
 }
 
 #[test]
+fn formatter_shows_compute_annotation_without_polluting_the_section_title() {
+    let program = mech_syntax::parser::parse(
+        "ekf-batch @cpu\n-------------------------------------------------------------------------------\nx := 1\n",
+    )
+    .expect("unnumbered compute region must parse");
+    let mut formatter = Formatter::new();
+    formatter.html = true;
+    let html = formatter.program(&program);
+
+    assert!(html.contains("class=\"mechdown-section mechdown-titled-section\""));
+    assert!(html.contains(">ekf-batch</a>"), "{html}");
+    assert!(
+        html.contains("class=\"mech-section-annotations\">@cpu</span>"),
+        "{html}",
+    );
+    assert!(html.contains("data-mech-annotations=\"@cpu\""), "{html}");
+    assert!(!html.contains(">5. ekf-batch</a>"), "{html}");
+}
+
+#[test]
 fn formatter_preserves_new_prefix_context_resource_read() {
     let mut formatter = Formatter::new();
     let statement = first_statement("name := @browser/body/content/input/_value");

--- a/src/wasm/Cargo.toml
+++ b/src/wasm/Cargo.toml
@@ -81,7 +81,7 @@ browser_project = ["browser_project_core", "source", "sample_hold", "state_step"
 browser_compute = [
   "compiler", "f32", "f64", "row_vectord", "matrixd", "kind_annotation", "convert", "matrix_horzcat", "range_inclusive",
   "mech-runtime/compute",
-  "math_abs", "math_add", "math_sub", "math_mul", "math_div", "math_pow", "math_sqrt", "math_atan2", "math_sin", "math_cos",
+  "math_abs", "math_add", "math_sub", "math_mul", "math_div", "math_pow", "math_sqrt", "math_ceil", "math_atan2", "math_sin", "math_cos",
   "variables", "variable_define", "variable_assign", "tuple",
   "mech-stdlib/native-plan", "dep:mech-compute", "dep:mech-gpu", "mech-gpu/runtime-host",
 ]

--- a/src/wasm/Cargo.toml
+++ b/src/wasm/Cargo.toml
@@ -222,10 +222,11 @@ range_inclusive_increment = ["range_inclusive", "mech-stdlib/range_inclusive_inc
 range_exclusive_increment = ["range_exclusive", "mech-stdlib/range_exclusive_increment"]
 
 # Math
-math_default = ["math_ops_default", "math_root_default", "math_ops_assign_default", "math_trig_default"]
+math_default = ["math_ops_default", "math_root_default", "math_rounding_default", "math_ops_assign_default", "math_trig_default"]
 math = ["formulas", "functions"]
 math_ops_default = ["math_add", "math_sub", "math_mul", "math_div", "math_pow", "math_mod", "math_neg"]
 math_root_default = ["math_sqrt"]
+math_rounding_default = ["math_ceil"]
 math_ops_assign_default = ["math_add_assign", "math_sub_assign", "math_mul_assign", "math_div_assign"]
 math_trig_default = ["math_acos", "math_acosh", "math_acot", "math_acsc", "math_asec", "math_asin", "math_asinh", "math_atan", "math_atan2", "math_atanh", "math_cos", "math_cosh", "math_cot", "math_csc", "math_sec", "math_sin", "math_sinh", "math_tan", "math_tanh"]
 math_trig = ["math"]
@@ -264,6 +265,7 @@ math_pow = ["math_ops", "mech-stdlib/math_pow"]
 math_mod = ["math_ops", "mech-stdlib/math_mod"]
 math_neg = ["math_ops", "mech-stdlib/math_neg"]
 math_sqrt = ["math_root", "mech-stdlib/math_sqrt"]
+math_ceil = ["math", "mech-stdlib/math_ceil"]
 
 # Set
 set_default = ["set_membership_default", "set_modify_default",

--- a/src/wasm/Cargo.toml
+++ b/src/wasm/Cargo.toml
@@ -81,7 +81,7 @@ browser_project = ["browser_project_core", "source", "sample_hold", "state_step"
 browser_compute = [
   "compiler", "f32", "f64", "row_vectord", "matrixd", "kind_annotation", "convert", "matrix_horzcat", "range_inclusive",
   "mech-runtime/compute",
-  "math_add", "math_sub", "math_mul", "math_div", "math_mod", "math_sin", "math_cos",
+  "math_abs", "math_add", "math_sub", "math_mul", "math_div", "math_pow", "math_sqrt", "math_atan2", "math_sin", "math_cos",
   "variables", "variable_define", "variable_assign", "tuple",
   "mech-stdlib/native-plan", "dep:mech-compute", "dep:mech-gpu", "mech-gpu/runtime-host",
 ]
@@ -232,6 +232,7 @@ math_trig = ["math"]
 math_root = ["math"]
 math_ops = ["math"]
 math_op_assign = ["math"]
+math_abs = ["math", "mech-stdlib/math_abs"]
 math_add_assign = ["math_op_assign", "mech-stdlib/math_add_assign"]
 math_sub_assign = ["math_op_assign", "mech-stdlib/math_sub_assign"]
 math_mul_assign = ["math_op_assign", "mech-stdlib/math_mul_assign"]

--- a/src/wasm/src/gpu.rs
+++ b/src/wasm/src/gpu.rs
@@ -1,7 +1,9 @@
 use std::collections::BTreeMap;
 
-use js_sys::{Array, Float32Array, Object, Reflect};
-use mech_gpu::{ElementwiseKernel, GpuBindingAccess, GpuBindingRole, WORKGROUP_SIZE};
+use js_sys::{Array, Float32Array, Object, Reflect, Uint32Array};
+use mech_gpu::{
+    ElementwiseKernel, FixedShapeKernel, GpuBindingAccess, GpuBindingRole, WORKGROUP_SIZE,
+};
 use wasm_bindgen::JsValue;
 use web_time::Instant;
 
@@ -14,92 +16,229 @@ pub(crate) struct CompileTimings {
     pub(crate) input_capture: f64,
 }
 
+#[derive(Clone, Copy)]
+pub(crate) enum BrowserGpuProgram<'a> {
+    Elementwise(&'a ElementwiseKernel),
+    FixedShape(&'a FixedShapeKernel),
+}
+
 pub(crate) fn gpu_program_manifest(
-    program: &ElementwiseKernel,
+    program: BrowserGpuProgram<'_>,
     input_values: &BTreeMap<String, Vec<f32>>,
     timings: CompileTimings,
 ) -> Result<JsValue, JsValue> {
     let manifest_started = Instant::now();
 
     let manifest = Object::new();
-    set(&manifest, "wgsl", program.wgsl())?;
+    let (wgsl, dispatch_elements, kernel_kind) = match program {
+        BrowserGpuProgram::Elementwise(program) => {
+            (program.wgsl(), program.dispatch_elements(), "elementwise")
+        }
+        BrowserGpuProgram::FixedShape(program) => (
+            program.wgsl(),
+            u64::from(program.instances()),
+            "fixed-shape",
+        ),
+    };
+    set(&manifest, "kernelKind", kernel_kind)?;
+    set(&manifest, "wgsl", wgsl)?;
     set(&manifest, "workgroupSize", WORKGROUP_SIZE)?;
     set(
         &manifest,
         "dispatchElements",
-        u32::try_from(program.dispatch_elements())
+        u32::try_from(dispatch_elements)
             .map_err(|_| error("GPU dispatch size exceeds the browser limit"))?,
     )?;
+    let fixed_inputs = match program {
+        BrowserGpuProgram::FixedShape(program) => Some(
+            program
+                .physical_inputs(input_values)
+                .map_err(|failure| error(failure.to_string()))?,
+        ),
+        BrowserGpuProgram::Elementwise(_) => None,
+    };
+    let fixed_states = match program {
+        BrowserGpuProgram::FixedShape(program) => Some(program.physical_states()),
+        BrowserGpuProgram::Elementwise(_) => None,
+    };
 
     let bindings = Array::new();
-    for binding in program.bindings() {
-        let value = Object::new();
-        set(&value, "binding", binding.binding)?;
-        set(&value, "name", binding.name.as_str())?;
-        set(
-            &value,
-            "access",
-            match binding.access {
-                GpuBindingAccess::Read => "read",
-                GpuBindingAccess::ReadWrite => "read-write",
-            },
-        )?;
-        set(
-            &value,
-            "role",
-            match binding.role() {
-                GpuBindingRole::Input => "input",
-                GpuBindingRole::StateRead => "state-read",
-                GpuBindingRole::StateWrite => "state-write",
-                GpuBindingRole::Output => "output",
-            },
-        )?;
-        set(&value, "slot", binding.slot().get())?;
-        set(
-            &value,
-            "elements",
-            u32::try_from(binding.elements)
-                .map_err(|_| error("GPU binding size exceeds the browser limit"))?,
-        )?;
-        if let Some(initial) = input_values.get(&binding.name) {
-            set(
-                &value,
-                "initialValues",
-                Float32Array::from(initial.as_slice()),
-            )?;
+    match program {
+        BrowserGpuProgram::Elementwise(program) => {
+            for binding in program.bindings() {
+                let value = binding_value(
+                    binding.binding,
+                    &binding.name,
+                    match binding.access {
+                        GpuBindingAccess::Read => "read",
+                        GpuBindingAccess::ReadWrite => "read-write",
+                    },
+                    match binding.role() {
+                        GpuBindingRole::Input => "input",
+                        GpuBindingRole::StateRead => "state-read",
+                        GpuBindingRole::StateWrite => "state-write",
+                        GpuBindingRole::Output => "output",
+                    },
+                    binding.slot().get(),
+                    usize::try_from(binding.elements)
+                        .map_err(|_| error("GPU binding size exceeds the browser limit"))?,
+                    "f32",
+                )?;
+                if let Some(initial) = input_values.get(&binding.name) {
+                    set(
+                        &value,
+                        "initialValues",
+                        Float32Array::from(initial.as_slice()),
+                    )?;
+                }
+                bindings.push(&value);
+            }
         }
-        bindings.push(&value);
+        BrowserGpuProgram::FixedShape(program) => {
+            for input in fixed_inputs.as_ref().expect("fixed input plan exists") {
+                let value = binding_value(
+                    input.binding,
+                    &input.name,
+                    "read",
+                    "input",
+                    input.slot.get(),
+                    input.elements,
+                    "f32",
+                )?;
+                set(
+                    &value,
+                    "initialValues",
+                    Float32Array::from(input.initial_values.as_slice()),
+                )?;
+                bindings.push(&value);
+            }
+            for state in fixed_states.as_ref().expect("fixed state plan exists") {
+                let read = binding_value(
+                    state.read_binding,
+                    &format!("state.{}.read", state.slot.get()),
+                    "read",
+                    "state-read",
+                    state.slot.get(),
+                    state.elements,
+                    "f32",
+                )?;
+                bindings.push(&read);
+                let write = binding_value(
+                    state.write_binding,
+                    &format!("state.{}.write", state.slot.get()),
+                    "read-write",
+                    "state-write",
+                    state.slot.get(),
+                    state.elements,
+                    "f32",
+                )?;
+                bindings.push(&write);
+            }
+            if let Some(fault) = program.integrity_buffer() {
+                let value = binding_value(
+                    fault.binding,
+                    "integrity-fault",
+                    "read-write",
+                    "integrity-fault",
+                    0,
+                    fault.words,
+                    "u32",
+                )?;
+                set(
+                    &value,
+                    "initialValues",
+                    Uint32Array::from([0_u32, u32::MAX].as_slice()),
+                )?;
+                bindings.push(&value);
+            }
+        }
     }
     set(&manifest, "bindings", bindings)?;
 
     let states = Array::new();
-    for (slot, elements, initializer) in program.state_initializers() {
-        let value = Object::new();
-        set(&value, "slot", slot.get())?;
-        set(
-            &value,
-            "elements",
-            u32::try_from(elements)
-                .map_err(|_| error("GPU state size exceeds the browser limit"))?,
-        )?;
-        set(&value, "initialValues", Float32Array::from(initializer))?;
-        states.push(&value);
+    match program {
+        BrowserGpuProgram::Elementwise(program) => {
+            for (slot, elements, initializer) in program.state_initializers() {
+                let value = Object::new();
+                set(&value, "slot", slot.get())?;
+                set(
+                    &value,
+                    "elements",
+                    u32::try_from(elements)
+                        .map_err(|_| error("GPU state size exceeds the browser limit"))?,
+                )?;
+                set(
+                    &value,
+                    "elementsPerInstance",
+                    u32::try_from(elements)
+                        .map_err(|_| error("GPU state shape exceeds the browser limit"))?,
+                )?;
+                set(&value, "initialValues", Float32Array::from(initializer))?;
+                states.push(&value);
+            }
+        }
+        BrowserGpuProgram::FixedShape(program) => {
+            for state in fixed_states.as_ref().expect("fixed state plan exists") {
+                let value = Object::new();
+                set(&value, "slot", state.slot.get())?;
+                set(
+                    &value,
+                    "elements",
+                    u32::try_from(state.elements)
+                        .map_err(|_| error("GPU state size exceeds the browser limit"))?,
+                )?;
+                set(
+                    &value,
+                    "elementsPerInstance",
+                    u32::try_from(state.elements_per_instance)
+                        .map_err(|_| error("GPU state shape exceeds the browser limit"))?,
+                )?;
+                set(
+                    &value,
+                    "initialValues",
+                    Float32Array::from(state.initial_values.as_slice()),
+                )?;
+                states.push(&value);
+            }
+        }
     }
     set(&manifest, "states", states)?;
 
     let outputs = Array::new();
-    for (name, slot, elements) in program.outputs() {
+    let compute = match program {
+        BrowserGpuProgram::Elementwise(program) => program.compute_program(),
+        BrowserGpuProgram::FixedShape(program) => program.compute_program(),
+    };
+    for output in &compute.interface().outputs {
         let value = Object::new();
-        set(&value, "name", name)?;
-        set(&value, "slot", slot.get())?;
+        set(&value, "name", output.name.as_ref())?;
+        set(&value, "slot", output.slot.get())?;
+        let elements_per_instance = output
+            .elements()
+            .map_err(|failure| error(failure.to_string()))?;
+        let elements = match program {
+            BrowserGpuProgram::Elementwise(_) => elements_per_instance,
+            BrowserGpuProgram::FixedShape(program) => elements_per_instance
+                .checked_mul(program.instances() as usize)
+                .ok_or_else(|| error("GPU output size exceeds the browser limit"))?,
+        };
         set(
             &value,
             "elements",
             u32::try_from(elements)
                 .map_err(|_| error("GPU output size exceeds the browser limit"))?,
         )?;
+        set(
+            &value,
+            "elementsPerInstance",
+            u32::try_from(elements_per_instance)
+                .map_err(|_| error("GPU output shape exceeds the browser limit"))?,
+        )?;
         let dimensions = Array::new();
-        for dimension in program.output_dimensions(slot).unwrap_or_default() {
+        if let BrowserGpuProgram::FixedShape(program) = program {
+            dimensions.push(&JsValue::from_f64(f64::from(program.instances())));
+        }
+        for dimension in &output.dimensions {
             dimensions.push(&JsValue::from_f64(*dimension as f64));
         }
         set(&value, "dimensions", dimensions)?;
@@ -124,6 +263,30 @@ pub(crate) fn gpu_program_manifest(
     )?;
     set(&manifest, "compileTimings", compile_timings)?;
     Ok(manifest.into())
+}
+
+fn binding_value(
+    binding: u32,
+    name: &str,
+    access: &str,
+    role: &str,
+    slot: u32,
+    elements: usize,
+    scalar: &str,
+) -> Result<Object, JsValue> {
+    let value = Object::new();
+    set(&value, "binding", binding)?;
+    set(&value, "name", name)?;
+    set(&value, "access", access)?;
+    set(&value, "role", role)?;
+    set(&value, "slot", slot)?;
+    set(
+        &value,
+        "elements",
+        u32::try_from(elements).map_err(|_| error("GPU binding size exceeds the browser limit"))?,
+    )?;
+    set(&value, "scalar", scalar)?;
+    Ok(value)
 }
 
 fn milliseconds(started: Instant) -> f64 {

--- a/src/wasm/src/gpu.rs
+++ b/src/wasm/src/gpu.rs
@@ -26,6 +26,7 @@ pub(crate) enum BrowserGpuProgram<'a> {
 pub(crate) fn gpu_program_manifest(
     program: BrowserGpuProgram<'_>,
     input_values: &BTreeMap<String, Vec<f32>>,
+    backend: &str,
     timings: CompileTimings,
 ) -> Result<JsValue, JsValue> {
     let manifest_started = Instant::now();
@@ -39,6 +40,12 @@ pub(crate) fn gpu_program_manifest(
         input_values,
     )
     .map_err(|failure| error(failure.to_string()))?;
+    set(
+        &manifest,
+        "physicalRevision",
+        plan.physical_revision(backend)
+            .map_err(|failure| error(failure.to_string()))?,
+    )?;
     set(&manifest, "planVersion", plan.version)?;
     set(
         &manifest,

--- a/src/wasm/src/gpu.rs
+++ b/src/wasm/src/gpu.rs
@@ -155,6 +155,23 @@ pub(crate) fn gpu_program_manifest(
     }
     set(&manifest, "bindings", bindings)?;
 
+    let constraints = Array::new();
+    if let BrowserGpuProgram::FixedShape(program) = program {
+        for (index, (_id, name)) in program.named_integrity_constraints().enumerate() {
+            let value = Object::new();
+            set(
+                &value,
+                "code",
+                u32::try_from(index + 1).map_err(|_| {
+                    error("GPU integrity constraint count exceeds the browser limit")
+                })?,
+            )?;
+            set(&value, "name", name)?;
+            constraints.push(&value);
+        }
+    }
+    set(&manifest, "constraints", constraints)?;
+
     let states = Array::new();
     match program {
         BrowserGpuProgram::Elementwise(program) => {

--- a/src/wasm/src/gpu.rs
+++ b/src/wasm/src/gpu.rs
@@ -263,10 +263,21 @@ pub(crate) fn gpu_program_manifest(
         if let BrowserGpuProgram::FixedShape(program) = program {
             dimensions.push(&JsValue::from_f64(f64::from(program.instances())));
         }
+        let sample_dimensions = Array::new();
         for dimension in &output.dimensions {
             dimensions.push(&JsValue::from_f64(*dimension as f64));
+            sample_dimensions.push(&JsValue::from_f64(*dimension as f64));
         }
         set(&value, "dimensions", dimensions)?;
+        set(&value, "sampleDimensions", sample_dimensions)?;
+        set(
+            &value,
+            "physicalLayout",
+            match program {
+                BrowserGpuProgram::Elementwise(_) => "row-major",
+                BrowserGpuProgram::FixedShape(_) => "column-major",
+            },
+        )?;
         outputs.push(&value);
     }
     set(&manifest, "outputs", outputs)?;

--- a/src/wasm/src/gpu.rs
+++ b/src/wasm/src/gpu.rs
@@ -27,6 +27,7 @@ pub(crate) fn gpu_program_manifest(
     program: BrowserGpuProgram<'_>,
     input_values: &BTreeMap<String, Vec<f32>>,
     backend: &str,
+    retained_outputs: &std::collections::BTreeSet<String>,
     timings: CompileTimings,
 ) -> Result<JsValue, JsValue> {
     let manifest_started = Instant::now();
@@ -43,7 +44,7 @@ pub(crate) fn gpu_program_manifest(
     set(
         &manifest,
         "physicalRevision",
-        plan.physical_revision(backend)
+        plan.physical_revision_with_retained_outputs(backend, retained_outputs)
             .map_err(|failure| error(failure.to_string()))?,
     )?;
     set(&manifest, "planVersion", plan.version)?;

--- a/src/wasm/src/gpu.rs
+++ b/src/wasm/src/gpu.rs
@@ -61,6 +61,14 @@ pub(crate) fn gpu_program_manifest(
         BrowserGpuProgram::FixedShape(program) => Some(program.physical_states()),
         BrowserGpuProgram::Elementwise(_) => None,
     };
+    if let BrowserGpuProgram::FixedShape(program) = program
+        && program.integrity_buffer().is_some()
+        && program.instances() >= (1 << 24)
+    {
+        return Err(error(
+            "checked WebGPU fault records support fewer than 2^24 instances",
+        ));
+    }
 
     let bindings = Array::new();
     match program {

--- a/src/wasm/src/gpu.rs
+++ b/src/wasm/src/gpu.rs
@@ -2,7 +2,8 @@ use std::collections::BTreeMap;
 
 use js_sys::{Array, Float32Array, Object, Reflect, Uint32Array};
 use mech_gpu::{
-    ElementwiseKernel, FixedShapeKernel, GpuBindingAccess, GpuBindingRole, WORKGROUP_SIZE,
+    ElementwiseKernel, FixedShapeKernel, GpuExecutionPlan, GpuKernelPlanSource,
+    GpuPlanInitialValues, GpuPlanKernelKind, GpuPlanLayout, GpuPlanScalar,
 };
 use wasm_bindgen::JsValue;
 use web_time::Instant;
@@ -30,242 +31,127 @@ pub(crate) fn gpu_program_manifest(
     let manifest_started = Instant::now();
 
     let manifest = Object::new();
-    let (wgsl, dispatch_elements, kernel_kind) = match program {
-        BrowserGpuProgram::Elementwise(program) => {
-            (program.wgsl(), program.dispatch_elements(), "elementwise")
-        }
-        BrowserGpuProgram::FixedShape(program) => (
-            program.wgsl(),
-            u64::from(program.instances()),
-            "fixed-shape",
-        ),
-    };
-    set(&manifest, "kernelKind", kernel_kind)?;
-    set(&manifest, "wgsl", wgsl)?;
-    set(&manifest, "workgroupSize", WORKGROUP_SIZE)?;
+    let plan = GpuExecutionPlan::build(
+        match program {
+            BrowserGpuProgram::Elementwise(program) => GpuKernelPlanSource::Elementwise(program),
+            BrowserGpuProgram::FixedShape(program) => GpuKernelPlanSource::FixedShape(program),
+        },
+        input_values,
+    )
+    .map_err(|failure| error(failure.to_string()))?;
+    set(&manifest, "planVersion", plan.version)?;
     set(
         &manifest,
-        "dispatchElements",
-        u32::try_from(dispatch_elements)
-            .map_err(|_| error("GPU dispatch size exceeds the browser limit"))?,
+        "kernelKind",
+        match plan.kernel_kind {
+            GpuPlanKernelKind::Elementwise => "elementwise",
+            GpuPlanKernelKind::FixedShape => "fixed-shape",
+        },
     )?;
-    let fixed_inputs = match program {
-        BrowserGpuProgram::FixedShape(program) => Some(
-            program
-                .physical_inputs(input_values)
-                .map_err(|failure| error(failure.to_string()))?,
-        ),
-        BrowserGpuProgram::Elementwise(_) => None,
-    };
-    let fixed_states = match program {
-        BrowserGpuProgram::FixedShape(program) => Some(program.physical_states()),
-        BrowserGpuProgram::Elementwise(_) => None,
-    };
-    if let BrowserGpuProgram::FixedShape(program) = program
-        && program.integrity_buffer().is_some()
-        && program.instances() >= (1 << 24)
-    {
-        return Err(error(
-            "checked WebGPU fault records support fewer than 2^24 instances",
-        ));
-    }
+    set(&manifest, "wgsl", plan.wgsl.as_str())?;
+    set(&manifest, "workgroupSize", plan.workgroup_size)?;
+    set(&manifest, "dispatchElements", plan.dispatch_elements)?;
 
     let bindings = Array::new();
-    match program {
-        BrowserGpuProgram::Elementwise(program) => {
-            for binding in program.bindings() {
-                let value = binding_value(
-                    binding.binding,
-                    &binding.name,
-                    match binding.access {
-                        GpuBindingAccess::Read => "read",
-                        GpuBindingAccess::ReadWrite => "read-write",
-                    },
-                    match binding.role() {
-                        GpuBindingRole::Input => "input",
-                        GpuBindingRole::StateRead => "state-read",
-                        GpuBindingRole::StateWrite => "state-write",
-                        GpuBindingRole::Output => "output",
-                    },
-                    binding.slot().get(),
-                    usize::try_from(binding.elements)
-                        .map_err(|_| error("GPU binding size exceeds the browser limit"))?,
-                    "f32",
-                )?;
-                if let Some(initial) = input_values.get(&binding.name) {
-                    set(
-                        &value,
-                        "initialValues",
-                        Float32Array::from(initial.as_slice()),
-                    )?;
-                }
-                bindings.push(&value);
-            }
+    for binding in &plan.bindings {
+        let encoded = binding_value(
+            binding.binding,
+            &binding.name,
+            match binding.access {
+                mech_gpu::GpuPlanBindingAccess::Read => "read",
+                mech_gpu::GpuPlanBindingAccess::ReadWrite => "read-write",
+            },
+            match binding.role {
+                mech_gpu::GpuPlanBindingRole::Input => "input",
+                mech_gpu::GpuPlanBindingRole::StateRead => "state-read",
+                mech_gpu::GpuPlanBindingRole::StateWrite => "state-write",
+                mech_gpu::GpuPlanBindingRole::Output => "output",
+                mech_gpu::GpuPlanBindingRole::IntegrityFault => "integrity-fault",
+            },
+            binding.slot,
+            usize::try_from(binding.elements)
+                .map_err(|_| error("GPU binding size exceeds the browser limit"))?,
+            match binding.scalar {
+                GpuPlanScalar::F32 => "f32",
+                GpuPlanScalar::U32 => "u32",
+            },
+        )?;
+        match &binding.initial_values {
+            Some(GpuPlanInitialValues::F32(values)) => set(
+                &encoded,
+                "initialValues",
+                Float32Array::from(values.as_slice()),
+            )?,
+            Some(GpuPlanInitialValues::U32(values)) => set(
+                &encoded,
+                "initialValues",
+                Uint32Array::from(values.as_slice()),
+            )?,
+            None => {}
         }
-        BrowserGpuProgram::FixedShape(program) => {
-            for input in fixed_inputs.as_ref().expect("fixed input plan exists") {
-                let value = binding_value(
-                    input.binding,
-                    &input.name,
-                    "read",
-                    "input",
-                    input.slot.get(),
-                    input.elements,
-                    "f32",
-                )?;
-                set(
-                    &value,
-                    "initialValues",
-                    Float32Array::from(input.initial_values.as_slice()),
-                )?;
-                bindings.push(&value);
-            }
-            for state in fixed_states.as_ref().expect("fixed state plan exists") {
-                let read = binding_value(
-                    state.read_binding,
-                    &format!("state.{}.read", state.slot.get()),
-                    "read",
-                    "state-read",
-                    state.slot.get(),
-                    state.elements,
-                    "f32",
-                )?;
-                bindings.push(&read);
-                let write = binding_value(
-                    state.write_binding,
-                    &format!("state.{}.write", state.slot.get()),
-                    "read-write",
-                    "state-write",
-                    state.slot.get(),
-                    state.elements,
-                    "f32",
-                )?;
-                bindings.push(&write);
-            }
-            if let Some(fault) = program.integrity_buffer() {
-                let value = binding_value(
-                    fault.binding,
-                    "integrity-fault",
-                    "read-write",
-                    "integrity-fault",
-                    0,
-                    fault.words,
-                    "u32",
-                )?;
-                set(
-                    &value,
-                    "initialValues",
-                    Uint32Array::from([0_u32, u32::MAX].as_slice()),
-                )?;
-                bindings.push(&value);
-            }
-        }
+        bindings.push(&encoded);
     }
     set(&manifest, "bindings", bindings)?;
 
     let constraints = Array::new();
-    if let BrowserGpuProgram::FixedShape(program) = program {
-        for (index, (_id, name)) in program.named_integrity_constraints().enumerate() {
-            let value = Object::new();
-            set(
-                &value,
-                "code",
-                u32::try_from(index + 1).map_err(|_| {
-                    error("GPU integrity constraint count exceeds the browser limit")
-                })?,
-            )?;
-            set(&value, "name", name)?;
-            constraints.push(&value);
-        }
+    for constraint in &plan.constraints {
+        let value = Object::new();
+        set(&value, "code", constraint.code)?;
+        set(&value, "id", constraint.id.to_string())?;
+        set(&value, "name", constraint.name.as_str())?;
+        constraints.push(&value);
     }
     set(&manifest, "constraints", constraints)?;
 
     let states = Array::new();
-    match program {
-        BrowserGpuProgram::Elementwise(program) => {
-            for (slot, elements, initializer) in program.state_initializers() {
-                let value = Object::new();
-                set(&value, "slot", slot.get())?;
-                set(
-                    &value,
-                    "elements",
-                    u32::try_from(elements)
-                        .map_err(|_| error("GPU state size exceeds the browser limit"))?,
-                )?;
-                set(
-                    &value,
-                    "elementsPerInstance",
-                    u32::try_from(elements)
-                        .map_err(|_| error("GPU state shape exceeds the browser limit"))?,
-                )?;
-                set(&value, "initialValues", Float32Array::from(initializer))?;
-                states.push(&value);
-            }
-        }
-        BrowserGpuProgram::FixedShape(program) => {
-            for state in fixed_states.as_ref().expect("fixed state plan exists") {
-                let value = Object::new();
-                set(&value, "slot", state.slot.get())?;
-                set(
-                    &value,
-                    "elements",
-                    u32::try_from(state.elements)
-                        .map_err(|_| error("GPU state size exceeds the browser limit"))?,
-                )?;
-                set(
-                    &value,
-                    "elementsPerInstance",
-                    u32::try_from(state.elements_per_instance)
-                        .map_err(|_| error("GPU state shape exceeds the browser limit"))?,
-                )?;
-                set(
-                    &value,
-                    "initialValues",
-                    Float32Array::from(state.initial_values.as_slice()),
-                )?;
-                states.push(&value);
-            }
-        }
+    for state in &plan.states {
+        let value = Object::new();
+        set(&value, "slot", state.slot)?;
+        set(
+            &value,
+            "elements",
+            u32::try_from(state.elements)
+                .map_err(|_| error("GPU state size exceeds the browser limit"))?,
+        )?;
+        set(
+            &value,
+            "elementsPerInstance",
+            u32::try_from(state.elements_per_instance)
+                .map_err(|_| error("GPU state shape exceeds the browser limit"))?,
+        )?;
+        set(
+            &value,
+            "initialValues",
+            Float32Array::from(state.initial_values.as_slice()),
+        )?;
+        states.push(&value);
     }
     set(&manifest, "states", states)?;
 
     let outputs = Array::new();
-    let compute = match program {
-        BrowserGpuProgram::Elementwise(program) => program.compute_program(),
-        BrowserGpuProgram::FixedShape(program) => program.compute_program(),
-    };
-    for output in &compute.interface().outputs {
+    for output in &plan.outputs {
         let value = Object::new();
-        set(&value, "name", output.name.as_ref())?;
-        set(&value, "slot", output.slot.get())?;
-        let elements_per_instance = output
-            .elements()
-            .map_err(|failure| error(failure.to_string()))?;
-        let elements = match program {
-            BrowserGpuProgram::Elementwise(_) => elements_per_instance,
-            BrowserGpuProgram::FixedShape(program) => elements_per_instance
-                .checked_mul(program.instances() as usize)
-                .ok_or_else(|| error("GPU output size exceeds the browser limit"))?,
-        };
+        set(&value, "name", output.name.as_str())?;
+        set(&value, "slot", output.slot)?;
+        set(&value, "physicalOutput", output.physical_output)?;
         set(
             &value,
             "elements",
-            u32::try_from(elements)
+            u32::try_from(output.elements)
                 .map_err(|_| error("GPU output size exceeds the browser limit"))?,
         )?;
         set(
             &value,
             "elementsPerInstance",
-            u32::try_from(elements_per_instance)
+            u32::try_from(output.elements_per_instance)
                 .map_err(|_| error("GPU output shape exceeds the browser limit"))?,
         )?;
         let dimensions = Array::new();
-        if let BrowserGpuProgram::FixedShape(program) = program {
-            dimensions.push(&JsValue::from_f64(f64::from(program.instances())));
-        }
         let sample_dimensions = Array::new();
         for dimension in &output.dimensions {
             dimensions.push(&JsValue::from_f64(*dimension as f64));
+        }
+        for dimension in &output.sample_dimensions {
             sample_dimensions.push(&JsValue::from_f64(*dimension as f64));
         }
         set(&value, "dimensions", dimensions)?;
@@ -273,14 +159,37 @@ pub(crate) fn gpu_program_manifest(
         set(
             &value,
             "physicalLayout",
-            match program {
-                BrowserGpuProgram::Elementwise(_) => "row-major",
-                BrowserGpuProgram::FixedShape(_) => "column-major",
+            match output.physical_layout {
+                GpuPlanLayout::RowMajor => "row-major",
+                GpuPlanLayout::ColumnMajor => "column-major",
             },
         )?;
         outputs.push(&value);
     }
     set(&manifest, "outputs", outputs)?;
+
+    let physical_outputs = Array::new();
+    for output in &plan.physical_outputs {
+        let value = Object::new();
+        set(&value, "id", output.id)?;
+        set(&value, "slot", output.slot)?;
+        if let Some(binding) = output.binding {
+            set(&value, "binding", binding)?;
+        }
+        set(
+            &value,
+            "sampleElements",
+            u32::try_from(output.sample_elements)
+                .map_err(|_| error("GPU sampled output size exceeds the browser limit"))?,
+        )?;
+        let aliases = Array::new();
+        for alias in &output.aliases {
+            aliases.push(&JsValue::from_str(alias));
+        }
+        set(&value, "aliases", aliases)?;
+        physical_outputs.push(&value);
+    }
+    set(&manifest, "physicalOutputs", physical_outputs)?;
 
     let compile_timings = Object::new();
     set(&compile_timings, "catalogSetup", timings.catalog_setup)?;

--- a/src/wasm/src/mixed_compute.rs
+++ b/src/wasm/src/mixed_compute.rs
@@ -390,9 +390,14 @@ pub(crate) fn prepare_browser_compute_host(
     if let Some(previous) = previous.filter(|previous| {
         previous.backend == backend && previous.physical_revision() == physical_revision
     }) {
-        let resume = previous.host_state_snapshot().snapshot()?.ok_or_else(|| {
-            mixed_error("compatible browser compute state was retired before source replacement")
-        })?;
+        let resume = previous
+            .host_state_snapshot()
+            .snapshot_retained(&prepared.retained_outputs)?
+            .ok_or_else(|| {
+                mixed_error(
+                    "compatible browser compute state was retired before source replacement",
+                )
+            })?;
         factory = factory.with_resume_state(resume);
     }
     let host_state = factory.state_snapshot_handle();

--- a/src/wasm/src/mixed_compute.rs
+++ b/src/wasm/src/mixed_compute.rs
@@ -80,6 +80,7 @@ impl WasmMixedComputeProject {
             registry,
             ComputePlatform::Browser,
         )
+        .and_then(|factory| factory.with_retained_outputs(prepared.retained_outputs.clone()))
         .map_err(js_error)?;
         if !backend_override.is_empty() {
             compute_factory = compute_factory
@@ -93,6 +94,7 @@ impl WasmMixedComputeProject {
             prepared.kernel.browser_program(),
             &initializer_values(&prepared.program, &prepared.initializers).map_err(js_error)?,
             &backend,
+            &prepared.retained_outputs,
             prepared.timings,
         )?;
         let mut builder = RuntimeBuilder::new()
@@ -268,6 +270,7 @@ pub(crate) struct PreparedComputeRegion {
     pub(crate) coordinator: ProgramArtifact,
     pub(crate) program: ComputeProgram,
     pub(crate) initializers: ComputeInitializerSet,
+    pub(crate) retained_outputs: BTreeSet<String>,
     pub(crate) kernel: PreparedGpuKernel,
     pub(crate) timings: CompileTimings,
 }
@@ -363,7 +366,8 @@ pub(crate) fn prepare_browser_compute_host(
         prepared.initializers.clone(),
         registry,
         ComputePlatform::Browser,
-    )?;
+    )?
+    .with_retained_outputs(prepared.retained_outputs.clone())?;
     let backend = factory
         .resolved_backend_id(&document.hosts[compute_index].settings)?
         .to_string();
@@ -371,6 +375,7 @@ pub(crate) fn prepare_browser_compute_host(
         prepared.kernel.browser_program(),
         &initializer_values(&prepared.program, &prepared.initializers)?,
         &backend,
+        &prepared.retained_outputs,
         prepared.timings,
     )
     .map_err(|failure| mixed_error(format!("browser compute manifest failed: {failure:?}")))?;
@@ -498,6 +503,7 @@ pub(crate) fn prepare_compute_region(
         coordinator: mixed.coordinator.into_artifact(),
         program,
         initializers: mixed.compute.initializers,
+        retained_outputs: mixed.retained_outputs,
         kernel,
         timings: CompileTimings {
             catalog_setup,
@@ -2252,6 +2258,8 @@ state
             registry,
             ComputePlatform::Browser,
         )
+        .unwrap()
+        .with_retained_outputs(prepared.retained_outputs)
         .unwrap()
         .with_backend_override(request);
         let backend = factory

--- a/src/wasm/src/mixed_compute.rs
+++ b/src/wasm/src/mixed_compute.rs
@@ -734,6 +734,7 @@ pub(crate) struct ComputeCommandHandle {
 #[derive(Default)]
 struct ComputeCommandState {
     changed_inputs: BTreeMap<String, Vec<f32>>,
+    completed_outputs: BTreeMap<String, Vec<f32>>,
     queued: Option<QueuedComputeCommand>,
     next_dispatch_id: u32,
     in_flight: BTreeSet<u32>,
@@ -761,6 +762,7 @@ struct QueuedComputeCommand {
 #[derive(Debug)]
 pub(crate) struct ComputeCommandData {
     pub(crate) changed_inputs: BTreeMap<String, Vec<f32>>,
+    pub(crate) completed_outputs: BTreeMap<String, Vec<f32>>,
     pub(crate) dispatch_id: Option<u32>,
     pub(crate) acknowledgement_required: bool,
 }
@@ -789,6 +791,7 @@ impl ComputeCommandHandle {
         }
         Ok(Some(ComputeCommandData {
             changed_inputs: std::mem::take(&mut state.changed_inputs),
+            completed_outputs: std::mem::take(&mut state.completed_outputs),
             dispatch_id: command.dispatch_id,
             acknowledgement_required: command.acknowledgement_required,
         }))
@@ -812,6 +815,7 @@ impl ComputeCommandHandle {
     fn commit_cpu(
         &self,
         changed_inputs: &mut BTreeMap<String, Vec<f32>>,
+        completed_outputs: &mut BTreeMap<String, Vec<f32>>,
     ) -> Result<(), ComputeExecutionError> {
         let mut state = self.state.lock().map_err(|_| {
             browser_execution_error(CPU_SCALAR_BACKEND, "dispatch", "command lock is poisoned")
@@ -824,6 +828,7 @@ impl ComputeCommandHandle {
             ));
         }
         state.changed_inputs.append(changed_inputs);
+        state.completed_outputs.append(completed_outputs);
         state.queued = Some(QueuedComputeCommand {
             dispatch_id: None,
             acknowledgement_required: false,
@@ -1013,6 +1018,14 @@ pub(crate) fn compute_command_value(
         inputs.push(&input);
     }
     set(&value, "inputs", inputs)?;
+    let outputs = Array::new();
+    for (name, values) in command.completed_outputs {
+        let output = Object::new();
+        set(&output, "name", name)?;
+        set(&output, "values", Float32Array::from(values.as_slice()))?;
+        outputs.push(&output);
+    }
+    set(&value, "outputs", outputs)?;
     Ok(value.into())
 }
 
@@ -1026,8 +1039,9 @@ impl BrowserOutputHandle {
         &self,
         program: &ComputeProgram,
         snapshot: &ComputeOutputSnapshot,
-    ) -> Result<(), ComputeExecutionError> {
+    ) -> Result<BTreeMap<String, Vec<f32>>, ComputeExecutionError> {
         let mut candidate = BTreeMap::new();
+        let mut completed = BTreeMap::new();
         for port in &program.interface().outputs {
             let value = snapshot.values.get(&port.id).ok_or_else(|| {
                 browser_execution_error(
@@ -1036,7 +1050,41 @@ impl BrowserOutputHandle {
                     format!("backend omitted output `{}`", port.name),
                 )
             })?;
-            candidate.insert(port.name.to_string(), value_elements(value));
+            let values = value_elements(value);
+            let completion_values = if let Some(storage) = program.fixed_shape_storage() {
+                let elements_per_instance = port.elements().map_err(|failure| {
+                    browser_execution_error(
+                        CPU_SCALAR_BACKEND,
+                        "publish outputs",
+                        format!("output `{}` has an invalid shape: {failure}", port.name),
+                    )
+                })?;
+                let expected_elements = elements_per_instance
+                    .checked_mul(storage.instances as usize)
+                    .ok_or_else(|| {
+                        browser_execution_error(
+                            CPU_SCALAR_BACKEND,
+                            "publish outputs",
+                            format!("output `{}` batch size overflowed", port.name),
+                        )
+                    })?;
+                if values.len() != expected_elements {
+                    return Err(browser_execution_error(
+                        CPU_SCALAR_BACKEND,
+                        "publish outputs",
+                        format!(
+                            "output `{}` contained {} values; expected {expected_elements}",
+                            port.name,
+                            values.len(),
+                        ),
+                    ));
+                }
+                values[..elements_per_instance].to_vec()
+            } else {
+                values.clone()
+            };
+            candidate.insert(port.name.to_string(), values);
+            completed.insert(port.name.to_string(), completion_values);
         }
         *self.values.lock().map_err(|_| {
             browser_execution_error(
@@ -1045,7 +1093,11 @@ impl BrowserOutputHandle {
                 "output lock is poisoned",
             )
         })? = candidate;
-        Ok(())
+        // Browser WebGPU only reads back lane zero for fixed-shape batches.
+        // Queue the same sampled output contract for the synchronous scalar
+        // backend so completion observers never pay for or depend on a full
+        // batch transfer.
+        Ok(completed)
     }
 
     fn output(&self, name: &str) -> MResult<Vec<f32>> {
@@ -1184,8 +1236,9 @@ impl ComputeSession for BrowserCpuSession {
         let result = (|| {
             let report = self.inner.dispatch(turns)?;
             let snapshot = self.inner.read_outputs(&ComputeOutputSelection::All)?;
-            self.outputs.publish(&self.program, &snapshot)?;
-            self.command.commit_cpu(&mut self.changed_inputs)?;
+            let mut completed_outputs = self.outputs.publish(&self.program, &snapshot)?;
+            self.command
+                .commit_cpu(&mut self.changed_inputs, &mut completed_outputs)?;
             Ok(report)
         })();
         if result.is_err() {
@@ -1783,6 +1836,8 @@ state
         let positions = outputs.output("result.0").unwrap();
         assert_eq!(positions.len(), 8);
         assert!(positions.iter().all(|value| value.is_finite()));
+        assert_eq!(state.completed_outputs["result.0"], positions);
+        assert_eq!(state.completed_outputs["result.1"].len(), 8);
     }
 
     #[test]

--- a/src/wasm/src/mixed_compute.rs
+++ b/src/wasm/src/mixed_compute.rs
@@ -14,8 +14,8 @@ use mech_compute::{
 use mech_core::{LegacyValue, MResult, MechError, MechErrorKind, Program};
 use mech_engine::ProgramArtifact;
 use mech_gpu::{
-    ComputeHostFactory, CpuScalarBackendFactory, ElementwiseKernel,
-    lower_elementwise_compute_program,
+    ComputeHostFactory, ComputeLowerer, CpuScalarBackendFactory, ElementwiseKernel,
+    FixedShapeKernel, lower_elementwise_compute_program,
 };
 use mech_runtime::{
     ConfigProfileOptions, ConfigValue, HostContextManifest, HostManifestConfig, MechConfigDocument,
@@ -27,7 +27,7 @@ use mech_runtime::{
 use wasm_bindgen::prelude::*;
 use web_time::Instant;
 
-use crate::gpu::{CompileTimings, gpu_program_manifest};
+use crate::gpu::{BrowserGpuProgram, CompileTimings, gpu_program_manifest};
 
 const POINTER_PATHS: [&str; 4] = ["pulse", "position", "pressed", "delta-seconds"];
 
@@ -89,7 +89,7 @@ impl WasmMixedComputeProject {
             .map_err(js_error)?
             .to_string();
         let manifest = gpu_program_manifest(
-            &prepared.render_program,
+            prepared.kernel.browser_program(),
             &initializer_values(&prepared.program, &prepared.initializers).map_err(js_error)?,
             prepared.timings,
         )?;
@@ -215,8 +215,30 @@ struct PreparedComputeRegion {
     coordinator: ProgramArtifact,
     program: ComputeProgram,
     initializers: ComputeInitializerSet,
-    render_program: ElementwiseKernel,
+    kernel: PreparedGpuKernel,
     timings: CompileTimings,
+}
+
+#[derive(Debug)]
+enum PreparedGpuKernel {
+    Elementwise(ElementwiseKernel),
+    FixedShape(FixedShapeKernel),
+}
+
+impl PreparedGpuKernel {
+    fn compute_program(&self) -> &ComputeProgram {
+        match self {
+            Self::Elementwise(program) => program.compute_program(),
+            Self::FixedShape(program) => program.compute_program(),
+        }
+    }
+
+    fn browser_program(&self) -> BrowserGpuProgram<'_> {
+        match self {
+            Self::Elementwise(program) => BrowserGpuProgram::Elementwise(program),
+            Self::FixedShape(program) => BrowserGpuProgram::FixedShape(program),
+        }
+    }
 }
 
 fn compile_named_compute_region(
@@ -247,10 +269,24 @@ fn compile_named_compute_region(
     let mixed = compiler.compile_mixed_tree(tree)?;
     let artifact_compilation = milliseconds(artifact_started);
     let lowering_started = Instant::now();
-    let program = lower_elementwise_compute_program(&mixed.compute.artifact)
-        .map_err(|failure| mixed_error(format!("compute lowering failed: {failure}")))?;
-    let render_program = ElementwiseKernel::from_compute_program(&program)
-        .map_err(|failure| mixed_error(format!("render lowering failed: {failure}")))?;
+    let initial_values =
+        initializer_values_from_interface(&mixed.compute.interface, &mixed.compute.initializers)?;
+    let kernel = match lower_elementwise_compute_program(&mixed.compute.artifact) {
+        Ok(program) => PreparedGpuKernel::Elementwise(
+            ElementwiseKernel::from_compute_program(&program)
+                .map_err(|failure| mixed_error(format!("elementwise lowering failed: {failure}")))?,
+        ),
+        Err(elementwise_failure) => PreparedGpuKernel::FixedShape(
+            ComputeLowerer
+                .compile_broadcast(&mixed.compute.artifact, &initial_values)
+                .map_err(|fixed_failure| {
+                    mixed_error(format!(
+                        "compute lowering failed for both portable kernels; elementwise: {elementwise_failure}; fixed-shape: {fixed_failure}",
+                    ))
+                })?,
+        ),
+    };
+    let program = kernel.compute_program().clone();
     let gpu_lowering = milliseconds(lowering_started);
     let input_started = Instant::now();
     initializer_values(&program, &mixed.compute.initializers)?;
@@ -261,7 +297,7 @@ fn compile_named_compute_region(
         coordinator: mixed.coordinator.into_artifact(),
         program,
         initializers: mixed.compute.initializers,
-        render_program,
+        kernel,
         timings: CompileTimings {
             catalog_setup,
             parsing,
@@ -270,6 +306,25 @@ fn compile_named_compute_region(
             input_capture,
         },
     })
+}
+
+fn initializer_values_from_interface(
+    interface: &mech_compute::ComputeRegionInterface,
+    initializers: &ComputeInitializerSet,
+) -> MResult<BTreeMap<String, Vec<f32>>> {
+    interface
+        .inputs
+        .iter()
+        .map(|port| {
+            let value = initializers.get(port.id).ok_or_else(|| {
+                mixed_error(format!("compute input `{}` has no initializer", port.name))
+            })?;
+            let value = port
+                .normalize_value(value.clone())
+                .map_err(|failure| mixed_error(failure.to_string()))?;
+            Ok((port.name.to_string(), value_elements(&value)))
+        })
+        .collect()
 }
 
 fn configured_host_index(document: &MechConfigDocument, provider: &str) -> MResult<usize> {
@@ -896,6 +951,8 @@ impl BrowserWgpuBackendFactory {
                 priority: 400,
                 capabilities: ComputeBackendCapabilities {
                     elementwise: true,
+                    fixed_shape: true,
+                    integrity_rejection: true,
                     browser: true,
                     ..Default::default()
                 },
@@ -918,12 +975,14 @@ impl ComputeBackendFactory for BrowserWgpuBackendFactory {
                 reason: "WebGPU is unavailable in this browser".into(),
             });
         }
-        if !matches!(program.kernel(), ComputeKernel::Elementwise(_))
-            || program.elementwise_storage().is_none()
-        {
+        let planned = match program.kernel() {
+            ComputeKernel::Elementwise(_) => program.elementwise_storage().is_some(),
+            ComputeKernel::FixedShape(_) => program.fixed_shape_storage().is_some(),
+        };
+        if !planned {
             return Err(ComputeBackendRejection {
                 backend: self.descriptor.id.clone(),
-                reason: "browser wgpu currently supports elementwise programs only".into(),
+                reason: "browser wgpu requires a complete physical storage plan".into(),
             });
         }
         Ok(())
@@ -933,12 +992,18 @@ impl ComputeBackendFactory for BrowserWgpuBackendFactory {
         &self,
         program: &ComputeProgram,
     ) -> Result<Box<dyn ComputeExecutable>, ComputeBackendError> {
-        ElementwiseKernel::from_compute_program(program).map_err(|failure| {
-            ComputeBackendError {
-                backend: self.descriptor.id.clone(),
-                operation: "compile",
-                detail: format!("{failure:?}").into(),
+        match program.kernel() {
+            ComputeKernel::Elementwise(_) => {
+                ElementwiseKernel::from_compute_program(program).map(|_| ())
             }
+            ComputeKernel::FixedShape(_) => {
+                FixedShapeKernel::from_compute_program(program).map(|_| ())
+            }
+        }
+        .map_err(|failure| ComputeBackendError {
+            backend: self.descriptor.id.clone(),
+            operation: "compile",
+            detail: format!("{failure:?}").into(),
         })?;
         Ok(Box::new(BrowserWgpuExecutable {
             backend: self.descriptor.id.clone(),
@@ -1149,6 +1214,17 @@ positions = next-positions
     const SERVED_CONFIG: &str = include_str!("../../../examples/gpu-particles/mech.mcfg");
     const SERVED_SOURCE: &str = include_str!("../../../examples/gpu-particles/particles.mec");
 
+    const FIXED_SHAPE_SOURCE: &str = r#"
++> math
+
+matrix-step @compute
+-------------------------------------------------------------------------------
+transform := [1f32 0f32; 0f32 1f32]
+~state := [1f32; 2f32]
+state = transform ** state + [0.5<f32>; 0.25<f32>]
+state
+"#;
+
     fn compile_fixture(config: &str, source: &str) -> (MechConfigDocument, PreparedComputeRegion) {
         let document =
             parse_config_document("test.mcfg", config, ConfigProfileOptions::default()).unwrap();
@@ -1242,10 +1318,27 @@ positions = next-positions
         let inputs = initializer_values(&prepared.program, &prepared.initializers).unwrap();
 
         assert_eq!(prepared.region, "particle-field");
-        assert_eq!(prepared.render_program.dispatch_elements(), 2_000_000);
+        let PreparedGpuKernel::Elementwise(kernel) = prepared.kernel else {
+            panic!("particle source must select the elementwise kernel")
+        };
+        assert_eq!(kernel.dispatch_elements(), 2_000_000);
         assert_eq!(inputs["force-point"], vec![0.0, 0.0]);
         assert_eq!(inputs["force-strength"], vec![0.0]);
         assert_eq!(inputs["dt"], vec![0.016666667]);
+    }
+
+    #[test]
+    fn browser_compiler_selects_the_generic_fixed_shape_kernel_for_matrix_batches() {
+        let (_document, prepared) = compile_fixture(CONFIG, FIXED_SHAPE_SOURCE);
+        let inputs = initializer_values(&prepared.program, &prepared.initializers).unwrap();
+        let PreparedGpuKernel::FixedShape(kernel) = prepared.kernel else {
+            panic!("matrix recurrence must select the fixed-shape kernel")
+        };
+
+        assert_eq!(kernel.instances(), 1);
+        assert!(kernel.physical_inputs(&inputs).unwrap().is_empty());
+        assert_eq!(kernel.physical_states()[0].elements, 2);
+        assert!(kernel.wgsl().contains("state_write_"));
     }
 
     #[test]

--- a/src/wasm/src/mixed_compute.rs
+++ b/src/wasm/src/mixed_compute.rs
@@ -9,7 +9,7 @@ use mech_compute::{
     ComputeBackendRejection, ComputeDispatchReport, ComputeExecutable, ComputeExecutionError,
     ComputeInitializerSet, ComputeInputUpdate, ComputeKernel, ComputeOutputSelection,
     ComputeOutputSnapshot, ComputePlatform, ComputeProgram, ComputeSession, ComputeValue,
-    WGPU_BACKEND,
+    TensorLayout, WGPU_BACKEND,
 };
 use mech_core::{LegacyValue, MResult, MechError, MechErrorKind, Program};
 use mech_engine::ProgramArtifact;
@@ -186,6 +186,16 @@ impl WasmMixedComputeProject {
         self.compute.acknowledge(dispatch_id)
     }
 
+    #[wasm_bindgen(js_name = completeComputeCommand)]
+    pub fn complete_compute_command(
+        &self,
+        dispatch_id: u32,
+        outputs: Array,
+    ) -> Result<(), JsValue> {
+        self.compute
+            .complete(dispatch_id, completed_outputs_from_js(outputs)?)
+    }
+
     #[wasm_bindgen(js_name = rejectComputeCommand)]
     pub fn reject_compute_command(&self, dispatch_id: u32, reason: &str) -> Result<(), JsValue> {
         self.compute.reject(dispatch_id, reason)
@@ -208,19 +218,129 @@ impl WasmMixedComputeProject {
     }
 }
 
-#[derive(Debug)]
-struct PreparedComputeRegion {
-    region: String,
-    placement: mech_core::ComputePlacement,
-    coordinator: ProgramArtifact,
-    program: ComputeProgram,
-    initializers: ComputeInitializerSet,
-    kernel: PreparedGpuKernel,
-    timings: CompileTimings,
+pub(crate) fn completed_outputs_from_js(
+    outputs: Array,
+) -> Result<BTreeMap<String, Vec<f32>>, JsValue> {
+    let mut completed = BTreeMap::new();
+    for value in outputs.iter() {
+        let name = Reflect::get(&value, &JsValue::from_str("name"))?
+            .as_string()
+            .ok_or_else(|| error("completed compute output is missing its name"))?;
+        let values = Reflect::get(&value, &JsValue::from_str("values"))?;
+        if !values.is_instance_of::<Float32Array>() {
+            return Err(error(format!(
+                "completed compute output `{name}` must contain Float32Array values"
+            )));
+        }
+        if completed
+            .insert(name.clone(), Float32Array::new(&values).to_vec())
+            .is_some()
+        {
+            return Err(error(format!(
+                "completed compute output `{name}` was supplied more than once"
+            )));
+        }
+    }
+    Ok(completed)
 }
 
 #[derive(Debug)]
-enum PreparedGpuKernel {
+pub(crate) struct PreparedComputeRegion {
+    pub(crate) region: String,
+    pub(crate) placement: mech_core::ComputePlacement,
+    pub(crate) coordinator: ProgramArtifact,
+    pub(crate) program: ComputeProgram,
+    pub(crate) initializers: ComputeInitializerSet,
+    pub(crate) kernel: PreparedGpuKernel,
+    pub(crate) timings: CompileTimings,
+}
+
+#[derive(Clone)]
+pub(crate) struct BrowserComputeBridge {
+    command: ComputeCommandHandle,
+    manifest: JsValue,
+    backend: String,
+}
+
+impl BrowserComputeBridge {
+    pub(crate) fn manifest(&self) -> JsValue {
+        self.manifest.clone()
+    }
+
+    pub(crate) fn backend(&self) -> String {
+        self.backend.clone()
+    }
+
+    pub(crate) fn take_command(&self) -> Result<JsValue, JsValue> {
+        self.command
+            .take_command_data()?
+            .map(|command| compute_command_value(&self.command.region, command))
+            .transpose()
+            .map(|command| command.unwrap_or(JsValue::NULL))
+    }
+
+    pub(crate) fn acknowledge(&self, dispatch_id: u32) -> Result<(), JsValue> {
+        self.command.acknowledge(dispatch_id)
+    }
+
+    pub(crate) fn complete(
+        &self,
+        dispatch_id: u32,
+        outputs: BTreeMap<String, Vec<f32>>,
+    ) -> Result<(), JsValue> {
+        self.command.complete(dispatch_id, outputs)
+    }
+
+    pub(crate) fn reject(&self, dispatch_id: u32, reason: &str) -> Result<(), JsValue> {
+        self.command.reject(dispatch_id, reason)
+    }
+}
+
+pub(crate) struct PreparedBrowserComputeHost {
+    pub(crate) factory: ComputeHostFactory,
+    pub(crate) coordinator: ProgramArtifact,
+    pub(crate) bridge: BrowserComputeBridge,
+}
+
+pub(crate) fn prepare_browser_compute_host(
+    document: &MechConfigDocument,
+    prepared: PreparedComputeRegion,
+    gpu_available: bool,
+) -> MResult<PreparedBrowserComputeHost> {
+    let compute_index = configured_host_index(document, "compute")?;
+    let command = ComputeCommandHandle::new(prepared.region.clone());
+    let outputs = BrowserOutputHandle::default();
+    let registry = browser_compute_backend_registry(command.clone(), outputs, gpu_available)?;
+    let factory = ComputeHostFactory::new(
+        prepared.region.clone(),
+        prepared.placement,
+        prepared.program.clone(),
+        prepared.initializers.clone(),
+        registry,
+        ComputePlatform::Browser,
+    )?;
+    let backend = factory
+        .resolved_backend_id(&document.hosts[compute_index].settings)?
+        .to_string();
+    let manifest = gpu_program_manifest(
+        prepared.kernel.browser_program(),
+        &initializer_values(&prepared.program, &prepared.initializers)?,
+        prepared.timings,
+    )
+    .map_err(|failure| mixed_error(format!("browser compute manifest failed: {failure:?}")))?;
+    Ok(PreparedBrowserComputeHost {
+        factory,
+        coordinator: prepared.coordinator,
+        bridge: BrowserComputeBridge {
+            command,
+            manifest,
+            backend,
+        },
+    })
+}
+
+#[derive(Debug)]
+pub(crate) enum PreparedGpuKernel {
     Elementwise(ElementwiseKernel),
     FixedShape(FixedShapeKernel),
 }
@@ -233,7 +353,7 @@ impl PreparedGpuKernel {
         }
     }
 
-    fn browser_program(&self) -> BrowserGpuProgram<'_> {
+    pub(crate) fn browser_program(&self) -> BrowserGpuProgram<'_> {
         match self {
             Self::Elementwise(program) => BrowserGpuProgram::Elementwise(program),
             Self::FixedShape(program) => BrowserGpuProgram::FixedShape(program),
@@ -265,12 +385,28 @@ fn compile_named_compute_region(
     }
     let mut compiler = builder.build_compiler()?;
     let catalog_setup = milliseconds(compiler_started);
+    prepare_compute_region(&mut compiler, tree, parsing, catalog_setup)
+}
+
+pub(crate) fn prepare_compute_region(
+    compiler: &mut mech_runtime::ProgramCompiler,
+    tree: &Program,
+    parsing: f64,
+    catalog_setup: f64,
+) -> MResult<PreparedComputeRegion> {
     let artifact_started = Instant::now();
     let mixed = compiler.compile_mixed_tree(tree)?;
     let artifact_compilation = milliseconds(artifact_started);
     let lowering_started = Instant::now();
     let initial_values =
         initializer_values_from_interface(&mixed.compute.interface, &mixed.compute.initializers)?;
+    let mut activation_values = initial_values.clone();
+    activation_values.extend(
+        mixed
+            .activation_inputs
+            .iter()
+            .map(|(name, value)| (name.clone(), value_elements(value))),
+    );
     let kernel = match lower_elementwise_compute_program(&mixed.compute.artifact) {
         Ok(program) => PreparedGpuKernel::Elementwise(
             ElementwiseKernel::from_compute_program(&program)
@@ -278,7 +414,7 @@ fn compile_named_compute_region(
         ),
         Err(elementwise_failure) => PreparedGpuKernel::FixedShape(
             ComputeLowerer
-                .compile_broadcast(&mixed.compute.artifact, &initial_values)
+                .compile_broadcast(&mixed.compute.artifact, &activation_values)
                 .map_err(|fixed_failure| {
                     mixed_error(format!(
                         "compute lowering failed for both portable kernels; elementwise: {elementwise_failure}; fixed-shape: {fixed_failure}",
@@ -343,7 +479,7 @@ fn configured_host_index(document: &MechConfigDocument, provider: &str) -> MResu
     Ok(hosts[0].0)
 }
 
-fn initializer_values(
+pub(crate) fn initializer_values(
     program: &ComputeProgram,
     initializers: &ComputeInitializerSet,
 ) -> MResult<BTreeMap<String, Vec<f32>>> {
@@ -580,8 +716,8 @@ impl RuntimeHostInputDriver for PointerInputDriver {
 }
 
 #[derive(Clone, Debug)]
-struct ComputeCommandHandle {
-    region: String,
+pub(crate) struct ComputeCommandHandle {
+    pub(crate) region: String,
     state: Arc<Mutex<ComputeCommandState>>,
 }
 
@@ -592,6 +728,7 @@ struct ComputeCommandState {
     next_dispatch_id: u32,
     in_flight: BTreeSet<u32>,
     acknowledged: u32,
+    completed_outputs: VecDeque<BTreeMap<String, Vec<f32>>>,
     rejected: VecDeque<(u32, String)>,
 }
 
@@ -602,21 +739,21 @@ struct QueuedComputeCommand {
 }
 
 #[derive(Debug)]
-struct ComputeCommandData {
-    changed_inputs: BTreeMap<String, Vec<f32>>,
-    dispatch_id: Option<u32>,
-    acknowledgement_required: bool,
+pub(crate) struct ComputeCommandData {
+    pub(crate) changed_inputs: BTreeMap<String, Vec<f32>>,
+    pub(crate) dispatch_id: Option<u32>,
+    pub(crate) acknowledgement_required: bool,
 }
 
 impl ComputeCommandHandle {
-    fn new(region: String) -> Self {
+    pub(crate) fn new(region: String) -> Self {
         Self {
             region,
             state: Arc::new(Mutex::new(ComputeCommandState::default())),
         }
     }
 
-    fn take_command_data(&self) -> Result<Option<ComputeCommandData>, JsValue> {
+    pub(crate) fn take_command_data(&self) -> Result<Option<ComputeCommandData>, JsValue> {
         let mut state = self
             .state
             .lock()
@@ -656,7 +793,7 @@ impl ComputeCommandHandle {
     fn queue_wgpu(
         &self,
         changed_inputs: &mut BTreeMap<String, Vec<f32>>,
-    ) -> Result<u32, ComputeExecutionError> {
+    ) -> Result<(u32, Option<BTreeMap<String, Vec<f32>>>), ComputeExecutionError> {
         let mut state = self.state.lock().map_err(|_| {
             browser_execution_error(WGPU_BACKEND, "dispatch", "command lock is poisoned")
         })?;
@@ -673,15 +810,27 @@ impl ComputeCommandHandle {
         })?;
         state.next_dispatch_id = dispatch_id;
         let completed_turns = std::mem::take(&mut state.acknowledged);
+        let mut latest_outputs = None;
+        for _ in 0..completed_turns {
+            latest_outputs = state.completed_outputs.pop_front();
+        }
         state.changed_inputs.append(changed_inputs);
         state.queued = Some(QueuedComputeCommand {
             dispatch_id: Some(dispatch_id),
             acknowledgement_required: true,
         });
-        Ok(completed_turns)
+        Ok((completed_turns, latest_outputs))
     }
 
-    fn acknowledge(&self, dispatch_id: u32) -> Result<(), JsValue> {
+    pub(crate) fn acknowledge(&self, dispatch_id: u32) -> Result<(), JsValue> {
+        self.complete(dispatch_id, BTreeMap::new())
+    }
+
+    pub(crate) fn complete(
+        &self,
+        dispatch_id: u32,
+        outputs: BTreeMap<String, Vec<f32>>,
+    ) -> Result<(), JsValue> {
         let mut state = self
             .state
             .lock()
@@ -695,10 +844,11 @@ impl ComputeCommandHandle {
             .acknowledged
             .checked_add(1)
             .ok_or_else(|| error("compute acknowledgement count overflow"))?;
+        state.completed_outputs.push_back(outputs);
         Ok(())
     }
 
-    fn reject(&self, dispatch_id: u32, reason: &str) -> Result<(), JsValue> {
+    pub(crate) fn reject(&self, dispatch_id: u32, reason: &str) -> Result<(), JsValue> {
         let mut state = self
             .state
             .lock()
@@ -734,7 +884,10 @@ fn ensure_command_slot_available(
     Ok(())
 }
 
-fn compute_command_value(region: &str, command: ComputeCommandData) -> Result<JsValue, JsValue> {
+pub(crate) fn compute_command_value(
+    region: &str,
+    command: ComputeCommandData,
+) -> Result<JsValue, JsValue> {
     let value = Object::new();
     set(&value, "region", region)?;
     set(&value, "dispatch", true)?;
@@ -758,7 +911,7 @@ fn compute_command_value(region: &str, command: ComputeCommandData) -> Result<Js
 }
 
 #[derive(Clone, Debug, Default)]
-struct BrowserOutputHandle {
+pub(crate) struct BrowserOutputHandle {
     values: Arc<Mutex<BTreeMap<String, Vec<f32>>>>,
 }
 
@@ -799,7 +952,7 @@ impl BrowserOutputHandle {
     }
 }
 
-fn browser_compute_backend_registry(
+pub(crate) fn browser_compute_backend_registry(
     command: ComputeCommandHandle,
     outputs: BrowserOutputHandle,
     gpu_available: bool,
@@ -1034,6 +1187,7 @@ impl ComputeExecutable for BrowserWgpuExecutable {
             program: self.program.clone(),
             command: self.command.clone(),
             changed_inputs: BTreeMap::new(),
+            outputs: ComputeOutputSnapshot::default(),
         }))
     }
 }
@@ -1043,6 +1197,7 @@ struct BrowserWgpuSession {
     program: ComputeProgram,
     command: ComputeCommandHandle,
     changed_inputs: BTreeMap<String, Vec<f32>>,
+    outputs: ComputeOutputSnapshot,
 }
 
 impl ComputeSession for BrowserWgpuSession {
@@ -1083,7 +1238,10 @@ impl ComputeSession for BrowserWgpuSession {
                 "the browser render bridge accepts one resident turn per frame",
             ));
         }
-        let completed_turns = self.command.queue_wgpu(&mut self.changed_inputs)?;
+        let (completed_turns, outputs) = self.command.queue_wgpu(&mut self.changed_inputs)?;
+        if let Some(outputs) = outputs.filter(|outputs| !outputs.is_empty()) {
+            self.outputs = browser_output_snapshot(&self.program, outputs)?;
+        }
         Ok(ComputeDispatchReport {
             completed_turns,
             ..Default::default()
@@ -1092,14 +1250,68 @@ impl ComputeSession for BrowserWgpuSession {
 
     fn read_outputs(
         &mut self,
-        _selection: &ComputeOutputSelection,
+        selection: &ComputeOutputSelection,
     ) -> Result<ComputeOutputSnapshot, ComputeExecutionError> {
-        Err(browser_execution_error(
-            WGPU_BACKEND,
-            "read outputs",
-            "browser WebGPU outputs remain resident in the JavaScript render bridge",
-        ))
+        let values = self
+            .outputs
+            .values
+            .iter()
+            .filter(|(port, _)| match selection {
+                ComputeOutputSelection::All => true,
+                ComputeOutputSelection::Ports(ports) => ports.contains(port),
+            })
+            .map(|(port, value)| (*port, value.clone()))
+            .collect();
+        Ok(ComputeOutputSnapshot { values })
     }
+}
+
+fn browser_output_snapshot(
+    program: &ComputeProgram,
+    completed: BTreeMap<String, Vec<f32>>,
+) -> Result<ComputeOutputSnapshot, ComputeExecutionError> {
+    let mut values = BTreeMap::new();
+    for (name, physical) in completed {
+        let port = program
+            .interface()
+            .outputs
+            .iter()
+            .find(|port| port.name.as_ref() == name)
+            .ok_or_else(|| {
+                browser_execution_error(
+                    WGPU_BACKEND,
+                    "read outputs",
+                    format!("browser bridge returned undeclared output `{name}`"),
+                )
+            })?;
+        let expected = port.elements().map_err(|failure| {
+            browser_execution_error(WGPU_BACKEND, "read outputs", failure.to_string())
+        })?;
+        if physical.len() != expected {
+            return Err(browser_execution_error(
+                WGPU_BACKEND,
+                "read outputs",
+                format!(
+                    "browser bridge returned {} values for `{name}`; expected {expected}",
+                    physical.len()
+                ),
+            ));
+        }
+        let value = if port.dimensions.is_empty() {
+            ComputeValue::ScalarF32(physical[0])
+        } else {
+            ComputeValue::TensorF32 {
+                dimensions: port.dimensions.clone(),
+                layout: match program.kernel() {
+                    ComputeKernel::FixedShape(_) => TensorLayout::ColumnMajor,
+                    ComputeKernel::Elementwise(_) => TensorLayout::RowMajor,
+                },
+                values: physical.into(),
+            }
+        };
+        values.insert(port.id, value);
+    }
+    Ok(ComputeOutputSnapshot { values })
 }
 
 fn value_elements(value: &ComputeValue) -> Vec<f32> {
@@ -1216,12 +1428,17 @@ positions = next-positions
 
     const FIXED_SHAPE_SOURCE: &str = r#"
 +> math
+@particles := compute://particles/kernel{:write(input/control), :write(turn)}
+lane := 1f32..=1000f32
+@particles/input/control <- lane * 0.001<f32>
+@particles/turn <- 1
 
-matrix-step @compute
+particle-field @compute
 -------------------------------------------------------------------------------
 transform := [1f32 0f32; 0f32 1f32]
 ~state := [1f32; 2f32]
-state = transform ** state + [0.5<f32>; 0.25<f32>]
+control := 0f32
+state = transform ** state + [control; 0.25<f32>]
 state
 "#;
 
@@ -1335,9 +1552,9 @@ state
             panic!("matrix recurrence must select the fixed-shape kernel")
         };
 
-        assert_eq!(kernel.instances(), 1);
-        assert!(kernel.physical_inputs(&inputs).unwrap().is_empty());
-        assert_eq!(kernel.physical_states()[0].elements, 2);
+        assert_eq!(kernel.instances(), 1_000);
+        assert_eq!(kernel.physical_inputs(&inputs).unwrap()[0].elements, 1_000);
+        assert_eq!(kernel.physical_states()[0].elements, 2_000);
         assert!(kernel.wgsl().contains("state_write_"));
     }
 
@@ -1404,7 +1621,7 @@ state
     fn wgpu_reports_completion_only_after_the_bridge_acknowledges_it() {
         let compute = ComputeCommandHandle::new("test".to_owned());
         let mut first_inputs = BTreeMap::from([("x".to_owned(), vec![1.0])]);
-        assert_eq!(compute.queue_wgpu(&mut first_inputs).unwrap(), 0);
+        assert_eq!(compute.queue_wgpu(&mut first_inputs).unwrap(), (0, None));
 
         let first = compute.take_command_data().unwrap().unwrap();
         assert!(first.acknowledgement_required);
@@ -1412,7 +1629,10 @@ state
         compute.acknowledge(dispatch_id).unwrap();
 
         let mut second_inputs = BTreeMap::new();
-        assert_eq!(compute.queue_wgpu(&mut second_inputs).unwrap(), 1);
+        assert_eq!(
+            compute.queue_wgpu(&mut second_inputs).unwrap(),
+            (1, Some(BTreeMap::new()))
+        );
     }
 
     #[test]

--- a/src/wasm/src/mixed_compute.rs
+++ b/src/wasm/src/mixed_compute.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet};
 use std::num::NonZeroU32;
 use std::sync::{Arc, Mutex};
 
@@ -6,10 +6,10 @@ use js_sys::{Array, Float32Array, Object, Reflect};
 use mech_compute::{
     BackendClass, BackendId, BackendRequest, CPU_SCALAR_BACKEND, ComputeBackendCapabilities,
     ComputeBackendDescriptor, ComputeBackendError, ComputeBackendFactory, ComputeBackendRegistry,
-    ComputeBackendRejection, ComputeDispatchReport, ComputeExecutable, ComputeExecutionError,
-    ComputeInitializerSet, ComputeInputUpdate, ComputeKernel, ComputeOutputSelection,
-    ComputeOutputSnapshot, ComputePlatform, ComputeProgram, ComputeSession, ComputeValue,
-    TensorLayout, WGPU_BACKEND,
+    ComputeBackendRejection, ComputeCompletionTarget, ComputeDispatchReport, ComputeExecutable,
+    ComputeExecutionError, ComputeFaultEvidence, ComputeInitializerSet, ComputeInputUpdate,
+    ComputeKernel, ComputeOutputSelection, ComputeOutputSnapshot, ComputePlatform, ComputeProgram,
+    ComputeSession, ComputeValue, TensorLayout, WGPU_BACKEND,
 };
 use mech_core::{LegacyValue, MResult, MechError, MechErrorKind, Program};
 use mech_engine::ProgramArtifact;
@@ -293,6 +293,16 @@ impl BrowserComputeBridge {
 
     pub(crate) fn reject(&self, dispatch_id: u32, reason: &str) -> Result<(), JsValue> {
         self.command.reject(dispatch_id, reason)
+    }
+
+    pub(crate) fn reject_integrity(
+        &self,
+        dispatch_id: u32,
+        constraint: &str,
+        instance: u32,
+    ) -> Result<(), JsValue> {
+        self.command
+            .reject_integrity(dispatch_id, constraint, instance)
     }
 }
 
@@ -715,21 +725,31 @@ impl RuntimeHostInputDriver for PointerInputDriver {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub(crate) struct ComputeCommandHandle {
     pub(crate) region: String,
     state: Arc<Mutex<ComputeCommandState>>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 struct ComputeCommandState {
     changed_inputs: BTreeMap<String, Vec<f32>>,
     queued: Option<QueuedComputeCommand>,
     next_dispatch_id: u32,
     in_flight: BTreeSet<u32>,
-    acknowledged: u32,
-    completed_outputs: VecDeque<BTreeMap<String, Vec<f32>>>,
-    rejected: VecDeque<(u32, String)>,
+    cpu_reserved: bool,
+    completion_program: Option<ComputeProgram>,
+    completion_target: Option<Arc<dyn ComputeCompletionTarget>>,
+    fault_count: u64,
+}
+
+impl std::fmt::Debug for ComputeCommandHandle {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ComputeCommandHandle")
+            .field("region", &self.region)
+            .finish_non_exhaustive()
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -774,52 +794,85 @@ impl ComputeCommandHandle {
         }))
     }
 
-    fn queue_cpu(
+    fn reserve_cpu(&self) -> Result<(), ComputeExecutionError> {
+        let mut state = self.state.lock().map_err(|_| {
+            browser_execution_error(CPU_SCALAR_BACKEND, "dispatch", "command lock is poisoned")
+        })?;
+        ensure_command_slot_available(&state, CPU_SCALAR_BACKEND)?;
+        state.cpu_reserved = true;
+        Ok(())
+    }
+
+    fn cancel_cpu_reservation(&self) {
+        if let Ok(mut state) = self.state.lock() {
+            state.cpu_reserved = false;
+        }
+    }
+
+    fn commit_cpu(
         &self,
         changed_inputs: &mut BTreeMap<String, Vec<f32>>,
     ) -> Result<(), ComputeExecutionError> {
         let mut state = self.state.lock().map_err(|_| {
             browser_execution_error(CPU_SCALAR_BACKEND, "dispatch", "command lock is poisoned")
         })?;
-        ensure_command_slot_available(&state, CPU_SCALAR_BACKEND)?;
+        if !state.cpu_reserved {
+            return Err(browser_execution_error(
+                CPU_SCALAR_BACKEND,
+                "dispatch",
+                "the browser CPU command slot was not reserved",
+            ));
+        }
         state.changed_inputs.append(changed_inputs);
         state.queued = Some(QueuedComputeCommand {
             dispatch_id: None,
             acknowledgement_required: false,
         });
+        state.cpu_reserved = false;
         Ok(())
     }
 
     fn queue_wgpu(
         &self,
         changed_inputs: &mut BTreeMap<String, Vec<f32>>,
-    ) -> Result<(u32, Option<BTreeMap<String, Vec<f32>>>), ComputeExecutionError> {
+    ) -> Result<(), ComputeExecutionError> {
         let mut state = self.state.lock().map_err(|_| {
             browser_execution_error(WGPU_BACKEND, "dispatch", "command lock is poisoned")
         })?;
-        if let Some((dispatch_id, reason)) = state.rejected.pop_front() {
-            return Err(browser_execution_error(
-                WGPU_BACKEND,
-                "complete dispatch",
-                format!("browser bridge rejected dispatch {dispatch_id}: {reason}"),
-            ));
-        }
         ensure_command_slot_available(&state, WGPU_BACKEND)?;
         let dispatch_id = state.next_dispatch_id.checked_add(1).ok_or_else(|| {
             browser_execution_error(WGPU_BACKEND, "dispatch", "dispatch ID space exhausted")
         })?;
         state.next_dispatch_id = dispatch_id;
-        let completed_turns = std::mem::take(&mut state.acknowledged);
-        let mut latest_outputs = None;
-        for _ in 0..completed_turns {
-            latest_outputs = state.completed_outputs.pop_front();
-        }
         state.changed_inputs.append(changed_inputs);
         state.queued = Some(QueuedComputeCommand {
             dispatch_id: Some(dispatch_id),
             acknowledgement_required: true,
         });
-        Ok((completed_turns, latest_outputs))
+        Ok(())
+    }
+
+    fn configure_completion(&self, program: &ComputeProgram) -> Result<(), ComputeBackendError> {
+        let mut state = self.state.lock().map_err(|_| ComputeBackendError {
+            backend: BackendId::new(WGPU_BACKEND).expect("static backend ID is valid"),
+            operation: "compile",
+            detail: "compute command lock is poisoned".into(),
+        })?;
+        state.completion_program = Some(program.clone());
+        Ok(())
+    }
+
+    fn bind_completion_target(
+        &self,
+        target: Arc<dyn ComputeCompletionTarget>,
+    ) -> Result<(), ComputeBackendError> {
+        let mut state = self.state.lock().map_err(|_| ComputeBackendError {
+            backend: BackendId::new(WGPU_BACKEND).expect("static backend ID is valid"),
+            operation: "bind completion",
+            detail: "compute command lock is poisoned".into(),
+        })?;
+        state.completion_target = Some(target);
+        Ok(())
     }
 
     pub(crate) fn acknowledge(&self, dispatch_id: u32) -> Result<(), JsValue> {
@@ -831,21 +884,81 @@ impl ComputeCommandHandle {
         dispatch_id: u32,
         outputs: BTreeMap<String, Vec<f32>>,
     ) -> Result<(), JsValue> {
-        let mut state = self
-            .state
+        let (program, target, report) = {
+            let state = self
+                .state
+                .lock()
+                .map_err(|_| error("compute command state lock is poisoned"))?;
+            if !state.in_flight.contains(&dispatch_id) {
+                return Err(error(format!(
+                    "compute dispatch {dispatch_id} is not awaiting acknowledgement"
+                )));
+            }
+            let program = state
+                .completion_program
+                .clone()
+                .ok_or_else(|| error("compute completion has no compiled output contract"))?;
+            let target = state
+                .completion_target
+                .clone()
+                .ok_or_else(|| error("compute completion has no resident publication target"))?;
+            let report = ComputeDispatchReport {
+                completed_turns: 1,
+                fault_count: state.fault_count,
+                ..Default::default()
+            };
+            (program, target, report)
+        };
+        let snapshot = browser_output_snapshot(&program, outputs)
+            .map_err(|failure| error(format!("{}: {}", failure.operation, failure.detail)))?;
+        self.state
             .lock()
-            .map_err(|_| error("compute command state lock is poisoned"))?;
-        if !state.in_flight.remove(&dispatch_id) {
-            return Err(error(format!(
-                "compute dispatch {dispatch_id} is not awaiting acknowledgement"
-            )));
-        }
-        state.acknowledged = state
-            .acknowledged
-            .checked_add(1)
-            .ok_or_else(|| error("compute acknowledgement count overflow"))?;
-        state.completed_outputs.push_back(outputs);
+            .map_err(|_| error("compute command state lock is poisoned"))?
+            .in_flight
+            .remove(&dispatch_id);
+        target
+            .complete(report, snapshot)
+            .map_err(|failure| error(format!("{}: {}", failure.operation, failure.detail)))?;
         Ok(())
+    }
+
+    pub(crate) fn reject_integrity(
+        &self,
+        dispatch_id: u32,
+        constraint: &str,
+        instance: u32,
+    ) -> Result<(), JsValue> {
+        let (target, report) = {
+            let mut state = self
+                .state
+                .lock()
+                .map_err(|_| error("compute command state lock is poisoned"))?;
+            if !state.in_flight.remove(&dispatch_id) {
+                return Err(error(format!(
+                    "compute dispatch {dispatch_id} is not awaiting acknowledgement"
+                )));
+            }
+            state.fault_count = state.fault_count.saturating_add(1);
+            let target = state
+                .completion_target
+                .clone()
+                .ok_or_else(|| error("compute completion has no resident publication target"))?;
+            let report = ComputeDispatchReport {
+                completed_turns: 0,
+                fault_count: state.fault_count,
+                last_fault: Some(ComputeFaultEvidence {
+                    attempted_turn: u64::from(dispatch_id),
+                    constraint: constraint.to_owned().into_boxed_str(),
+                    detail: format!("candidate rejected at batch instance {instance}")
+                        .into_boxed_str(),
+                }),
+                ..Default::default()
+            };
+            (target, report)
+        };
+        target
+            .complete(report, ComputeOutputSnapshot::default())
+            .map_err(|failure| error(format!("{}: {}", failure.operation, failure.detail)))
     }
 
     pub(crate) fn reject(&self, dispatch_id: u32, reason: &str) -> Result<(), JsValue> {
@@ -858,14 +971,7 @@ impl ComputeCommandHandle {
                 "compute dispatch {dispatch_id} is not awaiting acknowledgement"
             )));
         }
-        state.rejected.push_back((
-            dispatch_id,
-            if reason.trim().is_empty() {
-                "WebGPU completion failed".to_owned()
-            } else {
-                reason.to_owned()
-            },
-        ));
+        let _ = reason;
         Ok(())
     }
 }
@@ -874,7 +980,7 @@ fn ensure_command_slot_available(
     state: &ComputeCommandState,
     backend: &str,
 ) -> Result<(), ComputeExecutionError> {
-    if state.queued.is_some() {
+    if state.queued.is_some() || !state.in_flight.is_empty() || state.cpu_reserved {
         return Err(browser_execution_error(
             backend,
             "dispatch",
@@ -921,14 +1027,7 @@ impl BrowserOutputHandle {
         program: &ComputeProgram,
         snapshot: &ComputeOutputSnapshot,
     ) -> Result<(), ComputeExecutionError> {
-        let mut values = self.values.lock().map_err(|_| {
-            browser_execution_error(
-                CPU_SCALAR_BACKEND,
-                "publish outputs",
-                "output lock is poisoned",
-            )
-        })?;
-        values.clear();
+        let mut candidate = BTreeMap::new();
         for port in &program.interface().outputs {
             let value = snapshot.values.get(&port.id).ok_or_else(|| {
                 browser_execution_error(
@@ -937,8 +1036,15 @@ impl BrowserOutputHandle {
                     format!("backend omitted output `{}`", port.name),
                 )
             })?;
-            values.insert(port.name.to_string(), value_elements(value));
+            candidate.insert(port.name.to_string(), value_elements(value));
         }
+        *self.values.lock().map_err(|_| {
+            browser_execution_error(
+                CPU_SCALAR_BACKEND,
+                "publish outputs",
+                "output lock is poisoned",
+            )
+        })? = candidate;
         Ok(())
     }
 
@@ -1074,11 +1180,18 @@ impl ComputeSession for BrowserCpuSession {
         &mut self,
         turns: NonZeroU32,
     ) -> Result<ComputeDispatchReport, ComputeExecutionError> {
-        let report = self.inner.dispatch(turns)?;
-        let snapshot = self.inner.read_outputs(&ComputeOutputSelection::All)?;
-        self.outputs.publish(&self.program, &snapshot)?;
-        self.command.queue_cpu(&mut self.changed_inputs)?;
-        Ok(report)
+        self.command.reserve_cpu()?;
+        let result = (|| {
+            let report = self.inner.dispatch(turns)?;
+            let snapshot = self.inner.read_outputs(&ComputeOutputSelection::All)?;
+            self.outputs.publish(&self.program, &snapshot)?;
+            self.command.commit_cpu(&mut self.changed_inputs)?;
+            Ok(report)
+        })();
+        if result.is_err() {
+            self.command.cancel_cpu_reservation();
+        }
+        result
     }
 
     fn read_outputs(
@@ -1158,11 +1271,19 @@ impl ComputeBackendFactory for BrowserWgpuBackendFactory {
             operation: "compile",
             detail: format!("{failure:?}").into(),
         })?;
+        self.command.configure_completion(program)?;
         Ok(Box::new(BrowserWgpuExecutable {
             backend: self.descriptor.id.clone(),
             program: program.clone(),
             command: self.command.clone(),
         }))
+    }
+
+    fn bind_completion_target(
+        &self,
+        target: Arc<dyn ComputeCompletionTarget>,
+    ) -> Result<(), ComputeBackendError> {
+        self.command.bind_completion_target(target)
     }
 }
 
@@ -1187,7 +1308,6 @@ impl ComputeExecutable for BrowserWgpuExecutable {
             program: self.program.clone(),
             command: self.command.clone(),
             changed_inputs: BTreeMap::new(),
-            outputs: ComputeOutputSnapshot::default(),
         }))
     }
 }
@@ -1197,7 +1317,6 @@ struct BrowserWgpuSession {
     program: ComputeProgram,
     command: ComputeCommandHandle,
     changed_inputs: BTreeMap<String, Vec<f32>>,
-    outputs: ComputeOutputSnapshot,
 }
 
 impl ComputeSession for BrowserWgpuSession {
@@ -1238,12 +1357,9 @@ impl ComputeSession for BrowserWgpuSession {
                 "the browser render bridge accepts one resident turn per frame",
             ));
         }
-        let (completed_turns, outputs) = self.command.queue_wgpu(&mut self.changed_inputs)?;
-        if let Some(outputs) = outputs.filter(|outputs| !outputs.is_empty()) {
-            self.outputs = browser_output_snapshot(&self.program, outputs)?;
-        }
+        self.command.queue_wgpu(&mut self.changed_inputs)?;
         Ok(ComputeDispatchReport {
-            completed_turns,
+            completed_turns: 0,
             ..Default::default()
         })
     }
@@ -1252,17 +1368,8 @@ impl ComputeSession for BrowserWgpuSession {
         &mut self,
         selection: &ComputeOutputSelection,
     ) -> Result<ComputeOutputSnapshot, ComputeExecutionError> {
-        let values = self
-            .outputs
-            .values
-            .iter()
-            .filter(|(port, _)| match selection {
-                ComputeOutputSelection::All => true,
-                ComputeOutputSelection::Ports(ports) => ports.contains(port),
-            })
-            .map(|(port, value)| (*port, value.clone()))
-            .collect();
-        Ok(ComputeOutputSnapshot { values })
+        let _ = selection;
+        Ok(ComputeOutputSnapshot::default())
     }
 }
 
@@ -1270,6 +1377,29 @@ fn browser_output_snapshot(
     program: &ComputeProgram,
     completed: BTreeMap<String, Vec<f32>>,
 ) -> Result<ComputeOutputSnapshot, ComputeExecutionError> {
+    if completed.len() != program.interface().outputs.len() {
+        let missing = program
+            .interface()
+            .outputs
+            .iter()
+            .filter(|port| !completed.contains_key(port.name.as_ref()))
+            .map(|port| port.name.as_ref())
+            .collect::<Vec<_>>();
+        return Err(browser_execution_error(
+            WGPU_BACKEND,
+            "read outputs",
+            format!(
+                "browser bridge returned {} outputs; expected {}{}",
+                completed.len(),
+                program.interface().outputs.len(),
+                if missing.is_empty() {
+                    String::new()
+                } else {
+                    format!("; missing {}", missing.join(", "))
+                },
+            ),
+        ));
+    }
     let mut values = BTreeMap::new();
     for (name, physical) in completed {
         let port = program
@@ -1369,6 +1499,22 @@ fn error(message: impl AsRef<str>) -> JsValue {
 mod tests {
     use super::*;
     use std::collections::BTreeSet;
+
+    #[derive(Default)]
+    struct RecordingCompletion {
+        reports: Mutex<Vec<ComputeDispatchReport>>,
+    }
+
+    impl ComputeCompletionTarget for RecordingCompletion {
+        fn complete(
+            &self,
+            report: ComputeDispatchReport,
+            _snapshot: ComputeOutputSnapshot,
+        ) -> Result<(), ComputeExecutionError> {
+            self.reports.lock().unwrap().push(report);
+            Ok(())
+        }
+    }
 
     const CONFIG: &str = r#"
 config := {
@@ -1582,9 +1728,31 @@ state
         assert_eq!(command.changed_inputs["force-point"], vec![0.25, -0.5]);
         assert_eq!(command.changed_inputs["force-strength"], vec![1.0]);
         let dispatch_id = command.dispatch_id.unwrap();
-        assert_eq!(compute.state.lock().unwrap().acknowledged, 0);
-        compute.acknowledge(dispatch_id).unwrap();
-        assert_eq!(compute.state.lock().unwrap().acknowledged, 1);
+        assert!(
+            compute
+                .state
+                .lock()
+                .unwrap()
+                .in_flight
+                .contains(&dispatch_id)
+        );
+        compute
+            .complete(
+                dispatch_id,
+                BTreeMap::from([
+                    ("result.0".to_owned(), vec![0.0; 8]),
+                    ("result.1".to_owned(), vec![0.0; 8]),
+                ]),
+            )
+            .unwrap();
+        assert!(
+            !compute
+                .state
+                .lock()
+                .unwrap()
+                .in_flight
+                .contains(&dispatch_id)
+        );
     }
 
     #[test]
@@ -1618,25 +1786,22 @@ state
     }
 
     #[test]
-    fn wgpu_reports_completion_only_after_the_bridge_acknowledges_it() {
+    fn wgpu_holds_the_command_slot_until_the_bridge_completes_it() {
         let compute = ComputeCommandHandle::new("test".to_owned());
         let mut first_inputs = BTreeMap::from([("x".to_owned(), vec![1.0])]);
-        assert_eq!(compute.queue_wgpu(&mut first_inputs).unwrap(), (0, None));
+        compute.queue_wgpu(&mut first_inputs).unwrap();
 
         let first = compute.take_command_data().unwrap().unwrap();
         assert!(first.acknowledgement_required);
         let dispatch_id = first.dispatch_id.unwrap();
-        compute.acknowledge(dispatch_id).unwrap();
-
         let mut second_inputs = BTreeMap::new();
-        assert_eq!(
-            compute.queue_wgpu(&mut second_inputs).unwrap(),
-            (1, Some(BTreeMap::new()))
-        );
+        assert!(compute.queue_wgpu(&mut second_inputs).is_err());
+        compute.reject(dispatch_id, "test cleanup").unwrap();
+        compute.queue_wgpu(&mut second_inputs).unwrap();
     }
 
     #[test]
-    fn wgpu_bridge_rejection_is_returned_to_the_next_dispatch() {
+    fn wgpu_bridge_rejection_releases_the_command_slot() {
         let compute = ComputeCommandHandle::new("test".to_owned());
         let mut inputs = BTreeMap::new();
         compute.queue_wgpu(&mut inputs).unwrap();
@@ -1645,9 +1810,59 @@ state
             .reject(command.dispatch_id.unwrap(), "device lost")
             .unwrap();
 
-        let error = compute.queue_wgpu(&mut inputs).unwrap_err();
-        assert_eq!(error.operation, "complete dispatch");
-        assert!(error.detail.contains("device lost"));
+        compute.queue_wgpu(&mut inputs).unwrap();
+    }
+
+    #[test]
+    fn wgpu_completion_validates_the_whole_snapshot_before_publishing() {
+        let (_document, prepared) = compile_fixture(CONFIG, SOURCE);
+        let compute = ComputeCommandHandle::new("test".to_owned());
+        compute.configure_completion(&prepared.program).unwrap();
+        let completion = Arc::new(RecordingCompletion::default());
+        compute.bind_completion_target(completion.clone()).unwrap();
+        let mut inputs = BTreeMap::new();
+        compute.queue_wgpu(&mut inputs).unwrap();
+        let dispatch_id = compute
+            .take_command_data()
+            .unwrap()
+            .unwrap()
+            .dispatch_id
+            .unwrap();
+
+        let error = browser_output_snapshot(
+            &prepared.program,
+            BTreeMap::from([("result.0".to_owned(), vec![0.0; 8])]),
+        )
+        .unwrap_err();
+        assert!(error.detail.contains("missing result.1"));
+        assert!(
+            compute
+                .state
+                .lock()
+                .unwrap()
+                .in_flight
+                .contains(&dispatch_id)
+        );
+        assert!(completion.reports.lock().unwrap().is_empty());
+
+        compute
+            .complete(
+                dispatch_id,
+                BTreeMap::from([
+                    ("result.0".to_owned(), vec![0.0; 8]),
+                    ("result.1".to_owned(), vec![0.0; 8]),
+                ]),
+            )
+            .unwrap();
+        assert_eq!(completion.reports.lock().unwrap()[0].completed_turns, 1);
+        assert!(
+            !compute
+                .state
+                .lock()
+                .unwrap()
+                .in_flight
+                .contains(&dispatch_id)
+        );
     }
 
     #[test]

--- a/src/wasm/src/mixed_compute.rs
+++ b/src/wasm/src/mixed_compute.rs
@@ -15,8 +15,8 @@ use mech_compute::{
 use mech_core::{LegacyValue, MResult, MechError, MechErrorKind, Program};
 use mech_engine::ProgramArtifact;
 use mech_gpu::{
-    ComputeHostFactory, ComputeLowerer, CpuScalarBackendFactory, ElementwiseKernel,
-    FixedShapeKernel, lower_elementwise_compute_program,
+    ComputeHostFactory, ComputeHostStateSnapshotHandle, ComputeLowerer, CpuScalarBackendFactory,
+    ElementwiseKernel, FixedShapeKernel, lower_elementwise_compute_program,
 };
 use mech_runtime::{
     ConfigProfileOptions, ConfigValue, HostContextManifest, HostManifestConfig, MechConfigDocument,
@@ -92,6 +92,7 @@ impl WasmMixedComputeProject {
         let manifest = gpu_program_manifest(
             prepared.kernel.browser_program(),
             &initializer_values(&prepared.program, &prepared.initializers).map_err(js_error)?,
+            &backend,
             prepared.timings,
         )?;
         let mut builder = RuntimeBuilder::new()
@@ -276,6 +277,8 @@ pub(crate) struct BrowserComputeBridge {
     command: ComputeCommandHandle,
     manifest: JsValue,
     backend: String,
+    physical_revision: String,
+    host_state: ComputeHostStateSnapshotHandle,
 }
 
 impl BrowserComputeBridge {
@@ -289,6 +292,18 @@ impl BrowserComputeBridge {
 
     pub(crate) fn generation(&self) -> u64 {
         self.command.generation()
+    }
+
+    pub(crate) fn physical_revision(&self) -> &str {
+        &self.physical_revision
+    }
+
+    pub(crate) fn host_state_snapshot(&self) -> &ComputeHostStateSnapshotHandle {
+        &self.host_state
+    }
+
+    pub(crate) fn ensure_source_replacement_ready(&self) -> MResult<()> {
+        self.command.ensure_source_replacement_ready()
     }
 
     pub(crate) fn take_command(&self) -> Result<JsValue, JsValue> {
@@ -336,11 +351,12 @@ pub(crate) fn prepare_browser_compute_host(
     prepared: PreparedComputeRegion,
     gpu_available: bool,
     generation: u64,
+    previous: Option<&BrowserComputeBridge>,
 ) -> MResult<PreparedBrowserComputeHost> {
     let compute_index = configured_host_index(document, "compute")?;
     let command = ComputeCommandHandle::new(prepared.region.clone(), generation);
     let registry = browser_resident_compute_backend_registry(command.clone(), gpu_available)?;
-    let factory = ComputeHostFactory::new(
+    let mut factory = ComputeHostFactory::new(
         prepared.region.clone(),
         prepared.placement,
         prepared.program.clone(),
@@ -354,9 +370,27 @@ pub(crate) fn prepare_browser_compute_host(
     let manifest = gpu_program_manifest(
         prepared.kernel.browser_program(),
         &initializer_values(&prepared.program, &prepared.initializers)?,
+        &backend,
         prepared.timings,
     )
     .map_err(|failure| mixed_error(format!("browser compute manifest failed: {failure:?}")))?;
+    let physical_revision = Reflect::get(&manifest, &JsValue::from_str("physicalRevision"))
+        .map_err(|failure| {
+            mixed_error(format!(
+                "browser compute manifest revision could not be read: {failure:?}"
+            ))
+        })?
+        .as_string()
+        .ok_or_else(|| mixed_error("browser compute manifest has no physical revision"))?;
+    if let Some(previous) = previous.filter(|previous| {
+        previous.backend == backend && previous.physical_revision() == physical_revision
+    }) {
+        let resume = previous.host_state_snapshot().snapshot()?.ok_or_else(|| {
+            mixed_error("compatible browser compute state was retired before source replacement")
+        })?;
+        factory = factory.with_resume_state(resume);
+    }
+    let host_state = factory.state_snapshot_handle();
     Ok(PreparedBrowserComputeHost {
         factory,
         coordinator: prepared.coordinator,
@@ -364,6 +398,8 @@ pub(crate) fn prepare_browser_compute_host(
             command,
             manifest,
             backend,
+            physical_revision,
+            host_state,
         },
     })
 }
@@ -852,6 +888,31 @@ impl ComputeCommandHandle {
 
     pub(crate) fn generation(&self) -> u64 {
         self.state.lock().map(|state| state.generation).unwrap_or(0)
+    }
+
+    fn ensure_source_replacement_ready(&self) -> MResult<()> {
+        let state = self
+            .state
+            .lock()
+            .map_err(|_| mixed_error("compute command state lock is poisoned"))?;
+        let phase = match &state.phase {
+            ComputeCommandPhase::CpuReserved => Some("cpu-reserved"),
+            ComputeCommandPhase::Queued(_) => Some("queued"),
+            ComputeCommandPhase::Serializing(_) => Some("serializing"),
+            ComputeCommandPhase::Claimed(_) => Some("claimed"),
+            ComputeCommandPhase::Completing(_) => Some("completing"),
+            ComputeCommandPhase::Idle | ComputeCommandPhase::Terminal(_) => None,
+        };
+        match phase {
+            Some(phase) => Err(MechError::new(
+                ComputeSourceReplacementBusy {
+                    region: self.region.clone(),
+                    phase,
+                },
+                None,
+            )),
+            None => Ok(()),
+        }
     }
 
     pub(crate) fn take_command_data(&self) -> Result<Option<ComputeCommandData>, JsValue> {
@@ -1948,6 +2009,26 @@ fn mixed_error(message: impl Into<String>) -> MechError {
     MechError::new(MixedComputeProjectError(message.into()), None).with_compiler_loc()
 }
 
+#[derive(Clone, Debug)]
+struct ComputeSourceReplacementBusy {
+    region: String,
+    phase: &'static str,
+}
+
+impl MechErrorKind for ComputeSourceReplacementBusy {
+    fn name(&self) -> &str {
+        "ComputeSourceReplacementBusy"
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "compute region `{}` is {phase}; wait for its current turn to complete before replacing source",
+            self.region,
+            phase = self.phase,
+        )
+    }
+}
+
 fn milliseconds(started: Instant) -> f64 {
     started.elapsed().as_secs_f64() * 1_000.0
 }
@@ -2591,6 +2672,37 @@ state
             replacement.validate_token_value(replacement_token).unwrap(),
             replacement_token
         );
+    }
+
+    #[test]
+    fn source_replacement_is_recoverably_busy_until_the_command_completes() {
+        let (_document, prepared) = compile_fixture(CONFIG, SOURCE);
+        let compute = ComputeCommandHandle::new("test".to_owned(), 19);
+        compute.configure_completion(&prepared.program).unwrap();
+        compute
+            .bind_completion_target(Arc::new(RecordingCompletion::default()))
+            .unwrap();
+        assert!(compute.ensure_source_replacement_ready().is_ok());
+
+        let mut inputs = BTreeMap::new();
+        compute
+            .queue_wgpu(&mut inputs, &ComputeDispatchRequest::default())
+            .unwrap();
+        let queued = compute.ensure_source_replacement_ready().unwrap_err();
+        assert_eq!(queued.kind_name(), "ComputeSourceReplacementBusy");
+        assert!(queued.display_message().contains("queued"));
+
+        let token = compute
+            .take_command_data()
+            .unwrap()
+            .unwrap()
+            .dispatch_token
+            .unwrap();
+        let claimed = compute.ensure_source_replacement_ready().unwrap_err();
+        assert!(claimed.display_message().contains("claimed"));
+
+        compute.acknowledge(token).unwrap();
+        assert!(compute.ensure_source_replacement_ready().is_ok());
     }
 
     #[test]

--- a/src/wasm/src/mixed_compute.rs
+++ b/src/wasm/src/mixed_compute.rs
@@ -2331,6 +2331,25 @@ state
     }
 
     #[test]
+    fn browser_compute_lowers_ceil_to_wgsl() {
+        let source = SOURCE.replacen(
+            "acceleration := (0f32 - positions) * 0.435<f32> + offset * pointer-pull",
+            "acceleration := math/ceil((0f32 - positions) * 0.435<f32> + offset * pointer-pull)",
+            1,
+        );
+        let (_document, prepared) = compile_fixture(CONFIG, &source);
+        let PreparedGpuKernel::Elementwise(kernel) = prepared.kernel else {
+            panic!("elementwise ceil source must select the elementwise kernel")
+        };
+
+        assert!(
+            kernel.wgsl().contains("ceil("),
+            "generated WGSL did not contain ceil:\n{}",
+            kernel.wgsl()
+        );
+    }
+
+    #[test]
     fn one_document_runs_the_coordinator_and_wgpu_bridge_through_the_common_host() {
         let (document, prepared) = compile_fixture(CONFIG, SOURCE);
         let input_names = prepared

--- a/src/wasm/src/mixed_compute.rs
+++ b/src/wasm/src/mixed_compute.rs
@@ -339,8 +339,7 @@ pub(crate) fn prepare_browser_compute_host(
 ) -> MResult<PreparedBrowserComputeHost> {
     let compute_index = configured_host_index(document, "compute")?;
     let command = ComputeCommandHandle::new(prepared.region.clone(), generation);
-    let outputs = BrowserOutputHandle::default();
-    let registry = browser_compute_backend_registry(command.clone(), outputs, gpu_available)?;
+    let registry = browser_resident_compute_backend_registry(command.clone(), gpu_available)?;
     let factory = ComputeHostFactory::new(
         prepared.region.clone(),
         prepared.placement,
@@ -1090,9 +1089,11 @@ impl ComputeCommandHandle {
                 required
             )));
         }
+        let attempted_turn = request.logical_turn;
         self.publish_completion(
             request,
             ComputeCompletionOutcome::Completed {
+                attempted_turn,
                 report: self.success_report()?,
                 snapshot: ComputeOutputSnapshot::default(),
             },
@@ -1123,9 +1124,11 @@ impl ComputeCommandHandle {
                 return Err(failure);
             }
         };
+        let attempted_turn = request.logical_turn;
         self.publish_completion(
             request,
             ComputeCompletionOutcome::Completed {
+                attempted_turn,
                 report: self.success_report()?,
                 snapshot,
             },
@@ -1168,9 +1171,13 @@ impl ComputeCommandHandle {
                 ..Default::default()
             }
         };
+        let attempted_turn = request.logical_turn;
         self.publish_completion(
             request,
-            ComputeCompletionOutcome::IntegrityRejected { report },
+            ComputeCompletionOutcome::IntegrityRejected {
+                attempted_turn,
+                report,
+            },
             false,
         )
     }
@@ -1467,6 +1474,29 @@ pub(crate) fn browser_compute_backend_registry(
             command.clone(),
             outputs,
         )))
+        .map_err(|failure| mixed_error(failure.to_string()))?;
+    registry
+        .register(Arc::new(BrowserWgpuBackendFactory::new(
+            command,
+            gpu_available,
+        )))
+        .map_err(|failure| mixed_error(failure.to_string()))?;
+    Ok(Arc::new(registry))
+}
+
+/// Backend registry for a resident browser document.
+///
+/// Scalar compute is executed and sampled directly by the resident compute
+/// host. Only WebGPU needs the browser command transport. Keeping that split
+/// here prevents the standalone presentation adapter from turning every CPU
+/// dispatch into an all-output readback and JavaScript command.
+pub(crate) fn browser_resident_compute_backend_registry(
+    command: ComputeCommandHandle,
+    gpu_available: bool,
+) -> MResult<Arc<ComputeBackendRegistry>> {
+    let mut registry = ComputeBackendRegistry::default();
+    registry
+        .register(Arc::new(CpuScalarBackendFactory::new()))
         .map_err(|failure| mixed_error(failure.to_string()))?;
     registry
         .register(Arc::new(BrowserWgpuBackendFactory::new(

--- a/src/wasm/src/mixed_compute.rs
+++ b/src/wasm/src/mixed_compute.rs
@@ -1235,6 +1235,14 @@ impl ComputeSession for BrowserCpuSession {
         self.command.reserve_cpu()?;
         let result = (|| {
             let report = self.inner.dispatch(turns)?;
+            if report.completed_turns == 0 {
+                // Integrity rejection preserves the backend's previously
+                // accepted state. There is no new snapshot or browser
+                // completion to publish for this attempted turn.
+                self.changed_inputs.clear();
+                self.command.cancel_cpu_reservation();
+                return Ok(report);
+            }
             let snapshot = self.inner.read_outputs(&ComputeOutputSelection::All)?;
             let mut completed_outputs = self.outputs.publish(&self.program, &snapshot)?;
             self.command
@@ -1569,6 +1577,40 @@ mod tests {
         }
     }
 
+    struct RejectingCpuSession;
+
+    impl ComputeSession for RejectingCpuSession {
+        fn update_inputs(
+            &mut self,
+            _updates: &[ComputeInputUpdate],
+        ) -> Result<(), ComputeExecutionError> {
+            Ok(())
+        }
+
+        fn dispatch(
+            &mut self,
+            _turns: NonZeroU32,
+        ) -> Result<ComputeDispatchReport, ComputeExecutionError> {
+            Ok(ComputeDispatchReport {
+                completed_turns: 0,
+                fault_count: 1,
+                last_fault: Some(ComputeFaultEvidence {
+                    attempted_turn: 1,
+                    constraint: "finite".into(),
+                    detail: "candidate rejected".into(),
+                }),
+                ..Default::default()
+            })
+        }
+
+        fn read_outputs(
+            &mut self,
+            _selection: &ComputeOutputSelection,
+        ) -> Result<ComputeOutputSnapshot, ComputeExecutionError> {
+            panic!("a rejected CPU turn must not read or publish outputs")
+        }
+    }
+
     const CONFIG: &str = r#"
 config := {
   runtime: {
@@ -1838,6 +1880,29 @@ state
         assert!(positions.iter().all(|value| value.is_finite()));
         assert_eq!(state.completed_outputs["result.0"], positions);
         assert_eq!(state.completed_outputs["result.1"].len(), 8);
+    }
+
+    #[test]
+    fn cpu_integrity_rejection_does_not_publish_a_completion_command() {
+        let (_document, prepared) = compile_fixture(CONFIG, SOURCE);
+        let command = ComputeCommandHandle::new(prepared.region.clone());
+        let outputs = BrowserOutputHandle::default();
+        let mut session = BrowserCpuSession {
+            inner: Box::new(RejectingCpuSession),
+            program: prepared.program,
+            command: command.clone(),
+            outputs: outputs.clone(),
+            changed_inputs: BTreeMap::from([("force-strength".to_owned(), vec![1.0])]),
+        };
+
+        let report = session.dispatch(NonZeroU32::new(1).unwrap()).unwrap();
+
+        assert_eq!(report.completed_turns, 0);
+        assert_eq!(report.fault_count, 1);
+        assert!(session.changed_inputs.is_empty());
+        assert!(command.take_command_data().unwrap().is_none());
+        assert!(!command.state.lock().unwrap().cpu_reserved);
+        assert!(outputs.values.lock().unwrap().is_empty());
     }
 
     #[test]

--- a/src/wasm/src/mixed_compute.rs
+++ b/src/wasm/src/mixed_compute.rs
@@ -1825,7 +1825,7 @@ fn browser_output_snapshot(
         ));
     }
     let mut values = BTreeMap::new();
-    for (name, physical) in completed {
+    for (name, logical) in completed {
         let port = program
             .interface()
             .outputs
@@ -1848,26 +1848,25 @@ fn browser_output_snapshot(
         let expected = port.elements().map_err(|failure| {
             browser_execution_error(WGPU_BACKEND, "read outputs", failure.to_string())
         })?;
-        if physical.len() != expected {
+        if logical.len() != expected {
             return Err(browser_execution_error(
                 WGPU_BACKEND,
                 "read outputs",
                 format!(
                     "browser bridge returned {} values for `{name}`; expected {expected}",
-                    physical.len()
+                    logical.len()
                 ),
             ));
         }
         let value = if port.dimensions.is_empty() {
-            ComputeValue::ScalarF32(physical[0])
+            ComputeValue::ScalarF32(logical[0])
         } else {
             ComputeValue::TensorF32 {
                 dimensions: port.dimensions.clone(),
-                layout: match program.kernel() {
-                    ComputeKernel::FixedShape(_) => TensorLayout::ColumnMajor,
-                    ComputeKernel::Elementwise(_) => TensorLayout::RowMajor,
-                },
-                values: physical.into(),
+                // The browser bridge canonicalizes every physical backend
+                // buffer before it crosses back into the portable runtime.
+                layout: TensorLayout::RowMajor,
+                values: logical.into(),
             }
         };
         values.insert(port.id, value);
@@ -2488,6 +2487,24 @@ state
             compute.state.lock().unwrap().phase,
             ComputeCommandPhase::Idle
         ));
+    }
+
+    #[test]
+    fn browser_completion_enters_the_runtime_in_portable_row_major_order() {
+        let (_document, prepared) = compile_fixture(CONFIG, FIXED_SHAPE_SOURCE);
+        let output = &prepared.program.interface().outputs[0];
+        let snapshot = browser_output_snapshot(
+            &prepared.program,
+            &BTreeSet::from([output.id]),
+            BTreeMap::from([(output.name.to_string(), vec![1.0, 2.0])]),
+        )
+        .unwrap();
+
+        let ComputeValue::TensorF32 { layout, values, .. } = &snapshot.values[&output.id] else {
+            panic!("the fixed-shape matrix output must remain a tensor");
+        };
+        assert_eq!(*layout, TensorLayout::RowMajor);
+        assert_eq!(values.as_ref(), [1.0, 2.0]);
     }
 
     #[test]

--- a/src/wasm/src/mixed_compute.rs
+++ b/src/wasm/src/mixed_compute.rs
@@ -6,9 +6,10 @@ use js_sys::{Array, Float32Array, Object, Reflect};
 use mech_compute::{
     BackendClass, BackendId, BackendRequest, CPU_SCALAR_BACKEND, ComputeBackendCapabilities,
     ComputeBackendDescriptor, ComputeBackendError, ComputeBackendFactory, ComputeBackendRegistry,
-    ComputeBackendRejection, ComputeCompletionTarget, ComputeDispatchReport, ComputeExecutable,
-    ComputeExecutionError, ComputeFaultEvidence, ComputeInitializerSet, ComputeInputUpdate,
-    ComputeKernel, ComputeOutputSelection, ComputeOutputSnapshot, ComputePlatform, ComputeProgram,
+    ComputeBackendRejection, ComputeCompletionOutcome, ComputeCompletionTarget,
+    ComputeDispatchReport, ComputeDispatchRequest, ComputeExecutable, ComputeExecutionError,
+    ComputeFaultEvidence, ComputeInitializerSet, ComputeInputUpdate, ComputeKernel,
+    ComputeOutputSelection, ComputeOutputSnapshot, ComputePlatform, ComputePortId, ComputeProgram,
     ComputeSession, ComputeValue, TensorLayout, WGPU_BACKEND,
 };
 use mech_core::{LegacyValue, MResult, MechError, MechErrorKind, Program};
@@ -66,7 +67,7 @@ impl WasmMixedComputeProject {
         let pointer = PointerInputHandle::new(document.hosts[pointer_index].name.as_str());
         let prepared = compile_named_compute_region(&document, &tree, parsing, pointer.clone())
             .map_err(js_error)?;
-        let compute = ComputeCommandHandle::new(prepared.region.clone());
+        let compute = ComputeCommandHandle::new(prepared.region.clone(), 1);
         let outputs = BrowserOutputHandle::default();
         let registry =
             browser_compute_backend_registry(compute.clone(), outputs.clone(), gpu_available)
@@ -175,30 +176,45 @@ impl WasmMixedComputeProject {
                 .drain_host_inputs(pending.min(max_inputs))
                 .map_err(js_error)?;
         }
-        let Some(command) = self.compute.take_command_data()? else {
-            return Ok(JsValue::NULL);
-        };
-        compute_command_value(&self.compute.region, command)
+        self.compute.take_command_value()
     }
 
     #[wasm_bindgen(js_name = acknowledgeComputeCommand)]
-    pub fn acknowledge_compute_command(&self, dispatch_id: u32) -> Result<(), JsValue> {
-        self.compute.acknowledge(dispatch_id)
+    pub fn acknowledge_compute_command(&self, dispatch_token: &str) -> Result<(), JsValue> {
+        let token = self.compute.validate_token(dispatch_token)?;
+        self.compute.acknowledge(token)
     }
 
     #[wasm_bindgen(js_name = completeComputeCommand)]
     pub fn complete_compute_command(
         &self,
-        dispatch_id: u32,
+        dispatch_token: &str,
         outputs: Array,
     ) -> Result<(), JsValue> {
+        let token = self.compute.validate_token(dispatch_token)?;
         self.compute
-            .complete(dispatch_id, completed_outputs_from_js(outputs)?)
+            .complete(token, completed_outputs_from_js(outputs)?)
     }
 
     #[wasm_bindgen(js_name = rejectComputeCommand)]
-    pub fn reject_compute_command(&self, dispatch_id: u32, reason: &str) -> Result<(), JsValue> {
-        self.compute.reject(dispatch_id, reason)
+    pub fn reject_compute_command(
+        &self,
+        dispatch_token: &str,
+        reason: &str,
+    ) -> Result<(), JsValue> {
+        let token = self.compute.validate_token(dispatch_token)?;
+        self.compute.reject(token, reason)
+    }
+
+    #[wasm_bindgen(js_name = rejectIntegrityComputeCommand)]
+    pub fn reject_integrity_compute_command(
+        &self,
+        dispatch_token: &str,
+        constraint: &str,
+        instance: u32,
+    ) -> Result<(), JsValue> {
+        let token = self.compute.validate_token(dispatch_token)?;
+        self.compute.reject_integrity(token, constraint, instance)
     }
 
     #[wasm_bindgen(js_name = cpuOutput)]
@@ -271,38 +287,41 @@ impl BrowserComputeBridge {
         self.backend.clone()
     }
 
-    pub(crate) fn take_command(&self) -> Result<JsValue, JsValue> {
-        self.command
-            .take_command_data()?
-            .map(|command| compute_command_value(&self.command.region, command))
-            .transpose()
-            .map(|command| command.unwrap_or(JsValue::NULL))
+    pub(crate) fn generation(&self) -> u64 {
+        self.command.generation()
     }
 
-    pub(crate) fn acknowledge(&self, dispatch_id: u32) -> Result<(), JsValue> {
-        self.command.acknowledge(dispatch_id)
+    pub(crate) fn take_command(&self) -> Result<JsValue, JsValue> {
+        self.command.take_command_value()
+    }
+
+    pub(crate) fn validate_token(&self, token: &str) -> Result<ComputeDispatchToken, JsValue> {
+        self.command.validate_token(token)
+    }
+
+    pub(crate) fn acknowledge(&self, token: ComputeDispatchToken) -> Result<(), JsValue> {
+        self.command.acknowledge(token)
     }
 
     pub(crate) fn complete(
         &self,
-        dispatch_id: u32,
+        token: ComputeDispatchToken,
         outputs: BTreeMap<String, Vec<f32>>,
     ) -> Result<(), JsValue> {
-        self.command.complete(dispatch_id, outputs)
+        self.command.complete(token, outputs)
     }
 
-    pub(crate) fn reject(&self, dispatch_id: u32, reason: &str) -> Result<(), JsValue> {
-        self.command.reject(dispatch_id, reason)
+    pub(crate) fn reject(&self, token: ComputeDispatchToken, reason: &str) -> Result<(), JsValue> {
+        self.command.reject(token, reason)
     }
 
     pub(crate) fn reject_integrity(
         &self,
-        dispatch_id: u32,
+        token: ComputeDispatchToken,
         constraint: &str,
         instance: u32,
     ) -> Result<(), JsValue> {
-        self.command
-            .reject_integrity(dispatch_id, constraint, instance)
+        self.command.reject_integrity(token, constraint, instance)
     }
 }
 
@@ -316,9 +335,10 @@ pub(crate) fn prepare_browser_compute_host(
     document: &MechConfigDocument,
     prepared: PreparedComputeRegion,
     gpu_available: bool,
+    generation: u64,
 ) -> MResult<PreparedBrowserComputeHost> {
     let compute_index = configured_host_index(document, "compute")?;
-    let command = ComputeCommandHandle::new(prepared.region.clone());
+    let command = ComputeCommandHandle::new(prepared.region.clone(), generation);
     let outputs = BrowserOutputHandle::default();
     let registry = browser_compute_backend_registry(command.clone(), outputs, gpu_available)?;
     let factory = ComputeHostFactory::new(
@@ -731,17 +751,26 @@ pub(crate) struct ComputeCommandHandle {
     state: Arc<Mutex<ComputeCommandState>>,
 }
 
-#[derive(Default)]
 struct ComputeCommandState {
-    changed_inputs: BTreeMap<String, Vec<f32>>,
-    completed_outputs: BTreeMap<String, Vec<f32>>,
-    queued: Option<QueuedComputeCommand>,
-    next_dispatch_id: u32,
-    in_flight: BTreeSet<u32>,
-    cpu_reserved: bool,
+    generation: u64,
+    next_dispatch_id: u64,
+    phase: ComputeCommandPhase,
     completion_program: Option<ComputeProgram>,
     completion_target: Option<Arc<dyn ComputeCompletionTarget>>,
     fault_count: u64,
+}
+
+impl ComputeCommandState {
+    fn new(generation: u64) -> Self {
+        Self {
+            generation,
+            next_dispatch_id: 0,
+            phase: ComputeCommandPhase::Idle,
+            completion_program: None,
+            completion_target: None,
+            fault_count: 0,
+        }
+    }
 }
 
 impl std::fmt::Debug for ComputeCommandHandle {
@@ -753,26 +782,77 @@ impl std::fmt::Debug for ComputeCommandHandle {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
-struct QueuedComputeCommand {
-    dispatch_id: Option<u32>,
-    acknowledgement_required: bool,
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) struct ComputeDispatchToken {
+    generation: u64,
+    dispatch: u64,
 }
 
-#[derive(Debug)]
+impl std::fmt::Display for ComputeDispatchToken {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}:{}", self.generation, self.dispatch)
+    }
+}
+
+impl std::str::FromStr for ComputeDispatchToken {
+    type Err = &'static str;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let (generation, dispatch) = value.split_once(':').ok_or("missing token separator")?;
+        if generation.is_empty() || dispatch.is_empty() || dispatch.contains(':') {
+            return Err("invalid token fields");
+        }
+        let generation = generation.parse().map_err(|_| "invalid generation")?;
+        let dispatch = dispatch.parse().map_err(|_| "invalid dispatch")?;
+        if generation == 0 || dispatch == 0 || value != format!("{generation}:{dispatch}") {
+            return Err("token is not canonical");
+        }
+        Ok(Self {
+            generation,
+            dispatch,
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ComputeCompletionRequest {
+    token: ComputeDispatchToken,
+    outputs: BTreeSet<ComputePortId>,
+    logical_turn: u128,
+}
+
+#[derive(Clone, Debug)]
+enum ComputeCommandPhase {
+    Idle,
+    CpuReserved,
+    Queued(Arc<ComputeCommandData>),
+    Serializing(Arc<ComputeCommandData>),
+    Claimed(ComputeCompletionRequest),
+    Completing(ComputeCompletionRequest),
+    Terminal(Box<str>),
+}
+
+#[derive(Clone, Debug)]
 pub(crate) struct ComputeCommandData {
-    pub(crate) changed_inputs: BTreeMap<String, Vec<f32>>,
-    pub(crate) completed_outputs: BTreeMap<String, Vec<f32>>,
-    pub(crate) dispatch_id: Option<u32>,
+    pub(crate) changed_inputs: BTreeMap<String, Arc<[f32]>>,
+    pub(crate) completed_outputs: BTreeMap<String, Arc<[f32]>>,
+    pub(crate) dispatch_token: Option<ComputeDispatchToken>,
+    pub(crate) requested_outputs: BTreeSet<String>,
     pub(crate) acknowledgement_required: bool,
+    completion_request: Option<ComputeCompletionRequest>,
 }
 
 impl ComputeCommandHandle {
-    pub(crate) fn new(region: String) -> Self {
+    pub(crate) fn new(region: String, generation: u64) -> Self {
+        debug_assert!(generation > 0);
         Self {
             region,
-            state: Arc::new(Mutex::new(ComputeCommandState::default())),
+            state: Arc::new(Mutex::new(ComputeCommandState::new(generation))),
         }
+    }
+
+    pub(crate) fn generation(&self) -> u64 {
+        self.state.lock().map(|state| state.generation).unwrap_or(0)
     }
 
     pub(crate) fn take_command_data(&self) -> Result<Option<ComputeCommandData>, JsValue> {
@@ -780,21 +860,65 @@ impl ComputeCommandHandle {
             .state
             .lock()
             .map_err(|_| error("compute command state lock is poisoned"))?;
-        let Some(command) = state.queued.take() else {
+        let ComputeCommandPhase::Queued(command) = &state.phase else {
             return Ok(None);
         };
-        if command.acknowledgement_required {
-            let dispatch_id = command
-                .dispatch_id
-                .expect("acknowledged commands have a dispatch ID");
-            state.in_flight.insert(dispatch_id);
+        let command = Arc::clone(command);
+        state.phase = claimed_phase(&command);
+        Ok(Some((*command).clone()))
+    }
+
+    pub(crate) fn take_command_value(&self) -> Result<JsValue, JsValue> {
+        let Some(command) = self.lease_command()? else {
+            return Ok(JsValue::NULL);
+        };
+        match compute_command_value(&self.region, &command) {
+            Ok(value) => {
+                self.commit_delivery(&command)?;
+                Ok(value)
+            }
+            Err(failure) => {
+                self.rollback_delivery(command);
+                Err(failure)
+            }
         }
-        Ok(Some(ComputeCommandData {
-            changed_inputs: std::mem::take(&mut state.changed_inputs),
-            completed_outputs: std::mem::take(&mut state.completed_outputs),
-            dispatch_id: command.dispatch_id,
-            acknowledgement_required: command.acknowledgement_required,
-        }))
+    }
+
+    fn lease_command(&self) -> Result<Option<Arc<ComputeCommandData>>, JsValue> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| error("compute command state lock is poisoned"))?;
+        let ComputeCommandPhase::Queued(command) = &state.phase else {
+            return Ok(None);
+        };
+        let command = Arc::clone(command);
+        state.phase = ComputeCommandPhase::Serializing(Arc::clone(&command));
+        Ok(Some(command))
+    }
+
+    fn commit_delivery(&self, command: &Arc<ComputeCommandData>) -> Result<(), JsValue> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| error("compute command state lock is poisoned"))?;
+        if !matches!(&state.phase, ComputeCommandPhase::Serializing(current) if Arc::ptr_eq(current, command))
+        {
+            return Err(error(
+                "compute command changed while it was being serialized",
+            ));
+        }
+        state.phase = claimed_phase(command);
+        Ok(())
+    }
+
+    fn rollback_delivery(&self, command: Arc<ComputeCommandData>) {
+        if let Ok(mut state) = self.state.lock() {
+            if matches!(&state.phase, ComputeCommandPhase::Serializing(current) if Arc::ptr_eq(current, &command))
+            {
+                state.phase = ComputeCommandPhase::Queued(command);
+            }
+        }
     }
 
     fn reserve_cpu(&self) -> Result<(), ComputeExecutionError> {
@@ -802,13 +926,27 @@ impl ComputeCommandHandle {
             browser_execution_error(CPU_SCALAR_BACKEND, "dispatch", "command lock is poisoned")
         })?;
         ensure_command_slot_available(&state, CPU_SCALAR_BACKEND)?;
-        state.cpu_reserved = true;
+        state.phase = ComputeCommandPhase::CpuReserved;
         Ok(())
     }
 
     fn cancel_cpu_reservation(&self) {
         if let Ok(mut state) = self.state.lock() {
-            state.cpu_reserved = false;
+            if matches!(state.phase, ComputeCommandPhase::CpuReserved) {
+                state.phase = ComputeCommandPhase::Idle;
+            }
+        }
+    }
+
+    fn fail_cpu(&self, failure: &ComputeExecutionError) {
+        if let Ok(mut state) = self.state.lock() {
+            if matches!(state.phase, ComputeCommandPhase::CpuReserved) {
+                state.phase = if failure.state_advanced {
+                    ComputeCommandPhase::Terminal(failure.to_string().into_boxed_str())
+                } else {
+                    ComputeCommandPhase::Idle
+                };
+            }
         }
     }
 
@@ -820,26 +958,28 @@ impl ComputeCommandHandle {
         let mut state = self.state.lock().map_err(|_| {
             browser_execution_error(CPU_SCALAR_BACKEND, "dispatch", "command lock is poisoned")
         })?;
-        if !state.cpu_reserved {
+        if !matches!(state.phase, ComputeCommandPhase::CpuReserved) {
             return Err(browser_execution_error(
                 CPU_SCALAR_BACKEND,
                 "dispatch",
                 "the browser CPU command slot was not reserved",
             ));
         }
-        state.changed_inputs.append(changed_inputs);
-        state.completed_outputs.append(completed_outputs);
-        state.queued = Some(QueuedComputeCommand {
-            dispatch_id: None,
+        state.phase = ComputeCommandPhase::Queued(Arc::new(ComputeCommandData {
+            changed_inputs: take_shared_values(changed_inputs),
+            completed_outputs: take_shared_values(completed_outputs),
+            dispatch_token: None,
+            requested_outputs: BTreeSet::new(),
             acknowledgement_required: false,
-        });
-        state.cpu_reserved = false;
+            completion_request: None,
+        }));
         Ok(())
     }
 
     fn queue_wgpu(
         &self,
         changed_inputs: &mut BTreeMap<String, Vec<f32>>,
+        request: &ComputeDispatchRequest,
     ) -> Result<(), ComputeExecutionError> {
         let mut state = self.state.lock().map_err(|_| {
             browser_execution_error(WGPU_BACKEND, "dispatch", "command lock is poisoned")
@@ -849,11 +989,39 @@ impl ComputeCommandHandle {
             browser_execution_error(WGPU_BACKEND, "dispatch", "dispatch ID space exhausted")
         })?;
         state.next_dispatch_id = dispatch_id;
-        state.changed_inputs.append(changed_inputs);
-        state.queued = Some(QueuedComputeCommand {
-            dispatch_id: Some(dispatch_id),
+        let token = ComputeDispatchToken {
+            generation: state.generation,
+            dispatch: dispatch_id,
+        };
+        let requested_outputs = state
+            .completion_program
+            .as_ref()
+            .ok_or_else(|| {
+                browser_execution_error(
+                    WGPU_BACKEND,
+                    "dispatch",
+                    "compute completion has no compiled output contract",
+                )
+            })?
+            .interface()
+            .outputs
+            .iter()
+            .filter(|port| request.outputs.contains(&port.id))
+            .map(|port| port.name.to_string())
+            .collect();
+        let completion_request = ComputeCompletionRequest {
+            token,
+            outputs: request.outputs.clone(),
+            logical_turn: request.logical_turn,
+        };
+        state.phase = ComputeCommandPhase::Queued(Arc::new(ComputeCommandData {
+            changed_inputs: take_shared_values(changed_inputs),
+            completed_outputs: BTreeMap::new(),
+            dispatch_token: Some(token),
+            requested_outputs,
             acknowledgement_required: true,
-        });
+            completion_request: Some(completion_request),
+        }));
         Ok(())
     }
 
@@ -880,104 +1048,270 @@ impl ComputeCommandHandle {
         Ok(())
     }
 
-    pub(crate) fn acknowledge(&self, dispatch_id: u32) -> Result<(), JsValue> {
-        self.complete(dispatch_id, BTreeMap::new())
+    pub(crate) fn validate_token(&self, token: &str) -> Result<ComputeDispatchToken, JsValue> {
+        let token: ComputeDispatchToken = token.parse().map_err(|detail| {
+            error(format!(
+                "invalid compute dispatch token `{token}`: {detail}"
+            ))
+        })?;
+        self.validate_token_value(token).map_err(js_execution_error)
+    }
+
+    fn validate_token_value(
+        &self,
+        token: ComputeDispatchToken,
+    ) -> Result<ComputeDispatchToken, ComputeExecutionError> {
+        let state = self
+            .state
+            .lock()
+            .map_err(|_| command_completion_error("compute command state lock is poisoned"))?;
+        match &state.phase {
+            ComputeCommandPhase::Claimed(request) if request.token == token => Ok(token),
+            ComputeCommandPhase::Completing(request) if request.token == token => Err(
+                command_completion_error(format!("compute dispatch {token} is already completing")),
+            ),
+            _ => Err(command_completion_error(format!(
+                "compute dispatch {token} does not belong to the active runtime command"
+            ))),
+        }
+    }
+
+    pub(crate) fn acknowledge(&self, token: ComputeDispatchToken) -> Result<(), JsValue> {
+        self.acknowledge_native(token).map_err(js_execution_error)
+    }
+
+    fn acknowledge_native(&self, token: ComputeDispatchToken) -> Result<(), ComputeExecutionError> {
+        let request = self.begin_completion(token)?;
+        if !request.outputs.is_empty() {
+            let required = request.outputs.len();
+            self.restore_claimed(request);
+            return Err(command_completion_error(format!(
+                "compute dispatch {token} requires {} output value(s)",
+                required
+            )));
+        }
+        self.publish_completion(
+            request,
+            ComputeCompletionOutcome::Completed {
+                report: self.success_report()?,
+                snapshot: ComputeOutputSnapshot::default(),
+            },
+            false,
+        )
     }
 
     pub(crate) fn complete(
         &self,
-        dispatch_id: u32,
+        token: ComputeDispatchToken,
         outputs: BTreeMap<String, Vec<f32>>,
     ) -> Result<(), JsValue> {
-        let (program, target, report) = {
-            let state = self
-                .state
-                .lock()
-                .map_err(|_| error("compute command state lock is poisoned"))?;
-            if !state.in_flight.contains(&dispatch_id) {
-                return Err(error(format!(
-                    "compute dispatch {dispatch_id} is not awaiting acknowledgement"
-                )));
+        self.complete_native(token, outputs)
+            .map_err(js_execution_error)
+    }
+
+    fn complete_native(
+        &self,
+        token: ComputeDispatchToken,
+        outputs: BTreeMap<String, Vec<f32>>,
+    ) -> Result<(), ComputeExecutionError> {
+        let program = self.completion_program()?;
+        let request = self.begin_completion(token)?;
+        let snapshot = match browser_output_snapshot(&program, &request.outputs, outputs) {
+            Ok(snapshot) => snapshot,
+            Err(failure) => {
+                self.restore_claimed(request);
+                return Err(failure);
             }
-            let program = state
-                .completion_program
-                .clone()
-                .ok_or_else(|| error("compute completion has no compiled output contract"))?;
-            let target = state
-                .completion_target
-                .clone()
-                .ok_or_else(|| error("compute completion has no resident publication target"))?;
-            let report = ComputeDispatchReport {
-                completed_turns: 1,
-                fault_count: state.fault_count,
-                ..Default::default()
-            };
-            (program, target, report)
         };
-        let snapshot = browser_output_snapshot(&program, outputs)
-            .map_err(|failure| error(format!("{}: {}", failure.operation, failure.detail)))?;
-        self.state
-            .lock()
-            .map_err(|_| error("compute command state lock is poisoned"))?
-            .in_flight
-            .remove(&dispatch_id);
-        target
-            .complete(report, snapshot)
-            .map_err(|failure| error(format!("{}: {}", failure.operation, failure.detail)))?;
-        Ok(())
+        self.publish_completion(
+            request,
+            ComputeCompletionOutcome::Completed {
+                report: self.success_report()?,
+                snapshot,
+            },
+            false,
+        )
     }
 
     pub(crate) fn reject_integrity(
         &self,
-        dispatch_id: u32,
+        token: ComputeDispatchToken,
         constraint: &str,
         instance: u32,
     ) -> Result<(), JsValue> {
-        let (target, report) = {
+        self.reject_integrity_native(token, constraint, instance)
+            .map_err(js_execution_error)
+    }
+
+    fn reject_integrity_native(
+        &self,
+        token: ComputeDispatchToken,
+        constraint: &str,
+        instance: u32,
+    ) -> Result<(), ComputeExecutionError> {
+        let request = self.begin_completion(token)?;
+        let report = {
             let mut state = self
                 .state
                 .lock()
-                .map_err(|_| error("compute command state lock is poisoned"))?;
-            if !state.in_flight.remove(&dispatch_id) {
-                return Err(error(format!(
-                    "compute dispatch {dispatch_id} is not awaiting acknowledgement"
-                )));
-            }
+                .map_err(|_| command_completion_error("compute command state lock is poisoned"))?;
             state.fault_count = state.fault_count.saturating_add(1);
-            let target = state
-                .completion_target
-                .clone()
-                .ok_or_else(|| error("compute completion has no resident publication target"))?;
-            let report = ComputeDispatchReport {
+            ComputeDispatchReport {
                 completed_turns: 0,
                 fault_count: state.fault_count,
                 last_fault: Some(ComputeFaultEvidence {
-                    attempted_turn: u64::from(dispatch_id),
+                    attempted_turn: request.logical_turn,
                     constraint: constraint.to_owned().into_boxed_str(),
                     detail: format!("candidate rejected at batch instance {instance}")
                         .into_boxed_str(),
                 }),
                 ..Default::default()
-            };
-            (target, report)
+            }
         };
-        target
-            .complete(report, ComputeOutputSnapshot::default())
-            .map_err(|failure| error(format!("{}: {}", failure.operation, failure.detail)))
+        self.publish_completion(
+            request,
+            ComputeCompletionOutcome::IntegrityRejected { report },
+            false,
+        )
     }
 
-    pub(crate) fn reject(&self, dispatch_id: u32, reason: &str) -> Result<(), JsValue> {
+    pub(crate) fn reject(&self, token: ComputeDispatchToken, reason: &str) -> Result<(), JsValue> {
+        self.reject_native(token, reason)
+            .map_err(js_execution_error)
+    }
+
+    fn reject_native(
+        &self,
+        token: ComputeDispatchToken,
+        reason: &str,
+    ) -> Result<(), ComputeExecutionError> {
+        let request = self.begin_completion(token)?;
+        self.publish_completion(
+            request.clone(),
+            ComputeCompletionOutcome::TransportFailed {
+                attempted_turn: request.logical_turn,
+                reason: reason.to_owned().into_boxed_str(),
+            },
+            true,
+        )
+    }
+
+    fn begin_completion(
+        &self,
+        token: ComputeDispatchToken,
+    ) -> Result<ComputeCompletionRequest, ComputeExecutionError> {
         let mut state = self
             .state
             .lock()
-            .map_err(|_| error("compute command state lock is poisoned"))?;
-        if !state.in_flight.remove(&dispatch_id) {
-            return Err(error(format!(
-                "compute dispatch {dispatch_id} is not awaiting acknowledgement"
+            .map_err(|_| command_completion_error("compute command state lock is poisoned"))?;
+        let ComputeCommandPhase::Claimed(request) = &state.phase else {
+            return Err(command_completion_error(format!(
+                "compute dispatch {token} is not awaiting acknowledgement"
+            )));
+        };
+        if request.token != token {
+            return Err(command_completion_error(format!(
+                "compute dispatch {token} does not own the active command"
             )));
         }
-        let _ = reason;
-        Ok(())
+        let request = request.clone();
+        state.phase = ComputeCommandPhase::Completing(request.clone());
+        Ok(request)
+    }
+
+    fn restore_claimed(&self, request: ComputeCompletionRequest) {
+        if let Ok(mut state) = self.state.lock() {
+            if matches!(&state.phase, ComputeCommandPhase::Completing(current) if current.token == request.token)
+            {
+                state.phase = ComputeCommandPhase::Claimed(request);
+            }
+        }
+    }
+
+    fn publish_completion(
+        &self,
+        request: ComputeCompletionRequest,
+        outcome: ComputeCompletionOutcome,
+        terminal: bool,
+    ) -> Result<(), ComputeExecutionError> {
+        let target = {
+            let mut state = self
+                .state
+                .lock()
+                .map_err(|_| command_completion_error("compute command state lock is poisoned"))?;
+            let Some(target) = state.completion_target.clone() else {
+                state.phase = ComputeCommandPhase::Terminal(
+                    "compute completion has no resident publication target".into(),
+                );
+                return Err(command_completion_error(
+                    "compute completion has no resident publication target",
+                ));
+            };
+            target
+        };
+        let result = target.complete(outcome);
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| command_completion_error("compute command state lock is poisoned"))?;
+        if !matches!(&state.phase, ComputeCommandPhase::Completing(current) if current.token == request.token)
+        {
+            return Err(command_completion_error(
+                "compute completion ownership changed during publication",
+            ));
+        }
+        match result {
+            Ok(()) if !terminal => {
+                state.phase = ComputeCommandPhase::Idle;
+                Ok(())
+            }
+            Ok(()) => {
+                state.phase =
+                    ComputeCommandPhase::Terminal("browser compute transport failed".into());
+                Ok(())
+            }
+            Err(failure) => {
+                state.phase = ComputeCommandPhase::Terminal(failure.to_string().into_boxed_str());
+                Err(failure)
+            }
+        }
+    }
+
+    fn completion_program(&self) -> Result<ComputeProgram, ComputeExecutionError> {
+        self.state
+            .lock()
+            .map_err(|_| command_completion_error("compute command state lock is poisoned"))?
+            .completion_program
+            .clone()
+            .ok_or_else(|| {
+                command_completion_error("compute completion has no compiled output contract")
+            })
+    }
+
+    fn success_report(&self) -> Result<ComputeDispatchReport, ComputeExecutionError> {
+        let state = self
+            .state
+            .lock()
+            .map_err(|_| command_completion_error("compute command state lock is poisoned"))?;
+        Ok(ComputeDispatchReport {
+            completed_turns: 1,
+            fault_count: state.fault_count,
+            ..Default::default()
+        })
+    }
+}
+
+fn take_shared_values(source: &mut BTreeMap<String, Vec<f32>>) -> BTreeMap<String, Arc<[f32]>> {
+    std::mem::take(source)
+        .into_iter()
+        .map(|(name, values)| (name, Arc::from(values)))
+        .collect()
+}
+
+fn claimed_phase(command: &ComputeCommandData) -> ComputeCommandPhase {
+    match &command.completion_request {
+        Some(request) => ComputeCommandPhase::Claimed(request.clone()),
+        None => ComputeCommandPhase::Idle,
     }
 }
 
@@ -985,7 +1319,14 @@ fn ensure_command_slot_available(
     state: &ComputeCommandState,
     backend: &str,
 ) -> Result<(), ComputeExecutionError> {
-    if state.queued.is_some() || !state.in_flight.is_empty() || state.cpu_reserved {
+    if let ComputeCommandPhase::Terminal(reason) = &state.phase {
+        return Err(browser_execution_error(
+            backend,
+            "dispatch",
+            format!("browser compute session is terminal: {reason}"),
+        ));
+    }
+    if !matches!(state.phase, ComputeCommandPhase::Idle) {
         return Err(browser_execution_error(
             backend,
             "dispatch",
@@ -997,7 +1338,7 @@ fn ensure_command_slot_available(
 
 pub(crate) fn compute_command_value(
     region: &str,
-    command: ComputeCommandData,
+    command: &ComputeCommandData,
 ) -> Result<JsValue, JsValue> {
     let value = Object::new();
     set(&value, "region", region)?;
@@ -1007,22 +1348,27 @@ pub(crate) fn compute_command_value(
         "acknowledgementRequired",
         command.acknowledgement_required,
     )?;
-    if let Some(dispatch_id) = command.dispatch_id {
-        set(&value, "dispatchId", dispatch_id)?;
+    if let Some(dispatch_token) = command.dispatch_token {
+        set(&value, "dispatchToken", dispatch_token.to_string())?;
     }
+    set(
+        &value,
+        "requestedOutputs",
+        Array::from_iter(command.requested_outputs.iter().map(JsValue::from)),
+    )?;
     let inputs = Array::new();
-    for (name, values) in command.changed_inputs {
+    for (name, values) in &command.changed_inputs {
         let input = Object::new();
         set(&input, "name", name)?;
-        set(&input, "values", Float32Array::from(values.as_slice()))?;
+        set(&input, "values", Float32Array::from(values.as_ref()))?;
         inputs.push(&input);
     }
     set(&value, "inputs", inputs)?;
     let outputs = Array::new();
-    for (name, values) in command.completed_outputs {
+    for (name, values) in &command.completed_outputs {
         let output = Object::new();
         set(&output, "name", name)?;
-        set(&output, "values", Float32Array::from(values.as_slice()))?;
+        set(&output, "values", Float32Array::from(values.as_ref()))?;
         outputs.push(&output);
     }
     set(&value, "outputs", outputs)?;
@@ -1243,14 +1589,21 @@ impl ComputeSession for BrowserCpuSession {
                 self.command.cancel_cpu_reservation();
                 return Ok(report);
             }
-            let snapshot = self.inner.read_outputs(&ComputeOutputSelection::All)?;
-            let mut completed_outputs = self.outputs.publish(&self.program, &snapshot)?;
+            let snapshot = self
+                .inner
+                .read_outputs(&ComputeOutputSelection::All)
+                .map_err(ComputeExecutionError::after_state_advance)?;
+            let mut completed_outputs = self
+                .outputs
+                .publish(&self.program, &snapshot)
+                .map_err(ComputeExecutionError::after_state_advance)?;
             self.command
-                .commit_cpu(&mut self.changed_inputs, &mut completed_outputs)?;
+                .commit_cpu(&mut self.changed_inputs, &mut completed_outputs)
+                .map_err(ComputeExecutionError::after_state_advance)?;
             Ok(report)
         })();
-        if result.is_err() {
-            self.command.cancel_cpu_reservation();
+        if let Err(failure) = &result {
+            self.command.fail_cpu(failure);
         }
         result
     }
@@ -1332,19 +1685,11 @@ impl ComputeBackendFactory for BrowserWgpuBackendFactory {
             operation: "compile",
             detail: format!("{failure:?}").into(),
         })?;
-        self.command.configure_completion(program)?;
         Ok(Box::new(BrowserWgpuExecutable {
             backend: self.descriptor.id.clone(),
             program: program.clone(),
             command: self.command.clone(),
         }))
-    }
-
-    fn bind_completion_target(
-        &self,
-        target: Arc<dyn ComputeCompletionTarget>,
-    ) -> Result<(), ComputeBackendError> {
-        self.command.bind_completion_target(target)
     }
 }
 
@@ -1364,6 +1709,7 @@ impl ComputeExecutable for BrowserWgpuExecutable {
             operation: "create session",
             detail: format!("{failure:?}").into(),
         })?;
+        self.command.configure_completion(&self.program)?;
         Ok(Box::new(BrowserWgpuSession {
             backend: self.backend.clone(),
             program: self.program.clone(),
@@ -1381,6 +1727,13 @@ struct BrowserWgpuSession {
 }
 
 impl ComputeSession for BrowserWgpuSession {
+    fn bind_completion_target(
+        &mut self,
+        target: Arc<dyn ComputeCompletionTarget>,
+    ) -> Result<(), ComputeBackendError> {
+        self.command.bind_completion_target(target)
+    }
+
     fn update_inputs(
         &mut self,
         updates: &[ComputeInputUpdate],
@@ -1411,6 +1764,14 @@ impl ComputeSession for BrowserWgpuSession {
         &mut self,
         turns: NonZeroU32,
     ) -> Result<ComputeDispatchReport, ComputeExecutionError> {
+        self.dispatch_requested(turns, &ComputeDispatchRequest::default())
+    }
+
+    fn dispatch_requested(
+        &mut self,
+        turns: NonZeroU32,
+        request: &ComputeDispatchRequest,
+    ) -> Result<ComputeDispatchReport, ComputeExecutionError> {
         if turns.get() != 1 {
             return Err(browser_execution_error(
                 WGPU_BACKEND,
@@ -1418,7 +1779,7 @@ impl ComputeSession for BrowserWgpuSession {
                 "the browser render bridge accepts one resident turn per frame",
             ));
         }
-        self.command.queue_wgpu(&mut self.changed_inputs)?;
+        self.command.queue_wgpu(&mut self.changed_inputs, request)?;
         Ok(ComputeDispatchReport {
             completed_turns: 0,
             ..Default::default()
@@ -1436,13 +1797,15 @@ impl ComputeSession for BrowserWgpuSession {
 
 fn browser_output_snapshot(
     program: &ComputeProgram,
+    requested: &BTreeSet<ComputePortId>,
     completed: BTreeMap<String, Vec<f32>>,
 ) -> Result<ComputeOutputSnapshot, ComputeExecutionError> {
-    if completed.len() != program.interface().outputs.len() {
+    if completed.len() != requested.len() {
         let missing = program
             .interface()
             .outputs
             .iter()
+            .filter(|port| requested.contains(&port.id))
             .filter(|port| !completed.contains_key(port.name.as_ref()))
             .map(|port| port.name.as_ref())
             .collect::<Vec<_>>();
@@ -1452,7 +1815,7 @@ fn browser_output_snapshot(
             format!(
                 "browser bridge returned {} outputs; expected {}{}",
                 completed.len(),
-                program.interface().outputs.len(),
+                requested.len(),
                 if missing.is_empty() {
                     String::new()
                 } else {
@@ -1475,6 +1838,13 @@ fn browser_output_snapshot(
                     format!("browser bridge returned undeclared output `{name}`"),
                 )
             })?;
+        if !requested.contains(&port.id) {
+            return Err(browser_execution_error(
+                WGPU_BACKEND,
+                "read outputs",
+                format!("browser bridge returned unrequested output `{name}`"),
+            ));
+        }
         let expected = port.elements().map_err(|failure| {
             browser_execution_error(WGPU_BACKEND, "read outputs", failure.to_string())
         })?;
@@ -1521,7 +1891,16 @@ fn browser_execution_error(
         backend: BackendId::new(backend).expect("browser backend ID is valid"),
         operation,
         detail: detail.into(),
+        state_advanced: false,
     }
+}
+
+fn command_completion_error(detail: impl Into<Box<str>>) -> ComputeExecutionError {
+    browser_execution_error(WGPU_BACKEND, "complete command", detail)
+}
+
+fn js_execution_error(failure: ComputeExecutionError) -> JsValue {
+    error(format!("{}: {}", failure.operation, failure.detail))
 }
 
 #[derive(Clone, Debug)]
@@ -1563,17 +1942,29 @@ mod tests {
 
     #[derive(Default)]
     struct RecordingCompletion {
-        reports: Mutex<Vec<ComputeDispatchReport>>,
+        outcomes: Mutex<Vec<ComputeCompletionOutcome>>,
     }
 
     impl ComputeCompletionTarget for RecordingCompletion {
+        fn complete(&self, outcome: ComputeCompletionOutcome) -> Result<(), ComputeExecutionError> {
+            self.outcomes.lock().unwrap().push(outcome);
+            Ok(())
+        }
+    }
+
+    struct FailingCompletion;
+
+    impl ComputeCompletionTarget for FailingCompletion {
         fn complete(
             &self,
-            report: ComputeDispatchReport,
-            _snapshot: ComputeOutputSnapshot,
+            _outcome: ComputeCompletionOutcome,
         ) -> Result<(), ComputeExecutionError> {
-            self.reports.lock().unwrap().push(report);
-            Ok(())
+            Err(browser_execution_error(
+                WGPU_BACKEND,
+                "publish completion",
+                "injected completion target failure",
+            )
+            .after_state_advance())
         }
     }
 
@@ -1608,6 +1999,36 @@ mod tests {
             _selection: &ComputeOutputSelection,
         ) -> Result<ComputeOutputSnapshot, ComputeExecutionError> {
             panic!("a rejected CPU turn must not read or publish outputs")
+        }
+    }
+
+    struct AdvancedCpuSession;
+
+    impl ComputeSession for AdvancedCpuSession {
+        fn update_inputs(
+            &mut self,
+            _updates: &[ComputeInputUpdate],
+        ) -> Result<(), ComputeExecutionError> {
+            Ok(())
+        }
+
+        fn dispatch(
+            &mut self,
+            _turns: NonZeroU32,
+        ) -> Result<ComputeDispatchReport, ComputeExecutionError> {
+            Ok(ComputeDispatchReport {
+                completed_turns: 1,
+                ..Default::default()
+            })
+        }
+
+        fn read_outputs(
+            &mut self,
+            _selection: &ComputeOutputSelection,
+        ) -> Result<ComputeOutputSnapshot, ComputeExecutionError> {
+            // The missing snapshot simulates any fallible readback or output
+            // contract failure after the scalar backend accepted the turn.
+            Ok(ComputeOutputSnapshot::default())
         }
     }
 
@@ -1708,7 +2129,7 @@ state
         let pointer_index = configured_host_index(document, "pointer").unwrap();
         let compute_index = configured_host_index(document, "compute").unwrap();
         let pointer = PointerInputHandle::new(document.hosts[pointer_index].name.as_str());
-        let compute = ComputeCommandHandle::new(prepared.region.clone());
+        let compute = ComputeCommandHandle::new(prepared.region.clone(), 1);
         let outputs = BrowserOutputHandle::default();
         let registry =
             browser_compute_backend_registry(compute.clone(), outputs.clone(), gpu_available)
@@ -1820,34 +2241,39 @@ state
         runtime.drain_host_inputs(1).unwrap();
         let command = compute.take_command_data().unwrap().unwrap();
         assert!(command.acknowledgement_required);
-        assert_eq!(command.changed_inputs["force-point"], vec![0.25, -0.5]);
-        assert_eq!(command.changed_inputs["force-strength"], vec![1.0]);
-        let dispatch_id = command.dispatch_id.unwrap();
-        assert!(
-            compute
-                .state
-                .lock()
-                .unwrap()
-                .in_flight
-                .contains(&dispatch_id)
-        );
-        compute
-            .complete(
-                dispatch_id,
-                BTreeMap::from([
-                    ("result.0".to_owned(), vec![0.0; 8]),
-                    ("result.1".to_owned(), vec![0.0; 8]),
-                ]),
-            )
-            .unwrap();
-        assert!(
-            !compute
-                .state
-                .lock()
-                .unwrap()
-                .in_flight
-                .contains(&dispatch_id)
-        );
+        assert_eq!(command.changed_inputs["force-point"].as_ref(), [0.25, -0.5]);
+        assert_eq!(command.changed_inputs["force-strength"].as_ref(), [1.0]);
+        let dispatch_token = command.dispatch_token.unwrap();
+        assert!(matches!(
+            compute.state.lock().unwrap().phase,
+            ComputeCommandPhase::Claimed(_)
+        ));
+        let completed = command
+            .requested_outputs
+            .iter()
+            .map(|name| {
+                let elements = compute
+                    .state
+                    .lock()
+                    .unwrap()
+                    .completion_program
+                    .as_ref()
+                    .unwrap()
+                    .interface()
+                    .outputs
+                    .iter()
+                    .find(|port| port.name.as_ref() == name)
+                    .unwrap()
+                    .elements()
+                    .unwrap();
+                (name.clone(), vec![0.0; elements])
+            })
+            .collect();
+        compute.complete(dispatch_token, completed).unwrap();
+        assert!(matches!(
+            compute.state.lock().unwrap().phase,
+            ComputeCommandPhase::Idle
+        ));
     }
 
     #[test]
@@ -1872,20 +2298,20 @@ state
 
         let state = compute.take_command_data().unwrap().unwrap();
         assert!(!state.acknowledgement_required);
-        assert_eq!(state.dispatch_id, None);
-        assert_eq!(state.changed_inputs["force-point"], vec![0.25, -0.5]);
-        assert_eq!(state.changed_inputs["force-strength"], vec![1.0]);
+        assert_eq!(state.dispatch_token, None);
+        assert_eq!(state.changed_inputs["force-point"].as_ref(), [0.25, -0.5]);
+        assert_eq!(state.changed_inputs["force-strength"].as_ref(), [1.0]);
         let positions = outputs.output("result.0").unwrap();
         assert_eq!(positions.len(), 8);
         assert!(positions.iter().all(|value| value.is_finite()));
-        assert_eq!(state.completed_outputs["result.0"], positions);
+        assert_eq!(state.completed_outputs["result.0"].as_ref(), positions);
         assert_eq!(state.completed_outputs["result.1"].len(), 8);
     }
 
     #[test]
     fn cpu_integrity_rejection_does_not_publish_a_completion_command() {
         let (_document, prepared) = compile_fixture(CONFIG, SOURCE);
-        let command = ComputeCommandHandle::new(prepared.region.clone());
+        let command = ComputeCommandHandle::new(prepared.region.clone(), 1);
         let outputs = BrowserOutputHandle::default();
         let mut session = BrowserCpuSession {
             inner: Box::new(RejectingCpuSession),
@@ -1901,88 +2327,249 @@ state
         assert_eq!(report.fault_count, 1);
         assert!(session.changed_inputs.is_empty());
         assert!(command.take_command_data().unwrap().is_none());
-        assert!(!command.state.lock().unwrap().cpu_reserved);
+        assert!(matches!(
+            command.state.lock().unwrap().phase,
+            ComputeCommandPhase::Idle
+        ));
         assert!(outputs.values.lock().unwrap().is_empty());
     }
 
     #[test]
-    fn wgpu_holds_the_command_slot_until_the_bridge_completes_it() {
-        let compute = ComputeCommandHandle::new("test".to_owned());
-        let mut first_inputs = BTreeMap::from([("x".to_owned(), vec![1.0])]);
-        compute.queue_wgpu(&mut first_inputs).unwrap();
+    fn cpu_publication_failure_reports_that_resident_state_advanced() {
+        let (_document, prepared) = compile_fixture(CONFIG, SOURCE);
+        let command = ComputeCommandHandle::new(prepared.region.clone(), 1);
+        let mut session = BrowserCpuSession {
+            inner: Box::new(AdvancedCpuSession),
+            program: prepared.program,
+            command: command.clone(),
+            outputs: BrowserOutputHandle::default(),
+            changed_inputs: BTreeMap::new(),
+        };
 
-        let first = compute.take_command_data().unwrap().unwrap();
-        assert!(first.acknowledgement_required);
-        let dispatch_id = first.dispatch_id.unwrap();
-        let mut second_inputs = BTreeMap::new();
-        assert!(compute.queue_wgpu(&mut second_inputs).is_err());
-        compute.reject(dispatch_id, "test cleanup").unwrap();
-        compute.queue_wgpu(&mut second_inputs).unwrap();
+        let error = session.dispatch(NonZeroU32::new(1).unwrap()).unwrap_err();
+
+        assert!(error.state_advanced);
+        assert!(command.take_command_data().unwrap().is_none());
+        assert!(matches!(
+            command.state.lock().unwrap().phase,
+            ComputeCommandPhase::Terminal(_)
+        ));
     }
 
     #[test]
-    fn wgpu_bridge_rejection_releases_the_command_slot() {
-        let compute = ComputeCommandHandle::new("test".to_owned());
-        let mut inputs = BTreeMap::new();
-        compute.queue_wgpu(&mut inputs).unwrap();
-        let command = compute.take_command_data().unwrap().unwrap();
+    fn wgpu_holds_the_command_slot_until_the_bridge_completes_it() {
+        let (_document, prepared) = compile_fixture(CONFIG, SOURCE);
+        let compute = ComputeCommandHandle::new("test".to_owned(), 1);
+        compute.configure_completion(&prepared.program).unwrap();
+        let completion = Arc::new(RecordingCompletion::default());
+        compute.bind_completion_target(completion).unwrap();
+        let mut first_inputs = BTreeMap::from([("x".to_owned(), vec![1.0])]);
         compute
-            .reject(command.dispatch_id.unwrap(), "device lost")
+            .queue_wgpu(
+                &mut first_inputs,
+                &ComputeDispatchRequest {
+                    outputs: BTreeSet::new(),
+                    logical_turn: 9,
+                },
+            )
             .unwrap();
 
-        compute.queue_wgpu(&mut inputs).unwrap();
+        let first = compute.take_command_data().unwrap().unwrap();
+        assert!(first.acknowledgement_required);
+        let dispatch_token = first.dispatch_token.unwrap();
+        let mut second_inputs = BTreeMap::new();
+        assert!(
+            compute
+                .queue_wgpu(&mut second_inputs, &ComputeDispatchRequest::default())
+                .is_err()
+        );
+        compute.acknowledge(dispatch_token).unwrap();
+        compute
+            .queue_wgpu(&mut second_inputs, &ComputeDispatchRequest::default())
+            .unwrap();
+    }
+
+    #[test]
+    fn wgpu_bridge_transport_rejection_makes_the_command_terminal() {
+        let (_document, prepared) = compile_fixture(CONFIG, SOURCE);
+        let compute = ComputeCommandHandle::new("test".to_owned(), 1);
+        compute.configure_completion(&prepared.program).unwrap();
+        compute
+            .bind_completion_target(Arc::new(RecordingCompletion::default()))
+            .unwrap();
+        let mut inputs = BTreeMap::new();
+        compute
+            .queue_wgpu(
+                &mut inputs,
+                &ComputeDispatchRequest {
+                    outputs: BTreeSet::new(),
+                    logical_turn: 41,
+                },
+            )
+            .unwrap();
+        let command = compute.take_command_data().unwrap().unwrap();
+        compute
+            .reject(command.dispatch_token.unwrap(), "device lost")
+            .unwrap();
+
+        assert!(
+            compute
+                .queue_wgpu(&mut inputs, &ComputeDispatchRequest::default())
+                .is_err()
+        );
+        assert!(matches!(
+            compute.state.lock().unwrap().phase,
+            ComputeCommandPhase::Terminal(_)
+        ));
     }
 
     #[test]
     fn wgpu_completion_validates_the_whole_snapshot_before_publishing() {
         let (_document, prepared) = compile_fixture(CONFIG, SOURCE);
-        let compute = ComputeCommandHandle::new("test".to_owned());
+        let compute = ComputeCommandHandle::new("test".to_owned(), 1);
         compute.configure_completion(&prepared.program).unwrap();
         let completion = Arc::new(RecordingCompletion::default());
         compute.bind_completion_target(completion.clone()).unwrap();
         let mut inputs = BTreeMap::new();
-        compute.queue_wgpu(&mut inputs).unwrap();
-        let dispatch_id = compute
+        let requested = prepared
+            .program
+            .interface()
+            .outputs
+            .iter()
+            .map(|port| port.id)
+            .collect();
+        compute
+            .queue_wgpu(
+                &mut inputs,
+                &ComputeDispatchRequest {
+                    outputs: requested,
+                    logical_turn: 17,
+                },
+            )
+            .unwrap();
+        let dispatch_token = compute
             .take_command_data()
             .unwrap()
             .unwrap()
-            .dispatch_id
+            .dispatch_token
             .unwrap();
+        let requested = match &compute.state.lock().unwrap().phase {
+            ComputeCommandPhase::Claimed(request) => request.outputs.clone(),
+            phase => panic!("expected claimed command, got {phase:?}"),
+        };
 
         let error = browser_output_snapshot(
             &prepared.program,
+            &requested,
             BTreeMap::from([("result.0".to_owned(), vec![0.0; 8])]),
         )
         .unwrap_err();
         assert!(error.detail.contains("missing result.1"));
-        assert!(
-            compute
-                .state
-                .lock()
-                .unwrap()
-                .in_flight
-                .contains(&dispatch_id)
-        );
-        assert!(completion.reports.lock().unwrap().is_empty());
+        assert!(matches!(
+            compute.state.lock().unwrap().phase,
+            ComputeCommandPhase::Claimed(_)
+        ));
+        assert!(completion.outcomes.lock().unwrap().is_empty());
 
         compute
             .complete(
-                dispatch_id,
+                dispatch_token,
                 BTreeMap::from([
                     ("result.0".to_owned(), vec![0.0; 8]),
                     ("result.1".to_owned(), vec![0.0; 8]),
                 ]),
             )
             .unwrap();
-        assert_eq!(completion.reports.lock().unwrap()[0].completed_turns, 1);
-        assert!(
-            !compute
-                .state
-                .lock()
-                .unwrap()
-                .in_flight
-                .contains(&dispatch_id)
+        assert!(matches!(
+            &completion.outcomes.lock().unwrap()[0],
+            ComputeCompletionOutcome::Completed { report, .. } if report.completed_turns == 1
+        ));
+        assert!(matches!(
+            compute.state.lock().unwrap().phase,
+            ComputeCommandPhase::Idle
+        ));
+    }
+
+    #[test]
+    fn failed_js_delivery_rolls_the_exact_command_back_to_queued() {
+        let (_document, prepared) = compile_fixture(CONFIG, SOURCE);
+        let compute = ComputeCommandHandle::new("test".to_owned(), 7);
+        compute.configure_completion(&prepared.program).unwrap();
+        let mut inputs = BTreeMap::new();
+        compute
+            .queue_wgpu(&mut inputs, &ComputeDispatchRequest::default())
+            .unwrap();
+
+        let lease = compute.lease_command().unwrap().unwrap();
+        assert!(matches!(
+            compute.state.lock().unwrap().phase,
+            ComputeCommandPhase::Serializing(_)
+        ));
+        compute.rollback_delivery(lease);
+        let delivered = compute.take_command_data().unwrap().unwrap();
+        assert_eq!(delivered.dispatch_token.unwrap().to_string(), "7:1");
+    }
+
+    #[test]
+    fn stale_generation_cannot_complete_replacement_dispatch_one() {
+        let (_document, prepared) = compile_fixture(CONFIG, SOURCE);
+        let request = ComputeDispatchRequest::default();
+        let completion = Arc::new(RecordingCompletion::default());
+        let old = ComputeCommandHandle::new("test".to_owned(), 17);
+        old.configure_completion(&prepared.program).unwrap();
+        old.bind_completion_target(completion.clone()).unwrap();
+        let replacement = ComputeCommandHandle::new("test".to_owned(), 18);
+        replacement.configure_completion(&prepared.program).unwrap();
+        replacement.bind_completion_target(completion).unwrap();
+        let mut inputs = BTreeMap::new();
+        old.queue_wgpu(&mut inputs, &request).unwrap();
+        let old_token = old
+            .take_command_data()
+            .unwrap()
+            .unwrap()
+            .dispatch_token
+            .unwrap();
+        replacement.queue_wgpu(&mut inputs, &request).unwrap();
+        let replacement_token = replacement
+            .take_command_data()
+            .unwrap()
+            .unwrap()
+            .dispatch_token
+            .unwrap();
+
+        assert_eq!(old_token.to_string(), "17:1");
+        assert_eq!(replacement_token.to_string(), "18:1");
+        assert!(replacement.validate_token_value(old_token).is_err());
+        assert_eq!(
+            replacement.validate_token_value(replacement_token).unwrap(),
+            replacement_token
         );
+    }
+
+    #[test]
+    fn completion_target_failure_retires_advanced_command_as_terminal() {
+        let (_document, prepared) = compile_fixture(CONFIG, SOURCE);
+        let compute = ComputeCommandHandle::new("test".to_owned(), 1);
+        compute.configure_completion(&prepared.program).unwrap();
+        compute
+            .bind_completion_target(Arc::new(FailingCompletion))
+            .unwrap();
+        let mut inputs = BTreeMap::new();
+        compute
+            .queue_wgpu(&mut inputs, &ComputeDispatchRequest::default())
+            .unwrap();
+        let token = compute
+            .take_command_data()
+            .unwrap()
+            .unwrap()
+            .dispatch_token
+            .unwrap();
+
+        assert!(compute.acknowledge_native(token).is_err());
+        assert!(matches!(
+            compute.state.lock().unwrap().phase,
+            ComputeCommandPhase::Terminal(_)
+        ));
     }
 
     #[test]
@@ -1990,7 +2577,7 @@ state
         let hard_gpu = SOURCE.replacen("@compute", "@gpu", 1);
         let (_, prepared) = compile_fixture(CONFIG, &hard_gpu);
         let registry = browser_compute_backend_registry(
-            ComputeCommandHandle::new(prepared.region),
+            ComputeCommandHandle::new(prepared.region, 1),
             BrowserOutputHandle::default(),
             true,
         )
@@ -2009,7 +2596,7 @@ state
         let hard_cpu = SOURCE.replacen("@compute", "@cpu", 1);
         let (_, prepared) = compile_fixture(CONFIG, &hard_cpu);
         let registry = browser_compute_backend_registry(
-            ComputeCommandHandle::new(prepared.region),
+            ComputeCommandHandle::new(prepared.region, 1),
             BrowserOutputHandle::default(),
             true,
         )

--- a/src/wasm/src/project.rs
+++ b/src/wasm/src/project.rs
@@ -4339,6 +4339,22 @@ rows := |id<string> x<f64>|
         )
         .unwrap();
         let source = include_str!("../../../examples/ekf/localization.mec").to_string();
+        assert!(
+            source.contains("ekf-predict(μ<[f32]:3,1>, Σ<[f32]:3,3>"),
+            "the EKF prediction must remain an ordinary fixed-shape Mech function",
+        );
+        assert!(
+            source.contains("ekf-correct(μ-<[f32]:3,1>, Σ-<[f32]:3,3>"),
+            "the EKF correction must remain an ordinary fixed-shape Mech function",
+        );
+        assert!(
+            source.contains("K := (S \\ B)'"),
+            "the Kalman gain must use the language's matrix solve operation",
+        );
+        assert!(
+            !source.contains("innovation-inverse") && !source.contains("innovation-determinant"),
+            "the example must not expand a matrix inverse by hand",
+        );
         let sources = HashMap::from([("localization.mec".to_string(), source.clone())]);
         let timer_factory = TestManualTimerHostFactory::new();
         let timer_driver = timer_factory.driver.clone();

--- a/src/wasm/src/project.rs
+++ b/src/wasm/src/project.rs
@@ -4364,8 +4364,8 @@ rows := |id<string> x<f64>|
         };
         assert_eq!(
             runtime.program_execution_info().observation_count,
-            2,
-            "the resident artifact must observe the timer and one packed compute sample"
+            3,
+            "the resident artifact must observe the timer, compute completion, and packed sample"
         );
         assert!(scene_backend.latest().is_none());
         let pi = 3.141592654_f64;
@@ -4748,6 +4748,22 @@ rows := |id<string> x<f64>|
             maximum_guide_deviation < 0.5,
             "the closed-loop square controller drifted {maximum_guide_deviation} field units from its guide",
         );
+        let final_snapshot = scene_backend.latest().unwrap();
+        for id in ["truth-path", "estimate-path"] {
+            let path = final_snapshot
+                .line_strips
+                .iter()
+                .find(|strip| strip.id == id)
+                .unwrap_or_else(|| panic!("EKF scene must render `{id}`"));
+            let (minimum_x, maximum_x) = path.positions.iter().fold(
+                (f64::INFINITY, f64::NEG_INFINITY),
+                |(minimum, maximum), point| (minimum.min(point[0]), maximum.max(point[0])),
+            );
+            assert!(
+                maximum_x - minimum_x > 100.0,
+                "`{id}` must advance across compute/timer scheduling boundaries",
+            );
+        }
         assert_eq!(
             runtime.program_execution_info().resident_accepted_turns,
             840

--- a/src/wasm/src/project.rs
+++ b/src/wasm/src/project.rs
@@ -4489,6 +4489,8 @@ rows := |id<string> x<f64>|
                 registry,
                 mech_compute::ComputePlatform::Browser,
             )
+            .unwrap()
+            .with_retained_outputs(prepared.retained_outputs)
             .unwrap();
             (prepared.coordinator, factory, command)
         };

--- a/src/wasm/src/project.rs
+++ b/src/wasm/src/project.rs
@@ -5055,7 +5055,11 @@ mod browser_tests {
 
     wasm_bindgen_test_configure!(run_in_browser);
 
-    #[cfg(all(feature = "browser_host_timer", feature = "browser_host_scene"))]
+    #[cfg(all(
+        feature = "browser_host_timer",
+        feature = "browser_host_scene",
+        feature = "browser_compute"
+    ))]
     #[wasm_bindgen_test]
     fn ekf_filter_recurrence_runs_in_browser_wasm() {
         super::tests::assert_ekf_scene_advances_on_every_resident_timer_packet();

--- a/src/wasm/src/project.rs
+++ b/src/wasm/src/project.rs
@@ -2727,7 +2727,32 @@ fn js_error(message: impl Into<String>) -> JsValue {
     JsValue::from_str(&message.into())
 }
 fn to_js_error(error: MechError) -> JsValue {
-    js_error(format!("{error:?}"))
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let _ = error;
+        JsValue::NULL
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        let recoverable_resident_turn = error
+            .kind_as::<mech_runtime::ResidentHostTurnFailed>()
+            .is_some_and(mech_runtime::ResidentHostTurnFailed::is_recoverable);
+        let kind = error.kind_name();
+        let rendered = format!("{error:?}");
+        let javascript_error = js_sys::Error::new(&rendered);
+        let target = javascript_error.as_ref();
+        let _ = Reflect::set(
+            target,
+            &JsValue::from_str("mechKind"),
+            &JsValue::from_str(&kind),
+        );
+        let _ = Reflect::set(
+            target,
+            &JsValue::from_str("mechRecoverableResidentTurn"),
+            &JsValue::from_bool(recoverable_resident_turn),
+        );
+        javascript_error.into()
+    }
 }
 
 #[cfg(test)]

--- a/src/wasm/src/project.rs
+++ b/src/wasm/src/project.rs
@@ -1466,6 +1466,24 @@ mod document {
             bridge.reject_integrity(token, constraint, instance)
         }
 
+        #[cfg(feature = "browser_host_scene")]
+        #[wasm_bindgen(js_name = scenePointerInput)]
+        pub fn scene_pointer_input(
+            &self,
+            instance: &str,
+            x: f64,
+            y: f64,
+            pressed: bool,
+            delta_seconds: f64,
+        ) -> Result<(), JsValue> {
+            self.bootstrap
+                .source()
+                .lifecycle
+                .scenes()
+                .submit_pointer(instance, x, y, pressed, delta_seconds)
+                .map_err(to_js_error)
+        }
+
         pub fn frame(&mut self, max_inputs: usize) -> Result<JsValue, JsValue> {
             if max_inputs == 0 {
                 return Err(js_error("max_inputs must be greater than zero"));
@@ -1564,6 +1582,28 @@ mod document {
         pub fn repl_invoke(&mut self, source: &str) -> Result<JsValue, JsValue> {
             let accepted_before = self.repl.session.source().to_string();
             let response = self.repl.invoke(source)?;
+            if self.repl.session.source() != accepted_before {
+                self.refresh_document_output_ordinals()
+                    .map_err(to_js_error)?;
+            }
+            Ok(response)
+        }
+
+        /// Return the complete source currently accepted by the resident
+        /// document session. This is the read side of the editor handoff; REPL
+        /// submissions continue to use `replInvoke`.
+        #[wasm_bindgen(js_name = replSource)]
+        pub fn repl_source(&self) -> String {
+            self.repl.source()
+        }
+
+        /// Transactionally replace the complete accepted document source.
+        /// Compatible hosts migrate resident state; incompatible hosts start
+        /// from their new plan initializers and report that reset explicitly.
+        #[wasm_bindgen(js_name = replReplaceSource)]
+        pub fn repl_replace_source(&mut self, source: &str) -> Result<JsValue, JsValue> {
+            let accepted_before = self.repl.session.source().to_string();
+            let response = self.repl.replace_source(source)?;
             if self.repl.session.source() != accepted_before {
                 self.refresh_document_output_ordinals()
                     .map_err(to_js_error)?;

--- a/src/wasm/src/project.rs
+++ b/src/wasm/src/project.rs
@@ -4424,6 +4424,10 @@ rows := |id<string> x<f64>|
             "the Kalman gain must use the language's matrix solve operation",
         );
         assert!(
+            source.contains("observation-guard := 1f32 - math/ceil(z[3])"),
+            "only a fully invisible camera may perturb singular observation geometry",
+        );
+        assert!(
             !source.contains("innovation-inverse") && !source.contains("innovation-determinant"),
             "the example must not expand a matrix inverse by hand",
         );
@@ -4562,8 +4566,8 @@ rows := |id<string> x<f64>|
         };
         assert_eq!(
             runtime.program_execution_info().observation_count,
-            3,
-            "the resident artifact must observe the timer, compute completion, and packed sample"
+            7,
+            "the resident artifact must observe the timer, four pointer fields, compute completion, and packed sample"
         );
         assert!(scene_backend.latest().is_none());
         let pi = 3.141592654_f64;
@@ -4607,6 +4611,7 @@ rows := |id<string> x<f64>|
         let camera_schedule = [0_usize, 1, 1, 2, 2, 3, 3, 0];
         let mut saw_prediction_only_turn = false;
         let mut saw_camera_update = false;
+        let mut saw_faded_camera_update = false;
         let mut saw_zero_camera_turn = false;
         let mut maximum_visible_cameras = 0_usize;
         let mut visited_sides = [false; 4];
@@ -4787,6 +4792,7 @@ rows := |id<string> x<f64>|
                 + filter_visibility * (observed_covariance - predicted_covariance);
             saw_prediction_only_turn |= visibility == 0.0;
             saw_camera_update |= visibility == 1.0;
+            saw_faded_camera_update |= visibility > 0.0 && visibility < 1.0;
 
             let snapshot = scene_backend.latest().unwrap();
             let actual_truth = rendered_truth(&snapshot);
@@ -4943,6 +4949,10 @@ rows := |id<string> x<f64>|
         assert!(
             saw_camera_update,
             "at least one camera must reacquire the robot"
+        );
+        assert!(
+            saw_faded_camera_update,
+            "the oracle must exercise a fractional camera fade update"
         );
         assert!(
             saw_zero_camera_turn,

--- a/src/wasm/src/project.rs
+++ b/src/wasm/src/project.rs
@@ -384,7 +384,7 @@ struct SourceBackedDocumentBootstrap {
 struct DocumentRuntimeLifecycle {
     drivers_started: Rc<Cell<bool>>,
     #[cfg(feature = "browser_compute")]
-    compute_generation: Rc<Cell<u32>>,
+    compute_generation: Rc<Cell<u64>>,
     #[cfg(feature = "browser_host_scene")]
     scenes: Rc<RefCell<BrowserSceneRegistry>>,
     #[cfg(feature = "browser_host_scene")]
@@ -432,8 +432,16 @@ impl DocumentRuntimeLifecycle {
     }
 
     #[cfg(feature = "browser_compute")]
-    fn compute_generation(&self) -> u32 {
+    fn compute_generation(&self) -> u64 {
         self.compute_generation.get()
+    }
+
+    #[cfg(feature = "browser_compute")]
+    fn next_compute_generation(&self) -> MResult<u64> {
+        self.compute_generation
+            .get()
+            .checked_add(1)
+            .ok_or_else(|| document_runtime_error("browser compute generation space exhausted"))
     }
 
     #[cfg(feature = "browser_compute")]
@@ -443,9 +451,19 @@ impl DocumentRuntimeLifecycle {
 
     #[cfg(feature = "browser_compute")]
     fn commit_compute(&self) {
-        *self.compute.borrow_mut() = self.pending_compute.borrow_mut().take();
-        self.compute_generation
-            .set(self.compute_generation.get().wrapping_add(1));
+        let next = self
+            .compute_generation
+            .get()
+            .checked_add(1)
+            .expect("compute generation exhaustion is rejected while preparing the runtime");
+        let pending = self.pending_compute.borrow_mut().take();
+        debug_assert!(
+            pending
+                .as_ref()
+                .is_none_or(|bridge| bridge.generation() == next)
+        );
+        *self.compute.borrow_mut() = pending;
+        self.compute_generation.set(next);
     }
 
     #[cfg(feature = "browser_compute")]
@@ -675,6 +693,7 @@ fn build_document_repl_runtime_for_tree(
                     &document,
                     prepared,
                     browser_gpu_available(),
+                    source.lifecycle.next_compute_generation()?,
                 )?)
             } else {
                 None
@@ -1318,65 +1337,101 @@ mod document {
 
         #[cfg(feature = "browser_compute")]
         #[wasm_bindgen(js_name = computeGeneration)]
-        pub fn compute_generation(&self) -> u32 {
-            self.bootstrap.source().lifecycle.compute_generation()
+        pub fn compute_generation(&self) -> String {
+            self.bootstrap
+                .source()
+                .lifecycle
+                .compute_generation()
+                .to_string()
+        }
+
+        /// Rebuild the accepted source generation after the browser has
+        /// withdrawn WebGPU availability. Compatible resident state is
+        /// migrated through the ordinary runtime handoff, so auto fallback
+        /// never reconstructs an obsolete initial document.
+        #[cfg(feature = "browser_compute")]
+        #[wasm_bindgen(js_name = fallbackComputeToCpu)]
+        pub fn fallback_compute_to_cpu(&mut self) -> Result<(), JsValue> {
+            if self.compute_backend() != mech_compute::WGPU_BACKEND {
+                return Ok(());
+            }
+            self.repl
+                .session
+                .rebuild_runtime_preserving_state()
+                .map_err(to_js_error)?;
+            self.refresh_document_output_ordinals()
+                .map_err(to_js_error)?;
+            if self.compute_backend() == mech_compute::WGPU_BACKEND {
+                return Err(js_error(
+                    "browser compute fallback rebuilt the accepted generation with WebGPU still selected",
+                ));
+            }
+            Ok(())
         }
 
         #[cfg(feature = "browser_compute")]
         #[wasm_bindgen(js_name = acknowledgeComputeCommand)]
-        pub fn acknowledge_compute_command(&self, dispatch_id: u32) -> Result<(), JsValue> {
-            self.bootstrap
+        pub fn acknowledge_compute_command(&self, dispatch_token: &str) -> Result<(), JsValue> {
+            let bridge = self
+                .bootstrap
                 .source()
                 .lifecycle
                 .compute()
-                .ok_or_else(|| js_error("document has no compute region"))?
-                .acknowledge(dispatch_id)
+                .ok_or_else(|| js_error("document has no compute region"))?;
+            let token = bridge.validate_token(dispatch_token)?;
+            bridge.acknowledge(token)
         }
 
         #[cfg(feature = "browser_compute")]
         #[wasm_bindgen(js_name = completeComputeCommand)]
         pub fn complete_compute_command(
             &self,
-            dispatch_id: u32,
+            dispatch_token: &str,
             outputs: Array,
         ) -> Result<(), JsValue> {
-            self.bootstrap
+            let bridge = self
+                .bootstrap
                 .source()
                 .lifecycle
                 .compute()
-                .ok_or_else(|| js_error("document has no compute region"))?
-                .complete(dispatch_id, completed_outputs_from_js(outputs)?)
+                .ok_or_else(|| js_error("document has no compute region"))?;
+            let token = bridge.validate_token(dispatch_token)?;
+            bridge.complete(token, completed_outputs_from_js(outputs)?)
         }
 
         #[cfg(feature = "browser_compute")]
         #[wasm_bindgen(js_name = rejectComputeCommand)]
         pub fn reject_compute_command(
             &self,
-            dispatch_id: u32,
+            dispatch_token: &str,
             reason: &str,
         ) -> Result<(), JsValue> {
-            self.bootstrap
+            let bridge = self
+                .bootstrap
                 .source()
                 .lifecycle
                 .compute()
-                .ok_or_else(|| js_error("document has no compute region"))?
-                .reject(dispatch_id, reason)
+                .ok_or_else(|| js_error("document has no compute region"))?;
+            let token = bridge.validate_token(dispatch_token)?;
+            bridge.reject(token, reason)
         }
 
         #[cfg(feature = "browser_compute")]
         #[wasm_bindgen(js_name = rejectIntegrityComputeCommand)]
         pub fn reject_integrity_compute_command(
             &self,
-            dispatch_id: u32,
+            dispatch_token: &str,
             constraint: &str,
             instance: u32,
         ) -> Result<(), JsValue> {
-            self.bootstrap
+            let bridge = self
+                .bootstrap
                 .source()
                 .lifecycle
                 .compute()
-                .ok_or_else(|| js_error("document has no compute region"))?
-                .reject_integrity(dispatch_id, constraint, instance)
+                .ok_or_else(|| js_error("document has no compute region"))?;
+            let token = bridge.validate_token(dispatch_token)?;
+            bridge.reject_integrity(token, constraint, instance)
         }
 
         pub fn frame(&mut self, max_inputs: usize) -> Result<JsValue, JsValue> {
@@ -3294,6 +3349,35 @@ phase"#;
         );
     }
 
+    #[cfg(feature = "browser_compute")]
+    #[test]
+    fn accepted_generation_rebuild_preserves_source_and_resident_state() {
+        let tree = mech_syntax::parser::parse("~answer := 0\nanswer += 41\nanswer").unwrap();
+        let encoded = mech_core::nodes::compress_and_encode(&tree).unwrap();
+        let mut document = WasmDocument::from_encoded(&encoded).unwrap();
+        document.repl.session.submit("answer += 1").unwrap();
+        let accepted_source = document.repl.session.source().to_owned();
+        let generation = document.compute_generation();
+
+        document
+            .repl
+            .session
+            .rebuild_runtime_preserving_state()
+            .unwrap();
+
+        assert_eq!(document.repl.session.source(), accepted_source);
+        assert_eq!(
+            document
+                .runtime()
+                .unwrap()
+                .root_symbol_value("answer")
+                .unwrap()
+                .to_string(),
+            "42",
+        );
+        assert_ne!(document.compute_generation(), generation);
+    }
+
     #[test]
     fn selecting_a_large_document_value_is_runtime_local_until_ans_is_consumed() {
         let tree =
@@ -4260,7 +4344,8 @@ rows := |id<string> x<f64>|
             let prepared =
                 crate::mixed_compute::prepare_compute_region(&mut compiler, &tree, 0.0, 0.0)
                     .unwrap();
-            let command = crate::mixed_compute::ComputeCommandHandle::new(prepared.region.clone());
+            let command =
+                crate::mixed_compute::ComputeCommandHandle::new(prepared.region.clone(), 1);
             let registry = crate::mixed_compute::browser_compute_backend_registry(
                 command.clone(),
                 crate::mixed_compute::BrowserOutputHandle::default(),

--- a/src/wasm/src/project.rs
+++ b/src/wasm/src/project.rs
@@ -383,6 +383,8 @@ struct SourceBackedDocumentBootstrap {
 #[derive(Clone, Default)]
 struct DocumentRuntimeLifecycle {
     drivers_started: Rc<Cell<bool>>,
+    #[cfg(feature = "browser_compute")]
+    compute_generation: Rc<Cell<u32>>,
     #[cfg(feature = "browser_host_scene")]
     scenes: Rc<RefCell<BrowserSceneRegistry>>,
     #[cfg(feature = "browser_host_scene")]
@@ -430,6 +432,11 @@ impl DocumentRuntimeLifecycle {
     }
 
     #[cfg(feature = "browser_compute")]
+    fn compute_generation(&self) -> u32 {
+        self.compute_generation.get()
+    }
+
+    #[cfg(feature = "browser_compute")]
     fn stage_compute(&self, compute: Option<BrowserComputeBridge>) {
         *self.pending_compute.borrow_mut() = compute;
     }
@@ -437,6 +444,8 @@ impl DocumentRuntimeLifecycle {
     #[cfg(feature = "browser_compute")]
     fn commit_compute(&self) {
         *self.compute.borrow_mut() = self.pending_compute.borrow_mut().take();
+        self.compute_generation
+            .set(self.compute_generation.get().wrapping_add(1));
     }
 
     #[cfg(feature = "browser_compute")]
@@ -1308,6 +1317,12 @@ mod document {
         }
 
         #[cfg(feature = "browser_compute")]
+        #[wasm_bindgen(js_name = computeGeneration)]
+        pub fn compute_generation(&self) -> u32 {
+            self.bootstrap.source().lifecycle.compute_generation()
+        }
+
+        #[cfg(feature = "browser_compute")]
         #[wasm_bindgen(js_name = acknowledgeComputeCommand)]
         pub fn acknowledge_compute_command(&self, dispatch_id: u32) -> Result<(), JsValue> {
             self.bootstrap
@@ -1346,6 +1361,22 @@ mod document {
                 .compute()
                 .ok_or_else(|| js_error("document has no compute region"))?
                 .reject(dispatch_id, reason)
+        }
+
+        #[cfg(feature = "browser_compute")]
+        #[wasm_bindgen(js_name = rejectIntegrityComputeCommand)]
+        pub fn reject_integrity_compute_command(
+            &self,
+            dispatch_id: u32,
+            constraint: &str,
+            instance: u32,
+        ) -> Result<(), JsValue> {
+            self.bootstrap
+                .source()
+                .lifecycle
+                .compute()
+                .ok_or_else(|| js_error("document has no compute region"))?
+                .reject_integrity(dispatch_id, constraint, instance)
         }
 
         pub fn frame(&mut self, max_inputs: usize) -> Result<JsValue, JsValue> {

--- a/src/wasm/src/project.rs
+++ b/src/wasm/src/project.rs
@@ -4465,7 +4465,11 @@ rows := |id<string> x<f64>|
                 / 2.0;
             let turn_fraction = commanded_omega.powi(2).sqrt() / turn_rate_limit;
             let commanded_speed = cruise_speed * (1.0 - 0.42 * turn_fraction);
-            let simulation_time = (turn * 5) as f64 * dt;
+            // The application advances simulation time once per accepted
+            // resident timer packet. Absolute timer values may skip when a
+            // latest-only host coalesces packets, but those scheduling gaps
+            // must not change the physical or measurement input sequence.
+            let simulation_time = turn as f64 * dt;
             let actual_speed = commanded_speed * (0.965 + 0.025 * (simulation_time * 0.73).sin());
             let actual_omega =
                 commanded_omega * (0.99 + 0.01 * (simulation_time * 0.51 + 0.8).sin());

--- a/src/wasm/src/project.rs
+++ b/src/wasm/src/project.rs
@@ -47,6 +47,11 @@ use serde::Deserialize;
 
 #[cfg(feature = "browser_host_dom")]
 use crate::host::WasmBrowserDomBackend;
+#[cfg(feature = "browser_compute")]
+use crate::mixed_compute::{
+    BrowserComputeBridge, completed_outputs_from_js, prepare_browser_compute_host,
+    prepare_compute_region,
+};
 
 #[wasm_bindgen]
 pub struct WasmProject {
@@ -382,6 +387,10 @@ struct DocumentRuntimeLifecycle {
     scenes: Rc<RefCell<BrowserSceneRegistry>>,
     #[cfg(feature = "browser_host_scene")]
     pending_scenes: Rc<RefCell<Option<BrowserSceneRegistry>>>,
+    #[cfg(feature = "browser_compute")]
+    compute: Rc<RefCell<Option<BrowserComputeBridge>>>,
+    #[cfg(feature = "browser_compute")]
+    pending_compute: Rc<RefCell<Option<BrowserComputeBridge>>>,
 }
 
 impl DocumentRuntimeLifecycle {
@@ -413,6 +422,26 @@ impl DocumentRuntimeLifecycle {
     #[cfg(feature = "browser_host_scene")]
     fn abort_scenes(&self) {
         self.pending_scenes.borrow_mut().take();
+    }
+
+    #[cfg(feature = "browser_compute")]
+    fn compute(&self) -> Option<BrowserComputeBridge> {
+        self.compute.borrow().clone()
+    }
+
+    #[cfg(feature = "browser_compute")]
+    fn stage_compute(&self, compute: Option<BrowserComputeBridge>) {
+        *self.pending_compute.borrow_mut() = compute;
+    }
+
+    #[cfg(feature = "browser_compute")]
+    fn commit_compute(&self) {
+        *self.compute.borrow_mut() = self.pending_compute.borrow_mut().take();
+    }
+
+    #[cfg(feature = "browser_compute")]
+    fn abort_compute(&self) {
+        self.pending_compute.borrow_mut().take();
     }
 }
 
@@ -475,11 +504,15 @@ impl WasmDocumentBootstrap {
     pub(crate) fn commit(&self) {
         #[cfg(feature = "browser_host_scene")]
         self.source().lifecycle.commit_scenes();
+        #[cfg(feature = "browser_compute")]
+        self.source().lifecycle.commit_compute();
     }
 
     pub(crate) fn abort(&self) {
         #[cfg(feature = "browser_host_scene")]
         self.source().lifecycle.abort_scenes();
+        #[cfg(feature = "browser_compute")]
+        self.source().lifecycle.abort_compute();
     }
 }
 
@@ -510,6 +543,11 @@ pub(crate) fn activate_document_repl_runtime_tree(
     if source.trim().is_empty() {
         #[cfg(feature = "browser_host_scene")]
         bootstrap.source().lifecycle.stage_scenes(candidate.scenes);
+        #[cfg(feature = "browser_compute")]
+        bootstrap
+            .source()
+            .lifecycle
+            .stage_compute(candidate.compute.clone());
         return Ok((
             candidate.runtime,
             RuntimeProgramLoadOutcome {
@@ -521,6 +559,16 @@ pub(crate) fn activate_document_repl_runtime_tree(
     }
     let runtime = &mut candidate.runtime;
     let durability = runtime.config().resident_durability;
+    #[cfg(feature = "browser_compute")]
+    let activation = match candidate.coordinator.take() {
+        Some(coordinator) => runtime.load_compiled_program(coordinator, durability),
+        None => runtime.load_interactive_root_program(
+            SourceRequest::new(&bootstrap.source().root_specifier),
+            browser_module_options(),
+            durability,
+        ),
+    };
+    #[cfg(not(feature = "browser_compute"))]
     let activation = runtime.load_interactive_root_program(
         SourceRequest::new(&bootstrap.source().root_specifier),
         browser_module_options(),
@@ -536,11 +584,20 @@ pub(crate) fn activate_document_repl_runtime_tree(
     };
     #[cfg(feature = "browser_host_scene")]
     bootstrap.source().lifecycle.stage_scenes(candidate.scenes);
+    #[cfg(feature = "browser_compute")]
+    bootstrap
+        .source()
+        .lifecycle
+        .stage_compute(candidate.compute);
     Ok((candidate.runtime, outcome))
 }
 
 struct DocumentRuntimeCandidate {
     runtime: MechRuntime,
+    #[cfg(feature = "browser_compute")]
+    coordinator: Option<mech_engine::ProgramArtifact>,
+    #[cfg(feature = "browser_compute")]
+    compute: Option<BrowserComputeBridge>,
     #[cfg(feature = "browser_host_scene")]
     scenes: BrowserSceneRegistry,
 }
@@ -552,15 +609,92 @@ fn build_document_repl_runtime_for_tree(
 ) -> MResult<DocumentRuntimeCandidate> {
     let source = bootstrap.source();
     let (candidate_tree, _) = document_runtime_tree(source, candidate_tree)?;
-    let resolver = document_source_resolver(candidate_tree, source)?;
     #[cfg(feature = "browser_host_scene")]
     let candidate_scenes = BrowserSceneRegistry::new();
+
+    #[cfg(all(feature = "browser_compute", feature = "served_project_authority"))]
+    let prepared_compute = match bootstrap {
+        WasmDocumentBootstrap::Served(served) => {
+            let document = parse_config_document(
+                "mech.mcfg",
+                &served.config_source,
+                ConfigProfileOptions::default(),
+            )?;
+            if document.hosts.iter().any(|host| host.provider == "compute") {
+                #[cfg(feature = "browser_host_scene")]
+                let planning_scenes = BrowserSceneRegistry::new();
+                let mut planning = runtime_builder_with_factories(
+                    Some(events.clone()),
+                    #[cfg(feature = "browser_host_scene")]
+                    planning_scenes,
+                )
+                .map_err(js_value_to_mech_error)?
+                .function_catalog(mech_stdlib::source_native_plan_catalog())
+                .config(served.authority.into_runtime_config()?)
+                .source_resolver(document_source_resolver(candidate_tree.clone(), source)?);
+                for required in document
+                    .hosts
+                    .iter()
+                    .filter(|host| host.provider != "compute")
+                {
+                    if let Some(host) = served.authority.hosts.iter().find(|host| {
+                        host.name == required.name && host.provider == required.provider
+                    }) {
+                        planning = planning.host_instance(host.clone());
+                    }
+                }
+                for grant in required_issued_grants(&document, &served.authority) {
+                    planning = planning.run_resource_grant(grant);
+                }
+                planning = planning
+                    .host_instance(HostInstanceConfig {
+                        name: source.console_instance.clone(),
+                        provider: "console".to_string(),
+                        settings: ConfigValue::Map(Default::default()),
+                    })
+                    .run_resource_grant(RunResourceGrantConfig {
+                        target: format!("{}/output", source.console_instance),
+                        operations: vec!["write".to_string()],
+                        paths: vec!["line".to_string()],
+                    });
+                let compiler_started = web_time::Instant::now();
+                let mut compiler = planning.build_compiler()?;
+                let catalog_setup = compiler_started.elapsed().as_secs_f64() * 1_000.0;
+                let prepared =
+                    prepare_compute_region(&mut compiler, &candidate_tree, 0.0, catalog_setup)?;
+                Some(prepare_browser_compute_host(
+                    &document,
+                    prepared,
+                    browser_gpu_available(),
+                )?)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    };
+    #[cfg(all(feature = "browser_compute", feature = "served_project_authority"))]
+    let (compute_factory, compute_coordinator, compute_bridge) = match prepared_compute {
+        Some(prepared) => (
+            Some(prepared.factory),
+            Some(prepared.coordinator),
+            Some(prepared.bridge),
+        ),
+        None => (None, None, None),
+    };
+
     let mut builder = runtime_builder_with_factories(
         Some(events),
         #[cfg(feature = "browser_host_scene")]
         candidate_scenes.clone(),
     )
     .map_err(js_value_to_mech_error)?;
+    #[cfg(all(feature = "browser_compute", feature = "served_project_authority"))]
+    if let Some(factory) = compute_factory {
+        builder = builder.host_factory(Box::new(factory))?;
+    }
+
+    let resolver = document_source_resolver(candidate_tree, source)?;
 
     match bootstrap {
         WasmDocumentBootstrap::Detached(_) | WasmDocumentBootstrap::SourceBacked(_) => {
@@ -607,6 +741,14 @@ fn build_document_repl_runtime_for_tree(
         .build()?;
     Ok(DocumentRuntimeCandidate {
         runtime,
+        #[cfg(all(feature = "browser_compute", feature = "served_project_authority"))]
+        coordinator: compute_coordinator,
+        #[cfg(all(feature = "browser_compute", feature = "served_project_authority"))]
+        compute: compute_bridge,
+        #[cfg(all(feature = "browser_compute", not(feature = "served_project_authority")))]
+        coordinator: None,
+        #[cfg(all(feature = "browser_compute", not(feature = "served_project_authority")))]
+        compute: None,
         #[cfg(feature = "browser_host_scene")]
         scenes: candidate_scenes,
     })
@@ -1143,6 +1285,69 @@ mod document {
             Ok(())
         }
 
+        #[cfg(feature = "browser_compute")]
+        #[wasm_bindgen(js_name = computeManifest)]
+        pub fn compute_manifest(&self) -> JsValue {
+            self.bootstrap
+                .source()
+                .lifecycle
+                .compute()
+                .map(|compute| compute.manifest())
+                .unwrap_or(JsValue::NULL)
+        }
+
+        #[cfg(feature = "browser_compute")]
+        #[wasm_bindgen(js_name = computeBackend)]
+        pub fn compute_backend(&self) -> String {
+            self.bootstrap
+                .source()
+                .lifecycle
+                .compute()
+                .map(|compute| compute.backend())
+                .unwrap_or_default()
+        }
+
+        #[cfg(feature = "browser_compute")]
+        #[wasm_bindgen(js_name = acknowledgeComputeCommand)]
+        pub fn acknowledge_compute_command(&self, dispatch_id: u32) -> Result<(), JsValue> {
+            self.bootstrap
+                .source()
+                .lifecycle
+                .compute()
+                .ok_or_else(|| js_error("document has no compute region"))?
+                .acknowledge(dispatch_id)
+        }
+
+        #[cfg(feature = "browser_compute")]
+        #[wasm_bindgen(js_name = completeComputeCommand)]
+        pub fn complete_compute_command(
+            &self,
+            dispatch_id: u32,
+            outputs: Array,
+        ) -> Result<(), JsValue> {
+            self.bootstrap
+                .source()
+                .lifecycle
+                .compute()
+                .ok_or_else(|| js_error("document has no compute region"))?
+                .complete(dispatch_id, completed_outputs_from_js(outputs)?)
+        }
+
+        #[cfg(feature = "browser_compute")]
+        #[wasm_bindgen(js_name = rejectComputeCommand)]
+        pub fn reject_compute_command(
+            &self,
+            dispatch_id: u32,
+            reason: &str,
+        ) -> Result<(), JsValue> {
+            self.bootstrap
+                .source()
+                .lifecycle
+                .compute()
+                .ok_or_else(|| js_error("document has no compute region"))?
+                .reject(dispatch_id, reason)
+        }
+
         pub fn frame(&mut self, max_inputs: usize) -> Result<JsValue, JsValue> {
             if max_inputs == 0 {
                 return Err(js_error("max_inputs must be greater than zero"));
@@ -1210,6 +1415,15 @@ mod document {
                 &serde_wasm_bindgen::to_value(
                     &self.repl.session.drain_events().map_err(to_js_error)?,
                 )?,
+            )?;
+            #[cfg(feature = "browser_compute")]
+            Reflect::set(
+                &out,
+                &JsValue::from_str("computeCommand"),
+                &match self.bootstrap.source().lifecycle.compute() {
+                    Some(compute) => compute.take_command()?,
+                    None => JsValue::NULL,
+                },
             )?;
             Ok(out.into())
         }
@@ -1766,7 +1980,25 @@ fn compiled_browser_providers() -> BTreeMap<&'static str, &'static str> {
     providers.insert("console", "browser_host_console");
     #[cfg(feature = "browser_host_scene")]
     providers.insert("scene", "browser_host_scene");
+    #[cfg(feature = "browser_compute")]
+    providers.insert("compute", "browser_compute");
     providers
+}
+
+#[cfg(feature = "browser_compute")]
+fn browser_gpu_available() -> bool {
+    let Some(window) = web_sys::window() else {
+        return false;
+    };
+    if let Ok(available) = Reflect::get(window.as_ref(), &JsValue::from_str("__MECH_GPU_AVAILABLE"))
+        && let Some(available) = available.as_bool()
+    {
+        return available;
+    }
+    Reflect::get(window.as_ref(), &JsValue::from_str("navigator"))
+        .ok()
+        .and_then(|navigator| Reflect::get(&navigator, &JsValue::from_str("gpu")).ok())
+        .is_some_and(|gpu| !gpu.is_null() && !gpu.is_undefined())
 }
 
 fn standard_browser_provider_feature(provider: &str) -> Option<&'static str> {
@@ -1776,6 +2008,7 @@ fn standard_browser_provider_feature(provider: &str) -> Option<&'static str> {
         "timer" => Some("browser_host_timer"),
         "console" => Some("browser_host_console"),
         "scene" => Some("browser_host_scene"),
+        "compute" => Some("browser_compute"),
         _ => None,
     }
 }
@@ -3898,7 +4131,7 @@ rows := |id<string> x<f64>|
     }
 
     #[cfg(all(feature = "browser_host_timer", feature = "browser_host_scene"))]
-    #[derive(Debug)]
+    #[derive(Clone, Debug)]
     struct TestManualTimerHostFactory {
         manifest: mech_runtime::HostManifestConfig,
         driver: SharedManualTimerInputDriver,
@@ -3951,7 +4184,11 @@ rows := |id<string> x<f64>|
         }
     }
 
-    #[cfg(all(feature = "browser_host_timer", feature = "browser_host_scene"))]
+    #[cfg(all(
+        feature = "browser_host_timer",
+        feature = "browser_host_scene",
+        feature = "browser_compute"
+    ))]
     pub(super) fn assert_ekf_scene_advances_on_every_resident_timer_packet() {
         use nalgebra::{SMatrix, SVector};
 
@@ -3962,10 +4199,66 @@ rows := |id<string> x<f64>|
         )
         .unwrap();
         let source = include_str!("../../../examples/ekf/localization.mec").to_string();
-        let sources = HashMap::from([("localization.mec".to_string(), source)]);
+        let sources = HashMap::from([("localization.mec".to_string(), source.clone())]);
         let timer_factory = TestManualTimerHostFactory::new();
         let timer_driver = timer_factory.driver.clone();
         let scene_backend = mech_scene::RecordingSceneBackend::new();
+        #[cfg(feature = "browser_compute")]
+        let coordinator = {
+            let mut planning = RuntimeBuilder::new()
+                .function_catalog(mech_stdlib::source_native_plan_catalog())
+                .source_resolver(project_source_resolver(&sources).unwrap())
+                .host_factory(Box::new(timer_factory.clone()))
+                .unwrap()
+                .host_factory(Box::new(
+                    mech_scene::SceneHostFactory::with_backend(scene_backend.clone()).unwrap(),
+                ))
+                .unwrap();
+            for host in document
+                .hosts
+                .iter()
+                .filter(|host| host.provider != "compute")
+            {
+                planning = planning.host_instance(host.clone());
+            }
+            for grant in &document.run.as_ref().unwrap().grants {
+                planning = planning.run_resource_grant(grant.clone());
+            }
+            let mut compiler = planning.build_compiler().unwrap();
+            let tree = mech_syntax::parser::parse(&source).unwrap();
+            let prepared =
+                crate::mixed_compute::prepare_compute_region(&mut compiler, &tree, 0.0, 0.0)
+                    .unwrap();
+            let command = crate::mixed_compute::ComputeCommandHandle::new(prepared.region.clone());
+            let registry = crate::mixed_compute::browser_compute_backend_registry(
+                command.clone(),
+                crate::mixed_compute::BrowserOutputHandle::default(),
+                false,
+            )
+            .unwrap();
+            let storage = prepared
+                .program
+                .fixed_shape_storage()
+                .expect("EKF must lower to a fixed-shape kernel");
+            assert_eq!(
+                storage.instances, 1_000,
+                "the browser EKF must execute 1,000 independent filter lanes",
+            );
+            assert!(
+                storage.inputs.len() + storage.states.len() * 2 + 1 <= 8,
+                "the checked EKF kernel must fit WebGPU's portable minimum of eight storage buffers",
+            );
+            let factory = mech_gpu::ComputeHostFactory::new(
+                prepared.region,
+                prepared.placement,
+                prepared.program,
+                prepared.initializers,
+                registry,
+                mech_compute::ComputePlatform::Browser,
+            )
+            .unwrap();
+            (prepared.coordinator, factory, command)
+        };
         let mut builder = browser_runtime_builder()
             .source_resolver(project_source_resolver(&sources).unwrap())
             .host_input_capacity(16)
@@ -3975,6 +4268,10 @@ rows := |id<string> x<f64>|
                 mech_scene::SceneHostFactory::with_backend(scene_backend.clone()).unwrap(),
             ))
             .unwrap();
+        #[cfg(feature = "browser_compute")]
+        {
+            builder = builder.host_factory(Box::new(coordinator.1)).unwrap();
+        }
         for host in &document.hosts {
             builder = builder.host_instance(host.clone());
         }
@@ -3986,6 +4283,11 @@ rows := |id<string> x<f64>|
             .to_string_lossy()
             .to_string();
         let durability = runtime.config().resident_durability;
+        #[cfg(feature = "browser_compute")]
+        runtime
+            .load_compiled_program(coordinator.0, durability)
+            .unwrap();
+        #[cfg(not(feature = "browser_compute"))]
         runtime
             .load_interactive_root_program(
                 SourceRequest::new(root),
@@ -4031,8 +4333,8 @@ rows := |id<string> x<f64>|
         };
         assert_eq!(
             runtime.program_execution_info().observation_count,
-            1,
-            "EKF timer read must remain in the resident artifact"
+            2,
+            "the resident artifact must observe the timer and one packed compute sample"
         );
         assert!(scene_backend.latest().is_none());
         let pi = 3.141592654_f64;
@@ -4049,15 +4351,15 @@ rows := |id<string> x<f64>|
         let camera_max_range = 3.6_f64;
         let camera_range_fade = 0.18_f64;
         let mut expected_truth = [2.5_f64, 2.5_f64, 0.0_f64];
-        let mut expected_estimate = SVector::<f64, 3>::new(2.9, 2.15, 0.16);
-        let mut expected_covariance = SMatrix::<f64, 3, 3>::new(
+        let mut expected_estimate = SVector::<f32, 3>::new(2.9, 2.15, 0.16);
+        let mut expected_covariance = SMatrix::<f32, 3, 3>::new(
             0.45, 0.0, 0.0, //
             0.0, 0.45, 0.0, //
             0.0, 0.0, 0.08,
         );
-        let identity = SMatrix::<f64, 3, 3>::identity();
-        let process_covariance = SMatrix::<f64, 2, 2>::new(0.08, 0.0, 0.0, 0.018);
-        let measurement_covariance = SMatrix::<f64, 2, 2>::new(0.0225, 0.0, 0.0, 0.0004);
+        let identity = SMatrix::<f32, 3, 3>::identity();
+        let process_covariance = SMatrix::<f32, 2, 2>::new(0.08, 0.0, 0.0, 0.018);
+        let measurement_covariance = SMatrix::<f32, 2, 2>::new(0.0225, 0.0, 0.0, 0.0004);
         let camera_positions = [
             SVector::<f64, 2>::new(1.0, 1.0),
             SVector::<f64, 2>::new(9.0, 1.0),
@@ -4088,7 +4390,28 @@ rows := |id<string> x<f64>|
         // part of the next side exercises every camera and every dead zone.
         for turn in 1..=420 {
             assert_eq!(timer_driver.publish_steps(5).unwrap(), 1);
-            let outcomes = runtime.drain_host_inputs(1).unwrap();
+            // The compute driver publishes one initial telemetry packet before
+            // the first timer packet, then one sampled-output packet after each
+            // accepted dispatch. Allow all three on the first iteration; later
+            // iterations normally consume the timer and its sample together.
+            let mut outcomes = runtime.drain_host_inputs(3).unwrap();
+            let command = coordinator
+                .2
+                .take_command_data()
+                .unwrap()
+                .expect("every timer token must queue one compute command");
+            assert!(!command.acknowledgement_required);
+            assert_eq!(command.changed_inputs["control"].len(), 3_000);
+            assert_eq!(command.changed_inputs["measurement"].len(), 3_000);
+            outcomes.extend(runtime.drain_host_inputs(1).unwrap_or_else(|error| {
+                let events = runtime.list_events(Some(32)).unwrap_or_default();
+                panic!("compute completion turn failed: {error:?}; recent events={events:?}")
+            }));
+            assert_eq!(
+                outcomes.len(),
+                2,
+                "each timer packet must produce exactly one bounded compute-sample turn",
+            );
 
             let delivered_turn = (turn - 1) as usize;
             let drive_phase = ((delivered_turn / side_ticks) % 4) as f64;
@@ -4125,33 +4448,36 @@ rows := |id<string> x<f64>|
             // Reproduce the complete filter independently from the Mech
             // resident graph. This oracle checks the state and covariance,
             // not merely that a scene changed after each accepted packet.
-            let estimate_mid_heading = expected_estimate[2] + commanded_omega * dt / 2.0;
+            let filter_dt = dt as f32;
+            let filter_speed = commanded_speed as f32;
+            let filter_omega = commanded_omega as f32;
+            let estimate_mid_heading = expected_estimate[2] + filter_omega * filter_dt / 2.0_f32;
             let estimate_mid_cos = estimate_mid_heading.cos();
             let estimate_mid_sin = estimate_mid_heading.sin();
-            let motion_jacobian = SMatrix::<f64, 3, 3>::new(
+            let motion_jacobian = SMatrix::<f32, 3, 3>::new(
                 1.0,
                 0.0,
-                -commanded_speed * estimate_mid_sin * dt,
+                -filter_speed * estimate_mid_sin * filter_dt,
                 0.0,
                 1.0,
-                commanded_speed * estimate_mid_cos * dt,
+                filter_speed * estimate_mid_cos * filter_dt,
                 0.0,
                 0.0,
                 1.0,
             );
-            let control_jacobian = SMatrix::<f64, 3, 2>::new(
-                estimate_mid_cos * dt,
-                -commanded_speed * estimate_mid_sin * dt.powi(2) / 2.0,
-                estimate_mid_sin * dt,
-                commanded_speed * estimate_mid_cos * dt.powi(2) / 2.0,
+            let control_jacobian = SMatrix::<f32, 3, 2>::new(
+                estimate_mid_cos * filter_dt,
+                -filter_speed * estimate_mid_sin * filter_dt.powi(2) / 2.0_f32,
+                estimate_mid_sin * filter_dt,
+                filter_speed * estimate_mid_cos * filter_dt.powi(2) / 2.0_f32,
                 0.0,
-                dt,
+                filter_dt,
             );
             let predicted_estimate = expected_estimate
-                + SVector::<f64, 3>::new(
-                    commanded_speed * estimate_mid_cos * dt,
-                    commanded_speed * estimate_mid_sin * dt,
-                    commanded_omega * dt,
+                + SVector::<f32, 3>::new(
+                    filter_speed * estimate_mid_cos * filter_dt,
+                    filter_speed * estimate_mid_sin * filter_dt,
+                    filter_omega * filter_dt,
                 );
             let predicted_covariance =
                 motion_jacobian * expected_covariance * motion_jacobian.transpose()
@@ -4166,11 +4492,11 @@ rows := |id<string> x<f64>|
             let measured_bearing = truth_dy.atan2(truth_dx) - expected_truth[2]
                 + 0.011 * (simulation_time * 1.91 + (camera_index + 1) as f64).sin();
 
-            let predicted_dx = active_camera[0] - predicted_estimate[0];
-            let predicted_dy = active_camera[1] - predicted_estimate[1];
+            let predicted_dx = active_camera[0] as f32 - predicted_estimate[0];
+            let predicted_dy = active_camera[1] as f32 - predicted_estimate[1];
             let predicted_q = predicted_dx.powi(2) + predicted_dy.powi(2);
             let predicted_range = predicted_q.sqrt();
-            let observation_jacobian = SMatrix::<f64, 2, 3>::new(
+            let observation_jacobian = SMatrix::<f32, 2, 3>::new(
                 -predicted_dx / predicted_range,
                 -predicted_dy / predicted_range,
                 0.0,
@@ -4186,17 +4512,23 @@ rows := |id<string> x<f64>|
                 * innovation_covariance
                     .try_inverse()
                     .expect("EKF innovation covariance must remain invertible");
-            let bearing_residual =
-                measured_bearing - (predicted_dy.atan2(predicted_dx) - predicted_estimate[2]);
-            let innovation = SVector::<f64, 2>::new(
-                measured_range - predicted_range,
-                bearing_residual.sin().atan2(bearing_residual.cos()),
+            let innovation = SVector::<f32, 2>::new(
+                measured_range as f32 - predicted_range,
+                (measured_bearing as f32
+                    - (predicted_dy.atan2(predicted_dx) - predicted_estimate[2]))
+                    .sin()
+                    .atan2(
+                        (measured_bearing as f32
+                            - (predicted_dy.atan2(predicted_dx) - predicted_estimate[2]))
+                            .cos(),
+                    ),
             );
             let observed_estimate = predicted_estimate + kalman_gain * innovation;
             let joseph_a = identity - kalman_gain * observation_jacobian;
             let observed_covariance = joseph_a * predicted_covariance * joseph_a.transpose()
                 + kalman_gain * measurement_covariance * kalman_gain.transpose();
-            let observed_covariance = 0.5 * (observed_covariance + observed_covariance.transpose());
+            let observed_covariance =
+                0.5_f32 * (observed_covariance + observed_covariance.transpose());
             let visibility = clamp_unit(
                 (camera_max_range
                     - (camera_positions[camera_index]
@@ -4204,70 +4536,13 @@ rows := |id<string> x<f64>|
                     .norm())
                     / camera_range_fade,
             );
+            let filter_visibility = visibility as f32;
             expected_estimate =
-                predicted_estimate + visibility * (observed_estimate - predicted_estimate);
-            expected_covariance =
-                predicted_covariance + visibility * (observed_covariance - predicted_covariance);
+                predicted_estimate + filter_visibility * (observed_estimate - predicted_estimate);
+            expected_covariance = predicted_covariance
+                + filter_visibility * (observed_covariance - predicted_covariance);
             saw_prediction_only_turn |= visibility == 0.0;
             saw_camera_update |= visibility == 1.0;
-
-            let actual_visibility_ref = runtime
-                .root_symbol_value("active-camera-visibility")
-                .unwrap()
-                .into_value()
-                .as_f64()
-                .unwrap();
-            let actual_visibility = *actual_visibility_ref.borrow();
-            assert!(
-                (actual_visibility - visibility).abs() < 1.0e-9,
-                "selected camera visibility diverged on delivered turn {turn}: actual={actual_visibility} expected={visibility}",
-            );
-            let boundary_visibilities = runtime
-                .root_symbol_value("camera-boundary-probe-visibility")
-                .unwrap()
-                .into_value()
-                .as_vecf64()
-                .unwrap();
-            let boundary_corrections = runtime
-                .root_symbol_value("camera-boundary-probe-correction")
-                .unwrap()
-                .into_value()
-                .as_vecf64()
-                .unwrap();
-            assert_eq!(
-                boundary_visibilities.as_slice(),
-                [1.0, 0.0, 0.0, 0.0],
-                "the resident camera graph must be exactly zero at and beyond its physical boundary",
-            );
-            assert_eq!(
-                boundary_corrections.as_slice(),
-                [21.0, 12.0, 13.0, 14.0],
-                "zero visibility must leave the predicted state unchanged at and beyond the boundary",
-            );
-            let actual_predicted = runtime
-                .root_symbol_value("predicted-estimate")
-                .unwrap()
-                .into_value()
-                .as_vecf64()
-                .unwrap();
-            let actual_observed = runtime
-                .root_symbol_value("observed-estimate")
-                .unwrap()
-                .into_value()
-                .as_vecf64()
-                .unwrap();
-            for component in 0..3 {
-                assert!(
-                    (actual_predicted[component] - predicted_estimate[component]).abs() < 1.0e-8,
-                    "EKF prediction component {component} diverged on delivered turn {turn}: actual={actual_predicted:?} expected={:?}",
-                    predicted_estimate.as_slice(),
-                );
-                assert!(
-                    (actual_observed[component] - observed_estimate[component]).abs() < 1.0e-8,
-                    "EKF observation component {component} diverged on delivered turn {turn}: actual={actual_observed:?} expected={:?}",
-                    observed_estimate.as_slice(),
-                );
-            }
 
             let snapshot = scene_backend.latest().unwrap();
             let actual_truth = rendered_truth(&snapshot);
@@ -4288,47 +4563,6 @@ rows := |id<string> x<f64>|
                 );
             }
 
-            let actual_estimate = runtime
-                .root_symbol_value("estimate")
-                .unwrap()
-                .into_value()
-                .as_vecf64()
-                .unwrap();
-            let actual_covariance = runtime
-                .root_symbol_value("covariance")
-                .unwrap()
-                .into_value()
-                .as_vecf64()
-                .unwrap();
-            assert_eq!(actual_estimate.len(), 3);
-            assert_eq!(actual_covariance.len(), 9);
-            if actual_visibility == 0.0 {
-                assert_eq!(
-                    actual_estimate.as_slice(),
-                    actual_predicted.as_slice(),
-                    "a prediction-only runtime turn must not apply a hidden measurement correction",
-                );
-            }
-            for component in 0..3 {
-                assert!(
-                    (actual_estimate[component] - expected_estimate[component]).abs() < 1.0e-8,
-                    "EKF estimate component {component} diverged on delivered turn {turn}: actual={:?} expected={:?}",
-                    actual_estimate,
-                    expected_estimate.as_slice(),
-                );
-            }
-            let actual_covariance = SMatrix::<f64, 3, 3>::from_column_slice(&actual_covariance);
-            for row in 0..3 {
-                for column in 0..3 {
-                    assert!(
-                        (actual_covariance[(row, column)] - expected_covariance[(row, column)])
-                            .abs()
-                            < 1.0e-8,
-                        "EKF covariance ({row}, {column}) diverged on delivered turn {turn}: actual={actual_covariance:?} expected={expected_covariance:?}",
-                    );
-                }
-            }
-
             let rendered_covariance = snapshot
                 .line_strips
                 .iter()
@@ -4339,9 +4573,9 @@ rows := |id<string> x<f64>|
                 65,
                 "the covariance outline must retain every 0..=64 sample"
             );
-            let ellipse_a = expected_covariance[(0, 0)];
-            let ellipse_b = expected_covariance[(0, 1)];
-            let ellipse_c = expected_covariance[(1, 1)];
+            let ellipse_a = f64::from(expected_covariance[(0, 0)]);
+            let ellipse_b = f64::from(expected_covariance[(0, 1)]);
+            let ellipse_c = f64::from(expected_covariance[(1, 1)]);
             let ellipse_root = (((ellipse_a - ellipse_c) / 2.0).powi(2) + ellipse_b.powi(2)).sqrt();
             let ellipse_major = ((ellipse_a + ellipse_c) / 2.0 + ellipse_root).sqrt() * 2.0;
             let ellipse_minor = ((ellipse_a + ellipse_c) / 2.0 - ellipse_root).sqrt() * 2.0;
@@ -4356,19 +4590,19 @@ rows := |id<string> x<f64>|
                 let angle_sin = angle.sin();
                 let expected = [
                     120.0
-                        + expected_estimate[0] * 62.0
+                        + f64::from(expected_estimate[0]) * 62.0
                         + 62.0
                             * (display_major * angle_cos * rotation_cos
                                 - display_minor * angle_sin * rotation_sin),
                     700.0
-                        - expected_estimate[1] * 62.0
+                        - f64::from(expected_estimate[1]) * 62.0
                         - 62.0
                             * (display_major * angle_cos * rotation_sin
                                 + display_minor * angle_sin * rotation_cos),
                 ];
                 for axis in 0..2 {
                     assert!(
-                        (actual[axis] - expected[axis]).abs() < 1.0e-8,
+                        (actual[axis] - expected[axis]).abs() < 1.0e-3,
                         "rendered covariance sample {sample} axis {axis} diverged on delivered turn {turn}: actual={actual:?} expected={expected:?}",
                     );
                 }
@@ -4377,15 +4611,18 @@ rows := |id<string> x<f64>|
             let scene_estimate = rendered_estimate(&snapshot);
             for component in 0..3 {
                 let error = if component == 2 {
-                    (scene_estimate[component] - expected_estimate[component])
+                    (scene_estimate[component] - f64::from(expected_estimate[component]))
                         .sin()
-                        .atan2((scene_estimate[component] - expected_estimate[component]).cos())
+                        .atan2(
+                            (scene_estimate[component] - f64::from(expected_estimate[component]))
+                                .cos(),
+                        )
                         .abs()
                 } else {
-                    (scene_estimate[component] - expected_estimate[component]).abs()
+                    (scene_estimate[component] - f64::from(expected_estimate[component])).abs()
                 };
                 assert!(
-                    error < 1.0e-8,
+                    error < 2.0e-5,
                     "rendered EKF estimate component {component} diverged on delivered turn {turn}: actual={scene_estimate:?} expected={expected_estimate:?}",
                 );
             }
@@ -4395,13 +4632,7 @@ rows := |id<string> x<f64>|
             });
             let expected_visibilities = expected_distances
                 .map(|distance| clamp_unit((camera_max_range - distance) / camera_range_fade));
-            let actual_visibilities = runtime
-                .root_symbol_value("camera-visibility")
-                .unwrap()
-                .into_value()
-                .as_vecf64()
-                .unwrap();
-            let visible_camera_count = actual_visibilities
+            let visible_camera_count = expected_visibilities
                 .iter()
                 .filter(|visibility| **visibility > 0.0)
                 .count();
@@ -4409,19 +4640,8 @@ rows := |id<string> x<f64>|
             maximum_visible_cameras = maximum_visible_cameras.max(visible_camera_count);
             for (camera, expected_visibility) in expected_visibilities.iter().enumerate() {
                 if expected_distances[camera] >= camera_max_range {
-                    assert_eq!(
-                        actual_visibilities[camera],
-                        0.0,
-                        "runtime camera {} remained visible at or beyond its maximum range on delivered turn {turn}",
-                        camera + 1,
-                    );
+                    assert_eq!(*expected_visibility, 0.0);
                 }
-                assert!(
-                    (actual_visibilities[camera] - expected_visibility).abs() < 1.0e-9,
-                    "runtime camera {} visibility diverged on delivered turn {turn}: actual={} expected={expected_visibility}",
-                    camera + 1,
-                    actual_visibilities[camera],
-                );
                 let ring = snapshot
                     .circles
                     .iter()
@@ -4495,22 +4715,27 @@ rows := |id<string> x<f64>|
         );
         assert_eq!(
             runtime.program_execution_info().resident_accepted_turns,
-            420
+            840
         );
-        assert_eq!(scene_backend.generation(), 420);
+        assert_eq!(scene_backend.generation(), 840);
     }
 
     #[cfg(all(
         not(target_arch = "wasm32"),
         feature = "browser_host_timer",
-        feature = "browser_host_scene"
+        feature = "browser_host_scene",
+        feature = "browser_compute"
     ))]
     #[test]
     fn ekf_scene_advances_on_every_resident_timer_packet() {
         assert_ekf_scene_advances_on_every_resident_timer_packet();
     }
 
-    #[cfg(all(feature = "browser_host_timer", feature = "browser_host_scene"))]
+    #[cfg(all(
+        feature = "browser_host_timer",
+        feature = "browser_host_scene",
+        feature = "browser_compute"
+    ))]
     fn generic_fixture_document() -> MechConfigDocument {
         parse_config_document(
             "generic-timer-table-scene/mech.mcfg",

--- a/src/wasm/src/project.rs
+++ b/src/wasm/src/project.rs
@@ -522,6 +522,10 @@ impl WasmDocumentBootstrap {
     }
 
     pub(crate) fn prepare_commit(&self, runtime: &mut MechRuntime) -> MResult<()> {
+        #[cfg(feature = "browser_compute")]
+        if let Some(compute) = self.source().lifecycle.compute() {
+            compute.ensure_source_replacement_ready()?;
+        }
         if self.source().lifecycle.drivers_started() {
             runtime.start_input_drivers()?;
         }
@@ -635,6 +639,12 @@ fn build_document_repl_runtime_for_tree(
     candidate_tree: mech_core::nodes::Program,
 ) -> MResult<DocumentRuntimeCandidate> {
     let source = bootstrap.source();
+    #[cfg(feature = "browser_compute")]
+    let previous_compute = source.lifecycle.compute();
+    #[cfg(feature = "browser_compute")]
+    if let Some(previous) = previous_compute.as_ref() {
+        previous.ensure_source_replacement_ready()?;
+    }
     let (candidate_tree, _) = document_runtime_tree(source, candidate_tree)?;
     #[cfg(feature = "browser_host_scene")]
     let candidate_scenes = BrowserSceneRegistry::new();
@@ -694,6 +704,7 @@ fn build_document_repl_runtime_for_tree(
                     prepared,
                     browser_gpu_available(),
                     source.lifecycle.next_compute_generation()?,
+                    previous_compute.as_ref(),
                 )?)
             } else {
                 None
@@ -1343,6 +1354,27 @@ mod document {
                 .lifecycle
                 .compute_generation()
                 .to_string()
+        }
+
+        #[cfg(feature = "browser_compute")]
+        #[wasm_bindgen(js_name = isComputeCommandTokenCurrent)]
+        pub fn is_compute_command_token_current(&self, dispatch_token: &str) -> bool {
+            self.bootstrap
+                .source()
+                .lifecycle
+                .compute()
+                .is_some_and(|compute| compute.validate_token(dispatch_token).is_ok())
+        }
+
+        #[cfg(feature = "browser_compute")]
+        #[wasm_bindgen(js_name = reportComputeStateReset)]
+        pub fn report_compute_state_reset(
+            &mut self,
+            previous_revision: &str,
+            next_revision: &str,
+        ) -> Result<JsValue, JsValue> {
+            self.repl
+                .report_compute_state_reset(previous_revision, next_revision)
         }
 
         /// Rebuild the accepted source generation after the browser has

--- a/src/wasm/src/project.rs
+++ b/src/wasm/src/project.rs
@@ -4731,11 +4731,7 @@ rows := |id<string> x<f64>|
         assert_ekf_scene_advances_on_every_resident_timer_packet();
     }
 
-    #[cfg(all(
-        feature = "browser_host_timer",
-        feature = "browser_host_scene",
-        feature = "browser_compute"
-    ))]
+    #[cfg(all(feature = "browser_host_timer", feature = "browser_host_scene"))]
     fn generic_fixture_document() -> MechConfigDocument {
         parse_config_document(
             "generic-timer-table-scene/mech.mcfg",

--- a/src/wasm/src/project.rs
+++ b/src/wasm/src/project.rs
@@ -4542,8 +4542,19 @@ rows := |id<string> x<f64>|
                 .unwrap()
                 .expect("every timer token must queue one compute command");
             assert!(!command.acknowledgement_required);
-            assert_eq!(command.changed_inputs["control"].len(), 3_000);
-            assert_eq!(command.changed_inputs["measurement"].len(), 3_000);
+            for (name, width) in [
+                ("control", 3_000),
+                ("camera", 2_000),
+                ("measurement", 3_000),
+            ] {
+                if let Some(values) = command.changed_inputs.get(name) {
+                    assert_eq!(
+                        values.len(),
+                        width,
+                        "compute input `{name}` had the wrong batch extent"
+                    );
+                }
+            }
             outcomes.extend(runtime.drain_host_inputs(1).unwrap_or_else(|error| {
                 let events = runtime.list_events(Some(32)).unwrap_or_default();
                 panic!("compute completion turn failed: {error:?}; recent events={events:?}")
@@ -4878,7 +4889,11 @@ rows := |id<string> x<f64>|
             runtime.program_execution_info().resident_accepted_turns,
             840
         );
-        assert_eq!(scene_backend.generation(), 840);
+        assert_eq!(
+            scene_backend.generation(),
+            840,
+            "the asynchronous scene must publish current robot truth on timer turns and completed estimates on filter turns",
+        );
     }
 
     #[cfg(all(

--- a/src/wasm/src/repl.rs
+++ b/src/wasm/src/repl.rs
@@ -13,7 +13,7 @@ use mech_runtime::{
     OutputContent, OutputEvent, REPL_COMMAND_SPECS, ReplComponentKind, ReplDispatchControl,
     ReplEvent, ReplHostAvailability, ReplHostRequest, ReplHostRequirement, ReplResponse,
     ReplResponseKind, ReplResponseStatus, ReplStepMode, ResidentReplRuntimeFactory,
-    ResidentReplSession, RunResourceGrantConfig, RuntimeConfig, TableOutput, TextOutput,
+    ResidentReplSession, RunResourceGrantConfig, RuntimeConfig, Severity, TableOutput, TextOutput,
     ValueOutput, dispatch_repl_request, emit_host_response, emit_step_complete, parse_repl_request,
 };
 
@@ -582,6 +582,22 @@ impl WasmRepl {
                 .unwrap_or(JsValue::NULL),
         )?;
         Ok(response.into())
+    }
+
+    pub(crate) fn report_compute_state_reset(
+        &mut self,
+        previous_revision: &str,
+        next_revision: &str,
+    ) -> Result<JsValue, JsValue> {
+        self.session.emit_message_diagnostic(
+            Severity::Warning,
+            DiagnosticPhase::Host,
+            "ComputeStateReset",
+            format!(
+                "The physical compute plan changed from `{previous_revision}` to `{next_revision}`; GPU-resident state was reinitialized."
+            ),
+        );
+        self.response(None)
     }
 
     fn handle_host_request(&mut self, request: ReplHostRequest) {

--- a/src/wasm/src/repl.rs
+++ b/src/wasm/src/repl.rs
@@ -517,6 +517,20 @@ impl WasmRepl {
         self.session.source().to_string()
     }
 
+    /// Replace the complete accepted source through the same transactional
+    /// runtime handoff used by document editors and source reloaders.
+    pub(crate) fn replace_source(&mut self, source: &str) -> Result<JsValue, JsValue> {
+        if self.transition_after_program_barrier(WasmReplTransition::Submit)?
+            == WasmReplTransitionResult::Rejected
+        {
+            return self.response(None);
+        }
+        self.session
+            .replace_source(source.to_string())
+            .map_err(to_js_error)?;
+        self.response(None)
+    }
+
     pub fn shutdown(&mut self) -> Result<JsValue, JsValue> {
         self.terminate_session().map_err(to_js_error)?;
         self.response(None)

--- a/src/wasm/tests/function_system_source_contract.rs
+++ b/src/wasm/tests/function_system_source_contract.rs
@@ -167,6 +167,12 @@ fn enabled_standard_profile_is_fully_catalog_owned() {
     );
 }
 
+#[cfg(feature = "browser_compute")]
+#[wasm_bindgen_test]
+fn browser_compute_feature_closure_includes_ceil() {
+    assert!(source_catalog().module_export("math", "ceil").is_some());
+}
+
 #[wasm_bindgen_test]
 fn scalar_source_addition_uses_the_explicit_catalog() {
     let mut runtime = browser_runtime_builder()

--- a/src/web_host.rs
+++ b/src/web_host.rs
@@ -46,6 +46,11 @@ fn standard_browser_runtime_provider_profile() -> MResult<BrowserRuntimeProvider
     profile.register(mech_scene::scene_host_manifest()?, |settings| {
         mech_scene::scene_settings_from_config(settings).map(|_| ())
     })?;
+    #[cfg(feature = "compute_backends_native")]
+    profile.register(
+        mech_gpu::compute_host_manifest(),
+        mech_gpu::validate_compute_host_settings,
+    )?;
     Ok(profile)
 }
 
@@ -404,5 +409,38 @@ mod tests {
                 .any(|grant| grant.target == "native/command")
         );
         assert!(browser_runtime_injection_config_script(&config).is_ok());
+    }
+
+    #[cfg(feature = "compute_backends_native")]
+    #[test]
+    fn ekf_authority_preserves_the_declared_browser_compute_host_and_grants() {
+        let document = parse_config_document(
+            "examples/ekf/mech.mcfg",
+            include_str!("../examples/ekf/mech.mcfg"),
+            ConfigProfileOptions::default(),
+        )
+        .unwrap();
+        let config =
+            web_runtime_injection_config_from_document(&document, &RuntimeConfig::default())
+                .unwrap();
+
+        assert!(config.hosts.iter().any(|host| {
+            host.name == "filters"
+                && host.provider == "compute"
+                && matches!(
+                    &host.settings,
+                    ConfigValue::Map(settings)
+                        if settings.get("region")
+                            == Some(&ConfigValue::String("ekf-batch".to_owned()))
+                )
+        }));
+        let grant = config
+            .run_grants
+            .iter()
+            .find(|grant| grant.target == "filters/kernel")
+            .expect("compute authority must retain the declared kernel grant");
+        assert_eq!(grant.operations, ["read", "write"]);
+        assert!(grant.paths.iter().any(|path| path == "sample/result.0"));
+        assert!(grant.paths.iter().any(|path| path == "turn"));
     }
 }

--- a/tests/architecture/distributions/full.json
+++ b/tests/architecture/distributions/full.json
@@ -2,8 +2,8 @@
   "dependency_count": 409,
   "distribution": "full",
   "native_planning_owner_count": 6,
-  "runtime_factory_count": 9081,
-  "runtime_surface_digest": "0228bf738f02fe8bb1ff6dc557d447c5a79e7303ee071769602fbf40f4f90aa7",
+  "runtime_factory_count": 9084,
+  "runtime_surface_digest": "fe9127d1ae19599a7a6970250a0ea42a25fe06d5135520e2d6dd9d76631a92d5",
   "runtime_surface_digest_algorithm": "sha256-canonical-id-tab-name-lf-v1",
   "schema": "mech.distribution-contract.v1",
   "selected_hosts": [
@@ -259,6 +259,6 @@
     "web_host"
   ],
   "source_specializer_count": 119,
-  "surface_digest": "65313081df5b8c9db2de682a5358ecb15df18b8d5a57f7080de288d5ce1122e4",
+  "surface_digest": "68f7642bd1fb37663d7d2b4e9cebc3f50c9f29e209682d71ae922da3eb74e5dd",
   "surface_digest_algorithm": "sha256-canonical-selected-cargo-surface-v1"
 }

--- a/tests/architecture/distributions/profile-contracts.json
+++ b/tests/architecture/distributions/profile-contracts.json
@@ -45,12 +45,12 @@
     },
     {
       "profile_name": "full-runtime",
-      "catalog_factory_count": 9028,
+      "catalog_factory_count": 9031,
       "source_specializer_count": 0,
       "intrinsic_count": 0,
       "prelude_count": 0,
       "module_export_count": 0,
-      "runtime_surface_digest": "16d6ed2ce31a15696398540dc5b0a116836b039f4a27cbc219ce25c828fbea37",
+      "runtime_surface_digest": "29efa79d9ce1c2f10626775a1f3dab7274a42b747856fb3ef10f293bb70bf2e1",
       "digest_algorithm": "sha256-canonical-id-tab-name-lf-v1",
       "required_packages": [
         "mech-combinatorics",
@@ -108,12 +108,12 @@
     },
     {
       "profile_name": "full-source",
-      "catalog_factory_count": 9029,
+      "catalog_factory_count": 9032,
       "source_specializer_count": 119,
       "intrinsic_count": 10,
       "prelude_count": 52,
       "module_export_count": 50,
-      "runtime_surface_digest": "471a0c091702b82028212f59c3d888a2b12a7cdec828e23cf9839f2e57837ecb",
+      "runtime_surface_digest": "427478979de64b5ad5d05a0c7ccda8718b8bfbe8be78bc3213785b6eec6f8daf",
       "digest_algorithm": "sha256-canonical-id-tab-name-lf-v1",
       "required_packages": [
         "mech-combinatorics",
@@ -172,12 +172,12 @@
     },
     {
       "profile_name": "full-compiler",
-      "catalog_factory_count": 9029,
+      "catalog_factory_count": 9032,
       "source_specializer_count": 119,
       "intrinsic_count": 10,
       "prelude_count": 52,
       "module_export_count": 50,
-      "runtime_surface_digest": "471a0c091702b82028212f59c3d888a2b12a7cdec828e23cf9839f2e57837ecb",
+      "runtime_surface_digest": "427478979de64b5ad5d05a0c7ccda8718b8bfbe8be78bc3213785b6eec6f8daf",
       "digest_algorithm": "sha256-canonical-id-tab-name-lf-v1",
       "required_packages": [
         "mech-bytecode",

--- a/tests/architecture/distributions/standard.json
+++ b/tests/architecture/distributions/standard.json
@@ -2,8 +2,8 @@
   "dependency_count": 407,
   "distribution": "standard",
   "native_planning_owner_count": 6,
-  "runtime_factory_count": 1379,
-  "runtime_surface_digest": "cb904e39b9e93a25d1806a3cf0375ece2bfe89da39b53f2cd9f29d17ed8bff2b",
+  "runtime_factory_count": 1380,
+  "runtime_surface_digest": "4c4451372bf0bfe0140c41948ef43f10858bbf9ceb2ac21533e4016097f8c8cb",
   "runtime_surface_digest_algorithm": "sha256-canonical-id-tab-name-lf-v1",
   "schema": "mech.distribution-contract.v1",
   "selected_hosts": [
@@ -193,6 +193,6 @@
     "web_host"
   ],
   "source_specializer_count": 70,
-  "surface_digest": "3d73cf133ac27bd35578def18d93810f9f338e7448e8de632359d9e3fb174673",
+  "surface_digest": "9b60c06989b53a739f735bae82e8b49e311ff0b0676e3efc29e9f481721871bb",
   "surface_digest_algorithm": "sha256-canonical-selected-cargo-surface-v1"
 }

--- a/tests/architecture/function-system/runtime-factory-surface.json
+++ b/tests/architecture/function-system/runtime-factory-surface.json
@@ -28969,6 +28969,21 @@
       "owner": "mech-math"
     },
     {
+      "name": "MatrixSolveMDMD<f32>",
+      "id_hex": "00405178b4b50d2f",
+      "owner": "mech-matrix"
+    },
+    {
+      "name": "MatrixSolveMDMD<f64>",
+      "id_hex": "003ec4f968646717",
+      "owner": "mech-matrix"
+    },
+    {
+      "name": "MatrixSolveMDVD<f32>",
+      "id_hex": "00c3def1222b905d",
+      "owner": "mech-matrix"
+    },
+    {
       "name": "MatrixSolveMDVD<f64>",
       "id_hex": "002588af33ff6a84",
       "owner": "mech-matrix"

--- a/tests/architecture/native-linkage/coverage.json
+++ b/tests/architecture/native-linkage/coverage.json
@@ -2,53 +2,53 @@
   "schema": "mech.native-linkage-coverage-summary.v1",
   "detail_schema": "mech.native-linkage-coverage.v2",
   "full": {
-    "entry_count": 9028,
-    "linked_entry_count": 9028,
+    "entry_count": 9031,
+    "linked_entry_count": 9031,
     "missing_linkage_count": 0,
-    "runtime_surface_digest": "bd3aca01f2b367a73a651bffde0583dc7b9568d61d01dec2c1cf265c8b56a838",
-    "installer_surface_digest": "0a287b6650b6b16a74d53360a563c73bbc340bb461a4e616a421cc9666daf389",
-    "feature_surface_digest": "060dbbaf6b4e35a6c9c55d76ec8d1208a24608e16a604c3106102eaef5895334",
-    "runtime_contract_count": 9028,
+    "runtime_surface_digest": "6e8bfba2fb47424bb00385e520edbc121bd252a49cfccc80c91a31c68355d541",
+    "installer_surface_digest": "90ac274bd8969460ccd0fa6b423f55519554309f189754386a15d6f2dddb8a54",
+    "feature_surface_digest": "6b986024583168adedb119dea26e05ae689dc5c79c236640f54749482962d746",
+    "runtime_contract_count": 9031,
     "missing_contract_count": 0,
-    "runtime_contract_surface_digest": "9bbcfea9dda7207c0f8efee088f8e9d78e8f367deea3316dc9a727a78279de72",
-    "runtime_signature_count": 9028,
+    "runtime_contract_surface_digest": "a8e4a0bffc47fe1ccb80ffc997eb8b7c8f8dc1574d65174c5bfcce90261c8df6",
+    "runtime_signature_count": 9031,
     "missing_signature_count": 0,
-    "runtime_signature_surface_digest": "772f3cddfe055e0b5399429a79926971244e51ad6034b6df08ca207876e88cf2"
+    "runtime_signature_surface_digest": "0fc9989c37bfeb7dad1480037b96e0c533f622cf470c1f210bef98aafb4f9045"
   },
   "extended": {
-    "entry_count": 120025,
-    "linked_entry_count": 120025,
+    "entry_count": 120028,
+    "linked_entry_count": 120028,
     "missing_linkage_count": 0,
-    "runtime_surface_digest": "0d8fcaa7c8758731a0cd843bf15ed8b25bd081bd56dfe97bcbf5cafb1d0cb980",
-    "installer_surface_digest": "e239dd8374b5dba99f0dd75256ecad157c2e63860829ef1239db354bdaf3ab1c",
-    "feature_surface_digest": "6831779d9f52668945c18d11134413c3538c95d78be7e2b2ec5af5d28ec80371",
-    "runtime_contract_count": 120025,
+    "runtime_surface_digest": "3ac7123849807e6bdf7e72a6878e31f2487acd734be05141b6b1be81d530d98e",
+    "installer_surface_digest": "f733736ed944841980267bc1d9b2a5e966791b4221ec2b36bdf1db85a308a62f",
+    "feature_surface_digest": "7c4e21a74a4ff1925eb8498b1bb7202b3e01b0edb0daf26473f189d2347fff5f",
+    "runtime_contract_count": 120028,
     "missing_contract_count": 0,
-    "runtime_contract_surface_digest": "67a14070fdf03c92e4fa4050a65624266153f929649bf0828d637592d1d8130f",
-    "runtime_signature_count": 120025,
+    "runtime_contract_surface_digest": "7a4ae7f0510c8f93c717d6bea5bcf9da1bb24b29e2cfa11162cca842eaf4a8fc",
+    "runtime_signature_count": 120028,
     "missing_signature_count": 0,
-    "runtime_signature_surface_digest": "e93900b65900d1d9d2eb39ecad8b1ae356eb1b9be0f7ba89d97796c5356c27a7"
+    "runtime_signature_surface_digest": "e8e93f4652a092865698a8f44db8260626a66128c31d4b40ab528a132f43c43c"
   },
   "signature_invariants": {
     "same_runtime_id_different_signature_count": 0,
     "representation_feature_missing_count": 0,
     "representation_feature_manually_listed_extra_count": 0,
     "feature_dependent_output_representation_count": 0,
-    "exact_closure_count": 34024,
+    "exact_closure_count": 34027,
     "exact_closure_shard_counts": [
       4321,
       4214,
       4253,
-      4121,
+      4122,
       4235,
       4257,
-      4243,
-      4380
+      4244,
+      4381
     ]
   },
   "coverage_digest": {
     "algorithm": "sha256-canonical-json-without-coverage-digest-v2",
-    "sha256": "a0b8a3e507a696c09a7fafb53c6aa64105005dc68f3722a05859437cb191554f"
+    "sha256": "ad3a7f0c0784815a7218da5458589e4e71ad1e01f7fdf3b2afe0d2cdb236a5ae"
   },
   "detail_artifact": {
     "path": "target/native-linkage/coverage-full.json",

--- a/tests/architecture/value-system/current-inventory.json
+++ b/tests/architecture/value-system/current-inventory.json
@@ -16,6 +16,7 @@
     "hosts/gpu/src/batched/mod.rs",
     "hosts/gpu/src/compute_backends.rs",
     "hosts/gpu/src/compute_provider.rs",
+    "hosts/gpu/src/execution_plan.rs",
     "hosts/gpu/src/lib.rs",
     "hosts/gpu/src/native.rs",
     "hosts/robot-arm/src/lib.rs",
@@ -2100,6 +2101,7 @@
     "hosts/gpu/src/batched/mod.rs",
     "hosts/gpu/src/compute_backends.rs",
     "hosts/gpu/src/compute_provider.rs",
+    "hosts/gpu/src/execution_plan.rs",
     "hosts/gpu/src/lib.rs",
     "hosts/gpu/src/native.rs",
     "hosts/gpu/tests/parallel_ekf.rs",
@@ -61262,7 +61264,7 @@
       "directory": ".",
       "manifest": "Cargo.toml",
       "name": "mech",
-      "rust_file_count": 903
+      "rust_file_count": 904
     },
     {
       "directory": "hosts/browser",
@@ -61280,7 +61282,7 @@
       "directory": "hosts/gpu",
       "manifest": "hosts/gpu/Cargo.toml",
       "name": "mech-gpu",
-      "rust_file_count": 12
+      "rust_file_count": 13
     },
     {
       "directory": "hosts/robot-arm",

--- a/tests/architecture/value-system/current-inventory.json
+++ b/tests/architecture/value-system/current-inventory.json
@@ -34248,7 +34248,7 @@
     {
       "column": 9,
       "enum": "LegacyValue",
-      "line": 442,
+      "line": 453,
       "path": "hosts/scene/src/provider.rs",
       "variant": "MatrixF64"
     },

--- a/tests/architecture/value-system/current-inventory.json
+++ b/tests/architecture/value-system/current-inventory.json
@@ -6851,17 +6851,17 @@
           {
             "column": 39,
             "fingerprint": "65b4b58cb20e5223130687830656c33e29ae47e12817fb17e5df776819218be2",
-            "line": 752
+            "line": 768
           },
           {
             "column": 43,
             "fingerprint": "65b4b58cb20e5223130687830656c33e29ae47e12817fb17e5df776819218be2",
-            "line": 793
+            "line": 809
           },
           {
             "column": 43,
             "fingerprint": "65b4b58cb20e5223130687830656c33e29ae47e12817fb17e5df776819218be2",
-            "line": 798
+            "line": 814
           }
         ]
       },
@@ -12985,17 +12985,17 @@
           {
             "column": 26,
             "fingerprint": "4cb42bb02f42a32ae6aef73e6cc41820e96d404232c9abd326437c2683d29e1d",
-            "line": 752
+            "line": 768
           },
           {
             "column": 30,
             "fingerprint": "4cb42bb02f42a32ae6aef73e6cc41820e96d404232c9abd326437c2683d29e1d",
-            "line": 793
+            "line": 809
           },
           {
             "column": 30,
             "fingerprint": "4cb42bb02f42a32ae6aef73e6cc41820e96d404232c9abd326437c2683d29e1d",
-            "line": 798
+            "line": 814
           }
         ]
       },
@@ -18671,7 +18671,7 @@
     {
       "column": 59,
       "enum": "LegacyValue",
-      "line": 816,
+      "line": 832,
       "path": "src/engine/src/program/compiler_planning.rs",
       "variant": "Bool"
     },
@@ -19854,21 +19854,21 @@
     {
       "column": 25,
       "enum": "LegacyValue",
-      "line": 788,
+      "line": 804,
       "path": "src/engine/src/program/compiler_planning.rs",
       "variant": "Empty"
     },
     {
       "column": 28,
       "enum": "LegacyValue",
-      "line": 794,
+      "line": 810,
       "path": "src/engine/src/program/compiler_planning.rs",
       "variant": "Empty"
     },
     {
       "column": 28,
       "enum": "LegacyValue",
-      "line": 799,
+      "line": 815,
       "path": "src/engine/src/program/compiler_planning.rs",
       "variant": "Empty"
     },
@@ -46398,21 +46398,21 @@
     {
       "column": 26,
       "enum": "LegacyValue",
-      "line": 752,
+      "line": 768,
       "path": "src/engine/src/program/compiler_planning.rs",
       "variant": "MutableReference"
     },
     {
       "column": 30,
       "enum": "LegacyValue",
-      "line": 793,
+      "line": 809,
       "path": "src/engine/src/program/compiler_planning.rs",
       "variant": "MutableReference"
     },
     {
       "column": 30,
       "enum": "LegacyValue",
-      "line": 798,
+      "line": 814,
       "path": "src/engine/src/program/compiler_planning.rs",
       "variant": "MutableReference"
     },
@@ -48302,56 +48302,56 @@
     {
       "column": 24,
       "enum": "LegacyValue",
-      "line": 755,
+      "line": 771,
       "path": "src/engine/src/program/compiler_planning.rs",
       "variant": "String"
     },
     {
       "column": 30,
       "enum": "LegacyValue",
-      "line": 756,
+      "line": 772,
       "path": "src/engine/src/program/compiler_planning.rs",
       "variant": "String"
     },
     {
       "column": 21,
       "enum": "LegacyValue",
-      "line": 759,
+      "line": 775,
       "path": "src/engine/src/program/compiler_planning.rs",
       "variant": "String"
     },
     {
       "column": 21,
       "enum": "LegacyValue",
-      "line": 762,
+      "line": 778,
       "path": "src/engine/src/program/compiler_planning.rs",
       "variant": "String"
     },
     {
       "column": 21,
       "enum": "LegacyValue",
-      "line": 765,
+      "line": 781,
       "path": "src/engine/src/program/compiler_planning.rs",
       "variant": "String"
     },
     {
       "column": 21,
       "enum": "LegacyValue",
-      "line": 768,
+      "line": 784,
       "path": "src/engine/src/program/compiler_planning.rs",
       "variant": "String"
     },
     {
       "column": 21,
       "enum": "LegacyValue",
-      "line": 771,
+      "line": 787,
       "path": "src/engine/src/program/compiler_planning.rs",
       "variant": "String"
     },
     {
       "column": 21,
       "enum": "LegacyValue",
-      "line": 774,
+      "line": 790,
       "path": "src/engine/src/program/compiler_planning.rs",
       "variant": "String"
     },

--- a/tests/architecture/value-system/current-inventory.json
+++ b/tests/architecture/value-system/current-inventory.json
@@ -34248,7 +34248,7 @@
     {
       "column": 9,
       "enum": "LegacyValue",
-      "line": 273,
+      "line": 442,
       "path": "hosts/scene/src/provider.rs",
       "variant": "MatrixF64"
     },

--- a/tests/architecture/value-system/frozen-semantic-targets-v1.json
+++ b/tests/architecture/value-system/frozen-semantic-targets-v1.json
@@ -14650,7 +14650,7 @@
       "sites": [
         {
           "column": 9,
-          "line": 442
+          "line": 453
         }
       ],
       "target": "typed-matrix-snapshot",

--- a/tests/architecture/value-system/frozen-semantic-targets-v1.json
+++ b/tests/architecture/value-system/frozen-semantic-targets-v1.json
@@ -14650,7 +14650,7 @@
       "sites": [
         {
           "column": 9,
-          "line": 273
+          "line": 442
         }
       ],
       "target": "typed-matrix-snapshot",

--- a/tests/architecture/value-system/frozen-semantic-targets-v1.json
+++ b/tests/architecture/value-system/frozen-semantic-targets-v1.json
@@ -2506,7 +2506,7 @@
       "sites": [
         {
           "column": 59,
-          "line": 816
+          "line": 832
         }
       ],
       "target": "bool-snapshot",
@@ -3686,15 +3686,15 @@
       "sites": [
         {
           "column": 25,
-          "line": 788
+          "line": 804
         },
         {
           "column": 28,
-          "line": 794
+          "line": 810
         },
         {
           "column": 28,
-          "line": 799
+          "line": 815
         }
       ],
       "target": "option-absence",
@@ -24774,15 +24774,15 @@
       "sites": [
         {
           "column": 26,
-          "line": 752
+          "line": 768
         },
         {
           "column": 30,
-          "line": 793
+          "line": 809
         },
         {
           "column": 30,
-          "line": 798
+          "line": 814
         }
       ],
       "target": "mutable-reference-runtime-storage",
@@ -26670,35 +26670,35 @@
       "sites": [
         {
           "column": 24,
-          "line": 755
-        },
-        {
-          "column": 30,
-          "line": 756
-        },
-        {
-          "column": 21,
-          "line": 759
-        },
-        {
-          "column": 21,
-          "line": 762
-        },
-        {
-          "column": 21,
-          "line": 765
-        },
-        {
-          "column": 21,
-          "line": 768
-        },
-        {
-          "column": 21,
           "line": 771
         },
         {
+          "column": 30,
+          "line": 772
+        },
+        {
           "column": 21,
-          "line": 774
+          "line": 775
+        },
+        {
+          "column": 21,
+          "line": 778
+        },
+        {
+          "column": 21,
+          "line": 781
+        },
+        {
+          "column": 21,
+          "line": 784
+        },
+        {
+          "column": 21,
+          "line": 787
+        },
+        {
+          "column": 21,
+          "line": 790
         }
       ],
       "target": "string-snapshot",

--- a/tests/architecture/value-system/migration.json
+++ b/tests/architecture/value-system/migration.json
@@ -35319,7 +35319,7 @@
       "sites": [
         {
           "column": 59,
-          "line": 816
+          "line": 832
         }
       ],
       "target": "bool-snapshot",
@@ -35334,15 +35334,15 @@
       "sites": [
         {
           "column": 25,
-          "line": 788
+          "line": 804
         },
         {
           "column": 28,
-          "line": 794
+          "line": 810
         },
         {
           "column": 28,
-          "line": 799
+          "line": 815
         }
       ],
       "target": "option-absence",
@@ -35358,15 +35358,15 @@
       "sites": [
         {
           "column": 26,
-          "line": 752
+          "line": 768
         },
         {
           "column": 30,
-          "line": 793
+          "line": 809
         },
         {
           "column": 30,
-          "line": 798
+          "line": 814
         }
       ],
       "target": "mutable-reference-runtime-storage",
@@ -35381,35 +35381,35 @@
       "sites": [
         {
           "column": 24,
-          "line": 755
-        },
-        {
-          "column": 30,
-          "line": 756
-        },
-        {
-          "column": 21,
-          "line": 759
-        },
-        {
-          "column": 21,
-          "line": 762
-        },
-        {
-          "column": 21,
-          "line": 765
-        },
-        {
-          "column": 21,
-          "line": 768
-        },
-        {
-          "column": 21,
           "line": 771
         },
         {
+          "column": 30,
+          "line": 772
+        },
+        {
           "column": 21,
-          "line": 774
+          "line": 775
+        },
+        {
+          "column": 21,
+          "line": 778
+        },
+        {
+          "column": 21,
+          "line": 781
+        },
+        {
+          "column": 21,
+          "line": 784
+        },
+        {
+          "column": 21,
+          "line": 787
+        },
+        {
+          "column": 21,
+          "line": 790
         }
       ],
       "target": "string-snapshot",

--- a/tests/architecture/value-system/migration.json
+++ b/tests/architecture/value-system/migration.json
@@ -4842,7 +4842,7 @@
       "sites": [
         {
           "column": 9,
-          "line": 273
+          "line": 442
         }
       ],
       "target": "typed-matrix-snapshot",

--- a/tests/architecture/value-system/migration.json
+++ b/tests/architecture/value-system/migration.json
@@ -4842,7 +4842,7 @@
       "sites": [
         {
           "column": 9,
-          "line": 442
+          "line": 453
         }
       ],
       "target": "typed-matrix-snapshot",


### PR DESCRIPTION
Stacked on #775.

This PR turns the EKF example into a genuine 1,000-lane resident workload. Each lane owns an independent state/covariance estimate; the selected lane is sampled back into the resident graph and rendered while the full batch executes through WebGPU when selected. The ordinary resident CPU path remains scalar and backend-neutral.

Current exact head: `16a884608`.

Architecture:
- `d9adde12c` defines one versioned physical GPU execution plan in `mech-gpu`; native elementwise, native fixed-shape, WASM serialization, browser allocation, binding, dispatch, integrity, alias grouping, and readback all consume that plan
- `0fd7e8480` gives each resident compute host one terminal `Ready` / `InFlight` / `Failed` phase across planning, reads, writes, effects, dispatch, and exact-identity completion
- browser submission lifecycle is generation-scoped; automatic CPU fallback is permitted only before the first WebGPU submission, while in-flight or post-acceptance device loss is terminal
- integrity rejection is a matching completion that leaves the host reusable without publishing candidate state
- resident `cpu` uses the ordinary scalar compute backend and selected samples only; the standalone presentation adapter remains separate
- physical readback accounting includes integrity bytes exactly once, keeps logical output accounting separate, and never multiplies transfers for aliases
- `db9fa10c0` makes the real-browser particle proof performance-independent: one baseline turn plus one pointer-bearing turn, with timeout state evidence
- `3d4494c9f` bounds only CI's SwiftShader declaration to 16,384 lanes (256 workgroups); the checked-in/default/manual application and full-size compiler/native parity tests remain one million lanes
- `231c22ae1` gives the particle and EKF browser gates one canonical Chromium WebGPU test-adapter policy
- `26789a3e6` queues test input only while `dispatchPending` is true, making the required second-turn/backpressure proof an explicit state transition rather than an animation-timing inference
- `acd384607` captures the exact compute/readback completion immediately after compute submission and passes it through both browser bridges before any unrelated canvas presentation work is submitted
- `16a884608` aligns GPU-less Linux with Chromium's required Vulkan shared-context path and SwiftShader Vulkan driver, while retaining the dedicated Dawn SwiftShader adapter; timeout evidence preserves adapter identity and the first page error
- required real-browser particle CI delays publication, proves one command in flight, advances a second turn, performs zero report-only output readback, reports no page errors, and verifies disposal

Direct supporting scope:
- fixed-shape matrix solve lowering, catalog entries, broadcast validation, and distribution snapshots are required to express and package the compact broadcast EKF used by this PR
- relative Windows serve-selector resolution directly fixes `mech serve examples/ekf` from a Windows checkout
- EKF truth, phase, measurement, trail, and rendering changes make presentation state follow accepted compute turns

Inherited scope:
- the REPL, site, and general presentation work remains in #775; this PR changes it only where the EKF/compute proof directly consumes the inherited surface

Exact-head local validation:
- `cargo check -p mech-gpu --all-features`
- `cargo check -p mech-wasm --features browser_compute,served_project_authority --no-default-features`
- `mech-gpu` library: 23 passed, including host phase boundaries, exact completion identity, absorbing failure, and reusable integrity rejection
- `mech-compute` library: 17 passed
- `mech-wasm` library with browser compute: 1 passed
- particle source lowering and physical alias-plan fixtures passed
- 1,000-lane EKF physical-plan and aliased-state fixtures passed
- unchanged one-million-particle application passed locally in real Chrome with the dedicated WebGPU SwiftShader adapter
- exact 16,384-lane CI workload passed locally through the same adapter with two serialized completion-backed turns, queued input, zero report-only output readback, no page errors, and disposal
- EKF WebGPU browser oracle passed locally through the same adapter policy with finite covariance/path metrics, smooth square driving, and zero browser errors
- browser lifecycle unit coverage rejects queue-wide completion widening and requires the exact submission promise

The exact-head CI run is tracked on this PR and must be green before completion.
