### PR TITLE
[PR1] refactor(engine): quarantine IndexAll at the specialization boundary

### DIFF
--- a/src/engine/src/artifact/ir.rs
+++ b/src/engine/src/artifact/ir.rs
@@ -93,6 +93,8 @@ pub fn compiler_ir_from_legacy_pseudo_value(
 ) -> Result<ExpressionIR, CompilerIrError> {
     match value {
         LegacyValue::Empty => Ok(ExpressionIR::Empty),
+        // Retained only for legacy pseudo-value compatibility. Production
+        // source-to-artifact integration will migrate independently.
         LegacyValue::IndexAll => Ok(ExpressionIR::Selection(SelectionIR::All)),
         _ => Err(CompilerIrError::PseudoValueNotCompilerIr),
     }

--- a/src/engine/src/expressions/subscripts/brace.rs
+++ b/src/engine/src/expressions/subscripts/brace.rs
@@ -52,11 +52,6 @@ pub(super) fn access(
                     plan.borrow_mut()
                         .push(catalog_access_function(p, "access/range", &fxn_input)?);
                 }
-                /*[Subscript::All] => {
-                  fxn_input.push(LegacyValue::IndexAll);
-                  #[cfg(feature = "matrix")]
-                  plan.borrow_mut().push(MapAccessAll{}.specialize(&fxn_input)?);
-                },*/
                 _ => {
                     todo!("Implement brace subscript")
                 }

--- a/src/engine/src/expressions/subscripts/bracket.rs
+++ b/src/engine/src/expressions/subscripts/bracket.rs
@@ -17,7 +17,7 @@ fn specialize_bracket_access(
     arguments: &[LegacyValue],
     selectors: &[MatrixSelector],
 ) -> MResult<Box<dyn MechFunction>> {
-    crate::intrinsics::access::specialize_source_access(
+    crate::intrinsics::access::specialize_matrix_access(
         execution,
         canonical_name,
         arguments[0].clone(),

--- a/src/engine/src/expressions/subscripts/bracket.rs
+++ b/src/engine/src/expressions/subscripts/bracket.rs
@@ -4,12 +4,26 @@ use super::string::{
     current_string_access_expression_live, string_access_argument_is_live,
     string_access_index_argument, string_access_source_argument,
 };
-use super::{
-    Environment, catalog_access_function, subscript_formula, subscript_formula_ix, subscript_range,
+use super::{Environment, subscript_formula, subscript_formula_ix, subscript_range};
+use crate::{
+    InterpreterExecution, LegacyValue, MResult, MatrixSelector, MechFunction, Subscript, ValueKind,
 };
-use crate::{InterpreterExecution, LegacyValue, MResult, Subscript, ValueKind};
 #[cfg(feature = "subscript_formula")]
 use crate::{StringAccessCompileMode, set_next_string_access_compile_mode};
+
+fn specialize_bracket_access(
+    execution: &InterpreterExecution<'_>,
+    canonical_name: &str,
+    arguments: &[LegacyValue],
+    selectors: &[MatrixSelector],
+) -> MResult<Box<dyn MechFunction>> {
+    crate::intrinsics::access::specialize_source_access(
+        execution,
+        canonical_name,
+        arguments[0].clone(),
+        selectors,
+    )
+}
 
 pub(super) fn access(
     sbscrpt: &Subscript,
@@ -28,6 +42,7 @@ pub(super) fn access(
             } else {
                 vec![val.clone()]
             };
+            let mut selectors = Vec::with_capacity(subs.len());
             match &subs[..] {
                 #[cfg(feature = "subscript_formula")]
                 [Subscript::Formula(_)] => {
@@ -52,29 +67,33 @@ pub(super) fn access(
                         set_next_string_access_compile_mode(mode);
                     }
                     let shape = index_arg.shape();
+                    selectors.push(MatrixSelector::Value(index_arg.clone()));
                     fxn_input.push(index_arg);
                     match shape[..] {
                         [1, 1] => {
-                            plan.borrow_mut().push(catalog_access_function(
+                            plan.borrow_mut().push(specialize_bracket_access(
                                 p,
                                 "access/scalar",
                                 &fxn_input,
+                                &selectors,
                             )?);
                         }
                         #[cfg(feature = "subscript_range")]
                         [1, _] => {
-                            plan.borrow_mut().push(catalog_access_function(
+                            plan.borrow_mut().push(specialize_bracket_access(
                                 p,
                                 "access/range",
                                 &fxn_input,
+                                &selectors,
                             )?);
                         }
                         #[cfg(feature = "subscript_range")]
                         [_, 1] => {
-                            plan.borrow_mut().push(catalog_access_function(
+                            plan.borrow_mut().push(specialize_bracket_access(
                                 p,
                                 "access/range",
                                 &fxn_input,
+                                &selectors,
                             )?);
                         }
                         _ => todo!(),
@@ -83,17 +102,23 @@ pub(super) fn access(
                 #[cfg(feature = "subscript_range")]
                 [Subscript::Range(_)] => {
                     let result = subscript_range(&subs[0], env, p)?;
+                    selectors.push(MatrixSelector::Value(result.clone()));
                     fxn_input.push(result);
-                    plan.borrow_mut()
-                        .push(catalog_access_function(p, "access/range", &fxn_input)?);
+                    plan.borrow_mut().push(specialize_bracket_access(
+                        p,
+                        "access/range",
+                        &fxn_input,
+                        &selectors,
+                    )?);
                 }
                 [Subscript::All] => {
-                    fxn_input.push(LegacyValue::IndexAll);
+                    selectors.push(MatrixSelector::All);
                     #[cfg(feature = "matrix")]
-                    plan.borrow_mut().push(catalog_access_function(
+                    plan.borrow_mut().push(specialize_bracket_access(
                         p,
                         "access/scalar",
                         &fxn_input,
+                        &selectors,
                     )?);
                 }
                 [Subscript::All, Subscript::All] => todo!(),
@@ -101,41 +126,47 @@ pub(super) fn access(
                 [Subscript::Formula(_), Subscript::Formula(_)] => {
                     let result = subscript_formula_ix(&subs[0], env, p)?;
                     let shape1 = result.shape();
+                    selectors.push(MatrixSelector::Value(result.clone()));
                     fxn_input.push(result);
                     let result = subscript_formula_ix(&subs[1], env, p)?;
                     let shape2 = result.shape();
+                    selectors.push(MatrixSelector::Value(result.clone()));
                     fxn_input.push(result);
                     match ((shape1[0], shape1[1]), (shape2[0], shape2[1])) {
                         #[cfg(feature = "matrix")]
                         ((1, 1), (1, 1)) => {
-                            plan.borrow_mut().push(catalog_access_function(
+                            plan.borrow_mut().push(specialize_bracket_access(
                                 p,
                                 "access/scalar",
                                 &fxn_input,
+                                &selectors,
                             )?);
                         }
                         #[cfg(feature = "matrix")]
                         ((1, 1), (_, 1)) => {
-                            plan.borrow_mut().push(catalog_access_function(
+                            plan.borrow_mut().push(specialize_bracket_access(
                                 p,
                                 "access/range",
                                 &fxn_input,
+                                &selectors,
                             )?);
                         }
                         #[cfg(feature = "matrix")]
                         ((_, 1), (1, 1)) => {
-                            plan.borrow_mut().push(catalog_access_function(
+                            plan.borrow_mut().push(specialize_bracket_access(
                                 p,
                                 "access/range",
                                 &fxn_input,
+                                &selectors,
                             )?);
                         }
                         #[cfg(feature = "matrix")]
                         ((_, 1), (_, 1)) => {
-                            plan.borrow_mut().push(catalog_access_function(
+                            plan.borrow_mut().push(specialize_bracket_access(
                                 p,
                                 "access/range",
                                 &fxn_input,
+                                &selectors,
                             )?);
                         }
                         _ => unreachable!(),
@@ -144,42 +175,52 @@ pub(super) fn access(
                 #[cfg(feature = "subscript_range")]
                 [Subscript::Range(_), Subscript::Range(_)] => {
                     let result = subscript_range(&subs[0], env, p)?;
+                    selectors.push(MatrixSelector::Value(result.clone()));
                     fxn_input.push(result);
                     let result = subscript_range(&subs[1], env, p)?;
+                    selectors.push(MatrixSelector::Value(result.clone()));
                     fxn_input.push(result);
                     #[cfg(feature = "matrix")]
-                    plan.borrow_mut()
-                        .push(catalog_access_function(p, "access/range", &fxn_input)?);
+                    plan.borrow_mut().push(specialize_bracket_access(
+                        p,
+                        "access/range",
+                        &fxn_input,
+                        &selectors,
+                    )?);
                 }
                 #[cfg(all(feature = "subscript_range", feature = "subscript_formula"))]
                 [Subscript::All, Subscript::Formula(_)] => {
-                    fxn_input.push(LegacyValue::IndexAll);
+                    selectors.push(MatrixSelector::All);
                     let result = subscript_formula_ix(&subs[1], env, p)?;
                     let shape = result.shape();
+                    selectors.push(MatrixSelector::Value(result.clone()));
                     fxn_input.push(result);
                     match &shape[..] {
                         #[cfg(feature = "matrix")]
                         [1, 1] => {
-                            plan.borrow_mut().push(catalog_access_function(
+                            plan.borrow_mut().push(specialize_bracket_access(
                                 p,
                                 "access/scalar",
                                 &fxn_input,
+                                &selectors,
                             )?);
                         }
                         #[cfg(feature = "matrix")]
                         [1, _] => {
-                            plan.borrow_mut().push(catalog_access_function(
+                            plan.borrow_mut().push(specialize_bracket_access(
                                 p,
                                 "access/range",
                                 &fxn_input,
+                                &selectors,
                             )?);
                         }
                         #[cfg(feature = "matrix")]
                         [_, 1] => {
-                            plan.borrow_mut().push(catalog_access_function(
+                            plan.borrow_mut().push(specialize_bracket_access(
                                 p,
                                 "access/range",
                                 &fxn_input,
+                                &selectors,
                             )?);
                         }
                         _ => todo!(),
@@ -189,31 +230,35 @@ pub(super) fn access(
                 [Subscript::Formula(_), Subscript::All] => {
                     let result = subscript_formula_ix(&subs[0], env, p)?;
                     let shape = result.shape();
+                    selectors.push(MatrixSelector::Value(result.clone()));
                     fxn_input.push(result);
-                    fxn_input.push(LegacyValue::IndexAll);
+                    selectors.push(MatrixSelector::All);
                     match &shape[..] {
                         #[cfg(feature = "matrix")]
                         [1, 1] => {
-                            plan.borrow_mut().push(catalog_access_function(
+                            plan.borrow_mut().push(specialize_bracket_access(
                                 p,
                                 "access/scalar",
                                 &fxn_input,
+                                &selectors,
                             )?);
                         }
                         #[cfg(feature = "matrix")]
                         [1, _] => {
-                            plan.borrow_mut().push(catalog_access_function(
+                            plan.borrow_mut().push(specialize_bracket_access(
                                 p,
                                 "access/range",
                                 &fxn_input,
+                                &selectors,
                             )?);
                         }
                         #[cfg(feature = "matrix")]
                         [_, 1] => {
-                            plan.borrow_mut().push(catalog_access_function(
+                            plan.borrow_mut().push(specialize_bracket_access(
                                 p,
                                 "access/range",
                                 &fxn_input,
+                                &selectors,
                             )?);
                         }
                         _ => todo!(),
@@ -222,33 +267,38 @@ pub(super) fn access(
                 #[cfg(all(feature = "subscript_range", feature = "subscript_formula"))]
                 [Subscript::Range(_), Subscript::Formula(_)] => {
                     let result = subscript_range(&subs[0], env, p)?;
+                    selectors.push(MatrixSelector::Value(result.clone()));
                     fxn_input.push(result);
                     let result = subscript_formula_ix(&subs[1], env, p)?;
                     let shape = result.shape();
+                    selectors.push(MatrixSelector::Value(result.clone()));
                     fxn_input.push(result);
                     match &shape[..] {
                         #[cfg(feature = "matrix")]
                         [1, 1] => {
-                            plan.borrow_mut().push(catalog_access_function(
+                            plan.borrow_mut().push(specialize_bracket_access(
                                 p,
                                 "access/range",
                                 &fxn_input,
+                                &selectors,
                             )?);
                         }
                         #[cfg(feature = "matrix")]
                         [1, _] => {
-                            plan.borrow_mut().push(catalog_access_function(
+                            plan.borrow_mut().push(specialize_bracket_access(
                                 p,
                                 "access/range",
                                 &fxn_input,
+                                &selectors,
                             )?);
                         }
                         #[cfg(feature = "matrix")]
                         [_, 1] => {
-                            plan.borrow_mut().push(catalog_access_function(
+                            plan.borrow_mut().push(specialize_bracket_access(
                                 p,
                                 "access/range",
                                 &fxn_input,
+                                &selectors,
                             )?);
                         }
                         _ => todo!(),
@@ -258,32 +308,37 @@ pub(super) fn access(
                 [Subscript::Formula(_), Subscript::Range(_)] => {
                     let result = subscript_formula_ix(&subs[0], env, p)?;
                     let shape = result.shape();
+                    selectors.push(MatrixSelector::Value(result.clone()));
                     fxn_input.push(result);
                     let result = subscript_range(&subs[1], env, p)?;
+                    selectors.push(MatrixSelector::Value(result.clone()));
                     fxn_input.push(result);
                     match &shape[..] {
                         #[cfg(feature = "matrix")]
                         [1, 1] => {
-                            plan.borrow_mut().push(catalog_access_function(
+                            plan.borrow_mut().push(specialize_bracket_access(
                                 p,
                                 "access/range",
                                 &fxn_input,
+                                &selectors,
                             )?);
                         }
                         #[cfg(feature = "matrix")]
                         [1, _] => {
-                            plan.borrow_mut().push(catalog_access_function(
+                            plan.borrow_mut().push(specialize_bracket_access(
                                 p,
                                 "access/range",
                                 &fxn_input,
+                                &selectors,
                             )?);
                         }
                         #[cfg(feature = "matrix")]
                         [_, 1] => {
-                            plan.borrow_mut().push(catalog_access_function(
+                            plan.borrow_mut().push(specialize_bracket_access(
                                 p,
                                 "access/range",
                                 &fxn_input,
+                                &selectors,
                             )?);
                         }
                         _ => todo!(),
@@ -291,21 +346,31 @@ pub(super) fn access(
                 }
                 #[cfg(feature = "subscript_range")]
                 [Subscript::All, Subscript::Range(_)] => {
-                    fxn_input.push(LegacyValue::IndexAll);
+                    selectors.push(MatrixSelector::All);
                     let result = subscript_range(&subs[1], env, p)?;
+                    selectors.push(MatrixSelector::Value(result.clone()));
                     fxn_input.push(result);
                     #[cfg(feature = "matrix")]
-                    plan.borrow_mut()
-                        .push(catalog_access_function(p, "access/range", &fxn_input)?);
+                    plan.borrow_mut().push(specialize_bracket_access(
+                        p,
+                        "access/range",
+                        &fxn_input,
+                        &selectors,
+                    )?);
                 }
                 #[cfg(feature = "subscript_range")]
                 [Subscript::Range(_), Subscript::All] => {
                     let result = subscript_range(&subs[0], env, p)?;
+                    selectors.push(MatrixSelector::Value(result.clone()));
                     fxn_input.push(result);
-                    fxn_input.push(LegacyValue::IndexAll);
+                    selectors.push(MatrixSelector::All);
                     #[cfg(feature = "matrix")]
-                    plan.borrow_mut()
-                        .push(catalog_access_function(p, "access/range", &fxn_input)?);
+                    plan.borrow_mut().push(specialize_bracket_access(
+                        p,
+                        "access/range",
+                        &fxn_input,
+                        &selectors,
+                    )?);
                 }
                 _ => unreachable!(),
             };

--- a/src/engine/src/expressions/tests/matrix_selection.rs
+++ b/src/engine/src/expressions/tests/matrix_selection.rs
@@ -1,0 +1,150 @@
+use crate::{
+    BytecodeCompilerContext, FunctionCatalog, FunctionCatalogBuilder, FunctionExport,
+    FunctionExposure, FunctionSpecializer, Interpreter, LegacyValue, MResult, MechFunction,
+    MechFunctionCompiler, MechFunctionImpl, Ref, Register,
+};
+use mech_core::matrix::Matrix as RuntimeMatrix;
+use nalgebra::DVector;
+use std::sync::Arc;
+
+#[derive(Debug)]
+struct InclusiveRangeFunction {
+    out: LegacyValue,
+}
+
+impl MechFunctionImpl for InclusiveRangeFunction {
+    fn solve_result(&self) -> MResult<()> {
+        Ok(())
+    }
+
+    fn out(&self) -> LegacyValue {
+        self.out.clone()
+    }
+
+    fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
+        Ok(self.reactive_output_values())
+    }
+
+    fn to_string(&self) -> String {
+        "TestInclusiveRange".to_string()
+    }
+}
+
+impl MechFunctionCompiler for InclusiveRangeFunction {
+    fn compile(&self, _: &mut dyn BytecodeCompilerContext) -> MResult<Register> {
+        Ok(0)
+    }
+}
+
+struct InclusiveRangeSpecializer;
+
+impl FunctionSpecializer for InclusiveRangeSpecializer {
+    fn specialize(&self, arguments: &[LegacyValue]) -> MResult<Box<dyn MechFunction>> {
+        let [start, terminal] = arguments else {
+            panic!("inclusive range test double expects two arguments");
+        };
+        let start = *start.as_f64()?.borrow() as usize;
+        let terminal = *terminal.as_f64()?.borrow() as usize;
+        let values = (start..=terminal).map(|value| value as f64).collect();
+        Ok(Box::new(InclusiveRangeFunction {
+            out: LegacyValue::MatrixF64(RuntimeMatrix::DVector(Ref::new(DVector::from_vec(
+                values,
+            )))),
+        }))
+    }
+}
+
+fn function_catalog_with_range() -> Arc<FunctionCatalog> {
+    let mut builder = FunctionCatalogBuilder::new();
+    crate::test_support::catalog::install_intrinsic_runtime(&mut builder).unwrap();
+    crate::test_support::catalog::install_intrinsic_source(&mut builder).unwrap();
+    let operation = builder
+        .insert_specializer("range/inclusive", Arc::new(InclusiveRangeSpecializer))
+        .unwrap();
+    builder
+        .insert_export(FunctionExport {
+            operation,
+            canonical_name: "range/inclusive".to_string(),
+            module: None,
+            item: None,
+            exposure: FunctionExposure::Prelude,
+        })
+        .unwrap();
+    Arc::new(builder.build().unwrap())
+}
+
+fn evaluate_selection(selector: &str) -> (Vec<usize>, Vec<f64>) {
+    let source = format!("x := [1.0 2.0 3.0; 4.0 5.0 6.0; 7.0 8.0 9.0]; x{selector}");
+    let tree = mech_syntax::parser::parse(&source).unwrap();
+    let catalog = if selector.contains("..=") {
+        function_catalog_with_range()
+    } else {
+        crate::test_support::catalog::function_catalog()
+    };
+    let mut interpreter = Interpreter::with_function_catalog(0, 10_000, catalog);
+    let output = interpreter.interpret(&tree).unwrap();
+    let output = match output {
+        LegacyValue::MutableReference(value) => value.borrow().clone(),
+        value => value,
+    };
+    let shape = output.shape();
+    let LegacyValue::MatrixF64(matrix) = output else {
+        panic!("expected an f64 matrix selection");
+    };
+    (shape, matrix.as_vec())
+}
+
+#[test]
+fn explicit_all_selector_preserves_linear_and_scalar_axis_access() {
+    assert_eq!(
+        evaluate_selection("[:]"),
+        (
+            vec![9, 1],
+            vec![1.0, 4.0, 7.0, 2.0, 5.0, 8.0, 3.0, 6.0, 9.0]
+        )
+    );
+    assert_eq!(
+        evaluate_selection("[:,2]"),
+        (vec![3, 1], vec![2.0, 5.0, 8.0])
+    );
+    assert_eq!(
+        evaluate_selection("[2,:]"),
+        (vec![1, 3], vec![4.0, 5.0, 6.0])
+    );
+}
+
+#[test]
+fn explicit_all_selector_preserves_range_access_on_both_axes() {
+    assert_eq!(
+        evaluate_selection("[:,1..=2]"),
+        (vec![3, 2], vec![1.0, 4.0, 7.0, 2.0, 5.0, 8.0])
+    );
+    assert_eq!(
+        evaluate_selection("[1..=2,:]"),
+        (vec![2, 3], vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0])
+    );
+}
+
+#[test]
+fn explicit_all_selector_preserves_index_vector_access_on_both_axes() {
+    assert_eq!(
+        evaluate_selection("[:,[1 3]]"),
+        (vec![3, 2], vec![1.0, 4.0, 7.0, 3.0, 6.0, 9.0])
+    );
+    assert_eq!(
+        evaluate_selection("[[1 3],:]"),
+        (vec![2, 3], vec![1.0, 7.0, 2.0, 8.0, 3.0, 9.0])
+    );
+}
+
+#[test]
+fn explicit_all_selector_preserves_logical_mask_access_on_both_axes() {
+    assert_eq!(
+        evaluate_selection("[:,[true false true]]"),
+        (vec![3, 2], vec![1.0, 4.0, 7.0, 3.0, 6.0, 9.0])
+    );
+    assert_eq!(
+        evaluate_selection("[[true false true],:]"),
+        (vec![2, 3], vec![1.0, 7.0, 2.0, 8.0, 3.0, 9.0])
+    );
+}

--- a/src/engine/src/expressions/tests/matrix_selection.rs
+++ b/src/engine/src/expressions/tests/matrix_selection.rs
@@ -1,87 +1,13 @@
-use crate::{
-    BytecodeCompilerContext, FunctionCatalog, FunctionCatalogBuilder, FunctionExport,
-    FunctionExposure, FunctionSpecializer, Interpreter, LegacyValue, MResult, MechFunction,
-    MechFunctionCompiler, MechFunctionImpl, Ref, Register,
-};
-use mech_core::matrix::Matrix as RuntimeMatrix;
-use nalgebra::DVector;
-use std::sync::Arc;
-
-#[derive(Debug)]
-struct InclusiveRangeFunction {
-    out: LegacyValue,
-}
-
-impl MechFunctionImpl for InclusiveRangeFunction {
-    fn solve_result(&self) -> MResult<()> {
-        Ok(())
-    }
-
-    fn out(&self) -> LegacyValue {
-        self.out.clone()
-    }
-
-    fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
-        Ok(self.reactive_output_values())
-    }
-
-    fn to_string(&self) -> String {
-        "TestInclusiveRange".to_string()
-    }
-}
-
-impl MechFunctionCompiler for InclusiveRangeFunction {
-    fn compile(&self, _: &mut dyn BytecodeCompilerContext) -> MResult<Register> {
-        Ok(0)
-    }
-}
-
-struct InclusiveRangeSpecializer;
-
-impl FunctionSpecializer for InclusiveRangeSpecializer {
-    fn specialize(&self, arguments: &[LegacyValue]) -> MResult<Box<dyn MechFunction>> {
-        let [start, terminal] = arguments else {
-            panic!("inclusive range test double expects two arguments");
-        };
-        let start = *start.as_f64()?.borrow() as usize;
-        let terminal = *terminal.as_f64()?.borrow() as usize;
-        let values = (start..=terminal).map(|value| value as f64).collect();
-        Ok(Box::new(InclusiveRangeFunction {
-            out: LegacyValue::MatrixF64(RuntimeMatrix::DVector(Ref::new(DVector::from_vec(
-                values,
-            )))),
-        }))
-    }
-}
-
-fn function_catalog_with_range() -> Arc<FunctionCatalog> {
-    let mut builder = FunctionCatalogBuilder::new();
-    crate::test_support::catalog::install_intrinsic_runtime(&mut builder).unwrap();
-    crate::test_support::catalog::install_intrinsic_source(&mut builder).unwrap();
-    let operation = builder
-        .insert_specializer("range/inclusive", Arc::new(InclusiveRangeSpecializer))
-        .unwrap();
-    builder
-        .insert_export(FunctionExport {
-            operation,
-            canonical_name: "range/inclusive".to_string(),
-            module: None,
-            item: None,
-            exposure: FunctionExposure::Prelude,
-        })
-        .unwrap();
-    Arc::new(builder.build().unwrap())
-}
+use crate::{Interpreter, LegacyValue};
 
 fn evaluate_selection(selector: &str) -> (Vec<usize>, Vec<f64>) {
     let source = format!("x := [1.0 2.0 3.0; 4.0 5.0 6.0; 7.0 8.0 9.0]; x{selector}");
     let tree = mech_syntax::parser::parse(&source).unwrap();
-    let catalog = if selector.contains("..=") {
-        function_catalog_with_range()
-    } else {
-        crate::test_support::catalog::function_catalog()
-    };
-    let mut interpreter = Interpreter::with_function_catalog(0, 10_000, catalog);
+    let mut interpreter = Interpreter::with_function_catalog(
+        0,
+        10_000,
+        crate::test_support::catalog::function_catalog(),
+    );
     let output = interpreter.interpret(&tree).unwrap();
     let output = match output {
         LegacyValue::MutableReference(value) => value.borrow().clone(),

--- a/src/engine/src/expressions/tests/mod.rs
+++ b/src/engine/src/expressions/tests/mod.rs
@@ -18,6 +18,19 @@ mod registration;
 mod structural_access;
 
 #[cfg(all(
+    feature = "access",
+    feature = "bool",
+    feature = "f64",
+    feature = "logical_indexing",
+    feature = "matrix",
+    feature = "matrixd",
+    feature = "subscript_formula",
+    feature = "subscript_range",
+    feature = "subscript_slice"
+))]
+mod matrix_selection;
+
+#[cfg(all(
     feature = "functions",
     feature = "f64",
     feature = "u64",

--- a/src/engine/src/intrinsics/access/mod.rs
+++ b/src/engine/src/intrinsics/access/mod.rs
@@ -256,7 +256,7 @@ fn compile_matrix_access(arguments: &[LegacyValue]) -> MResult<Box<dyn MechFunct
 
 /// Lowers source-level selectors at the legacy access specialization boundary.
 #[cfg(feature = "semantic-compiler")]
-pub(crate) fn specialize_source_access(
+pub(crate) fn specialize_matrix_access(
     execution: &InterpreterExecution<'_>,
     canonical_name: &str,
     source: LegacyValue,

--- a/src/engine/src/intrinsics/access/mod.rs
+++ b/src/engine/src/intrinsics/access/mod.rs
@@ -51,6 +51,8 @@ use crate::{
     FunctionCatalogBuilder, FunctionSpecializer, IncorrectNumberOfArguments, LegacyValue, MResult,
     MechError, MechFunction, UnhandledFunctionArgumentKind2,
 };
+#[cfg(feature = "semantic-compiler")]
+use crate::{InterpreterExecution, MatrixSelector, OperationId};
 #[cfg(any(feature = "record", feature = "table"))]
 use crate::{MechTuple, Ref, UndefinedRecordFieldError};
 #[cfg(feature = "table")]
@@ -181,34 +183,66 @@ fn matrix_access_index_is_scalar(index: &LegacyValue) -> bool {
     index.shape().as_slice() == [1, 1]
 }
 
+#[cfg(any(feature = "matrix", feature = "semantic-compiler"))]
+fn legacy_all_selector() -> LegacyValue {
+    LegacyValue::IndexAll
+}
+
+#[cfg(feature = "matrix")]
+#[derive(Clone, Copy)]
+enum MatrixAccessIndexKind {
+    All,
+    Scalar,
+    Range,
+}
+
+#[cfg(feature = "matrix")]
+fn matrix_access_index_kind(index: &LegacyValue) -> MatrixAccessIndexKind {
+    if index == &legacy_all_selector() {
+        MatrixAccessIndexKind::All
+    } else if matrix_access_index_is_scalar(index) {
+        MatrixAccessIndexKind::Scalar
+    } else {
+        MatrixAccessIndexKind::Range
+    }
+}
+
 #[cfg(feature = "matrix")]
 fn compile_matrix_access(arguments: &[LegacyValue]) -> MResult<Box<dyn MechFunction>> {
-    match arguments.get(1..).unwrap_or_default() {
-        [LegacyValue::IndexAll] => MatrixAccessAll {}.specialize(arguments),
-        [index] if matrix_access_index_is_scalar(index) => {
-            MatrixAccessScalar {}.specialize(arguments)
-        }
-        [_] => MatrixAccessRange {}.specialize(arguments),
-        [LegacyValue::IndexAll, index] if matrix_access_index_is_scalar(index) => {
+    let index_kinds = arguments
+        .get(1..)
+        .unwrap_or_default()
+        .iter()
+        .map(matrix_access_index_kind)
+        .collect::<Vec<_>>();
+    match index_kinds.as_slice() {
+        [MatrixAccessIndexKind::All] => MatrixAccessAll {}.specialize(arguments),
+        [MatrixAccessIndexKind::Scalar] => MatrixAccessScalar {}.specialize(arguments),
+        [MatrixAccessIndexKind::Range] => MatrixAccessRange {}.specialize(arguments),
+        [MatrixAccessIndexKind::All, MatrixAccessIndexKind::Scalar] => {
             MatrixAccessAllScalar {}.specialize(arguments)
         }
-        [LegacyValue::IndexAll, _] => MatrixAccessAllRange {}.specialize(arguments),
-        [index, LegacyValue::IndexAll] if matrix_access_index_is_scalar(index) => {
+        [MatrixAccessIndexKind::All, MatrixAccessIndexKind::Range] => {
+            MatrixAccessAllRange {}.specialize(arguments)
+        }
+        [MatrixAccessIndexKind::Scalar, MatrixAccessIndexKind::All] => {
             MatrixAccessScalarAll {}.specialize(arguments)
         }
-        [_, LegacyValue::IndexAll] => MatrixAccessRangeAll {}.specialize(arguments),
-        [left, right]
-            if matrix_access_index_is_scalar(left) && matrix_access_index_is_scalar(right) =>
-        {
+        [MatrixAccessIndexKind::Range, MatrixAccessIndexKind::All] => {
+            MatrixAccessRangeAll {}.specialize(arguments)
+        }
+        [MatrixAccessIndexKind::Scalar, MatrixAccessIndexKind::Scalar] => {
             MatrixAccessScalarScalar {}.specialize(arguments)
         }
-        [left, _] if matrix_access_index_is_scalar(left) => {
+        [MatrixAccessIndexKind::Scalar, MatrixAccessIndexKind::Range] => {
             MatrixAccessScalarRange {}.specialize(arguments)
         }
-        [_, right] if matrix_access_index_is_scalar(right) => {
+        [MatrixAccessIndexKind::Range, MatrixAccessIndexKind::Scalar] => {
             MatrixAccessRangeScalar {}.specialize(arguments)
         }
-        [_, _] => MatrixAccessRangeRange {}.specialize(arguments),
+        [MatrixAccessIndexKind::Range, MatrixAccessIndexKind::Range] => {
+            MatrixAccessRangeRange {}.specialize(arguments)
+        }
         _ => Err(MechError::new(
             IncorrectNumberOfArguments {
                 expected: 1,
@@ -218,6 +252,27 @@ fn compile_matrix_access(arguments: &[LegacyValue]) -> MResult<Box<dyn MechFunct
         )
         .with_compiler_loc()),
     }
+}
+
+/// Lowers source-level selectors at the legacy access specialization boundary.
+#[cfg(feature = "semantic-compiler")]
+pub(crate) fn specialize_source_access(
+    execution: &InterpreterExecution<'_>,
+    canonical_name: &str,
+    source: LegacyValue,
+    selectors: &[MatrixSelector],
+) -> MResult<Box<dyn MechFunction>> {
+    let mut arguments = Vec::with_capacity(selectors.len() + 1);
+    arguments.push(source);
+    arguments.extend(selectors.iter().map(|selector| match selector {
+        MatrixSelector::All => legacy_all_selector(),
+        MatrixSelector::Value(value) => value.clone(),
+    }));
+    execution.specialize_visible_operation_named(
+        OperationId::from_name(canonical_name),
+        Some(canonical_name),
+        &arguments,
+    )
 }
 
 pub struct AccessScalar {}

--- a/src/engine/src/intrinsics/assign/mod.rs
+++ b/src/engine/src/intrinsics/assign/mod.rs
@@ -1,4 +1,6 @@
 use crate::intrinsics::*;
+#[cfg(feature = "semantic-compiler")]
+use crate::{InterpreterExecution, MatrixSelector, OperationId};
 
 pub mod catalog;
 pub use self::catalog::install_runtime;
@@ -871,15 +873,44 @@ enum AssignmentIndexKind {
     All,
 }
 
+#[cfg(any(feature = "matrix", feature = "semantic-compiler"))]
+fn legacy_all_selector() -> LegacyValue {
+    LegacyValue::IndexAll
+}
+
 #[cfg(feature = "matrix")]
 fn assignment_index_kind(value: &LegacyValue) -> AssignmentIndexKind {
+    if value == &legacy_all_selector() {
+        return AssignmentIndexKind::All;
+    }
     match value {
-        LegacyValue::IndexAll => AssignmentIndexKind::All,
         LegacyValue::Index(_) => AssignmentIndexKind::Scalar,
         LegacyValue::MatrixIndex(_) => AssignmentIndexKind::Range,
         _ if value.shape() == [1, 1] => AssignmentIndexKind::Scalar,
         _ => AssignmentIndexKind::Range,
     }
+}
+
+/// Lowers source-level selectors at the legacy assignment specialization boundary.
+#[cfg(feature = "semantic-compiler")]
+pub(crate) fn specialize_matrix_assignment(
+    execution: &InterpreterExecution<'_>,
+    canonical_name: &str,
+    sink: LegacyValue,
+    source: LegacyValue,
+    selectors: &[MatrixSelector],
+) -> MResult<Box<dyn MechFunction>> {
+    let mut arguments = Vec::with_capacity(selectors.len() + 2);
+    arguments.extend([sink, source]);
+    arguments.extend(selectors.iter().map(|selector| match selector {
+        MatrixSelector::All => legacy_all_selector(),
+        MatrixSelector::Value(value) => value.clone(),
+    }));
+    execution.specialize_visible_operation_named(
+        OperationId::from_name(canonical_name),
+        Some(canonical_name),
+        &arguments,
+    )
 }
 
 #[cfg(feature = "matrix")]

--- a/src/engine/src/lib.rs
+++ b/src/engine/src/lib.rs
@@ -54,7 +54,11 @@ pub mod intrinsics;
 #[cfg(feature = "semantic-compiler")]
 pub mod literals;
 #[cfg(feature = "semantic-compiler")]
+mod matrix_selector;
+#[cfg(feature = "semantic-compiler")]
 pub mod mechdown;
+#[cfg(feature = "semantic-compiler")]
+pub(crate) use matrix_selector::MatrixSelector;
 #[cfg(feature = "semantic-compiler")]
 pub mod patterns;
 #[cfg(any(

--- a/src/engine/src/matrix_selector.rs
+++ b/src/engine/src/matrix_selector.rs
@@ -1,0 +1,15 @@
+use crate::LegacyValue;
+
+/// Short-lived source-compiler control for matrix specialization.
+///
+/// `All` represents the source-level `:` selector. Every evaluated selector
+/// remains a value until the narrow legacy specialization boundary consumes it.
+#[derive(Clone, Debug)]
+pub(crate) enum MatrixSelector {
+    All,
+    #[expect(
+        dead_code,
+        reason = "wired to evaluated selectors in the next stack commit"
+    )]
+    Value(LegacyValue),
+}

--- a/src/engine/src/matrix_selector.rs
+++ b/src/engine/src/matrix_selector.rs
@@ -7,9 +7,5 @@ use crate::LegacyValue;
 #[derive(Clone, Debug)]
 pub(crate) enum MatrixSelector {
     All,
-    #[expect(
-        dead_code,
-        reason = "wired to evaluated selectors in the next stack commit"
-    )]
     Value(LegacyValue),
 }

--- a/src/engine/src/statements/op_assign.rs
+++ b/src/engine/src/statements/op_assign.rs
@@ -21,6 +21,16 @@ use super::{AddressedAssignmentUnsupported, NotMutableError, UndefinedVariableEr
     ),
     any(feature = "subscript_formula", feature = "subscript_range")
 ))]
+use crate::MatrixSelector;
+#[cfg(all(
+    any(
+        feature = "math_add_assign",
+        feature = "math_sub_assign",
+        feature = "math_div_assign",
+        feature = "math_mul_assign"
+    ),
+    any(feature = "subscript_formula", feature = "subscript_range")
+))]
 use crate::Subscript;
 #[cfg(all(
     any(
@@ -53,16 +63,6 @@ use crate::{
     MechError, OpAssign, OpAssignOp, execute_catalog_operation_with_registration_arguments,
     expression,
 };
-#[cfg(all(
-    any(
-        feature = "math_add_assign",
-        feature = "math_sub_assign",
-        feature = "math_div_assign",
-        feature = "math_mul_assign"
-    ),
-    any(feature = "subscript_formula", feature = "subscript_range")
-))]
-use crate::{MechFunction, OperationId};
 #[cfg(all(
     any(
         feature = "math_add_assign",
@@ -206,27 +206,6 @@ fn engine_add_assignment_sink(sink: &LegacyValue) -> bool {
     ),
     any(feature = "subscript_formula", feature = "subscript_range")
 ))]
-fn catalog_op_assignment_function(
-    p: &InterpreterExecution<'_>,
-    canonical_name: &str,
-    arguments: &[LegacyValue],
-) -> MResult<Box<dyn MechFunction>> {
-    p.specialize_visible_operation_named(
-        OperationId::from_name(canonical_name),
-        Some(canonical_name),
-        arguments,
-    )
-}
-
-#[cfg(all(
-    any(
-        feature = "math_add_assign",
-        feature = "math_sub_assign",
-        feature = "math_div_assign",
-        feature = "math_mul_assign"
-    ),
-    any(feature = "subscript_formula", feature = "subscript_range")
-))]
 macro_rules! op_assign {
   ($fxn_name:ident, $op:tt, $range_operation:literal, $range_all_operation:literal) => {
     paste!{
@@ -243,52 +222,51 @@ macro_rules! op_assign {
             todo!()
           },
           Subscript::Bracket(subs) => {
-            let mut fxn_input = vec![sink.clone()];
-            match &subs[..] {
+            let (canonical_name, selectors) = match &subs[..] {
               #[cfg(feature = "subscript_formula")]
               [Subscript::Formula(_)] => {
-                fxn_input.push(source.clone());
                 let ixes = subscript_formula_ix(&subs[0], env, p)?;
                 let shape = ixes.shape();
-                fxn_input.push(ixes);
-                match shape[..] {
-                  [1,1] => { plan.borrow_mut().push(catalog_op_assignment_function(p, "assign", &fxn_input)?); }
-                  [1,_] => { plan.borrow_mut().push(catalog_op_assignment_function(p, $range_operation, &fxn_input)?); }
-                  [_,1] => { plan.borrow_mut().push(catalog_op_assignment_function(p, $range_operation, &fxn_input)?); }
+                let operation = match shape[..] {
+                  [1,1] => "assign",
+                  [1,_] => $range_operation,
+                  [_,1] => $range_operation,
                   _ => todo!(),
-                }
+                };
+                (operation, vec![MatrixSelector::Value(ixes)])
               },
               #[cfg(feature = "subscript_formula")]
               [Subscript::Formula(_),Subscript::All] => {
-                fxn_input.push(source.clone());
                 let ix = subscript_formula_ix(&subs[0], env, p)?;
                 let shape = ix.shape();
-                fxn_input.push(ix);
-                fxn_input.push(LegacyValue::IndexAll);
-                match shape[..] {
-                  [1,1] => { plan.borrow_mut().push(catalog_op_assignment_function(p, "assign", &fxn_input)?); }
-                  [1,_] => { plan.borrow_mut().push(catalog_op_assignment_function(p, $range_all_operation, &fxn_input)?); }
-                  [_,1] => { plan.borrow_mut().push(catalog_op_assignment_function(p, $range_all_operation, &fxn_input)?); }
+                let operation = match shape[..] {
+                  [1,1] => "assign",
+                  [1,_] => $range_all_operation,
+                  [_,1] => $range_all_operation,
                   _ => todo!(),
-                }
+                };
+                (operation, vec![MatrixSelector::Value(ix), MatrixSelector::All])
               },
               #[cfg(feature = "subscript_range")]
               [Subscript::Range(_)] => {
-                fxn_input.push(source.clone());
                 let ixes = subscript_range(&subs[0], env, p)?;
-                fxn_input.push(ixes);
-                plan.borrow_mut().push(catalog_op_assignment_function(p, $range_operation, &fxn_input)?);
+                ($range_operation, vec![MatrixSelector::Value(ixes)])
               },
               #[cfg(feature = "subscript_range")]
               [Subscript::Range(_), Subscript::All] => {
-                fxn_input.push(source.clone());
                 let ixes = subscript_range(&subs[0], env, p)?;
-                fxn_input.push(ixes);
-                fxn_input.push(LegacyValue::IndexAll);
-                plan.borrow_mut().push(catalog_op_assignment_function(p, $range_all_operation, &fxn_input)?);
+                ($range_all_operation, vec![MatrixSelector::Value(ixes), MatrixSelector::All])
               },
               x => todo!("{:?}", x),
             };
+            let new_fxn = crate::intrinsics::assign::specialize_matrix_assignment(
+              p,
+              canonical_name,
+              sink.clone(),
+              source.clone(),
+              &selectors,
+            )?;
+            plan.borrow_mut().push(new_fxn);
             let plan_brrw = plan.borrow();
             let new_fxn = &plan_brrw.last().unwrap();
             new_fxn.solve_result()?;

--- a/src/engine/src/statements/tests/op_assign.rs
+++ b/src/engine/src/statements/tests/op_assign.rs
@@ -2,7 +2,9 @@ use super::support::{
     cell, distinct_assignment_graph_shape, expected_distinct_assignment_shape, register,
     register_node_id_for_output, root_cell, set_value, symbol, value,
 };
-use crate::{Interpreter, ReactiveDependencyKind, ReactiveNodeKind, ReactiveTurnState};
+use crate::{
+    Interpreter, LegacyValue, ReactiveDependencyKind, ReactiveNodeKind, ReactiveTurnState,
+};
 
 #[cfg(feature = "math_add_assign")]
 #[test]
@@ -46,6 +48,84 @@ fn whole_add_assignment_alias_is_sampled_once() {
     assert_eq!(node.inputs[0].kind, ReactiveDependencyKind::Sampled);
     assert!(plan.sampled_consumers_for(x_cell).contains(&node_id));
     assert!(!plan.reactive_consumers_for(x_cell).contains(&node_id));
+}
+
+#[cfg(all(
+    feature = "bool",
+    feature = "f64",
+    feature = "logical_indexing",
+    feature = "math_add_assign",
+    feature = "matrix",
+    feature = "matrixd",
+    feature = "range_inclusive",
+    feature = "subscript_formula",
+    feature = "subscript_range",
+    feature = "subscript_slice"
+))]
+fn matrix_after_indexed_add_assignment(selector: &str, value: &str) -> Vec<f64> {
+    let source =
+        format!("~x := [1.0 2.0 3.0; 4.0 5.0 6.0; 7.0 8.0 9.0]; x{selector} += {value}; x");
+    let tree = mech_syntax::parser::parse(&source).unwrap();
+    let mut interpreter = Interpreter::with_function_catalog(
+        0,
+        10_000,
+        crate::test_support::catalog::function_catalog(),
+    );
+    let output = interpreter
+        .interpret(&tree)
+        .unwrap_or_else(|error| panic!("{selector}: {error:?}"));
+    let output = match output {
+        LegacyValue::MutableReference(value) => value.borrow().clone(),
+        value => value,
+    };
+    let LegacyValue::MatrixF64(matrix) = output else {
+        panic!("expected an f64 matrix add-assignment result");
+    };
+    matrix.as_vec()
+}
+
+#[cfg(all(
+    feature = "bool",
+    feature = "f64",
+    feature = "logical_indexing",
+    feature = "math_add_assign",
+    feature = "matrix",
+    feature = "matrixd",
+    feature = "range_inclusive",
+    feature = "subscript_formula",
+    feature = "subscript_range",
+    feature = "subscript_slice"
+))]
+#[test]
+fn explicit_all_selector_preserves_applicable_matrix_add_assignment_layouts() {
+    for (selector, value, expected) in [
+        (
+            "[2,:]",
+            "10.0",
+            vec![1.0, 10.0, 7.0, 2.0, 10.0, 8.0, 3.0, 10.0, 9.0],
+        ),
+        (
+            "[1..=2,:]",
+            "10.0",
+            vec![11.0, 14.0, 7.0, 12.0, 15.0, 8.0, 13.0, 16.0, 9.0],
+        ),
+        (
+            "[[1 3],:]",
+            "10.0",
+            vec![11.0, 4.0, 17.0, 12.0, 5.0, 18.0, 13.0, 6.0, 19.0],
+        ),
+        (
+            "[[true false true],:]",
+            "[10.0 10.0 10.0; 10.0 10.0 10.0; 10.0 10.0 10.0]",
+            vec![11.0, 4.0, 17.0, 12.0, 5.0, 18.0, 13.0, 6.0, 19.0],
+        ),
+    ] {
+        assert_eq!(
+            matrix_after_indexed_add_assignment(selector, value),
+            expected,
+            "{selector}"
+        );
+    }
 }
 
 #[cfg(all(feature = "math_add", feature = "math_add_assign"))]

--- a/src/engine/src/statements/tests/variable_assign.rs
+++ b/src/engine/src/statements/tests/variable_assign.rs
@@ -65,6 +65,132 @@ fn whole_matrix_assignment_uses_root_cells() {
     assert_eq!(resolved_output, y);
 }
 
+#[cfg(all(
+    feature = "assign",
+    feature = "bool",
+    feature = "f64",
+    feature = "logical_indexing",
+    feature = "matrix",
+    feature = "matrixd",
+    feature = "range_inclusive",
+    feature = "subscript_formula",
+    feature = "subscript_range",
+    feature = "subscript_slice",
+    feature = "variable_assign"
+))]
+fn matrix_after_indexed_assignment(selector: &str, value: &str) -> Vec<f64> {
+    let source = format!("~x := [1.0 2.0 3.0; 4.0 5.0 6.0; 7.0 8.0 9.0]; x{selector} = {value}; x");
+    let tree = mech_syntax::parser::parse(&source).unwrap();
+    let mut interpreter = Interpreter::with_function_catalog(
+        0,
+        10_000,
+        crate::test_support::catalog::function_catalog(),
+    );
+    let output = interpreter
+        .interpret(&tree)
+        .unwrap_or_else(|error| panic!("{selector}: {error:?}"));
+    let output = match output {
+        LegacyValue::MutableReference(value) => value.borrow().clone(),
+        value => value,
+    };
+    let LegacyValue::MatrixF64(matrix) = output else {
+        panic!("expected an f64 matrix assignment result");
+    };
+    matrix.as_vec()
+}
+
+#[cfg(all(
+    feature = "assign",
+    feature = "bool",
+    feature = "f64",
+    feature = "logical_indexing",
+    feature = "matrix",
+    feature = "matrixd",
+    feature = "range_inclusive",
+    feature = "subscript_formula",
+    feature = "subscript_range",
+    feature = "subscript_slice",
+    feature = "variable_assign"
+))]
+#[test]
+fn explicit_all_selector_preserves_plain_matrix_assignment_layouts() {
+    for (selector, value, expected) in [
+        ("[:]", "0.0", vec![0.0; 9]),
+        (
+            "[:,2]",
+            "0.0",
+            vec![1.0, 4.0, 7.0, 0.0, 0.0, 0.0, 3.0, 6.0, 9.0],
+        ),
+        (
+            "[2,:]",
+            "0.0",
+            vec![1.0, 0.0, 7.0, 2.0, 0.0, 8.0, 3.0, 0.0, 9.0],
+        ),
+        (
+            "[:,1..=2]",
+            "0.0",
+            vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3.0, 6.0, 9.0],
+        ),
+        (
+            "[1..=2,:]",
+            "0.0",
+            vec![0.0, 0.0, 7.0, 0.0, 0.0, 8.0, 0.0, 0.0, 9.0],
+        ),
+        (
+            "[:,[1 3]]",
+            "0.0",
+            vec![0.0, 0.0, 0.0, 2.0, 5.0, 8.0, 0.0, 0.0, 0.0],
+        ),
+        (
+            "[[1 3],:]",
+            "0.0",
+            vec![0.0, 4.0, 0.0, 0.0, 5.0, 0.0, 0.0, 6.0, 0.0],
+        ),
+        (
+            "[:,[true false true]]",
+            "0.0",
+            vec![0.0, 0.0, 0.0, 2.0, 5.0, 8.0, 0.0, 0.0, 0.0],
+        ),
+        (
+            "[[true false true],:]",
+            "[0.0 0.0 0.0; 0.0 0.0 0.0; 0.0 0.0 0.0]",
+            vec![0.0, 4.0, 0.0, 0.0, 5.0, 0.0, 0.0, 6.0, 0.0],
+        ),
+    ] {
+        assert_eq!(
+            matrix_after_indexed_assignment(selector, value),
+            expected,
+            "{selector}"
+        );
+    }
+}
+
+#[cfg(all(
+    feature = "assign",
+    feature = "f64",
+    feature = "matrix",
+    feature = "matrixd",
+    feature = "subscript_range",
+    feature = "subscript_slice",
+    feature = "variable_assign"
+))]
+#[test]
+fn all_all_matrix_assignment_remains_rejected() {
+    let result = std::panic::catch_unwind(|| {
+        let tree = mech_syntax::parser::parse("~x := [1.0 2.0; 3.0 4.0]; x[:,:] = 0.0; x").unwrap();
+        let mut interpreter = Interpreter::with_function_catalog(
+            0,
+            10_000,
+            crate::test_support::catalog::function_catalog(),
+        );
+        interpreter.interpret(&tree)
+    });
+    assert!(match result {
+        Err(_) => true,
+        Ok(result) => result.is_err(),
+    });
+}
+
 #[cfg(all(feature = "math_add", feature = "math_add_assign"))]
 #[test]
 fn register_commit_plain_assignment_updates_register_only() {

--- a/src/engine/src/statements/variable_assign.rs
+++ b/src/engine/src/statements/variable_assign.rs
@@ -12,12 +12,12 @@ use crate::subscript_range;
     all(feature = "subscript", feature = "assign")
 ))]
 use crate::{Environment, InterpreterExecution, MResult};
+#[cfg(all(feature = "subscript", feature = "assign"))]
+use crate::{MatrixSelector, MechFunction, OperationId};
 #[cfg(feature = "variable_assign")]
 use crate::{
     MechError, VariableAssign, execute_catalog_operation_with_registration_arguments, expression,
 };
-#[cfg(all(feature = "subscript", feature = "assign"))]
-use crate::{MechFunction, OperationId};
 #[cfg(all(
     feature = "subscript",
     feature = "assign",
@@ -52,6 +52,22 @@ fn catalog_assignment_function(
         OperationId::from_name(canonical_name),
         Some(canonical_name),
         arguments,
+    )
+}
+
+#[cfg(all(feature = "subscript", feature = "assign"))]
+fn source_assignment_function(
+    p: &InterpreterExecution<'_>,
+    canonical_name: &str,
+    arguments: &[LegacyValue],
+    selectors: &[MatrixSelector],
+) -> MResult<Box<dyn MechFunction>> {
+    crate::intrinsics::assign::specialize_matrix_assignment(
+        p,
+        canonical_name,
+        arguments[0].clone(),
+        arguments[1].clone(),
+        selectors,
     )
 }
 
@@ -147,226 +163,149 @@ pub fn subscript_ref(
             unreachable!()
         }
         Subscript::Bracket(subs) => {
-            let mut fxn_input = vec![sink.clone()];
+            let fxn_input = vec![sink.clone(), source.clone()];
+            let mut selectors = Vec::with_capacity(subs.len());
             match &subs[..] {
                 #[cfg(feature = "subscript_formula")]
                 [Subscript::Formula(_)] => {
-                    fxn_input.push(source.clone());
                     let ixes = subscript_formula_ix(&subs[0], env, p)?;
                     let shape = ixes.shape();
-                    fxn_input.push(ixes);
+                    selectors.push(MatrixSelector::Value(ixes.clone()));
                     match shape[..] {
                         #[cfg(feature = "matrix")]
-                        [1, 1] => {
-                            plan.borrow_mut()
-                                .push(catalog_assignment_function(p, "assign", &fxn_input)?);
-                        }
+                        [1, 1] => {}
                         #[cfg(all(
                             feature = "matrix",
                             feature = "subscript_range",
                             feature = "assign"
                         ))]
-                        [1, _] => {
-                            plan.borrow_mut()
-                                .push(catalog_assignment_function(p, "assign", &fxn_input)?);
-                        }
+                        [1, _] => {}
                         #[cfg(all(
                             feature = "matrix",
                             feature = "subscript_range",
                             feature = "assign"
                         ))]
-                        [_, 1] => {
-                            plan.borrow_mut()
-                                .push(catalog_assignment_function(p, "assign", &fxn_input)?);
-                        }
+                        [_, 1] => {}
                         _ => todo!(),
                     }
                 }
                 #[cfg(all(feature = "matrix", feature = "subscript_range"))]
                 [Subscript::Range(_)] => {
-                    fxn_input.push(source.clone());
                     let ixes = subscript_range(&subs[0], env, p)?;
-                    fxn_input.push(ixes);
-                    plan.borrow_mut()
-                        .push(catalog_assignment_function(p, "assign", &fxn_input)?);
+                    selectors.push(MatrixSelector::Value(ixes));
                 }
                 #[cfg(all(feature = "matrix", feature = "subscript_range"))]
                 [Subscript::All] => {
-                    fxn_input.push(source.clone());
-                    fxn_input.push(LegacyValue::IndexAll);
-                    plan.borrow_mut()
-                        .push(catalog_assignment_function(p, "assign", &fxn_input)?);
+                    selectors.push(MatrixSelector::All);
                 }
                 [Subscript::All, Subscript::All] => todo!(),
                 #[cfg(feature = "subscript_formula")]
                 [Subscript::Formula(_), Subscript::Formula(_)] => {
-                    fxn_input.push(source.clone());
                     let result1 = subscript_formula_ix(&subs[0], env, p)?;
                     let result2 = subscript_formula_ix(&subs[1], env, p)?;
                     let shape1 = result1.shape();
                     let shape2 = result2.shape();
-                    fxn_input.push(result1);
-                    fxn_input.push(result2);
+                    selectors.push(MatrixSelector::Value(result1));
+                    selectors.push(MatrixSelector::Value(result2));
                     match ((shape1[0], shape1[1]), (shape2[0], shape2[1])) {
                         #[cfg(feature = "matrix")]
-                        ((1, 1), (1, 1)) => {
-                            plan.borrow_mut()
-                                .push(catalog_assignment_function(p, "assign", &fxn_input)?);
-                        }
+                        ((1, 1), (1, 1)) => {}
                         #[cfg(all(feature = "matrix", feature = "subscript_range"))]
-                        ((1, 1), (_, 1)) => {
-                            plan.borrow_mut()
-                                .push(catalog_assignment_function(p, "assign", &fxn_input)?);
-                        }
+                        ((1, 1), (_, 1)) => {}
                         #[cfg(all(feature = "matrix", feature = "subscript_range"))]
-                        ((_, 1), (1, 1)) => {
-                            plan.borrow_mut()
-                                .push(catalog_assignment_function(p, "assign", &fxn_input)?);
-                        }
+                        ((_, 1), (1, 1)) => {}
                         #[cfg(all(feature = "matrix", feature = "subscript_range"))]
-                        ((_, 1), (_, 1)) => {
-                            plan.borrow_mut()
-                                .push(catalog_assignment_function(p, "assign", &fxn_input)?);
-                        }
+                        ((_, 1), (_, 1)) => {}
                         _ => unreachable!(),
                     }
                 }
                 #[cfg(all(feature = "matrix", feature = "subscript_range"))]
                 [Subscript::Range(_), Subscript::Range(_)] => {
-                    fxn_input.push(source.clone());
                     let result = subscript_range(&subs[0], env, p)?;
-                    fxn_input.push(result);
+                    selectors.push(MatrixSelector::Value(result));
                     let result = subscript_range(&subs[1], env, p)?;
-                    fxn_input.push(result);
-                    plan.borrow_mut()
-                        .push(catalog_assignment_function(p, "assign", &fxn_input)?);
+                    selectors.push(MatrixSelector::Value(result));
                 }
                 #[cfg(all(feature = "matrix", feature = "subscript_formula"))]
                 [Subscript::All, Subscript::Formula(_)] => {
-                    fxn_input.push(source.clone());
-                    fxn_input.push(LegacyValue::IndexAll);
+                    selectors.push(MatrixSelector::All);
                     let ix = subscript_formula_ix(&subs[1], env, p)?;
                     let shape = ix.shape();
-                    fxn_input.push(ix);
+                    selectors.push(MatrixSelector::Value(ix));
                     match shape[..] {
-                        #[cfg(feature = "matrix")]
-                        [1, 1] => {
-                            plan.borrow_mut()
-                                .push(catalog_assignment_function(p, "assign", &fxn_input)?);
-                        }
-                        #[cfg(feature = "matrix")]
-                        [1, _] => {
-                            plan.borrow_mut()
-                                .push(catalog_assignment_function(p, "assign", &fxn_input)?);
-                        }
-                        #[cfg(feature = "matrix")]
-                        [_, 1] => {
-                            plan.borrow_mut()
-                                .push(catalog_assignment_function(p, "assign", &fxn_input)?);
-                        }
+                        [1, 1] => {}
+                        [1, _] => {}
+                        [_, 1] => {}
                         _ => todo!(),
                     }
                 }
                 #[cfg(feature = "subscript_formula")]
                 [Subscript::Formula(_), Subscript::All] => {
-                    fxn_input.push(source.clone());
                     let ix = subscript_formula_ix(&subs[0], env, p)?;
                     let shape = ix.shape();
-                    fxn_input.push(ix);
-                    fxn_input.push(LegacyValue::IndexAll);
+                    selectors.push(MatrixSelector::Value(ix));
+                    selectors.push(MatrixSelector::All);
                     match shape[..] {
                         #[cfg(feature = "matrix")]
-                        [1, 1] => {
-                            plan.borrow_mut()
-                                .push(catalog_assignment_function(p, "assign", &fxn_input)?);
-                        }
+                        [1, 1] => {}
                         #[cfg(all(feature = "matrix", feature = "subscript_range"))]
-                        [1, _] => {
-                            plan.borrow_mut()
-                                .push(catalog_assignment_function(p, "assign", &fxn_input)?);
-                        }
+                        [1, _] => {}
                         #[cfg(all(feature = "matrix", feature = "subscript_range"))]
-                        [_, 1] => {
-                            plan.borrow_mut()
-                                .push(catalog_assignment_function(p, "assign", &fxn_input)?);
-                        }
+                        [_, 1] => {}
                         _ => todo!(),
                     }
                 }
                 #[cfg(all(feature = "subscript_formula", feature = "subscript_range"))]
                 [Subscript::Range(_), Subscript::Formula(_)] => {
-                    fxn_input.push(source.clone());
                     let result = subscript_range(&subs[0], env, p)?;
-                    fxn_input.push(result);
+                    selectors.push(MatrixSelector::Value(result));
                     let result = subscript_formula_ix(&subs[1], env, p)?;
                     let shape = result.shape();
-                    fxn_input.push(result);
+                    selectors.push(MatrixSelector::Value(result));
                     match &shape[..] {
                         #[cfg(feature = "matrix")]
-                        [1, 1] => {
-                            plan.borrow_mut()
-                                .push(catalog_assignment_function(p, "assign", &fxn_input)?);
-                        }
+                        [1, 1] => {}
                         #[cfg(feature = "matrix")]
-                        [1, _] => {
-                            plan.borrow_mut()
-                                .push(catalog_assignment_function(p, "assign", &fxn_input)?);
-                        }
+                        [1, _] => {}
                         #[cfg(feature = "matrix")]
-                        [_, 1] => {
-                            plan.borrow_mut()
-                                .push(catalog_assignment_function(p, "assign", &fxn_input)?);
-                        }
+                        [_, 1] => {}
                         _ => todo!(),
                     }
                 }
                 #[cfg(all(feature = "subscript_formula", feature = "subscript_range"))]
                 [Subscript::Formula(_), Subscript::Range(_)] => {
-                    fxn_input.push(source.clone());
                     let result = subscript_formula_ix(&subs[0], env, p)?;
                     let shape = result.shape();
-                    fxn_input.push(result);
+                    selectors.push(MatrixSelector::Value(result));
                     let result = subscript_range(&subs[1], env, p)?;
-                    fxn_input.push(result);
+                    selectors.push(MatrixSelector::Value(result));
                     match &shape[..] {
                         #[cfg(feature = "matrix")]
-                        [1, 1] => {
-                            plan.borrow_mut()
-                                .push(catalog_assignment_function(p, "assign", &fxn_input)?);
-                        }
+                        [1, 1] => {}
                         #[cfg(feature = "matrix")]
-                        [1, _] => {
-                            plan.borrow_mut()
-                                .push(catalog_assignment_function(p, "assign", &fxn_input)?);
-                        }
+                        [1, _] => {}
                         #[cfg(feature = "matrix")]
-                        [_, 1] => {
-                            plan.borrow_mut()
-                                .push(catalog_assignment_function(p, "assign", &fxn_input)?);
-                        }
+                        [_, 1] => {}
                         _ => todo!(),
                     }
                 }
                 #[cfg(all(feature = "matrix", feature = "subscript_range"))]
                 [Subscript::All, Subscript::Range(_)] => {
-                    fxn_input.push(source.clone());
-                    fxn_input.push(LegacyValue::IndexAll);
+                    selectors.push(MatrixSelector::All);
                     let result = subscript_range(&subs[1], env, p)?;
-                    fxn_input.push(result);
-                    plan.borrow_mut()
-                        .push(catalog_assignment_function(p, "assign", &fxn_input)?);
+                    selectors.push(MatrixSelector::Value(result));
                 }
                 #[cfg(all(feature = "matrix", feature = "subscript_range"))]
                 [Subscript::Range(_), Subscript::All] => {
-                    fxn_input.push(source.clone());
                     let result = subscript_range(&subs[0], env, p)?;
-                    fxn_input.push(result);
-                    fxn_input.push(LegacyValue::IndexAll);
-                    plan.borrow_mut()
-                        .push(catalog_assignment_function(p, "assign", &fxn_input)?);
+                    selectors.push(MatrixSelector::Value(result));
+                    selectors.push(MatrixSelector::All);
                 }
                 _ => unreachable!(),
             };
+            plan.borrow_mut().push(source_assignment_function(
+                p, "assign", &fxn_input, &selectors,
+            )?);
             let plan_brrw = plan.borrow();
             let new_fxn = &plan_brrw.last().unwrap();
             new_fxn.solve_result()?;

--- a/src/engine/tests/support/catalog.rs
+++ b/src/engine/tests/support/catalog.rs
@@ -43,7 +43,15 @@ pub(crate) fn function_catalog() -> Arc<FunctionCatalog> {
 
 #[cfg(test)]
 mod test_operations {
+    #[cfg(all(
+        feature = "f64",
+        feature = "matrix",
+        any(feature = "math_add_assign", feature = "range_inclusive")
+    ))]
+    use mech_core::matrix::Matrix;
     use mech_core::*;
+    #[cfg(all(feature = "f64", feature = "matrix", feature = "range_inclusive"))]
+    use nalgebra::DVector;
     use std::sync::Arc;
 
     #[derive(Clone, Copy, Debug)]
@@ -409,6 +417,195 @@ mod test_operations {
         }
     }
 
+    #[cfg(all(feature = "f64", feature = "matrix", feature = "range_inclusive"))]
+    #[derive(Debug)]
+    struct InclusiveRangeFunction {
+        start: Ref<f64>,
+        terminal: Ref<f64>,
+        out: Ref<DVector<f64>>,
+    }
+
+    #[cfg(all(feature = "f64", feature = "matrix", feature = "range_inclusive"))]
+    impl MechFunctionImpl for InclusiveRangeFunction {
+        fn solve_result(&self) -> MResult<()> {
+            let start = *self.start.borrow() as usize;
+            let terminal = *self.terminal.borrow() as usize;
+            *self.out.borrow_mut() =
+                DVector::from_vec((start..=terminal).map(|value| value as f64).collect());
+            Ok(())
+        }
+
+        fn out(&self) -> LegacyValue {
+            LegacyValue::MatrixF64(Matrix::DVector(self.out.clone()))
+        }
+
+        fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
+            Ok(self.reactive_output_values())
+        }
+
+        fn to_string(&self) -> String {
+            "TestInclusiveRange".to_string()
+        }
+    }
+
+    #[cfg(all(
+        feature = "f64",
+        feature = "matrix",
+        feature = "range_inclusive",
+        feature = "semantic-compiler"
+    ))]
+    impl MechFunctionCompiler for InclusiveRangeFunction {
+        fn compile(&self, _: &mut dyn BytecodeCompilerContext) -> MResult<Register> {
+            Ok(0)
+        }
+    }
+
+    #[cfg(all(feature = "f64", feature = "matrix", feature = "range_inclusive"))]
+    struct InclusiveRangeSpecializer;
+
+    #[cfg(all(feature = "f64", feature = "matrix", feature = "range_inclusive"))]
+    impl FunctionSpecializer for InclusiveRangeSpecializer {
+        fn specialize(&self, arguments: &[LegacyValue]) -> MResult<Box<dyn MechFunction>> {
+            let [start, terminal] = arguments else {
+                return Err(test_operation_error(
+                    "inclusive range expects two arguments",
+                ));
+            };
+            let start = start.as_f64()?;
+            let terminal = terminal.as_f64()?;
+            let out = Ref::new(DVector::from_vec(Vec::new()));
+            let function = Self::function(start, terminal, out);
+            function.solve_result()?;
+            Ok(Box::new(function))
+        }
+    }
+
+    #[cfg(all(feature = "f64", feature = "matrix", feature = "range_inclusive"))]
+    impl InclusiveRangeSpecializer {
+        fn function(
+            start: Ref<f64>,
+            terminal: Ref<f64>,
+            out: Ref<DVector<f64>>,
+        ) -> InclusiveRangeFunction {
+            InclusiveRangeFunction {
+                start,
+                terminal,
+                out,
+            }
+        }
+    }
+
+    #[cfg(all(feature = "f64", feature = "matrix", feature = "math_add_assign"))]
+    fn test_f64_matrix(value: &LegacyValue) -> MResult<Matrix<f64>> {
+        match value {
+            LegacyValue::MatrixF64(matrix) => Ok(matrix.clone()),
+            LegacyValue::MutableReference(value) => test_f64_matrix(&value.borrow()),
+            _ => Err(test_operation_error(
+                "matrix range/all add assignment expects an f64 matrix sink",
+            )),
+        }
+    }
+
+    #[cfg(all(feature = "f64", feature = "matrix", feature = "math_add_assign"))]
+    #[derive(Debug)]
+    struct AddAssignRangeAllFunction {
+        sink: Matrix<f64>,
+        source: LegacyValue,
+        rows: Vec<usize>,
+    }
+
+    #[cfg(all(feature = "f64", feature = "matrix", feature = "math_add_assign"))]
+    impl MechFunctionImpl for AddAssignRangeAllFunction {
+        fn solve_result(&self) -> MResult<()> {
+            let shape = self.sink.shape();
+            let mut sink_values = self.sink.as_vec();
+            let source_matrix = test_f64_matrix(&self.source).ok();
+            let source_scalar = self.source.as_f64().ok();
+            for column in 0..shape[1] {
+                for row in &self.rows {
+                    let offset = column * shape[0] + row;
+                    let addend = if let Some(source) = &source_scalar {
+                        *source.borrow()
+                    } else if let Some(source) = &source_matrix {
+                        source.as_vec()[offset]
+                    } else {
+                        return Err(test_operation_error(
+                            "matrix range/all add assignment expects an f64 source",
+                        ));
+                    };
+                    sink_values[offset] += addend;
+                }
+            }
+            self.sink.set(sink_values);
+            Ok(())
+        }
+
+        fn out(&self) -> LegacyValue {
+            LegacyValue::MatrixF64(self.sink.clone())
+        }
+
+        fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
+            Ok(self.reactive_output_values())
+        }
+
+        fn to_string(&self) -> String {
+            "TestAddAssignRangeAll".to_string()
+        }
+    }
+
+    #[cfg(all(
+        feature = "f64",
+        feature = "matrix",
+        feature = "math_add_assign",
+        feature = "semantic-compiler"
+    ))]
+    impl MechFunctionCompiler for AddAssignRangeAllFunction {
+        fn compile(&self, _: &mut dyn BytecodeCompilerContext) -> MResult<Register> {
+            Ok(0)
+        }
+    }
+
+    #[cfg(all(feature = "f64", feature = "matrix", feature = "math_add_assign"))]
+    struct AddAssignRangeAllSpecializer;
+
+    #[cfg(all(feature = "f64", feature = "matrix", feature = "math_add_assign"))]
+    impl FunctionSpecializer for AddAssignRangeAllSpecializer {
+        fn specialize(&self, arguments: &[LegacyValue]) -> MResult<Box<dyn MechFunction>> {
+            let [sink, source, rows, all] = arguments else {
+                return Err(test_operation_error(
+                    "matrix range/all add assignment expects four arguments",
+                ));
+            };
+            if !matches!(all, LegacyValue::IndexAll) {
+                return Err(test_operation_error(
+                    "matrix range/all add assignment expects an all-column selector",
+                ));
+            }
+            let rows = match rows {
+                LegacyValue::MatrixIndex(rows) => {
+                    rows.as_vec().into_iter().map(|row| row - 1).collect()
+                }
+                #[cfg(feature = "bool")]
+                LegacyValue::MatrixBool(rows) => rows
+                    .as_vec()
+                    .into_iter()
+                    .enumerate()
+                    .filter_map(|(row, selected)| selected.then_some(row))
+                    .collect(),
+                _ => {
+                    return Err(test_operation_error(
+                        "matrix range/all add assignment expects row indices",
+                    ));
+                }
+            };
+            Ok(Box::new(AddAssignRangeAllFunction {
+                sink: test_f64_matrix(sink)?,
+                source: source.clone(),
+                rows,
+            }))
+        }
+    }
+
     fn values_equal(lhs: &LegacyValue, rhs: &LegacyValue) -> bool {
         match (lhs, rhs) {
             (LegacyValue::MutableReference(lhs), rhs) => values_equal(&lhs.borrow(), rhs),
@@ -475,6 +672,14 @@ mod test_operations {
         }
         builder.insert_intrinsic_specializer("logic/not", Arc::new(NotSpecializer))?;
         builder.insert_intrinsic_specializer("math/add-assign", Arc::new(AddAssignSpecializer))?;
+        #[cfg(all(feature = "f64", feature = "matrix", feature = "math_add_assign"))]
+        builder.insert_intrinsic_specializer(
+            "math/add-assign/range-all",
+            Arc::new(AddAssignRangeAllSpecializer),
+        )?;
+        #[cfg(all(feature = "f64", feature = "matrix", feature = "range_inclusive"))]
+        builder
+            .insert_intrinsic_specializer("range/inclusive", Arc::new(InclusiveRangeSpecializer))?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- add an engine-private MatrixSelector control type for matrix selection lowering
- carry explicit selectors through bracket access, plain assignment, and supported compound-assignment layouts
- recreate LegacyValue::IndexAll only inside the existing access and assignment specialization boundaries
- preserve concrete matrix factories, catalog identities, operation contracts, and the legacy artifact compatibility arm
- defer production source-to-artifact selection integration until that pipeline has a real lowering call site

## Stack

- stacked on PR #781 at base commit fecfeb157e7b8c1563b1010499f9058584fd0dde
- base branch: codex/value-system-retirement-mode
- PR #781 remains a draft
- do not merge this PR before PR #781

## Validation

- cargo +nightly-2026-03-03 fmt --all -- --check
- cargo test --locked -p mech-engine --lib --no-default-features --features full_compiler (279 passed)
- cargo test --locked -p mech-engine --test program_artifact_contract --no-default-features --features full_compiler (22 passed)
- python3 scripts/check-value-system-contract.py --mode retirement
- python3 scripts/check-value-execution-boundary.py
- python3 scripts/check-compiler-planning-quarantine.py
- python3 scripts/check-bytecode-v1-format.py
- bash scripts/check-function-system-contracts.sh source
- bash scripts/check-function-system-contracts.sh consumer
- git diff --check

Retirement audit: LegacyValue reviewed=4928, live=4912, removed=16; zero unreviewed audited occurrences. Frozen value-system and function-system JSON files are unchanged.