### PR TITLE
[PR0] chore(value-system): enable shrink-only LegacyValue retirement

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -66,11 +66,10 @@ jobs:
         run: cargo +nightly-2026-03-03 fetch --locked
       - name: Validate permanent architecture contracts
         run: |
-          python3 scripts/generate-value-system-inventory.py --check
           python3 scripts/generate-value-system-inventory.py \
             --git-ref d5e41f6fd43c9d21c5858d80dab50e7ce64e9a10 \
             --check-legacy-baseline
-          python3 scripts/check-value-system-contract.py
+          python3 scripts/check-value-system-contract.py --mode retirement
           python3 scripts/check-program-artifact-contract.py
           python3 scripts/check-operation-contract.py
           python3 scripts/check-resident-activation-contract.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
           scripts/check-unsafe-boundaries.sh
           python3 scripts/check-runtime-factory-safety.py
           python3 scripts/check-value-execution-boundary.py
+          python3 scripts/check-value-system-contract.py --mode retirement
           python3 -B -m unittest \
             scripts/tests/test_check_obsolete_program_reachability.py \
             scripts/tests/test_check_compiler_planning_quarantine.py \

--- a/scripts/check-value-system-contract.py
+++ b/scripts/check-value-system-contract.py
@@ -1041,11 +1041,20 @@ def type_contract_source_failures(
                 f"{inventory_path}:type_contract_sources",
             )
         )
-        return failures
-    exact_targets = GENERATOR.TYPE_CONTRACT_TARGETS
-    for group, records in actual.items():
-        target, gate = exact_targets[group]
-        for record in records:
+    if isinstance(actual, dict):
+        failures.extend(
+            type_contract_projection_failures(actual, inventory_path)
+        )
+    return failures
+
+
+def type_contract_projection_failures(
+    records: dict[str, list[dict[str, Any]]],
+    inventory_path: Path,
+) -> list[Failure]:
+    failures: list[Failure] = []
+    for group, (target, gate) in GENERATOR.TYPE_CONTRACT_TARGETS.items():
+        for record in records.get(group, []):
             if (
                 record.get("target") != target
                 or record.get("implementation_gate") != gate
@@ -1061,6 +1070,154 @@ def type_contract_source_failures(
                     )
                 )
     return failures
+
+
+def retirement_variant_failures(
+    reviewed: dict[str, Any],
+    live: dict[str, Any],
+    inventory_path: Path,
+) -> list[Failure]:
+    failures: list[Failure] = []
+    reviewed_enums = reviewed.get("enums", {})
+    live_enums = live.get("enums", {})
+    for enum_name in GENERATOR.AUDITED_ENUMS:
+        reviewed_enum = reviewed_enums.get(enum_name)
+        live_enum = live_enums.get(enum_name)
+        if not isinstance(reviewed_enum, dict):
+            continue
+        reviewed_source = reviewed_enum.get("source")
+        if not isinstance(live_enum, dict):
+            failures.append(
+                failure(
+                    "C0-RETIREMENT-ENUM-DRIFT",
+                    "audited enum source",
+                    str(reviewed_source),
+                    f"live {enum_name} enum at {reviewed_source!r}",
+                    "audited enum is missing",
+                    f"{inventory_path}:enums.{enum_name}",
+                    enum_name=enum_name,
+                )
+            )
+            continue
+        live_source = live_enum.get("source")
+        if live_source != reviewed_source:
+            failures.append(
+                failure(
+                    "C0-RETIREMENT-ENUM-DRIFT",
+                    "audited enum source",
+                    str(live_source or reviewed_source),
+                    repr(reviewed_source),
+                    repr(live_source),
+                    f"{inventory_path}:enums.{enum_name}.source",
+                    enum_name=enum_name,
+                )
+            )
+        reviewed_variants = {
+            record["name"]: record
+            for record in reviewed_enum.get("variants", [])
+        }
+        live_variants = {
+            record["name"]: record for record in live_enum.get("variants", [])
+        }
+        for variant in sorted(set(live_variants) - set(reviewed_variants)):
+            failures.append(
+                failure(
+                    "C0-RETIREMENT-VARIANT-GROWTH",
+                    "audited enum variant",
+                    str(live_source),
+                    "variant absent from the frozen reviewed ceiling",
+                    repr(live_variants[variant]),
+                    f"{inventory_path}:enums.{enum_name}.variants",
+                    enum_name=enum_name,
+                    variant=variant,
+                )
+            )
+        for variant in sorted(set(live_variants) & set(reviewed_variants)):
+            if live_variants[variant] == reviewed_variants[variant]:
+                continue
+            failures.append(
+                failure(
+                    "C0-RETIREMENT-VARIANT-DRIFT",
+                    "surviving audited enum variant",
+                    str(live_source),
+                    repr(reviewed_variants[variant]),
+                    repr(live_variants[variant]),
+                    f"{inventory_path}:enums.{enum_name}.variants",
+                    enum_name=enum_name,
+                    variant=variant,
+                )
+            )
+    return failures
+
+
+def retirement_occurrence_counts(
+    inventory: dict[str, Any],
+) -> Counter[tuple[str, str, str]]:
+    return Counter(
+        (record["enum"], record["variant"], record["path"])
+        for record in inventory.get("variant_uses", [])
+    )
+
+
+def retirement_occurrence_failures(
+    reviewed: dict[str, Any],
+    live: dict[str, Any],
+    inventory_path: Path,
+) -> list[Failure]:
+    reviewed_counts = retirement_occurrence_counts(reviewed)
+    live_counts = retirement_occurrence_counts(live)
+    first_live_site: dict[tuple[str, str, str], tuple[int, int]] = {}
+    for record in live.get("variant_uses", []):
+        key = (record["enum"], record["variant"], record["path"])
+        site = (int(record["line"]), int(record["column"]))
+        first_live_site[key] = min(first_live_site.get(key, site), site)
+    failures: list[Failure] = []
+    for (enum_name, variant, path), live_count in sorted(live_counts.items()):
+        reviewed_count = reviewed_counts[(enum_name, variant, path)]
+        if live_count <= reviewed_count:
+            continue
+        line, column = first_live_site[(enum_name, variant, path)]
+        failures.append(
+            failure(
+                "C0-RETIREMENT-OCCURRENCE-GROWTH",
+                f"{enum_name}::{variant}",
+                path,
+                f"reviewed maximum count {reviewed_count}",
+                f"live count {live_count}",
+                f"{inventory_path}:variant_uses (frozen retirement ceiling)",
+                line,
+                column,
+                enum_name,
+                variant,
+            )
+        )
+    return failures
+
+
+def retirement_summary(
+    reviewed: dict[str, Any], live: dict[str, Any]
+) -> dict[str, Any]:
+    reviewed_by_enum = Counter(
+        record["enum"] for record in reviewed.get("variant_uses", [])
+    )
+    live_by_enum = Counter(
+        record["enum"] for record in live.get("variant_uses", [])
+    )
+    reviewed_counts = retirement_occurrence_counts(reviewed)
+    live_counts = retirement_occurrence_counts(live)
+    summary: dict[str, Any] = {
+        enum_name: {
+            "reviewed": reviewed_by_enum[enum_name],
+            "live": live_by_enum[enum_name],
+            "removed": reviewed_by_enum[enum_name] - live_by_enum[enum_name],
+        }
+        for enum_name in GENERATOR.AUDITED_ENUMS
+    }
+    summary["unreviewed_audited_occurrences"] = sum(
+        max(0, count - reviewed_counts[key])
+        for key, count in live_counts.items()
+    )
+    return summary
 
 
 def auxiliary_fixture_failures(
@@ -3619,7 +3776,11 @@ def audit(
     check_gate_a: bool = True,
     check_c2_adapter: bool = True,
     baseline_inventory: dict[str, Any] | None = None,
+    mode: str = "exact",
+    summary_out: dict[str, Any] | None = None,
 ) -> list[Failure]:
+    if mode not in {"exact", "retirement"}:
+        raise ValueError(f"unsupported value-system contract mode: {mode!r}")
     root = root.resolve()
     inventory = load_json(inventory_path)
     migration = load_json(migration_path)
@@ -3680,7 +3841,11 @@ def audit(
     if scanner_failures:
         return sorted_failures(scanner_failures)
     try:
-        live = GENERATOR.generate(root, inventory["reference_commit"])
+        live = GENERATOR.generate(
+            root,
+            inventory["reference_commit"],
+            validate_type_contract_sources=mode == "exact",
+        )
     except GENERATOR.CargoMetadataError as error:
         return [
             failure(
@@ -3704,6 +3869,40 @@ def audit(
             )
         ]
     except ValueError as error:
+        if mode == "retirement":
+            missing = re.fullmatch(
+                r"pub enum (LegacyValue|Value|ValueKind|Kind) "
+                r"(?:was not found|has no body)",
+                str(error),
+            )
+            if missing is not None:
+                enum_name = (
+                    "LegacyValue"
+                    if missing.group(1) in {"LegacyValue", "Value"}
+                    else missing.group(1)
+                )
+                source = inventory["enums"][enum_name]["source"]
+                return [
+                    failure(
+                        "C0-RETIREMENT-ENUM-DRIFT",
+                        "audited enum source",
+                        source,
+                        f"live {enum_name} enum at {source!r}",
+                        str(error),
+                        f"{inventory_path}:enums.{enum_name}",
+                        enum_name=enum_name,
+                    )
+                ]
+            return [
+                failure(
+                    "C0-RETIREMENT-INVENTORY",
+                    "live retirement inventory",
+                    str(root),
+                    "a parseable audited retirement surface",
+                    str(error),
+                    "scripts/generate-value-system-inventory.py",
+                )
+            ]
         return [
             failure(
                 "C0-KIND-SCHEME-SEPARATION",
@@ -3714,23 +3913,38 @@ def audit(
                 f"{inventory_path}:type_contract_sources",
             )
         ]
+    if mode == "retirement" and summary_out is not None:
+        summary_out.clear()
+        summary_out.update(retirement_summary(inventory, live))
     failures.extend(
         reference_failures(
             root, inventory, migration, baseline, gate_b, verify_reference
         )
     )
-    if baseline_inventory is None:
+    if mode == "exact" and baseline_inventory is None:
         failures.extend(
             immutable_baseline_failures(
                 root, baseline, baseline_path, verify_git=verify_reference
             )
         )
-    failures.extend(coverage_failures(live, migration, migration_path))
-    failures.extend(family_contract_failures(live, migration, migration_path))
+    reviewed_surface = live if mode == "exact" else inventory
+    failures.extend(coverage_failures(reviewed_surface, migration, migration_path))
+    failures.extend(
+        family_contract_failures(reviewed_surface, migration, migration_path)
+    )
     failures.extend(target_applicability_failures(migration, migration_path))
-    failures.extend(occurrence_classification_failures(live, migration, migration_path))
+    failures.extend(
+        occurrence_classification_failures(
+            reviewed_surface, migration, migration_path
+        )
+    )
     failures.extend(frozen_semantics_failures(migration, migration_path))
-    failures.extend(matrix_value_classification_failures(migration, migration_path, root))
+    if mode == "exact":
+        failures.extend(
+            matrix_value_classification_failures(
+                migration, migration_path, root
+            )
+        )
     failures.extend(
         frozen_target_failures(
             migration, frozen_targets, migration_path, frozen_targets_path
@@ -3741,9 +3955,22 @@ def audit(
             migration, frozen_targets, migration_path, frozen_targets_path
         )
     )
-    failures.extend(type_contract_source_failures(root, live, inventory_path))
-    failures.extend(auxiliary_fixture_failures(inventory, live, inventory_path))
-    failures.extend(workspace_source_coverage_failures(inventory, live, inventory_path))
+    if mode == "exact":
+        failures.extend(type_contract_source_failures(root, live, inventory_path))
+        failures.extend(auxiliary_fixture_failures(inventory, live, inventory_path))
+        failures.extend(
+            workspace_source_coverage_failures(inventory, live, inventory_path)
+        )
+    else:
+        failures.extend(
+            type_contract_projection_failures(
+                inventory["type_contract_sources"], inventory_path
+            )
+        )
+        failures.extend(retirement_variant_failures(inventory, live, inventory_path))
+        failures.extend(
+            retirement_occurrence_failures(inventory, live, inventory_path)
+        )
     failures.extend(source_disposition_failures(inventory, inventory_path))
     failures.extend(qualification_failures(root, live))
     failures.extend(
@@ -3758,7 +3985,10 @@ def audit(
     failures.extend(legacy_alias_baseline_failures(baseline, live, baseline_path))
     failures.extend(compatibility_alias_failures(baseline, live, baseline_path))
     failures.extend(raw_approved_alias_failures(live))
-    if inventory_path.read_text(encoding="utf-8") != GENERATOR.render(live):
+    if (
+        mode == "exact"
+        and inventory_path.read_text(encoding="utf-8") != GENERATOR.render(live)
+    ):
         failures.append(
             failure(
                 "C0-INVENTORY-DRIFT",
@@ -3770,7 +4000,9 @@ def audit(
             )
         )
     if check_gate_a:
-        failures.extend(gate_a_failures(root, inventory))
+        failures.extend(
+            gate_a_failures(root, live if mode == "retirement" else inventory)
+        )
     if check_c2_adapter:
         failures.extend(
             c2_adapter_boundary_failures(
@@ -3794,8 +4026,9 @@ def audit(
     return sorted_failures(failures)
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=("exact", "retirement"), required=True)
     parser.add_argument("--root", type=Path, default=ROOT)
     parser.add_argument("--inventory", type=Path, default=DEFAULT_INVENTORY)
     parser.add_argument("--migration", type=Path, default=DEFAULT_MIGRATION)
@@ -3812,7 +4045,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--frozen-targets-schema", type=Path, default=DEFAULT_FROZEN_TARGETS_SCHEMA)
     parser.add_argument("--c2-adapter-boundary", type=Path, default=DEFAULT_C2_ADAPTER_BOUNDARY)
     parser.add_argument("--c2-adapter-boundary-schema", type=Path, default=DEFAULT_C2_ADAPTER_BOUNDARY_SCHEMA)
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 def report_result(failures: list[Failure]) -> int:
@@ -3825,8 +4058,31 @@ def report_result(failures: list[Failure]) -> int:
     return 1
 
 
+def report_retirement_result(
+    failures: list[Failure], summary: dict[str, Any]
+) -> int:
+    if failures:
+        print("value-system retirement contract failed:", file=sys.stderr)
+        for item in failures:
+            print(f"  {item.render()}", file=sys.stderr)
+        return 1
+    print("value-system retirement contract passed")
+    for enum_name in GENERATOR.AUDITED_ENUMS:
+        totals = summary[enum_name]
+        print(
+            f"{enum_name} occurrences: reviewed={totals['reviewed']} "
+            f"live={totals['live']} removed={totals['removed']}"
+        )
+    print(
+        "unreviewed audited occurrences: "
+        f"{summary['unreviewed_audited_occurrences']}"
+    )
+    return 0
+
+
 def main() -> int:
     args = parse_args()
+    summary: dict[str, Any] = {}
     try:
         failures = audit(
             args.root,
@@ -3845,10 +4101,14 @@ def main() -> int:
             frozen_targets_schema_path=args.frozen_targets_schema,
             c2_adapter_boundary_path=args.c2_adapter_boundary,
             c2_adapter_boundary_schema_path=args.c2_adapter_boundary_schema,
+            mode=args.mode,
+            summary_out=summary,
         )
     except (OSError, ValueError, KeyError, json.JSONDecodeError) as error:
         print(f"value-system contract checker failed internally: {error}", file=sys.stderr)
         return 2
+    if args.mode == "retirement":
+        return report_retirement_result(failures, summary)
     return report_result(failures)
 
 

--- a/scripts/check-value-system-contract.py
+++ b/scripts/check-value-system-contract.py
@@ -1352,7 +1352,11 @@ def high_risk_failures(
     baseline_path: Path,
     migration: dict[str, Any] | None = None,
     migration_path: Path = DEFAULT_MIGRATION,
+    *,
+    mode: str = "exact",
 ) -> list[Failure]:
+    if mode not in {"exact", "retirement"}:
+        raise ValueError(f"unsupported high-risk contract mode: {mode!r}")
     failures: list[Failure] = []
     baseline_uses = baseline["high_risk_api_uses"]
     live_uses = live["high_risk_api_uses"]
@@ -1362,14 +1366,15 @@ def high_risk_failures(
         for _ in range(row["count"])
     )
     observed_additions: Counter[tuple[str, str, str]] = Counter()
+    retirement_count_ceiling_identifiers = {
+        "valref-alias",
+        "mutable-reference-alias",
+        "value-mutable-reference",
+        "reactive-cell-id",
+    }
     for identifier, current_rows in live_uses.items():
-        approved_sites = Counter(
-            (row["path"], site["fingerprint"])
-            for row in baseline_uses.get(identifier, [])
-            for site in row["sites"]
-        )
-        current_sites = Counter(
-            (row["path"], site["fingerprint"])
+        filtered_current_rows = [
+            row
             for row in current_rows
             if not (
                 row["path"] == "src/core/src/legacy_adapter/value.rs"
@@ -1380,6 +1385,49 @@ def high_risk_failures(
                     "value-typed-wrapper",
                 }
             )
+        ]
+        if mode == "retirement" and identifier in retirement_count_ceiling_identifiers:
+            approved_counts = Counter(
+                row["path"]
+                for row in baseline_uses.get(identifier, [])
+                for _site in row["sites"]
+            )
+            approved_counts.update(
+                path
+                for (approved_identifier, path, _fingerprint), count in authorized.items()
+                if approved_identifier == identifier
+                for _ in range(count)
+            )
+            current_counts = Counter(
+                row["path"]
+                for row in filtered_current_rows
+                for _site in row["sites"]
+            )
+            additions = current_counts - approved_counts
+            for path, count in sorted(additions.items()):
+                row = next(row for row in filtered_current_rows if row["path"] == path)
+                for site in row["sites"][-count:]:
+                    failures.append(
+                        failure(
+                            "C0-LEGACY-GROWTH",
+                            identifier,
+                            path,
+                            "occurrence count at or below the immutable baseline plus authorized ceiling for this path",
+                            "new path or increased legacy occurrence count",
+                            f"{baseline_path}:high_risk_api_uses.{identifier}",
+                            site["line"],
+                            site["column"],
+                        )
+                    )
+            continue
+        approved_sites = Counter(
+            (row["path"], site["fingerprint"])
+            for row in baseline_uses.get(identifier, [])
+            for site in row["sites"]
+        )
+        current_sites = Counter(
+            (row["path"], site["fingerprint"])
+            for row in filtered_current_rows
             for site in row["sites"]
         )
         additions = current_sites - approved_sites
@@ -1398,7 +1446,7 @@ def high_risk_failures(
         additions -= approved_additions
         for path, fingerprint in sorted(additions):
             remaining = additions[(path, fingerprint)]
-            for row in current_rows:
+            for row in filtered_current_rows:
                 if row["path"] != path:
                     continue
                 for site in row["sites"]:
@@ -1419,18 +1467,19 @@ def high_risk_failures(
                     remaining -= 1
                 if remaining == 0:
                     break
-    excess_authorizations = authorized - observed_additions
-    for (identifier, path, fingerprint), count in sorted(excess_authorizations.items()):
-        failures.append(
-            failure(
-                "C0-LEGACY-AUTHORIZATION-STALE",
-                identifier,
-                path,
-                "every post-C0 authorization matches one live addition beyond the immutable baseline",
-                f"{count} unmatched authorization(s) for fingerprint {fingerprint}",
-                f"{migration_path}:authorized_high_risk_uses",
+    if mode == "exact":
+        excess_authorizations = authorized - observed_additions
+        for (identifier, path, fingerprint), count in sorted(excess_authorizations.items()):
+            failures.append(
+                failure(
+                    "C0-LEGACY-AUTHORIZATION-STALE",
+                    identifier,
+                    path,
+                    "every post-C0 authorization matches one live addition beyond the immutable baseline",
+                    f"{count} unmatched authorization(s) for fingerprint {fingerprint}",
+                    f"{migration_path}:authorized_high_risk_uses",
+                )
             )
-        )
     return failures
 
 
@@ -3980,6 +4029,7 @@ def audit(
             baseline_path,
             migration,
             migration_path,
+            mode=mode,
         )
     )
     failures.extend(legacy_alias_baseline_failures(baseline, live, baseline_path))

--- a/scripts/generate-value-system-inventory.py
+++ b/scripts/generate-value-system-inventory.py
@@ -1819,32 +1819,54 @@ def field_type(source: str, owner: str, field: str) -> str | None:
     return re.sub(r"\s+", "", body[start:end])
 
 
-def type_contract_sources(root: Path) -> dict[str, list[dict[str, str]]]:
+def expected_type_contract_sources() -> dict[str, list[dict[str, str]]]:
     inventory: dict[str, list[dict[str, str]]] = {}
     for group, specs in TYPE_CONTRACT_SOURCE_SPECS.items():
         target, gate = TYPE_CONTRACT_TARGETS[group]
         records: list[dict[str, str]] = []
         for relative, symbol in specs:
+            if "." in symbol:
+                expected_form = TYPE_CONTRACT_FIELD_FORMS[(relative, symbol)]
+                source_kind = "field"
+                source_form = f"field:{expected_form}"
+            else:
+                expected_form = TYPE_CONTRACT_DECLARATION_FORMS[(relative, symbol)]
+                source_kind = "declaration"
+                source_form = expected_form
+            records.append(
+                {
+                    "path": relative,
+                    "symbol": symbol,
+                    "source_kind": source_kind,
+                    "source_form": source_form,
+                    "target": target,
+                    "implementation_gate": gate,
+                }
+            )
+        inventory[group] = records
+    return inventory
+
+
+def type_contract_sources(root: Path) -> dict[str, list[dict[str, str]]]:
+    expected = expected_type_contract_sources()
+    for group, records in expected.items():
+        for record in records:
+            relative = record["path"]
+            symbol = record["symbol"]
             path = root / relative
             if not path.is_file():
                 raise TypeContractError(
                     f"type contract source is missing: {relative}::{symbol}"
                 )
             source = path.read_text(encoding="utf-8")
-            if "." in symbol:
+            if record["source_kind"] == "field":
                 owner, field = symbol.split(".", 1)
                 actual_form = field_type(source, owner, field)
                 expected_form = TYPE_CONTRACT_FIELD_FORMS[(relative, symbol)]
-                exists = actual_form == expected_form
-                source_kind = "field"
-                source_form = f"field:{expected_form}"
             else:
                 actual_form = declaration_form(source, symbol)
                 expected_form = TYPE_CONTRACT_DECLARATION_FORMS[(relative, symbol)]
-                exists = actual_form == expected_form
-                source_kind = "declaration"
-                source_form = expected_form
-            if not exists:
+            if actual_form != expected_form:
                 raise TypeContractError(
                     f"type contract source shape changed: {relative}::{symbol}; "
                     f"expected {expected_form}, found {actual_form}"
@@ -1861,18 +1883,7 @@ def type_contract_sources(root: Path) -> dict[str, list[dict[str, str]]]:
                         f"runtime representation source crosses into semantic typing: "
                         f"{relative}::{symbol} references {forbidden}"
                     )
-            records.append(
-                {
-                    "path": relative,
-                    "symbol": symbol,
-                    "source_kind": source_kind,
-                    "source_form": source_form,
-                    "target": target,
-                    "implementation_gate": gate,
-                }
-            )
-        inventory[group] = records
-    return inventory
+    return expected
 
 
 def generate(
@@ -1880,6 +1891,7 @@ def generate(
     reference_commit: str = REFERENCE_COMMIT,
     *,
     target_roots: Iterable[Path] | None = None,
+    validate_type_contract_sources: bool = True,
 ) -> dict[str, object]:
     digest = legacy_scanner_implementation_sha256()
     if digest != LEGACY_SCANNER_CONTRACT["implementation_sha256"]:
@@ -2001,7 +2013,11 @@ def generate(
             }
         },
         "variant_uses": uses,
-        "type_contract_sources": type_contract_sources(root),
+        "type_contract_sources": (
+            type_contract_sources(root)
+            if validate_type_contract_sources
+            else expected_type_contract_sources()
+        ),
         "auxiliary_rust_fixtures": auxiliary_fixtures,
         "auxiliary_cargo_fixtures": auxiliary_cargo_fixtures,
         "legacy_aliases": legacy_aliases,

--- a/scripts/tests/test_check_value_system_contract.py
+++ b/scripts/tests/test_check_value_system_contract.py
@@ -1341,10 +1341,25 @@ class LegacyGrowthTests(unittest.TestCase):
             ],
         }
 
-    def failures(self, baseline_rows, live_rows, identifier="valref-alias"):
+    def failures(
+        self,
+        baseline_rows,
+        live_rows,
+        identifier="valref-alias",
+        *,
+        migration=None,
+        mode="exact",
+    ):
         baseline = {"high_risk_api_uses": {identifier: baseline_rows}}
         live = {"high_risk_api_uses": {identifier: live_rows}}
-        return CHECKER.high_risk_failures(baseline, live, Path("baseline.json"))
+        return CHECKER.high_risk_failures(
+            baseline,
+            live,
+            Path("baseline.json"),
+            migration,
+            Path("migration.json"),
+            mode=mode,
+        )
 
     def test_new_legacy_use_fails(self):
         self.assertTrue(self.failures([self.row("a.rs", 1)], [self.row("a.rs", 2)]))
@@ -1416,6 +1431,83 @@ class LegacyGrowthTests(unittest.TestCase):
                     Path("baseline.json"),
                     migration,
                     Path("migration.json"),
+                )
+            },
+        )
+
+    def test_retirement_allows_authorized_site_deletion_but_exact_reports_stale(self):
+        authorization = {
+            "gate": "D1A",
+            "identifier": "valref-alias",
+            "path": "new.rs",
+            "fingerprint": "a" * 64,
+            "count": 1,
+            "reason": "authorized compiler adapter boundary",
+        }
+        migration = {"authorized_high_risk_uses": [authorization]}
+
+        self.assertEqual(
+            self.failures([], [], migration=migration, mode="retirement"), []
+        )
+        self.assertIn(
+            "C0-LEGACY-AUTHORIZATION-STALE",
+            {
+                item.contract_id
+                for item in self.failures([], [], migration=migration, mode="exact")
+            },
+        )
+
+    def test_retirement_alias_ceiling_ignores_clause_and_line_movement(self):
+        baseline = self.row("a.rs", 1)
+        live = self.row("a.rs", 1)
+        live["sites"][0]["line"] = 42
+        live["sites"][0]["fingerprint"] = "b" * 64
+
+        self.assertEqual(
+            self.failures([baseline], [live], mode="retirement"), []
+        )
+
+    def test_retirement_alias_ceiling_rejects_count_growth(self):
+        self.assertIn(
+            "C0-LEGACY-GROWTH",
+            {
+                item.contract_id
+                for item in self.failures(
+                    [self.row("a.rs", 1)],
+                    [self.row("a.rs", 2)],
+                    mode="retirement",
+                )
+            },
+        )
+
+    def test_retirement_alias_ceiling_rejects_new_path(self):
+        self.assertIn(
+            "C0-LEGACY-GROWTH",
+            {
+                item.contract_id
+                for item in self.failures(
+                    [self.row("a.rs", 1)],
+                    [self.row("b.rs", 1)],
+                    mode="retirement",
+                )
+            },
+        )
+
+    def test_retirement_pointer_identity_substitution_remains_fingerprint_exact(self):
+        baseline = self.row("a.rs", 1)
+        live = self.row("a.rs", 1)
+        live["sites"][0]["line"] = 42
+        live["sites"][0]["fingerprint"] = "b" * 64
+
+        self.assertIn(
+            "C0-LEGACY-GROWTH",
+            {
+                item.contract_id
+                for item in self.failures(
+                    [baseline],
+                    [live],
+                    "ref-addr-ufcs",
+                    mode="retirement",
                 )
             },
         )

--- a/scripts/tests/test_check_value_system_contract.py
+++ b/scripts/tests/test_check_value_system_contract.py
@@ -2,6 +2,7 @@ import copy
 import contextlib
 import hashlib
 import importlib.util
+import inspect
 import io
 import json
 import subprocess
@@ -298,6 +299,17 @@ class ReviewedContractsTests(unittest.TestCase):
             {item.contract_id for item in failures},
         )
 
+    def test_type_contract_target_projection_is_pure_and_exact(self):
+        records = copy.deepcopy(self.inventory["type_contract_sources"])
+        records["runtime_representation_sources"][0]["implementation_gate"] = "C1"
+        failures = CHECKER.type_contract_projection_failures(
+            records, CONTRACTS / "current-inventory.json"
+        )
+        self.assertEqual(
+            {item.contract_id for item in failures},
+            {"C0-KIND-SCHEME-SEPARATION"},
+        )
+
     def test_canonical_encoding_constants_are_exact(self):
         self.assertEqual(
             CHECKER.canonical_encoding_failures(
@@ -311,6 +323,243 @@ class ReviewedContractsTests(unittest.TestCase):
                 CONTRACTS / "canonical-encoding-v1-vectors.json",
             ),
             [],
+        )
+
+
+class RetirementSurfaceTests(unittest.TestCase):
+    def setUp(self):
+        self.inventory_path = Path("current-inventory.json")
+        self.reviewed = {
+            "enums": {
+                "LegacyValue": {
+                    "source": "src/core/src/value.rs",
+                    "variants": [
+                        {
+                            "name": "Empty",
+                            "cfg": None,
+                            "payload_type": None,
+                            "storage_ownership": "inline-value",
+                            "current_roles": ["semantic-payload"],
+                        },
+                        {
+                            "name": "MatrixValue",
+                            "cfg": 'feature = "matrix"',
+                            "payload_type": "Matrix<LegacyValue>",
+                            "storage_ownership": "owned-container",
+                            "current_roles": ["semantic-payload", "mutable-storage"],
+                        },
+                        {
+                            "name": "Retired",
+                            "cfg": None,
+                            "payload_type": None,
+                            "storage_ownership": "inline-value",
+                            "current_roles": ["diagnostic"],
+                        },
+                    ],
+                },
+                "ValueKind": {
+                    "source": "src/core/src/value.rs",
+                    "variants": [
+                        {"name": "Any", "cfg": None, "payload_type": None}
+                    ],
+                },
+                "Kind": {
+                    "source": "src/core/src/kind.rs",
+                    "variants": [
+                        {"name": "Any", "cfg": None, "payload_type": None}
+                    ],
+                },
+            },
+            "variant_uses": [
+                self.use("LegacyValue", "Empty", "src/a.rs", 10, 3),
+                self.use("LegacyValue", "Empty", "src/a.rs", 20, 5),
+                self.use("LegacyValue", "Empty", "src/b.rs", 7, 2),
+                self.use("LegacyValue", "MatrixValue", "src/a.rs", 30, 9),
+                self.use("ValueKind", "Any", "src/c.rs", 4, 1),
+                self.use("Kind", "Any", "src/d.rs", 5, 6),
+                self.use("Kind", "Any", "src/d.rs", 8, 6),
+            ],
+        }
+        self.live = copy.deepcopy(self.reviewed)
+
+    @staticmethod
+    def use(enum_name, variant, path, line, column):
+        return {
+            "enum": enum_name,
+            "variant": variant,
+            "path": path,
+            "line": line,
+            "column": column,
+        }
+
+    def failures(self):
+        return [
+            *CHECKER.retirement_variant_failures(
+                self.reviewed, self.live, self.inventory_path
+            ),
+            *CHECKER.retirement_occurrence_failures(
+                self.reviewed, self.live, self.inventory_path
+            ),
+        ]
+
+    def ids(self):
+        return {item.contract_id for item in self.failures()}
+
+    def test_identical_reviewed_and_live_surface_passes(self):
+        for enum in self.live["enums"].values():
+            enum["variants"].reverse()
+        self.assertEqual(self.failures(), [])
+
+    def test_line_and_column_movement_passes(self):
+        for index, record in enumerate(self.live["variant_uses"]):
+            record["line"] += 100 + index
+            record["column"] += 10 + index
+        self.assertEqual(self.failures(), [])
+
+    def test_one_deleted_occurrence_passes(self):
+        self.live["variant_uses"].pop(0)
+        self.assertEqual(self.failures(), [])
+
+    def test_all_occurrences_removed_from_one_file_pass(self):
+        self.live["variant_uses"] = [
+            row for row in self.live["variant_uses"] if row["path"] != "src/b.rs"
+        ]
+        self.assertEqual(self.failures(), [])
+
+    def test_count_growth_in_existing_file_fails(self):
+        self.live["variant_uses"].append(
+            self.use("LegacyValue", "Empty", "src/a.rs", 40, 2)
+        )
+        failures = self.failures()
+        self.assertEqual(
+            {item.contract_id for item in failures},
+            {"C0-RETIREMENT-OCCURRENCE-GROWTH"},
+        )
+        self.assertEqual(len(failures), 1)
+        self.assertEqual(
+            (
+                failures[0].path,
+                failures[0].line,
+                failures[0].column,
+                failures[0].expected,
+                failures[0].actual,
+            ),
+            ("src/a.rs", 10, 3, "reviewed maximum count 2", "live count 3"),
+        )
+
+    def test_new_path_fails(self):
+        self.live["variant_uses"].append(
+            self.use("LegacyValue", "Empty", "src/new.rs", 1, 1)
+        )
+        self.assertEqual(self.ids(), {"C0-RETIREMENT-OCCURRENCE-GROWTH"})
+
+    def test_moving_occurrence_between_files_fails(self):
+        moved = next(
+            row for row in self.live["variant_uses"] if row["path"] == "src/b.rs"
+        )
+        moved["path"] = "src/a.rs"
+        self.assertEqual(self.ids(), {"C0-RETIREMENT-OCCURRENCE-GROWTH"})
+
+    def test_replacing_variant_use_fails_at_growing_destination(self):
+        row = next(
+            row
+            for row in self.live["variant_uses"]
+            if row["variant"] == "Empty" and row["path"] == "src/a.rs"
+        )
+        row["variant"] = "MatrixValue"
+        failures = self.failures()
+        self.assertEqual(
+            {item.contract_id for item in failures},
+            {"C0-RETIREMENT-OCCURRENCE-GROWTH"},
+        )
+        self.assertEqual(failures[0].variant, "MatrixValue")
+
+    def test_removing_reviewed_variant_passes(self):
+        self.live["enums"]["LegacyValue"]["variants"] = [
+            row
+            for row in self.live["enums"]["LegacyValue"]["variants"]
+            if row["name"] != "Retired"
+        ]
+        self.assertEqual(self.failures(), [])
+
+    def test_adding_variant_fails(self):
+        self.live["enums"]["Kind"]["variants"].append(
+            {"name": "Added", "cfg": None, "payload_type": None}
+        )
+        self.assertEqual(self.ids(), {"C0-RETIREMENT-VARIANT-GROWTH"})
+
+    def change_legacy_variant(self, field, value):
+        variant = next(
+            row
+            for row in self.live["enums"]["LegacyValue"]["variants"]
+            if row["name"] == "MatrixValue"
+        )
+        variant[field] = value
+
+    def test_changing_payload_type_fails(self):
+        self.change_legacy_variant("payload_type", "Vec<LegacyValue>")
+        self.assertEqual(self.ids(), {"C0-RETIREMENT-VARIANT-DRIFT"})
+
+    def test_changing_cfg_fails(self):
+        self.change_legacy_variant("cfg", 'feature = "other"')
+        self.assertEqual(self.ids(), {"C0-RETIREMENT-VARIANT-DRIFT"})
+
+    def test_changing_legacy_value_storage_ownership_fails(self):
+        self.change_legacy_variant("storage_ownership", "shared-reference")
+        self.assertEqual(self.ids(), {"C0-RETIREMENT-VARIANT-DRIFT"})
+
+    def test_changing_legacy_value_current_roles_fails(self):
+        self.change_legacy_variant("current_roles", ["diagnostic"])
+        self.assertEqual(self.ids(), {"C0-RETIREMENT-VARIANT-DRIFT"})
+
+    def test_changing_enum_source_path_fails(self):
+        self.live["enums"]["Kind"]["source"] = "src/core/src/new_kind.rs"
+        self.assertEqual(self.ids(), {"C0-RETIREMENT-ENUM-DRIFT"})
+
+    def test_missing_audited_enum_fails(self):
+        del self.live["enums"]["Kind"]
+        self.assertEqual(self.ids(), {"C0-RETIREMENT-ENUM-DRIFT"})
+
+    def test_summary_totals_and_removed_counts_are_exact(self):
+        self.live["variant_uses"].pop(0)
+        self.live["variant_uses"] = [
+            row
+            for index, row in enumerate(self.live["variant_uses"])
+            if not (row["enum"] == "Kind" and index == 4)
+        ]
+        summary = CHECKER.retirement_summary(self.reviewed, self.live)
+        self.assertEqual(
+            summary,
+            {
+                "LegacyValue": {"reviewed": 4, "live": 3, "removed": 1},
+                "ValueKind": {"reviewed": 1, "live": 1, "removed": 0},
+                "Kind": {"reviewed": 2, "live": 1, "removed": 1},
+                "unreviewed_audited_occurrences": 0,
+            },
+        )
+
+
+class CheckerModeTests(unittest.TestCase):
+    def test_audit_python_api_defaults_to_exact(self):
+        self.assertEqual(
+            inspect.signature(CHECKER.audit).parameters["mode"].default,
+            "exact",
+        )
+
+    def test_audit_rejects_unknown_mode(self):
+        with self.assertRaisesRegex(ValueError, "unsupported value-system"):
+            CHECKER.audit(mode="unknown")
+
+    def test_parse_args_requires_mode(self):
+        with contextlib.redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
+            CHECKER.parse_args([])
+
+    def test_parse_args_accepts_exact(self):
+        self.assertEqual(CHECKER.parse_args(["--mode", "exact"]).mode, "exact")
+
+    def test_parse_args_accepts_retirement(self):
+        self.assertEqual(
+            CHECKER.parse_args(["--mode", "retirement"]).mode, "retirement"
         )
 
 
@@ -782,7 +1031,7 @@ class ValueSystemContractFixtureTests(unittest.TestCase):
             "use_classifications": classifications,
         }
 
-    def audit(self):
+    def audit(self, mode="exact", summary_out=None):
         return CHECKER.audit(
             self.root,
             self.inventory_path,
@@ -802,6 +1051,8 @@ class ValueSystemContractFixtureTests(unittest.TestCase):
             check_gate_a=False,
             check_c2_adapter=False,
             baseline_inventory=self.baseline,
+            mode=mode,
+            summary_out=summary_out,
         )
 
     @staticmethod
@@ -810,6 +1061,37 @@ class ValueSystemContractFixtureTests(unittest.TestCase):
 
     def test_valid_fixture_passes(self):
         self.assertEqual(self.audit(), [])
+
+    def test_audit_without_explicit_mode_remains_exact(self):
+        source = (self.root / "src/core/src/live.rs").read_text(encoding="utf-8")
+        self.write("src/core/src/live.rs", "\n" + source)
+        self.assertIn("C0-INVENTORY-DRIFT", self.ids(self.audit()))
+        self.assertEqual(self.audit(mode="retirement"), [])
+
+    def test_retirement_mode_uses_relaxed_type_contract_generation(self):
+        path = self.root / "src/core/src/function/signature.rs"
+        source = path.read_text(encoding="utf-8").replace(
+            "pub trait FunctionRuntimeType {}",
+            "pub struct FunctionRuntimeType;",
+        )
+        path.write_text(source, encoding="utf-8")
+        self.assertIn("C0-KIND-SCHEME-SEPARATION", self.ids(self.audit()))
+        summary = {}
+        self.assertEqual(
+            self.audit(mode="retirement", summary_out=summary), []
+        )
+        self.assertEqual(summary["unreviewed_audited_occurrences"], 0)
+
+    def test_retirement_mode_reports_a_missing_enum_as_enum_drift(self):
+        path = self.root / "src/core/src/kind.rs"
+        source = path.read_text(encoding="utf-8").replace(
+            "pub enum Kind", "pub struct Kind", 1
+        )
+        path.write_text(source, encoding="utf-8")
+        self.assertEqual(
+            self.ids(self.audit(mode="retirement")),
+            {"C0-RETIREMENT-ENUM-DRIFT"},
+        )
 
     def test_permanent_compatibility_aliases_are_exact_and_public(self):
         cases = (
@@ -2131,6 +2413,44 @@ class FinalQualificationFindingTests(unittest.TestCase):
         with contextlib.redirect_stderr(stderr):
             self.assertEqual(CHECKER.report_result([finding]), 1)
         self.assertIn("value-system contract failed", stderr.getvalue())
+
+    def test_retirement_success_summary_has_the_exact_cli_shape(self):
+        summary = {
+            "LegacyValue": {"reviewed": 10, "live": 7, "removed": 3},
+            "ValueKind": {"reviewed": 5, "live": 4, "removed": 1},
+            "Kind": {"reviewed": 2, "live": 2, "removed": 0},
+            "unreviewed_audited_occurrences": 0,
+        }
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            self.assertEqual(
+                CHECKER.report_retirement_result([], summary), 0
+            )
+        self.assertEqual(
+            stdout.getvalue(),
+            "value-system retirement contract passed\n"
+            "LegacyValue occurrences: reviewed=10 live=7 removed=3\n"
+            "ValueKind occurrences: reviewed=5 live=4 removed=1\n"
+            "Kind occurrences: reviewed=2 live=2 removed=0\n"
+            "unreviewed audited occurrences: 0\n",
+        )
+
+    def test_retirement_failure_uses_retirement_heading_only(self):
+        finding = CHECKER.failure(
+            "C0-RETIREMENT-OCCURRENCE-GROWTH",
+            "LegacyValue::Empty",
+            "src/new.rs",
+            "reviewed maximum count 0",
+            "live count 1",
+            "current-inventory.json",
+        )
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            self.assertEqual(
+                CHECKER.report_retirement_result([finding], {}), 1
+            )
+        self.assertIn("value-system retirement contract failed:", stderr.getvalue())
+        self.assertNotIn("value-system retirement contract passed", stderr.getvalue())
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_generate_value_system_inventory.py
+++ b/scripts/tests/test_generate_value_system_inventory.py
@@ -1,9 +1,13 @@
 import importlib.util
+import io
 import json
+import subprocess
 import sys
+import tarfile
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 SCRIPT = Path(__file__).resolve().parents[1] / "generate-value-system-inventory.py"
@@ -129,6 +133,17 @@ class ValueSystemInventoryGeneratorTests(unittest.TestCase):
         second = GENERATOR.render(self.generate(root))
         self.assertEqual(first, second)
         self.assertEqual(json.loads(first), json.loads(second))
+
+    def test_default_generation_matches_explicit_strict_generation(self):
+        root = self.repository()
+        default = self.generate(root)
+        explicit = GENERATOR.generate(
+            root,
+            "f" * 40,
+            target_roots=[root / "src/core/src/lib.rs"],
+            validate_type_contract_sources=True,
+        )
+        self.assertEqual(GENERATOR.render(default), GENERATOR.render(explicit))
 
     def test_complete_scanner_module_digest_covers_every_scanner_layer(self):
         scanner_path = Path(GENERATOR.LEGACY_SCANNER.__file__)
@@ -975,6 +990,76 @@ class ValueSystemInventoryGeneratorTests(unittest.TestCase):
         )
         with self.assertRaisesRegex(ValueError, "source shape changed"):
             GENERATOR.type_contract_sources(root)
+
+    def test_default_generate_validates_type_contract_source_shapes(self):
+        root = self.repository(
+            {
+                "src/core/src/function/signature.rs": SIGNATURE_SOURCE.replace(
+                    "pub trait FunctionRuntimeType {}",
+                    "pub struct FunctionRuntimeType;",
+                )
+            }
+        )
+        with self.assertRaisesRegex(ValueError, "source shape changed"):
+            self.generate(root)
+
+    def test_relaxed_generate_skips_only_type_contract_shape_validation(self):
+        root = self.repository(
+            {
+                "src/core/src/function/signature.rs": SIGNATURE_SOURCE.replace(
+                    "pub trait FunctionRuntimeType {}",
+                    "pub struct FunctionRuntimeType;",
+                ),
+                "src/core/src/live.rs": (
+                    "pub type ValRef = Ref<Value>;\n"
+                    "fn live(value: ValRef) {\n"
+                    "  let _ = value;\n"
+                    "  let _ = Value::Empty;\n"
+                    "  let _ = ValueKind::Any;\n"
+                    "  let _ = Kind::Any;\n"
+                    "}\n"
+                ),
+            }
+        )
+        inventory = GENERATOR.generate(
+            root,
+            "f" * 40,
+            target_roots=[root / "src/core/src/lib.rs"],
+            validate_type_contract_sources=False,
+        )
+        self.assertEqual(
+            inventory["type_contract_sources"],
+            GENERATOR.expected_type_contract_sources(),
+        )
+        self.assertEqual(
+            set(inventory["enums"]), {"LegacyValue", "ValueKind", "Kind"}
+        )
+        self.assertTrue(inventory["variant_uses"])
+        self.assertTrue(inventory["legacy_aliases"])
+        self.assertTrue(
+            any(inventory["high_risk_api_uses"].values())
+        )
+
+    def test_archived_generation_keeps_the_strict_default(self):
+        archive_bytes = io.BytesIO()
+        with tarfile.open(fileobj=archive_bytes, mode="w"):
+            pass
+        completed = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=archive_bytes.getvalue(), stderr=b""
+        )
+        reference = "a" * 40
+        with mock.patch.object(
+            GENERATOR.subprocess, "run", return_value=completed
+        ), mock.patch.object(
+            GENERATOR, "generate", return_value={"strict": True}
+        ) as generate:
+            self.assertEqual(
+                GENERATOR.archived_inventory(Path("/repository"), reference),
+                {"strict": True},
+            )
+        args, kwargs = generate.call_args
+        self.assertEqual(args[1], reference)
+        self.assertEqual(kwargs, {})
 
     def test_runtime_representation_body_cannot_reference_kind_scheme(self):
         root = self.repository(

--- a/tests/architecture/value-system/README.md
+++ b/tests/architecture/value-system/README.md
@@ -1,127 +1,115 @@
 # Value-system architecture contracts
 
-This directory freezes the exact reviewed Gate B value surface and its Gate C
-migration destinations. It does not implement immutable values.
+This directory preserves the reviewed value-system architecture while
+`LegacyValue`, `ValueKind`, and semantic `Kind` are retired. It does not
+implement immutable values or authorize new legacy behavior.
 
-- `current-inventory.json` is the regeneratable v5 inventory of `Value`,
-  `ValueKind`, semantic `Kind`, exact line/column variant occurrences, aliases,
-  high-risk legacy mechanisms, proven auxiliary Rust fixtures, and the three
-  distinct type-contract source classes.
+## Retirement contract
+
+`current-inventory.json` is the frozen reviewed retirement ceiling. Its v6
+inventory records the audited enums and variants, ordinary qualified variant
+occurrences, aliases, high-risk mechanisms, source coverage, and the three
+type-contract source groups. It is historical review evidence, not a file to
+regenerate after each migration edit.
+
+`migration.json` and `frozen-semantic-targets-v1.json` preserve the reviewed
+historical semantic classification. The former assigns every reviewed variant
+and occurrence to its migration family, role, and target. The latter freezes
+target definitions and the reviewed occurrence-to-target projection so those
+decisions cannot be rewritten during retirement.
+
+The line and column values for ordinary occurrences are historical evidence.
+Retirement validation compares the live and reviewed occurrence counts using
+the key `(enum, variant, path)`; line and column are deliberately excluded.
+Consequently:
+
+- deleting a reviewed occurrence passes;
+- moving an occurrence within the same file passes;
+- adding an occurrence in the same file fails;
+- moving an occurrence to another file fails because the destination grows;
+- replacing one variant with another fails if the replacement's per-file count
+  grows;
+- adding a variant or changing a surviving variant definition fails;
+- removing a reviewed variant passes.
+
+This is a per-file shrink-only ceiling, not a repository-wide aggregate.
+Equal global totals cannot relocate legacy debt. PR1 does not support deletion
+of an entire audited enum or `src/core/src/value.rs`; final enum and module
+removal belongs to the final-cutover PR.
+
+High-risk mechanisms remain fingerprint-precise. `MutableReference`, `ValRef`,
+`Ref` identity/address operations, transaction and journal mechanisms, legacy
+aliases, and the C2 adapter allowance retain their exact scanner and boundary
+checks. Canonical encoding, snapshot isolation, schema isolation,
+semantic-module isolation, adapter coexistence, resident hot-path boundaries,
+Gate A, Gate B, and frozen semantic targets remain enforced in retirement
+mode.
+
+## Contract documents
+
 - `legacy-growth-baseline.json` is generated only from archived reviewed B2
-  commit `d5e41f6fd43c9d21c5858d80dab50e7ce64e9a10`. It is the immutable growth
-  boundary; regenerating current inventory cannot expand it.
-- `migration.json` is the reviewed v3 semantic classification. Every generated
-  occurrence appears exactly once with roles and one applicable structured
-  target. Its 69 targets name the exact enum variants to which they apply.
-- `frozen-semantic-targets-v1.json` is the hand-maintained projection of every
-  target's ID, applicability, semantic category, representation,
-  implementation gate, key semantics, and runtime storage. It prevents the
-  migration manifest from silently redefining an accepted destination. Its
-  occurrence projection also freezes the reviewed target of every exact
-  production site, so targets cannot be swapped between two valid uses.
+  commit `d5e41f6fd43c9d21c5858d80dab50e7ce64e9a10`. The separate archived-source
+  check proves it remains byte-identical to that source oracle.
 - `canonical-encoding-v1.json` freezes `MechSnapshotEncodingV1`, SHA-256
-  identities, exact schema, kind and dimension tags, framing,
-  platform-independent primitive widths, aggregate order, and `KeyOrder`.
-- `canonical-encoding-v1-vectors.json` commits eleven positive value, five key,
-  seven dimension-normalization, seventeen invalid-value, and eight
-  invalid-schema vectors.
-  `scripts/tests/canonical_encoding_v1_reference.py` independently reproduces
-  them during contract tests.
+  identities, exact schema, kind and dimension tags, framing, primitive widths,
+  aggregate order, and `KeyOrder`.
+- `canonical-encoding-v1-vectors.json` contains the independent positive and
+  negative encoding vectors reproduced by
+  `scripts/tests/canonical_encoding_v1_reference.py`.
 - `gate-b-regression.json` freezes inherited efficacy requirements and the
   protected paths that require fresh evidence.
 - The adjacent `*-schema.json` files define each machine-readable contract.
 
-Production code must qualify every `Value`, `ValueKind`, and semantic `Kind`
-variant with its canonical enum name. Glob, grouped, single-variant,
-variant-alias, enum-alias, direct type-alias, raw-identifier, qualified-self,
-angle-qualified, and generic/turbofish spellings are rejected. `Self::Variant`
-and `<Self>::Variant` are rejected inside the audited enum's own `impl` blocks.
-This convention keeps inventory token-based and auditable without partial Rust
+The immutable legacy scanner is version `c2-legacy-growth-v2`, implemented by
+`scripts/value_system_legacy_scanner_v2.py`. Its frozen module SHA-256 is
+`78529f2ffce2e3c3fc0d3ffabd55c8df1846ace2edd11500c095e82c8a12eed3`.
+The scanner recognizes direct, qualified, aliased, raw-identifier, generic,
+UFCS, and supported identity-wrapper forms without relying on partial Rust
 name resolution.
 
-The v5 inventory contains 49 `Value` variants, 32 `ValueKind` variants, 17
-semantic `Kind` variants, 5,976 qualified production occurrences, nine
-`KindExpr` sources, five `KindScheme` sources, and ten runtime-representation
-sources. Runtime representation and native-lowering metadata never become
-`KindScheme`. `use_classifications` replaces file-wide role unions: several
-sites may share one record only when enum, variant, path, roles, and target are
-identical.
+Type-contract source records preserve the exact reviewed targets and
+implementation gates. Exact mode additionally validates today's declaration
+forms and field types, including the separation between semantic kind schemes
+and runtime-representation metadata. Retirement mode uses the frozen
+projection while continuing to scan live variants, ordinary occurrences,
+aliases, and high-risk mechanisms.
 
-Cargo metadata defines production and auxiliary target roots. The inventory
-enumerates 859 Rust files: 576 are audited, 261 are proven auxiliary through
-Cargo target/module reachability, and 22 are proven trybuild fixture roots.
-Production reachability overrides either auxiliary proof. Auxiliary files
-are excluded only when they are target/module-graph reachable from an
-auxiliary Cargo target or are literal `trybuild` fixture paths resolved from
-supported `compile_fail` and `pass` calls in the target root or any reachable
-helper module. Dynamic paths, unmatched files,
-production-reachable files, and paths that escape the repository remain
-audited or fail discovery. The current inventory records four trybuild call
-sites resolving to 22 fixture files.
+## Operating modes
 
-The immutable legacy scanner is version `c0-legacy-growth-v1`, implemented
-entirely by `scripts/value_system_legacy_scanner_v1.py`, with module SHA-256
-`9624eb89c01085cc5e412506b30671f442ba53b057c228b3fbcd113cc77ad834`.
-The inventory separates two removable legacy value aliases from two required
-public compatibility aliases (`SymbolTableRef` and `InterpreterRef`) and
-freezes their public re-export routes.
-
-The high-risk `Ref` inventory recognizes direct, turbofish, path-qualified,
-angle-qualified, nested-generic, local-type-alias, and imported-rename UFCS
-calls. Trait-qualified calls, unrelated receiver types, and instance methods
-are not counted. Audited enum aliases are rejected through transitive alias
-chains and generic identity wrappers, while ordinary containers such as
-`Ref<Value>` remain valid.
-
-Type-contract source records include exact declaration forms and field types.
-Runtime-representation declarations may not reference semantic KindScheme
-types. Canonical dimension constant folding uses checked `u64` arithmetic;
-overflow is invalid.
-
-`Value::Empty` is partitioned among `source-empty-expression`,
-`option-absence`, `execution-no-result`, `uninitialized-storage`,
-`unspecified-extent`, and `generic-dispatch`. `Value::MatrixValue` is
-partitioned among `matrix-construction-ir`, `homogeneous-matrix-snapshot`, and
-`legacy-matrix-value-adapter`. The nonempty bytecode-v1 rejection arm is frozen
-separately as `heterogeneous-matrix-rejected`; it must not be counted as a
-homogeneous immutable snapshot.
-
-Permitted role identifiers are:
-
-```text
-semantic-payload
-mutable-storage
-type-wrapper
-constant
-machine-argument
-machine-output
-host-input
-host-output
-serialization
-diagnostic
-reactive-identity
-journal-discovery
-selection-ir
-compiler-type-data
-temporal-payload
-compiler-shape-hole
-generic-dispatch
-reified-type
-binding-contract
-```
-
-Regenerate and validate with:
+Normal migration PRs run retirement mode and do not edit or regenerate the
+JSON contracts:
 
 ```sh
-python3 scripts/generate-value-system-inventory.py
-python3 scripts/generate-value-system-inventory.py --check
+python3 scripts/check-value-system-contract.py --mode retirement
+```
+
+Exact historical validation remains available for the reviewed tree:
+
+```sh
+python3 scripts/check-value-system-contract.py --mode exact
+```
+
+`generate-value-system-inventory.py --check` is an exact-tree diagnostic. It
+remains strict and byte-precise, but it is not part of normal retirement CI and
+must not be used to bless migration edits by regenerating
+`current-inventory.json`.
+
+Verify the archived legacy baseline separately:
+
+```sh
 python3 scripts/generate-value-system-inventory.py \
   --git-ref d5e41f6fd43c9d21c5858d80dab50e7ce64e9a10 \
   --check-legacy-baseline
-python3 scripts/check-value-system-contract.py
-python3 -B -m unittest scripts/tests/test_generate_value_system_inventory.py
-python3 -B -m unittest scripts/tests/test_check_value_system_contract.py
 ```
 
-Generated current inventory, immutable baseline evidence, and reviewed
-migration classification are separate. The checker never rewrites them.
+Run the focused Python suites with:
+
+```sh
+python3 -B -m unittest \
+  scripts/tests/test_generate_value_system_inventory.py \
+  scripts/tests/test_check_value_system_contract.py
+```
+
+The final deletion will replace this retirement ceiling with a rule requiring
+zero production `LegacyValue` occurrences. Until then, ordinary occurrences
+may only shrink and every permanent safety boundary remains active.

--- a/tests/ci/test_ci_full_contract.py
+++ b/tests/ci/test_ci_full_contract.py
@@ -76,10 +76,30 @@ class FullWorkflowContractTests(unittest.TestCase):
                     )
                 )
 
-    def test_value_system_contract_is_permanent_and_unwaived(self):
-        block = job_block(FULL, "architecture-contracts")
-        self.assertIn("scripts/check-value-system-contract.py", block)
-        self.assertNotIn("allow-only-c0-gate-b-evidence-stale", block)
+    def test_value_system_retirement_contract_is_permanent_and_unwaived(self):
+        static = job_block(CI, "static-contracts")
+        architecture = job_block(FULL, "architecture-contracts")
+        retirement = (
+            "python3 scripts/check-value-system-contract.py --mode retirement"
+        )
+        plain_inventory_check = re.compile(
+            r"(?m)^\s*python3 scripts/generate-value-system-inventory\.py "
+            r"--check\s*$"
+        )
+
+        self.assertIn(retirement, static)
+        self.assertIn(retirement, architecture)
+        self.assertRegex(
+            architecture,
+            r"(?m)^\s*python3 scripts/generate-value-system-inventory\.py \\\n"
+            r"\s*--git-ref d5e41f6fd43c9d21c5858d80dab50e7ce64e9a10 \\\n"
+            r"\s*--check-legacy-baseline\s*$",
+        )
+        self.assertNotRegex(architecture, plain_inventory_check)
+        for block in (static, architecture):
+            self.assertNotIn("--mode exact", block)
+            self.assertNotIn("continue-on-error", block)
+            self.assertNotIn("allow-only-c0-gate-b-evidence-stale", block)
 
     def test_architecture_contracts_prefetch_before_offline_historical_evidence(self):
         block = job_block(FULL, "architecture-contracts")


### PR DESCRIPTION
## Summary

- adds explicit exact and retirement modes to the value-system checker
- treats the reviewed inventory as a per-enum/per-variant/per-file shrink-only ceiling
- preserves exact high-risk, semantic, canonical, adapter, Gate A, and Gate B contracts
- permits retirement scanning after frozen type-contract declarations begin changing
- switches normal PR and full CI validation to retirement mode while retaining archived baseline verification

## Behavior

| Change                                         | Retirement result |
| ---------------------------------------------- | ----------------- |
| Delete reviewed occurrence                     | Pass              |
| Move occurrence within same file               | Pass              |
| Add occurrence in same file                    | Fail              |
| Move occurrence to another file                | Fail              |
| Add legacy variant                             | Fail              |
| Change surviving variant payload/cfg/ownership | Fail              |
| Remove legacy variant                          | Pass              |
| Add or substitute high-risk Ref mechanism      | Fail              |

## Non-goals

- no LegacyValue production migration
- no Rust runtime or compiler changes
- no contract JSON regeneration
- no semantic-target changes
- no weakening of canonical or resident boundaries

## Evidence

Base branch: `integration/value-executor-v0.4`

Recorded base SHA: `cf69c683abdc051b00b5b0b704b07ba8e62dd9f1`

Final head SHA: `fecfeb157e7b8c1563b1010499f9058584fd0dde`

All frozen `tests/architecture/value-system/*.json` files are unchanged.
The final diff contains exactly the eight authorized files.
Both exact and retirement modes pass on the PR0 tree.

Commands run from the repository root:

- `python3 -B -m unittest scripts/tests/test_generate_value_system_inventory.py` — passed, 73 tests
- `python3 -B -m unittest scripts/tests/test_check_value_system_contract.py` — passed, 156 tests
- `python3 -B -m unittest tests/ci/test_ci_full_contract.py tests/ci/test_ci_impact.py` — passed, 25 tests
- `python3 scripts/generate-value-system-inventory.py --check` — value-system inventory is current
- `python3 scripts/generate-value-system-inventory.py --git-ref d5e41f6fd43c9d21c5858d80dab50e7ce64e9a10 --check-legacy-baseline` — legacy-growth baseline is current
- `python3 scripts/check-value-system-contract.py --mode exact` — passed
- `python3 scripts/check-value-system-contract.py --mode retirement` — passed; LegacyValue 4928/4928, ValueKind 1181/1181, Kind 162/162, zero unreviewed occurrences
- `python3 scripts/check-value-execution-boundary.py` — passed
- `python3 scripts/check-compiler-planning-quarantine.py` — passed
- `python3 scripts/check-production-resident-routing.py` — passed
- `cargo +nightly-2026-03-03 fmt --all -- --check` — passed
- `git diff --check` — passed
- `git diff --exit-code origin/integration/value-executor-v0.4...HEAD -- 'tests/architecture/value-system/*.json'` — passed
- invocation discovery for both checker and generator scripts — active callers accounted for and explicit checker modes confirmed
