### PR TITLE
Fix idle CPU use in Mech server

### DIFF
--- a/src/runtime/src/service/workspace_session.rs
+++ b/src/runtime/src/service/workspace_session.rs
@@ -169,6 +169,10 @@ impl ServerWorkspaceSession {
         &self.watcher
     }
 
+    pub fn set_watch_event_notifier(&mut self, notifier: impl Fn() + Send + Sync + 'static) {
+        self.watcher.set_event_notifier(notifier);
+    }
+
     pub fn snapshot(&self) -> Option<&RuntimeWorkspaceSnapshot> {
         self.workspace.snapshot()
     }
@@ -454,6 +458,52 @@ mod tests {
 
         assert!(poll.events.is_empty());
         assert!(poll.refresh.is_none());
+    }
+
+    #[test]
+    fn server_workspace_session_notifies_when_a_watch_event_is_queued() {
+        let root = setup_session_root();
+        let main = root.join("main.mec");
+        std::fs::write(&main, "result := false\n").unwrap();
+        let main = main.canonicalize().unwrap();
+
+        let mut session = ServerWorkspaceSession::open(
+            &root,
+            vec![main_target()],
+            vec![recursive_root_folder()],
+            module_options(),
+        )
+        .unwrap();
+        let _ = session.poll(module_options()).unwrap();
+
+        let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+        session.set_watch_event_notifier(move || {
+            let _ = sender.try_send(());
+        });
+        std::fs::write(&main, "result := true\n").unwrap();
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let saw_main_event = loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            if remaining.is_zero() || receiver.recv_timeout(remaining).is_err() {
+                break false;
+            }
+            let poll = session.poll(module_options()).unwrap();
+            if poll
+                .events
+                .iter()
+                .any(|event| event.path.canonicalize().ok().as_ref() == Some(&main))
+            {
+                break true;
+            }
+        };
+        assert!(
+            saw_main_event,
+            "filesystem event did not wake the workspace session"
+        );
+
+        drop(session);
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/src/runtime/src/workspace/watch.rs
+++ b/src/runtime/src/workspace/watch.rs
@@ -2,7 +2,10 @@ use std::{
     collections::BTreeSet,
     ffi::OsStr,
     path::{Path, PathBuf},
-    sync::mpsc::{self, Receiver},
+    sync::{
+        Arc, Mutex,
+        mpsc::{self, Receiver},
+    },
 };
 
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
@@ -12,9 +15,13 @@ use super::*;
 pub struct RuntimeWorkspaceWatcher {
     watcher: RecommendedWatcher,
     receiver: Receiver<notify::Result<Event>>,
+    event_notifier: SharedWatchEventNotifier,
     watched_paths: BTreeSet<RuntimeWorkspaceWatchedPath>,
     watched_keys: BTreeSet<RuntimeWorkspaceWatchKey>,
 }
+
+type WatchEventNotifier = Arc<dyn Fn() + Send + Sync + 'static>;
+type SharedWatchEventNotifier = Arc<Mutex<Option<WatchEventNotifier>>>;
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct RuntimeWorkspaceWatchedPath {
@@ -60,15 +67,26 @@ pub enum RuntimeWorkspaceWatchEventKind {
 impl RuntimeWorkspaceWatcher {
     pub fn open(workspace: &RuntimeWorkspace, runtime: &mut MechRuntime) -> MResult<Self> {
         let (sender, receiver) = mpsc::channel();
+        let event_notifier = SharedWatchEventNotifier::default();
+        let callback_notifier = event_notifier.clone();
 
         let watcher = notify::recommended_watcher(move |event| {
-            let _ = sender.send(event);
+            let notifier = callback_notifier
+                .lock()
+                .ok()
+                .and_then(|notifier| notifier.clone());
+            if sender.send(event).is_ok()
+                && let Some(notifier) = notifier
+            {
+                notifier();
+            }
         })
         .map_err(|error| watch_error(format!("could not create watcher: {}", error)))?;
 
         let mut watcher = Self {
             watcher,
             receiver,
+            event_notifier,
             watched_paths: BTreeSet::new(),
             watched_keys: BTreeSet::new(),
         };
@@ -76,6 +94,16 @@ impl RuntimeWorkspaceWatcher {
         watcher.sync(workspace, runtime)?;
 
         Ok(watcher)
+    }
+
+    /// Registers a lightweight wake-up callback for newly queued filesystem events.
+    ///
+    /// The callback runs on the platform watcher's thread, so callers should only
+    /// use it to signal their own event loop and perform the actual refresh there.
+    pub fn set_event_notifier(&mut self, notifier: impl Fn() + Send + Sync + 'static) {
+        if let Ok(mut current) = self.event_notifier.lock() {
+            *current = Some(Arc::new(notifier));
+        }
     }
 
     pub fn poll(

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -689,6 +689,7 @@ pub struct MechServer {
     registry: Arc<RwLock<ServerSourceRegistry>>,
     events: Arc<RwLock<Vec<RuntimeEvent>>>,
     workspace_session: Option<Arc<Mutex<ServerWorkspaceSession>>>,
+    workspace_changed: Arc<tokio::sync::Notify>,
     workspace_root: Option<PathBuf>,
     project_overlay: Option<ConfiguredProjectOverlay>,
     js: Vec<u8>,
@@ -854,6 +855,7 @@ impl MechServer {
             registry: Arc::new(RwLock::new(ServerSourceRegistry::default())),
             events: Arc::new(RwLock::new(Vec::new())),
             workspace_session: None,
+            workspace_changed: Arc::new(tokio::sync::Notify::new()),
             workspace_root: None,
             project_overlay: None,
             js,
@@ -1158,6 +1160,10 @@ impl MechServer {
                 self.runtime_config.clone(),
                 mech_stdlib::source_catalog(),
             )?;
+        let workspace_changed = self.workspace_changed.clone();
+        session.set_watch_event_notifier(move || workspace_changed.notify_one());
+        // Drain any events queued while the workspace and notifier were being set up.
+        self.workspace_changed.notify_one();
         println!(
             "{} Runtime workspace session opened in {:?}.",
             self.badge(),
@@ -1329,11 +1335,10 @@ impl MechServer {
         if let (Some(session), Some(root)) = (&self.workspace_session, &root) {
             let html_shim = self.injected_html_shim()?;
             let generated_html_backing_paths = self.generated_html_backing_paths();
-            let mut interval = tokio::time::interval(std::time::Duration::from_millis(100));
             tokio::pin!(server);
             let requested = loop {
                 tokio::select! {
-                  _ = interval.tick() => {
+                  _ = self.workspace_changed.notified() => {
                     if let Err(error) = poll_workspace_once(session, &self.registry, &self.events, &root, &self.stylesheets, &html_shim, &generated_html_backing_paths, project_overlay.as_ref(), server_event_retention(&self.runtime_config)) {
                       eprintln!("[Mech Server] Workspace poll failed: {:?}", error);
                     }
@@ -1415,6 +1420,9 @@ fn poll_workspace_once(
         max_events,
     };
     let poll = session.poll_and_emit(module_options(), &mut sink)?;
+    if poll.events.is_empty() && poll.refresh.is_none() {
+        return Ok(());
+    }
     if !poll.events.is_empty() {
         println!("[Mech Server] Watch events: {}", poll.events.len());
         for event in &poll.events {
@@ -4213,6 +4221,50 @@ mod tests {
             .map(|event| event.id)
             .collect::<Vec<_>>();
         assert_eq!(ids, vec![EventId(2), EventId(3)]);
+    }
+
+    #[test]
+    fn empty_workspace_poll_does_not_clone_the_served_registry() {
+        let root = temp_root("empty-poll-registry");
+        let session =
+            ServerWorkspaceSession::open(&root, vec![], vec![], module_options()).unwrap();
+        let session = Arc::new(Mutex::new(session));
+
+        let mut served = ServerSourceRegistry::default();
+        served.insert_asset("known.txt", asset(b"known", "text/plain", None, Vec::new()));
+        let registry = Arc::new(RwLock::new(served));
+        let original_bytes = registry
+            .read()
+            .unwrap()
+            .get_route("known.txt")
+            .unwrap()
+            .bytes
+            .as_ptr();
+
+        poll_workspace_once(
+            &session,
+            &registry,
+            &Arc::new(RwLock::new(Vec::new())),
+            &root,
+            &HtmlStyleSheets::default(),
+            "",
+            &[],
+            None,
+            None,
+        )
+        .unwrap();
+
+        let current_bytes = registry
+            .read()
+            .unwrap()
+            .get_route("known.txt")
+            .unwrap()
+            .bytes
+            .as_ptr();
+        assert_eq!(current_bytes, original_bytes);
+
+        drop(session);
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- wake the async server directly when the OS workspace watcher queues an event
- remove the 100 ms workspace polling interval
- skip served-registry cloning when a poll contains no events or refresh
- add notifier and empty-poll regression coverage

## Verification
- cargo fmt --check
- git diff --check
- cargo check -p mech --lib --no-default-features --features serve,standard_source
- live debug server remained at 0.0% CPU across five idle samples
- editing a watched source immediately triggered one workspace refresh