### PR TITLE
[PR2] refactor(core): introduce explicit ValueCell state and retire ValRef

### DIFF
--- a/src/core/src/execution.rs
+++ b/src/core/src/execution.rs
@@ -1,6 +1,6 @@
 //! Explicit services supplied while Mech functions execute.
 
-use crate::{LegacyValue, MResult, MechError, MechErrorKind, ValRef};
+use crate::{LegacyValue, MResult, MechError, MechErrorKind, ValueCell};
 
 #[cfg(feature = "no_std")]
 use alloc::{borrow::ToOwned, format, string::String, vec::Vec};
@@ -112,7 +112,7 @@ pub trait MechExecutionServices {
         &mut self,
         interpreter_id: u64,
         request: &ExecutionResourceRequest,
-        target: ValRef,
+        target: ValueCell,
     ) -> MResult<()>;
 }
 
@@ -159,7 +159,7 @@ impl MechExecutionServices for NoMechExecutionServices {
         &mut self,
         interpreter_id: u64,
         request: &ExecutionResourceRequest,
-        _target: ValRef,
+        _target: ValueCell,
     ) -> MResult<()> {
         Err(MechError::new(
             LiveResourceBindingUnsupported {
@@ -322,7 +322,6 @@ impl MechErrorKind for ApplicationRequirementEncodingError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Ref;
 
     fn resource_request() -> ExecutionResourceRequest {
         ExecutionResourceRequest {
@@ -393,7 +392,7 @@ mod tests {
         );
 
         let bind_error = services
-            .bind_live_resource(17, &resource_request, Ref::new(LegacyValue::Empty))
+            .bind_live_resource(17, &resource_request, ValueCell::new(LegacyValue::Empty))
             .unwrap_err();
         assert_eq!(bind_error.kind_name(), "LiveResourceBindingUnsupported");
         let binding = bind_error

--- a/src/core/src/function/mod.rs
+++ b/src/core/src/function/mod.rs
@@ -740,7 +740,7 @@ pub struct FunctionDefinition {
     pub input: IndexMap<u64, KindAnnotation>,
     pub output: IndexMap<u64, KindAnnotation>,
     pub symbols: SymbolTableRef,
-    pub out: Ref<LegacyValue>,
+    pub out: ValueCell,
     pub plan: Plan,
 }
 
@@ -802,13 +802,13 @@ impl FunctionDefinition {
             code,
             input: IndexMap::new(),
             output: IndexMap::new(),
-            out: Ref::new(LegacyValue::Empty),
+            out: ValueCell::new(LegacyValue::Empty),
             symbols: Ref::new(SymbolTable::new()),
             plan: Plan::new(),
         }
     }
 
-    pub fn solve_result(&self) -> MResult<ValRef> {
+    pub fn solve_result(&self) -> MResult<ValueCell> {
         let plan_brrw = self.plan.borrow();
         for step in plan_brrw.iter() {
             step.solve_result()?;
@@ -816,7 +816,7 @@ impl FunctionDefinition {
         Ok(self.out.clone())
     }
 
-    pub fn out(&self) -> ValRef {
+    pub fn out(&self) -> ValueCell {
         self.out.clone()
     }
 }
@@ -836,9 +836,8 @@ impl MechFunctionImpl for UserFunction {
         self.fxn.out.borrow().clone()
     }
     fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
-        let mut values = vec![LegacyValue::MutableReference(self.fxn.out.clone())];
-        let mut seen_refs = HashSet::new();
-        seen_refs.insert(self.fxn.out.addr());
+        let mut values = vec![LegacyValue::MutableReference(self.fxn.out.legacy_ref())];
+        let mut seen_cells = vec![self.fxn.out.clone()];
         let symbols = self.fxn.symbols.try_borrow().map_err(|_| {
             MechError::new(
                 TransactionStateBorrowConflictError {
@@ -854,8 +853,9 @@ impl MechFunctionImpl for UserFunction {
             .values()
             .chain(symbols.mutable_variables.values())
         {
-            if seen_refs.insert(value.addr()) {
-                values.push(LegacyValue::MutableReference(value.clone()));
+            if !seen_cells.iter().any(|seen| seen.same_cell(value)) {
+                seen_cells.push(value.clone());
+                values.push(LegacyValue::MutableReference(value.legacy_ref()));
             }
         }
         drop(symbols);

--- a/src/core/src/function/tests/registry.rs
+++ b/src/core/src/function/tests/registry.rs
@@ -106,10 +106,13 @@ fn user_function_table_replaces_only_the_exact_same_name() {
     let replacement_out = replacement.out.clone();
     let replaced = definitions.insert_or_replace(replacement).unwrap().unwrap();
 
-    assert_eq!(replaced.out.addr(), first_out.addr());
-    assert_eq!(
-        definitions.resolve_name("local/read").unwrap().out.addr(),
-        replacement_out.addr(),
+    assert!(replaced.out.same_cell(&first_out));
+    assert!(
+        definitions
+            .resolve_name("local/read")
+            .unwrap()
+            .out
+            .same_cell(&replacement_out)
     );
     assert_eq!(definitions.definitions().len(), 1);
 }

--- a/src/core/src/function/tests/transaction_state.rs
+++ b/src/core/src/function/tests/transaction_state.rs
@@ -3,7 +3,7 @@ use super::super::MechFunctionCompiler;
 use super::super::{MechFunctionImpl, Plan, TransactionStateUnsupportedError};
 #[cfg(feature = "semantic-compiler")]
 use crate::{BytecodeCompilerContext, Register};
-use crate::{LegacyValue, MResult, MechError, Ref, ValRef};
+use crate::{LegacyValue, MResult, MechError, Ref, ValueCell};
 
 struct UnsupportedStateFunction;
 impl MechFunctionImpl for UnsupportedStateFunction {
@@ -34,14 +34,14 @@ impl MechFunctionCompiler for UnsupportedStateFunction {
 }
 
 struct MisleadingRuntimeHostNameFunction {
-    output: ValRef,
+    output: ValueCell,
 }
 impl MechFunctionImpl for MisleadingRuntimeHostNameFunction {
     fn solve_result(&self) -> MResult<()> {
         Ok(())
     }
     fn out(&self) -> LegacyValue {
-        LegacyValue::MutableReference(self.output.clone())
+        LegacyValue::MutableReference(self.output.legacy_ref())
     }
     fn to_string(&self) -> String {
         "ExternalHostCallFunction::misleading-name".to_string()
@@ -59,14 +59,14 @@ impl MechFunctionCompiler for MisleadingRuntimeHostNameFunction {
 }
 
 struct UnschedulableOutputFunction {
-    state: ValRef,
+    state: ValueCell,
 }
 impl MechFunctionImpl for UnschedulableOutputFunction {
     fn solve_result(&self) -> MResult<()> {
         Ok(())
     }
     fn out(&self) -> LegacyValue {
-        LegacyValue::MutableReference(self.state.clone())
+        LegacyValue::MutableReference(self.state.legacy_ref())
     }
     fn reactive_output_values(&self) -> Vec<LegacyValue> {
         Vec::new()
@@ -96,22 +96,26 @@ fn transaction_state_unsupported_error_is_structured() {
 #[test]
 fn host_like_display_name_does_not_change_checkpoint_behavior() {
     let plan = Plan::new();
-    let output = Ref::new(LegacyValue::Index(Ref::new(42)));
+    let output = ValueCell::new(LegacyValue::Index(Ref::new(42)));
     plan.add_function(Box::new(MisleadingRuntimeHostNameFunction {
         output: output.clone(),
     }));
 
     let values = plan.transaction_state_values().unwrap();
 
-    assert!(values.iter().any(|value| matches!(
-      value,
-      LegacyValue::MutableReference(cell) if cell.same_handle(&output)
-    ),));
+    let output_value = values
+        .iter()
+        .find_map(|value| match value {
+            LegacyValue::MutableReference(cell) => Some(ValueCell::from_legacy_ref(cell.clone())),
+            _ => None,
+        })
+        .expect("plan retains the function output");
+    assert!(output_value.same_cell(&output));
 }
 
 #[test]
 fn plan_transaction_state_retains_outputs_excluded_from_scheduling() {
-    let state = Ref::new(LegacyValue::Index(Ref::new(1)));
+    let state = ValueCell::new(LegacyValue::Index(Ref::new(1)));
     let plan = Plan::new();
     plan.add_function(Box::new(UnschedulableOutputFunction {
         state: state.clone(),
@@ -119,7 +123,12 @@ fn plan_transaction_state_retains_outputs_excluded_from_scheduling() {
 
     let values = plan.transaction_state_values().unwrap();
 
-    assert!(values.iter().any(
-        |value| matches!(value, LegacyValue::MutableReference(cell) if cell.addr() == state.addr())
-    ));
+    let retained_state = values
+        .iter()
+        .find_map(|value| match value {
+            LegacyValue::MutableReference(cell) => Some(ValueCell::from_legacy_ref(cell.clone())),
+            _ => None,
+        })
+        .expect("plan retains outputs excluded from scheduling");
+    assert!(retained_state.same_cell(&state));
 }

--- a/src/core/src/program/mod.rs
+++ b/src/core/src/program/mod.rs
@@ -34,10 +34,10 @@ pub struct IntegrityConstraint {
     pub id: u64,
     pub name: String,
     pub expression: String,
-    pub result: ValRef,
-    pub lhs: Option<ValRef>,
+    pub result: ValueCell,
+    pub lhs: Option<ValueCell>,
     pub operator: Option<FormulaOperator>,
-    pub rhs: Option<ValRef>,
+    pub rhs: Option<ValueCell>,
     pub tokens: Vec<Token>,
 }
 #[cfg(feature = "invariant_define")]

--- a/src/core/src/program/symbol_table.rs
+++ b/src/core/src/program/symbol_table.rs
@@ -7,19 +7,17 @@ pub type SymbolTableRef = Ref<SymbolTable>;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SymbolTableSnapshot {
-    symbols: HashMap<u64, ValRef>,
-    mutable_variables: HashMap<u64, ValRef>,
+    symbols: HashMap<u64, ValueCell>,
+    mutable_variables: HashMap<u64, ValueCell>,
     dictionary: Ref<Dictionary>,
     dictionary_contents: Dictionary,
-    reverse_lookup: HashMap<u64, u64>,
 }
 
 #[derive(Clone, Debug)]
 pub struct SymbolTable {
-    pub symbols: HashMap<u64, ValRef>,
-    pub mutable_variables: HashMap<u64, ValRef>,
+    pub symbols: HashMap<u64, ValueCell>,
+    pub mutable_variables: HashMap<u64, ValueCell>,
     pub dictionary: Ref<Dictionary>,
-    pub reverse_lookup: HashMap<u64, u64>,
 }
 
 impl SymbolTable {
@@ -29,7 +27,6 @@ impl SymbolTable {
             mutable_variables: self.mutable_variables.clone(),
             dictionary: self.dictionary.clone(),
             dictionary_contents: self.dictionary.borrow().clone(),
-            reverse_lookup: self.reverse_lookup.clone(),
         }
     }
 
@@ -55,7 +52,6 @@ impl SymbolTable {
         self.mutable_variables = snapshot.mutable_variables.clone();
         self.dictionary = snapshot.dictionary.clone();
         *self.dictionary.borrow_mut() = snapshot.dictionary_contents.clone();
-        self.reverse_lookup = snapshot.reverse_lookup.clone();
     }
 
     pub fn restore(&mut self, snapshot: SymbolTableSnapshot) {
@@ -67,7 +63,6 @@ impl SymbolTable {
             symbols: HashMap::new(),
             mutable_variables: HashMap::new(),
             dictionary: Ref::new(HashMap::new()),
-            reverse_lookup: HashMap::new(),
         }
     }
 
@@ -75,11 +70,11 @@ impl SymbolTable {
         self.dictionary.borrow().get(&id).cloned()
     }
 
-    pub fn get_mutable(&self, key: u64) -> Option<ValRef> {
+    pub fn get_mutable(&self, key: u64) -> Option<ValueCell> {
         self.mutable_variables.get(&key).cloned()
     }
 
-    pub fn get(&self, key: u64) -> Option<ValRef> {
+    pub fn get(&self, key: u64) -> Option<ValueCell> {
         self.symbols.get(&key).cloned()
     }
 
@@ -87,15 +82,12 @@ impl SymbolTable {
         self.symbols.contains_key(&key)
     }
 
-    pub fn insert(&mut self, key: u64, value: LegacyValue, mutable: bool) -> ValRef {
-        self.insert_cell(key, Ref::new(value), mutable)
+    pub fn insert(&mut self, key: u64, value: LegacyValue, mutable: bool) -> ValueCell {
+        self.insert_cell(key, ValueCell::new(value), mutable)
     }
 
-    pub fn insert_cell(&mut self, key: u64, cell: ValRef, mutable: bool) -> ValRef {
-        if let Some(previous) = self.symbols.insert(key, cell.clone()) {
-            self.reverse_lookup.remove(&previous.id());
-        }
-        self.reverse_lookup.insert(cell.id(), key);
+    pub fn insert_cell(&mut self, key: u64, cell: ValueCell, mutable: bool) -> ValueCell {
+        self.symbols.insert(key, cell.clone());
         if mutable {
             self.mutable_variables.insert(key, cell.clone());
         } else {
@@ -110,17 +102,45 @@ mod snapshot_tests {
     use super::*;
 
     #[test]
-    fn symbol_table_snapshot_restores_all_indexes_and_identity() {
+    fn symbol_table_cells_preserve_identity_and_mutability() {
+        let mut table = SymbolTable::new();
+        let outer = hash_str("outer");
+        let stored = table.insert(outer, LegacyValue::Index(Ref::new(1)), true);
+
+        assert!(stored.same_cell(&table.get(outer).unwrap()));
+        assert!(stored.same_cell(&table.get_mutable(outer).unwrap()));
+
+        let immutable = hash_str("immutable");
+        let immutable_cell = table.insert(immutable, LegacyValue::Index(Ref::new(2)), false);
+        assert!(immutable_cell.same_cell(&table.get(immutable).unwrap()));
+        assert!(table.get_mutable(immutable).is_none());
+    }
+
+    #[test]
+    fn replacing_equal_payloads_replaces_cell_identity() {
+        let mut table = SymbolTable::new();
+        let key = hash_str("value");
+        let first = table.insert(key, LegacyValue::Index(Ref::new(1)), false);
+        let second = ValueCell::new(LegacyValue::Index(Ref::new(1)));
+
+        let stored = table.insert_cell(key, second.clone(), false);
+        assert_eq!(first, second);
+        assert!(!first.same_cell(&second));
+        assert!(stored.same_cell(&second));
+        assert!(table.get(key).unwrap().same_cell(&second));
+    }
+
+    #[test]
+    fn symbol_table_snapshot_restores_cells_and_dictionary_identity() {
         let mut table = SymbolTable::new();
         let outer = hash_str("outer");
         let temporary = hash_str("temporary");
-        let outer_ref = table.insert(outer, LegacyValue::Index(Ref::new(1)), true);
+        let outer_cell = table.insert(outer, LegacyValue::Index(Ref::new(1)), true);
         table
             .dictionary
             .borrow_mut()
             .insert(outer, "outer".to_string());
-        let outer_addr = outer_ref.addr();
-        let dictionary_addr = table.dictionary.addr();
+        let original_dictionary = table.dictionary.clone();
         let original_snapshot = table.snapshot();
 
         table.insert(outer, LegacyValue::Index(Ref::new(2)), false);
@@ -140,8 +160,8 @@ mod snapshot_tests {
         assert_eq!(table.snapshot(), original_snapshot);
         assert!(!table.contains(temporary));
         assert!(table.get_mutable(outer).is_some());
-        assert_eq!(table.get(outer).unwrap().addr(), outer_addr);
-        assert_eq!(table.dictionary.addr(), dictionary_addr);
+        assert!(table.get(outer).unwrap().same_cell(&outer_cell));
+        assert!(table.dictionary.same_handle(&original_dictionary));
         assert_eq!(table.get_symbol_name_by_id(outer).as_deref(), Some("outer"));
     }
 }

--- a/src/core/src/reactive_transaction.rs
+++ b/src/core/src/reactive_transaction.rs
@@ -1,5 +1,5 @@
 use crate::{
-    LegacyValue, MResult, MechError, MechErrorKind, MechFunction, ValRef, ValueStateJournal,
+    LegacyValue, MResult, MechError, MechErrorKind, MechFunction, ValueCell, ValueStateJournal,
 };
 use std::cell::Cell;
 
@@ -22,8 +22,8 @@ impl ReactiveTurnJournal {
         self.values.capture_value(value)
     }
 
-    pub(crate) fn capture_val_ref(&mut self, value: &ValRef) -> MResult<()> {
-        self.values.capture_val_ref(value)
+    pub(crate) fn capture_value_cell(&mut self, value: &ValueCell) -> MResult<()> {
+        self.values.capture_value_cell(value)
     }
 
     pub(crate) fn capture_function_state(&mut self, function: &dyn MechFunction) -> MResult<()> {
@@ -80,8 +80,8 @@ impl ReactiveJournalParticipant<'_> {
         self.journal.capture_value(value)
     }
 
-    pub fn capture_val_ref(&mut self, value: &ValRef) -> MResult<()> {
-        self.journal.capture_val_ref(value)
+    pub fn capture_value_cell(&mut self, value: &ValueCell) -> MResult<()> {
+        self.journal.capture_value_cell(value)
     }
 
     pub fn capture_function_state(&mut self, function: &dyn MechFunction) -> MResult<()> {
@@ -633,9 +633,9 @@ mod tests {
     #[test]
     fn reactive_transaction_restores_nested_cell_identity() {
         let inner = Ref::new(3usize);
-        let outer = Ref::new(LegacyValue::Index(inner.clone()));
+        let outer = ValueCell::new(LegacyValue::Index(inner.clone()));
         let mut journal = ReactiveTurnJournal::new();
-        journal.capture_val_ref(&outer).unwrap();
+        journal.capture_value_cell(&outer).unwrap();
         *inner.borrow_mut() = 9;
         *outer.borrow_mut() = LegacyValue::Index(Ref::new(10));
 

--- a/src/core/src/state_journal/mod.rs
+++ b/src/core/src/state_journal/mod.rs
@@ -444,7 +444,7 @@ impl CaptureSide {
 #[derive(Clone)]
 enum ValueStateRoot {
     Value(LegacyValue),
-    ValRef(ValRef),
+    Cell(ValueCell),
 }
 
 trait ErasedValueStateEntry {
@@ -570,14 +570,15 @@ impl ValueStateJournal {
         Ok(())
     }
 
-    /// Captures the [`ValRef`] cell itself and every cell reachable from its
-    /// current [`Value`].
-    pub fn capture_val_ref(&mut self, value: &ValRef) -> MResult<()> {
+    /// Captures the [`ValueCell`] itself and every cell reachable from its
+    /// current [`LegacyValue`].
+    pub fn capture_value_cell(&mut self, cell: &ValueCell) -> MResult<()> {
         self.ensure_open()?;
+        let reference = cell.legacy_ref();
 
         let mut preflight_seen = HashSet::default();
         self.preflight_ref(
-            value,
+            &reference,
             CaptureSide::Before,
             &mut preflight_seen,
             |journal, value, seen| journal.preflight_value(value, CaptureSide::Before, seen),
@@ -585,12 +586,12 @@ impl ValueStateJournal {
 
         let mut capture_seen = HashSet::default();
         self.visit_ref(
-            value,
+            &reference,
             CaptureSide::Before,
             &mut capture_seen,
             |journal, value, seen| journal.visit_value(value, CaptureSide::Before, seen),
         )?;
-        self.roots.push(ValueStateRoot::ValRef(value.clone()));
+        self.roots.push(ValueStateRoot::Cell(cell.clone()));
         Ok(())
     }
 
@@ -688,8 +689,9 @@ impl ValueStateJournal {
     ) -> MResult<()> {
         match root {
             ValueStateRoot::Value(value) => self.preflight_value(value, side, seen),
-            ValueStateRoot::ValRef(value) => {
-                self.preflight_ref(value, side, seen, |journal, value, seen| {
+            ValueStateRoot::Cell(cell) => {
+                let reference = cell.legacy_ref();
+                self.preflight_ref(&reference, side, seen, |journal, value, seen| {
                     journal.preflight_value(value, side, seen)
                 })
             }
@@ -704,8 +706,9 @@ impl ValueStateJournal {
     ) -> MResult<()> {
         match root {
             ValueStateRoot::Value(value) => self.visit_value(value, side, seen),
-            ValueStateRoot::ValRef(value) => {
-                self.visit_ref(value, side, seen, |journal, value, seen| {
+            ValueStateRoot::Cell(cell) => {
+                let reference = cell.legacy_ref();
+                self.visit_ref(&reference, side, seen, |journal, value, seen| {
                     journal.visit_value(value, side, seen)
                 })
             }

--- a/src/core/src/state_journal/tests/borrow_conflicts.rs
+++ b/src/core/src/state_journal/tests/borrow_conflicts.rs
@@ -1,5 +1,7 @@
 use super::support::{record_value, scalar, scalar_value};
-use crate::{LegacyValue, MechMap, MechSet, Ref, ValueStateBorrowConflict, ValueStateJournal};
+use crate::{
+    LegacyValue, MechMap, MechSet, Ref, ValueCell, ValueStateBorrowConflict, ValueStateJournal,
+};
 use core::any::type_name;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 
@@ -37,6 +39,23 @@ fn state_journal_capture_conflict_is_structured_and_adds_nothing() {
     drop(held);
 
     journal.capture_value(&root).unwrap();
+    assert_eq!(journal.cell_count(), 1);
+}
+
+#[test]
+fn state_journal_value_cell_capture_preserves_root_borrow_conflicts() {
+    let root = ValueCell::new(LegacyValue::Empty);
+    let held = root.borrow_mut();
+    let mut journal = ValueStateJournal::new();
+
+    let error = journal.capture_value_cell(&root).unwrap_err();
+    let conflict = error.kind_as::<ValueStateBorrowConflict>().unwrap();
+    assert_eq!(conflict.phase, "capture-before");
+    assert_eq!(conflict.type_name, type_name::<LegacyValue>());
+    assert!(journal.is_empty());
+    drop(held);
+
+    journal.capture_value_cell(&root).unwrap();
     assert_eq!(journal.cell_count(), 1);
 }
 

--- a/src/core/src/state_journal/tests/nested.rs
+++ b/src/core/src/state_journal/tests/nested.rs
@@ -2,7 +2,9 @@ use super::support::{as_scalar, record_value, scalar, scalar_payload, scalar_val
 #[cfg(feature = "atom")]
 use crate::MechAtom;
 use crate::structures::matrix::Matrix as ValueMatrix;
-use crate::{LegacyValue, MechEnum, MechTuple, Ref, ValueKind, ValueStateJournal, hash_str};
+use crate::{
+    LegacyValue, MechEnum, MechTuple, Ref, ValueCell, ValueKind, ValueStateJournal, hash_str,
+};
 use nalgebra::DMatrix;
 use std::collections::HashMap;
 
@@ -30,43 +32,44 @@ fn state_journal_deduplicates_shared_cells_and_restores_aliases() {
 
 #[test]
 fn state_journal_self_reference_terminates_in_both_phases() {
-    let cell = Ref::new(LegacyValue::Empty);
-    *cell.borrow_mut() = LegacyValue::MutableReference(cell.clone());
+    let cell = ValueCell::new(LegacyValue::Empty);
+    let reference = cell.legacy_ref();
+    *cell.borrow_mut() = LegacyValue::MutableReference(reference.clone());
 
     let mut journal = ValueStateJournal::new();
-    journal.capture_val_ref(&cell).unwrap();
+    journal.capture_value_cell(&cell).unwrap();
     assert_eq!(journal.cell_count(), 1);
     journal.record_after().unwrap();
     let delta = journal.into_delta().unwrap();
 
     delta.rewind().unwrap();
     match &*cell.borrow() {
-        LegacyValue::MutableReference(inner) => assert_eq!(inner.addr(), cell.addr()),
+        LegacyValue::MutableReference(inner) => assert!(inner.same_handle(&reference)),
         _ => panic!("self-reference was not restored"),
     }
     delta.replay().unwrap();
     match &*cell.borrow() {
-        LegacyValue::MutableReference(inner) => assert_eq!(inner.addr(), cell.addr()),
+        LegacyValue::MutableReference(inner) => assert!(inner.same_handle(&reference)),
         _ => panic!("self-reference was not replayed"),
     }
 }
 
 #[test]
-fn state_journal_val_ref_tracks_replaced_root_and_after_only_cell() {
+fn state_journal_value_cell_tracks_replaced_root_and_after_only_cell() {
     let before = scalar(1.0);
     let after = scalar(2.0);
-    let root = Ref::new(scalar_value(&before));
-    let root_address = root.addr();
+    let root = ValueCell::new(scalar_value(&before));
+    let original_root = root.clone();
 
     let mut journal = ValueStateJournal::new();
-    journal.capture_val_ref(&root).unwrap();
+    journal.capture_value_cell(&root).unwrap();
     *root.borrow_mut() = scalar_value(&after);
     journal.record_after().unwrap();
     assert_eq!(journal.cell_count(), 3);
     let delta = journal.into_delta().unwrap();
 
     delta.rewind().unwrap();
-    assert_eq!(root.addr(), root_address);
+    assert!(root.same_cell(&original_root));
     assert_eq!(as_scalar(&root.borrow()).addr(), before.addr());
 
     *after.borrow_mut() = 22.0;
@@ -78,6 +81,23 @@ fn state_journal_val_ref_tracks_replaced_root_and_after_only_cell() {
     delta.rewind().unwrap();
     assert_eq!(as_scalar(&root.borrow()).addr(), before.addr());
     assert_eq!(*before.borrow(), 1.0);
+}
+
+#[test]
+fn state_journal_deduplicates_repeated_clones_of_one_value_cell() {
+    let nested = scalar(1.0);
+    let root = ValueCell::new(scalar_value(&nested));
+    let clone = root.clone();
+    let mut journal = ValueStateJournal::new();
+
+    journal.capture_value_cell(&root).unwrap();
+    journal.capture_value_cell(&clone).unwrap();
+
+    assert_eq!(journal.cell_count(), 2);
+    *clone.borrow_mut() = LegacyValue::Empty;
+    journal.restore_before().unwrap();
+    assert!(root.same_cell(&clone));
+    assert_eq!(as_scalar(&root.borrow()).addr(), nested.addr());
 }
 
 #[test]

--- a/src/core/src/state_journal/tests/nested.rs
+++ b/src/core/src/state_journal/tests/nested.rs
@@ -97,7 +97,7 @@ fn state_journal_deduplicates_repeated_clones_of_one_value_cell() {
     *clone.borrow_mut() = LegacyValue::Empty;
     journal.restore_before().unwrap();
     assert!(root.same_cell(&clone));
-    assert_eq!(as_scalar(&root.borrow()).addr(), nested.addr());
+    assert!(as_scalar(&root.borrow()).same_handle(&nested));
 }
 
 #[test]

--- a/src/core/src/types/mod.rs
+++ b/src/core/src/types/mod.rs
@@ -151,7 +151,6 @@ impl Debug for ValueCell {
 }
 
 pub type MutableReference = Ref<LegacyValue>;
-pub type ValRef = Ref<LegacyValue>;
 
 pub type MResult<T> = Result<T, MechError>;
 

--- a/src/core/src/types/mod.rs
+++ b/src/core/src/types/mod.rs
@@ -93,6 +93,63 @@ impl<T: PartialEq> PartialEq for Ref<T> {
 }
 impl<T: PartialEq> Eq for Ref<T> {}
 
+/// An opaque mutable program location with shared identity.
+///
+/// The current backing payload remains [`LegacyValue`] while legacy compiler
+/// and machinery boundaries are retired. Callers should use [`Self::same_cell`]
+/// when they need to compare location identity.
+#[derive(Clone, PartialEq, Eq)]
+pub struct ValueCell {
+    inner: Ref<LegacyValue>,
+}
+
+impl ValueCell {
+    pub fn new(value: LegacyValue) -> Self {
+        Self {
+            inner: Ref::new(value),
+        }
+    }
+
+    pub fn borrow(&self) -> cell::Ref<'_, LegacyValue> {
+        self.inner.borrow()
+    }
+
+    pub fn borrow_mut(&self) -> cell::RefMut<'_, LegacyValue> {
+        self.inner.borrow_mut()
+    }
+
+    pub fn try_borrow(&self) -> Result<cell::Ref<'_, LegacyValue>, cell::BorrowError> {
+        self.inner.try_borrow()
+    }
+
+    pub fn try_borrow_mut(&self) -> Result<cell::RefMut<'_, LegacyValue>, cell::BorrowMutError> {
+        self.inner.try_borrow_mut()
+    }
+
+    pub fn same_cell(&self, other: &Self) -> bool {
+        self.inner.same_handle(&other.inner)
+    }
+
+    #[doc(hidden)]
+    pub fn from_legacy_ref(inner: Ref<LegacyValue>) -> Self {
+        Self { inner }
+    }
+
+    #[doc(hidden)]
+    pub fn legacy_ref(&self) -> Ref<LegacyValue> {
+        self.inner.clone()
+    }
+}
+
+impl Debug for ValueCell {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.try_borrow() {
+            Ok(value) => write!(formatter, "ValueCell({value})"),
+            Err(_) => formatter.write_str("ValueCell(<borrowed>)"),
+        }
+    }
+}
+
 pub type MutableReference = Ref<LegacyValue>;
 pub type ValRef = Ref<LegacyValue>;
 
@@ -149,3 +206,68 @@ impl_pretty_print!(f32);
 #[cfg(feature = "f64")]
 impl_pretty_print!(f64);
 impl_pretty_print!(usize);
+
+#[cfg(test)]
+mod value_cell_tests {
+    use super::*;
+
+    fn index(value: usize) -> LegacyValue {
+        LegacyValue::Index(Ref::new(value))
+    }
+
+    #[test]
+    fn cloned_cells_preserve_identity_and_share_mutation() {
+        let cell = ValueCell::new(index(1));
+        let clone = cell.clone();
+
+        assert!(cell.same_cell(&clone));
+        *clone.borrow_mut() = index(2);
+        assert_eq!(*cell.borrow(), index(2));
+    }
+
+    #[test]
+    fn equal_payloads_do_not_imply_cell_identity() {
+        let left = ValueCell::new(index(1));
+        let right = ValueCell::new(index(1));
+
+        assert_eq!(left, right);
+        assert!(!left.same_cell(&right));
+    }
+
+    #[test]
+    fn fallible_borrows_report_conflicts() {
+        let cell = ValueCell::new(index(1));
+        {
+            let _write = cell.borrow_mut();
+            assert!(cell.try_borrow().is_err());
+        }
+        {
+            let _read = cell.borrow();
+            assert!(cell.try_borrow_mut().is_err());
+        }
+    }
+
+    #[test]
+    fn debug_output_is_address_free_even_during_borrow_conflicts() {
+        let cell = ValueCell::new(index(1));
+        let available = format!("{cell:?}");
+        assert!(available.starts_with("ValueCell("));
+        assert!(!available.contains("0x"));
+
+        let _write = cell.borrow_mut();
+        let borrowed = format!("{cell:?}");
+        assert_eq!(borrowed, "ValueCell(<borrowed>)");
+        assert!(!borrowed.contains("0x"));
+    }
+
+    #[test]
+    fn compatibility_bridges_preserve_the_underlying_handle() {
+        let cell = ValueCell::new(index(1));
+        let reference = cell.legacy_ref();
+        assert!(reference.same_handle(&cell.legacy_ref()));
+
+        let bridged = ValueCell::from_legacy_ref(reference.clone());
+        assert!(bridged.same_cell(&cell));
+        assert!(bridged.legacy_ref().same_handle(&reference));
+    }
+}

--- a/src/core/src/value.rs
+++ b/src/core/src/value.rs
@@ -1360,7 +1360,7 @@ impl LegacyValue {
     }
 }
 
-pub fn val_ref_reactive_cell_ids(value: &ValRef) -> Vec<ReactiveCellId> {
+pub fn legacy_ref_reactive_cell_ids(value: &Ref<LegacyValue>) -> Vec<ReactiveCellId> {
     let mut ids = Vec::new();
     let mut seen = HashSet::default();
 
@@ -5779,12 +5779,12 @@ mod reactive_cell_tests {
 
     #[cfg(feature = "f64")]
     #[test]
-    fn val_ref_helper_includes_program_cell() {
+    fn legacy_ref_helper_includes_program_cell() {
         let inner = Ref::new(1.0);
         let cell = Ref::new(LegacyValue::F64(inner.clone()));
 
         assert_eq!(
-            val_ref_reactive_cell_ids(&cell),
+            legacy_ref_reactive_cell_ids(&cell),
             cell_ids(&[cell.id(), inner.id()])
         );
     }

--- a/src/core/src/value_snapshot.rs
+++ b/src/core/src/value_snapshot.rs
@@ -3,7 +3,7 @@
 use core::any::{Any, TypeId};
 use core::fmt::Debug;
 
-use crate::{LegacyValue, MResult, MechError, MechErrorKind, Ref, ValRef};
+use crate::{LegacyValue, MResult, MechError, MechErrorKind, Ref};
 
 #[cfg(feature = "enum")]
 use crate::MechEnum;
@@ -444,7 +444,7 @@ impl ValueSnapshotCloneContext {
         Ok(snapshot)
     }
 
-    fn snapshot_mutable_reference(&mut self, source: &ValRef) -> MResult<LegacyValue> {
+    fn snapshot_mutable_reference(&mut self, source: &Ref<LegacyValue>) -> MResult<LegacyValue> {
         let key = ValueSnapshotKey::of_ref(source);
         if let Some(snapshot) = self.memoized::<LegacyValue>(key) {
             return Ok(snapshot);

--- a/src/engine/src/activation/tests/captures.rs
+++ b/src/engine/src/activation/tests/captures.rs
@@ -732,7 +732,6 @@ fn activation_pattern_capture_does_not_leak() {
 fn activation_pattern_capture_shadows_and_restores_outer_symbol() {
     let mut i = interpret("event := (1.0, 2.0)\nx := 99.0");
     let outer = symbol_ref(&i, "x");
-    let address = outer.addr();
     interpret_more(
         &mut i,
         "~> event\n  | (x, y) => {
@@ -743,7 +742,7 @@ fn activation_pattern_capture_shadows_and_restores_outer_symbol() {
     )
     .unwrap();
     assert_eq!(*symbol(&i, "x").as_f64().unwrap().borrow(), 99.);
-    assert_eq!(symbol_ref(&i, "x").addr(), address);
+    assert!(symbol_ref(&i, "x").same_cell(&outer));
     assert!(!i.symbols().borrow().contains(hash_str("y")));
     assert!(!i.symbols().borrow().contains(hash_str("selected")));
     let topology = plan_snapshot(&i);

--- a/src/engine/src/activation/tests/support.rs
+++ b/src/engine/src/activation/tests/support.rs
@@ -13,7 +13,7 @@ pub(super) use crate::{
     MechFunctionImpl, MechMap, MechRecord, MechSet, MechTable, MechTuple, Pattern,
     PatternActivationRegistration, PatternBinding, PatternMatch, R64, ReactiveCellId,
     ReactiveDependencyKind, ReactiveNodeId, ReactiveNodeKind, ReactiveRegisterCommit,
-    ReactiveTurnOutcome, Ref, SymbolTableSnapshot, ValRef, ValueKind, hash_str,
+    ReactiveTurnOutcome, Ref, SymbolTableSnapshot, ValueCell, ValueKind, hash_str,
 };
 pub(super) use mech_core::matrix::Matrix;
 pub(super) use std::collections::HashMap;
@@ -201,7 +201,7 @@ pub(super) fn interpret_more(interpreter: &mut Interpreter, source: &str) -> MRe
     interpreter.interpret(&tree)
 }
 
-pub(super) fn symbol_ref(interpreter: &Interpreter, name: &str) -> ValRef {
+pub(super) fn symbol_ref(interpreter: &Interpreter, name: &str) -> ValueCell {
     interpreter
         .symbols()
         .borrow()
@@ -654,25 +654,25 @@ pub(super) fn failed_elaboration_fixture() -> (
     SymbolTableSnapshot,
     Dictionary,
     PlanSnapshot,
-    ValRef,
-    usize,
+    ValueCell,
+    ValueCell,
 ) {
     let i = interpret("event := (1.0, 2.0)\nouter := 99.0");
     let symbols = i.symbols().borrow().snapshot();
     let dictionary = i.dictionary().borrow().clone();
     let topology = plan_snapshot(&i);
     let outer = symbol_ref(&i, "outer");
-    let address = outer.addr();
-    (i, symbols, dictionary, topology, outer, address)
+    (i, symbols, dictionary, topology, outer.clone(), outer)
 }
 pub(super) fn assert_failed_elaboration_restored() -> (
     Interpreter,
     SymbolTableSnapshot,
     Dictionary,
     PlanSnapshot,
-    usize,
+    ValueCell,
 ) {
-    let (mut i, symbols, dictionary, topology, outer, address) = failed_elaboration_fixture();
+    let (mut i, symbols, dictionary, topology, outer, original_outer) =
+        failed_elaboration_fixture();
     let error=interpret_more(&mut i,"~> event\n  | (x, y) => {\n      local-atom := :temporary\n      local-first := x + y\n      local-failure := function-that-does-not-exist(local-first)\n    }\n  | * => {
       fallback := 0.0
     }").unwrap_err();
@@ -689,7 +689,7 @@ pub(super) fn assert_failed_elaboration_restored() -> (
         assert!(!i.symbols().borrow().contains(hash_str(name)));
     }
     assert_eq!(*symbol(&i, "outer").as_f64().unwrap().borrow(), 99.);
-    assert_eq!(symbol_ref(&i, "outer").addr(), address);
+    assert!(symbol_ref(&i, "outer").same_cell(&original_outer));
     drop(outer);
-    (i, symbols, dictionary, topology, address)
+    (i, symbols, dictionary, topology, original_outer)
 }

--- a/src/engine/src/efficacy/ekf/closure.rs
+++ b/src/engine/src/efficacy/ekf/closure.rs
@@ -8,7 +8,7 @@ use mech_core::{
     FloatWidth, LegacyValue, MResult, MechError, MechErrorKind, MechExecutionServices, NodeId,
     ObservationReplayPolicy, OperationContractId, OutputConstruction, OutputId, ProgramRevision,
     ResolvedOperationContract, ResourceDelivery, ResourceIntent, SchemaBody, SchemaId, ShapeRule,
-    ValRef, ValueData,
+    ValueCell, ValueData,
 };
 use nalgebra::DVector;
 
@@ -918,7 +918,7 @@ fn validate_resource_request(request: &ExecutionResourceRequest) -> Result<(), (
 pub struct FrozenLiveBinding {
     pub interpreter_id: u64,
     pub request: ExecutionResourceRequest,
-    pub target: ValRef,
+    pub target: ValueCell,
 }
 
 #[derive(Debug)]
@@ -1026,7 +1026,7 @@ impl MechExecutionServices for FrozenEkfCompilationServices {
         &mut self,
         interpreter_id: u64,
         request: &ExecutionResourceRequest,
-        target: ValRef,
+        target: ValueCell,
     ) -> MResult<()> {
         Self::validate_request(request)?;
         if let Some(existing) = self
@@ -1034,7 +1034,7 @@ impl MechExecutionServices for FrozenEkfCompilationServices {
             .iter()
             .find(|binding| binding.interpreter_id == interpreter_id && binding.request == *request)
         {
-            if existing.target.addr() == target.addr() {
+            if existing.target.same_cell(&target) {
                 return Ok(());
             }
             return Err(frozen_service_error(

--- a/src/engine/src/expressions/comprehensions.rs
+++ b/src/engine/src/expressions/comprehensions.rs
@@ -13,7 +13,7 @@ use crate::patterns::PatternBindingSink;
 use crate::{
     ComprehensionQualifier, ExternalInteraction, FunctionSpecializer, Interpreter,
     InterpreterExecution, LegacyValue, MResult, MechError, MechFunction, ReactiveNodeKind, Ref,
-    execute_catalog_operation, hash_str, val_ref_reactive_cell_ids,
+    execute_catalog_operation, hash_str, legacy_ref_reactive_cell_ids,
 };
 #[cfg(feature = "set_comprehensions")]
 use crate::{MechSet, SetComprehension};
@@ -29,7 +29,7 @@ fn value_depends_on_reactive_turn(value: &LegacyValue, p: &InterpreterExecution<
         symbols
             .mutable_variables
             .values()
-            .flat_map(val_ref_reactive_cell_ids)
+            .flat_map(|cell| legacy_ref_reactive_cell_ids(&cell.legacy_ref()))
             .collect::<HashSet<_>>()
     };
     let plan = p.plan();

--- a/src/engine/src/expressions/subscripts/mod.rs
+++ b/src/engine/src/expressions/subscripts/mod.rs
@@ -52,7 +52,7 @@ pub fn slice(
                 let symbols_brrw = symbols.borrow();
                 match symbols_brrw.get(id) {
                     Some(val) => match symbols_brrw.get_mutable(id) {
-                        Some(_) => LegacyValue::MutableReference(val.clone()),
+                        Some(_) => LegacyValue::MutableReference(val.legacy_ref()),
                         None => val.borrow().clone(),
                     },
                     None => {
@@ -74,7 +74,7 @@ pub fn slice(
         let symbols_brrw = symbols.borrow();
         match symbols_brrw.get(id) {
             Some(val) => match symbols_brrw.get_mutable(id) {
-                Some(_) => LegacyValue::MutableReference(val.clone()),
+                Some(_) => LegacyValue::MutableReference(val.legacy_ref()),
                 None => val.borrow().clone(),
             },
             None => {

--- a/src/engine/src/expressions/subscripts/string.rs
+++ b/src/engine/src/expressions/subscripts/string.rs
@@ -117,7 +117,7 @@ fn mutable_reference_is_mutable_symbol(
     symbols_brrw
         .mutable_variables
         .values()
-        .any(|symbol| symbol.same_handle(reference))
+        .any(|symbol| symbol.legacy_ref().same_handle(reference))
 }
 
 #[cfg(feature = "subscript_formula")]

--- a/src/engine/src/expressions/tests/variables.rs
+++ b/src/engine/src/expressions/tests/variables.rs
@@ -1,7 +1,7 @@
 use crate::{
     ExecutionHostFunctionRequest, ExecutionResourceRequest, GenericError, Interpreter, LegacyValue,
     MResult, MechError, MechExecutionServices, ReactiveDependencyKind, Ref, ResourceDelivery,
-    ResourceIntent, ValRef, hash_str,
+    ResourceIntent, ValueCell, hash_str,
 };
 use mech_core::matrix::Matrix;
 use nalgebra::DVector;
@@ -10,7 +10,7 @@ struct RecordingContextReadServices {
     result: LegacyValue,
     fail_read: bool,
     reads: Vec<ExecutionResourceRequest>,
-    live_bindings: Vec<(u64, ExecutionResourceRequest, ValRef)>,
+    live_bindings: Vec<(u64, ExecutionResourceRequest, ValueCell)>,
     host_calls: Vec<ExecutionHostFunctionRequest>,
     writes: Vec<(ExecutionResourceRequest, LegacyValue)>,
 }
@@ -70,7 +70,7 @@ impl MechExecutionServices for RecordingContextReadServices {
         &mut self,
         interpreter_id: u64,
         request: &ExecutionResourceRequest,
-        target: ValRef,
+        target: ValueCell,
     ) -> MResult<()> {
         self.live_bindings
             .push((interpreter_id, request.clone(), target));
@@ -242,11 +242,7 @@ fn repeated_context_read_reuses_one_live_binding() {
         .borrow()
         .get(hash_str("@input/item"))
         .expect("successful addressed read must cache its output cell");
-    assert!(
-        addressed
-            .legacy_ref()
-            .same_handle(&services.live_bindings[0].2)
-    );
+    assert!(addressed.same_cell(&services.live_bindings[0].2));
     assert_eq!(
         addressed.borrow().reactive_root_cell_ids(),
         symbol_value(&interpreter, "first").reactive_root_cell_ids(),

--- a/src/engine/src/expressions/tests/variables.rs
+++ b/src/engine/src/expressions/tests/variables.rs
@@ -242,7 +242,11 @@ fn repeated_context_read_reuses_one_live_binding() {
         .borrow()
         .get(hash_str("@input/item"))
         .expect("successful addressed read must cache its output cell");
-    assert_eq!(addressed.addr(), services.live_bindings[0].2.addr());
+    assert!(
+        addressed
+            .legacy_ref()
+            .same_handle(&services.live_bindings[0].2)
+    );
     assert_eq!(
         addressed.borrow().reactive_root_cell_ids(),
         symbol_value(&interpreter, "first").reactive_root_cell_ids(),

--- a/src/engine/src/expressions/variables.rs
+++ b/src/engine/src/expressions/variables.rs
@@ -2,8 +2,7 @@ use super::{Environment, UndefinedVariableError};
 #[cfg(not(all(feature = "kind_annotation", feature = "convert")))]
 use crate::{FeatureNotEnabledError, MechError};
 use crate::{
-    Identifier, InterpreterExecution, LegacyValue, MResult, MutableReference, ValueCell, Var,
-    hash_str,
+    Identifier, InterpreterExecution, LegacyValue, MResult, MutableReference, Var, hash_str,
 };
 #[cfg(all(feature = "kind_annotation", feature = "convert"))]
 use crate::{execute_catalog_operation, kind_annotation};
@@ -119,9 +118,13 @@ fn lower_missing_addressed_variable(
     {
         let symbols = interpreter.symbols();
         let mut symbols = symbols.borrow_mut();
-        symbols.insert_cell(id, ValueCell::from_legacy_ref(output.clone()), false);
+        symbols.insert_cell(id, output.clone(), false);
         symbols.dictionary.borrow_mut().insert(id, addressed_name);
     }
 
-    maybe_cast_variable_to_kind(variable, LegacyValue::MutableReference(output), interpreter)
+    maybe_cast_variable_to_kind(
+        variable,
+        LegacyValue::MutableReference(output.legacy_ref()),
+        interpreter,
+    )
 }

--- a/src/engine/src/expressions/variables.rs
+++ b/src/engine/src/expressions/variables.rs
@@ -2,7 +2,8 @@ use super::{Environment, UndefinedVariableError};
 #[cfg(not(all(feature = "kind_annotation", feature = "convert")))]
 use crate::{FeatureNotEnabledError, MechError};
 use crate::{
-    Identifier, InterpreterExecution, LegacyValue, MResult, MutableReference, Var, hash_str,
+    Identifier, InterpreterExecution, LegacyValue, MResult, MutableReference, ValueCell, Var,
+    hash_str,
 };
 #[cfg(all(feature = "kind_annotation", feature = "convert"))]
 use crate::{execute_catalog_operation, kind_annotation};
@@ -89,8 +90,12 @@ pub fn var(
         symbols.get(id)
     };
     if let Some(value) = symbol_value {
-        mark_if_live_symbol(&value);
-        return maybe_cast_variable_to_kind(v, LegacyValue::MutableReference(value), p);
+        mark_if_live_symbol(&value.legacy_ref());
+        return maybe_cast_variable_to_kind(
+            v,
+            LegacyValue::MutableReference(value.legacy_ref()),
+            p,
+        );
     }
     if v.context.is_some() {
         return lower_missing_addressed_variable(v, p);
@@ -114,7 +119,7 @@ fn lower_missing_addressed_variable(
     {
         let symbols = interpreter.symbols();
         let mut symbols = symbols.borrow_mut();
-        symbols.insert_cell(id, output.clone(), false);
+        symbols.insert_cell(id, ValueCell::from_legacy_ref(output.clone()), false);
         symbols.dictionary.borrow_mut().insert(id, addressed_name);
     }
 

--- a/src/engine/src/function/external/host_call.rs
+++ b/src/engine/src/function/external/host_call.rs
@@ -2,7 +2,7 @@ use crate::apply_stable_value_update;
 use mech_core::{
     ExecutionHostFunctionRequest, InitialSolvePolicy, LegacyValue, MResult, MechExecutionServices,
     MechFunctionImpl, NoMechExecutionServices, ReactiveDependencyScope, ReactiveSolveStatus,
-    ValRef,
+    ValRef, ValueCell,
 };
 
 #[cfg(feature = "semantic-compiler")]
@@ -26,7 +26,7 @@ impl ExternalHostCallFunction {
             .map(LegacyValue::try_deep_snapshot)
             .collect::<MResult<Vec<_>>>()?;
         let result = services.invoke_host_function(&self.request, &arguments)?;
-        apply_stable_value_update(self.output.clone(), result)?;
+        apply_stable_value_update(ValueCell::from_legacy_ref(self.output.clone()), result)?;
         Ok(())
     }
 }

--- a/src/engine/src/function/external/host_call.rs
+++ b/src/engine/src/function/external/host_call.rs
@@ -2,7 +2,7 @@ use crate::apply_stable_value_update;
 use mech_core::{
     ExecutionHostFunctionRequest, InitialSolvePolicy, LegacyValue, MResult, MechExecutionServices,
     MechFunctionImpl, NoMechExecutionServices, ReactiveDependencyScope, ReactiveSolveStatus,
-    ValRef, ValueCell,
+    ValueCell,
 };
 
 #[cfg(feature = "semantic-compiler")]
@@ -12,7 +12,7 @@ use mech_core::{ApplicationRequirement, BytecodeCompilerContext, MechFunctionCom
 pub struct ExternalHostCallFunction {
     pub request: ExecutionHostFunctionRequest,
     pub arguments: Vec<LegacyValue>,
-    pub output: ValRef,
+    pub output: ValueCell,
     pub initial_solve_policy: InitialSolvePolicy,
 }
 
@@ -26,7 +26,7 @@ impl ExternalHostCallFunction {
             .map(LegacyValue::try_deep_snapshot)
             .collect::<MResult<Vec<_>>>()?;
         let result = services.invoke_host_function(&self.request, &arguments)?;
-        apply_stable_value_update(ValueCell::from_legacy_ref(self.output.clone()), result)?;
+        apply_stable_value_update(self.output.clone(), result)?;
         Ok(())
     }
 }
@@ -69,7 +69,9 @@ impl MechFunctionImpl for ExternalHostCallFunction {
     }
 
     fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
-        Ok(vec![LegacyValue::MutableReference(self.output.clone())])
+        Ok(vec![LegacyValue::MutableReference(
+            self.output.legacy_ref(),
+        )])
     }
 
     fn to_string(&self) -> String {

--- a/src/engine/src/function/external/mod.rs
+++ b/src/engine/src/function/external/mod.rs
@@ -8,25 +8,27 @@ pub use resource_write::*;
 
 #[cfg(feature = "semantic-compiler")]
 use mech_core::{
-    BytecodeCompilerContext, LegacyValue, MResult, Register, ValRef, compile_value_register,
+    BytecodeCompilerContext, LegacyValue, MResult, Register, ValueCell, compile_value_register,
 };
 
 #[cfg(feature = "semantic-compiler")]
 pub(super) fn compile_external_output(
-    output: &ValRef,
+    output: &ValueCell,
     context: &mut dyn BytecodeCompilerContext,
 ) -> MResult<Register> {
-    let value = output.borrow();
-    compile_external_value_with_fallback(&value, output.addr(), context)
+    let reference = output.legacy_ref();
+    let value = reference.borrow();
+    compile_external_value_with_fallback(&value, reference.addr(), context)
 }
 
 #[cfg(feature = "semantic-compiler")]
 pub(super) fn compile_runtime_produced_external_output(
-    output: &ValRef,
+    output: &ValueCell,
     context: &mut dyn BytecodeCompilerContext,
 ) -> MResult<Register> {
-    let value = output.borrow();
-    mech_core::compile_runtime_produced_register(&value, output.addr(), context)
+    let reference = output.legacy_ref();
+    let value = reference.borrow();
+    mech_core::compile_runtime_produced_register(&value, reference.addr(), context)
 }
 
 #[cfg(feature = "semantic-compiler")]
@@ -54,7 +56,7 @@ mod tests {
     use mech_core::{
         BytecodeInstruction, ExecutionHostFunctionRequest, ExecutionResourceRequest, GenericError,
         InitialSolvePolicy, LegacyValue, MResult, MechError, MechExecutionServices,
-        MechFunctionCompiler, MechFunctionImpl, Ref, ResourceDelivery, ResourceIntent, ValRef,
+        MechFunctionCompiler, MechFunctionImpl, Ref, ResourceDelivery, ResourceIntent, ValueCell,
     };
     use nalgebra::DMatrix;
     use std::collections::VecDeque;
@@ -105,7 +107,7 @@ mod tests {
             &mut self,
             _interpreter_id: u64,
             _request: &ExecutionResourceRequest,
-            _target: ValRef,
+            _target: ValueCell,
         ) -> MResult<()> {
             Err(Self::error("live resource bind"))
         }
@@ -117,7 +119,7 @@ mod tests {
         planning_calls: usize,
         resource_reads: usize,
         live_bindings: usize,
-        bound_targets: Vec<ValRef>,
+        bound_targets: Vec<ValueCell>,
     }
 
     impl RecordingReadServices {
@@ -173,7 +175,7 @@ mod tests {
             &mut self,
             _interpreter_id: u64,
             _request: &ExecutionResourceRequest,
-            target: ValRef,
+            target: ValueCell,
         ) -> MResult<()> {
             self.live_bindings += 1;
             self.bound_targets.push(target);
@@ -198,7 +200,7 @@ mod tests {
     }
 
     fn resource_read_function(
-        output: ValRef,
+        output: ValueCell,
         delivery: ResourceDelivery,
     ) -> ExternalResourceReadFunction {
         let mut request = resource_request(ResourceIntent::Read);
@@ -222,7 +224,7 @@ mod tests {
         observed: LegacyValue,
         delivery: ResourceDelivery,
     ) -> (CompiledBytecode, Vec<u8>, u32) {
-        let output = Ref::new(observed);
+        let output = ValueCell::new(observed);
         let function = resource_read_function(output, delivery);
         let mut context = CompileCtx::new();
         let destination = function.compile(&mut context).unwrap();
@@ -276,7 +278,7 @@ mod tests {
     fn typed_external_outputs_do_not_share_argument_registers() {
         let scalar = Ref::new(7.0);
         let bare_argument = LegacyValue::F64(scalar.clone());
-        let typed_output = Ref::new(LegacyValue::Typed(
+        let typed_output = ValueCell::new(LegacyValue::Typed(
             Box::new(LegacyValue::F64(scalar)),
             mech_core::ValueKind::Option(Box::new(mech_core::ValueKind::F64)),
         ));
@@ -298,8 +300,23 @@ mod tests {
     }
 
     #[test]
+    fn cloned_output_cells_reuse_registers_and_distinct_cells_do_not() {
+        let shared = ValueCell::new(LegacyValue::Empty);
+        let clone = shared.clone();
+        let distinct = ValueCell::new(LegacyValue::Empty);
+        let mut context = CompileCtx::new();
+
+        let shared_register = compile_external_output(&shared, &mut context).unwrap();
+        let clone_register = compile_external_output(&clone, &mut context).unwrap();
+        let distinct_register = compile_external_output(&distinct, &mut context).unwrap();
+
+        assert_eq!(shared_register, clone_register);
+        assert_ne!(shared_register, distinct_register);
+    }
+
+    #[test]
     fn host_call_failure_propagates_without_publishing_a_stale_output() {
-        let output = Ref::new(LegacyValue::F64(Ref::new(41.0)));
+        let output = ValueCell::new(LegacyValue::F64(Ref::new(41.0)));
         let function = ExternalHostCallFunction {
             request: ExecutionHostFunctionRequest {
                 name: "test/fail".into(),
@@ -319,7 +336,7 @@ mod tests {
 
     #[test]
     fn resource_read_failure_propagates_without_publishing_a_stale_output() {
-        let output = Ref::new(LegacyValue::F64(Ref::new(42.0)));
+        let output = ValueCell::new(LegacyValue::F64(Ref::new(42.0)));
         let function = ExternalResourceReadFunction {
             interpreter_id: 7,
             request: resource_request(ResourceIntent::Read),
@@ -338,28 +355,28 @@ mod tests {
 
     #[test]
     fn resource_read_initializes_empty_stable_output() {
-        let output = Ref::new(LegacyValue::Empty);
-        let output_address = output.addr();
+        let output = ValueCell::new(LegacyValue::Empty);
+        let original_output = output.clone();
         let function = resource_read_function(output.clone(), ResourceDelivery::Snapshot);
         let mut services = RecordingReadServices::new([LegacyValue::F64(Ref::new(42.0))]);
 
         function.solve_result_with(&mut services).unwrap();
 
-        assert_eq!(output.addr(), output_address);
+        assert!(output.same_cell(&original_output));
         assert!(matches!(&*output.borrow(), LegacyValue::F64(value) if *value.borrow() == 42.0));
         assert_eq!(services.resource_reads, 1);
     }
 
     #[test]
     fn resource_read_initializes_empty_matrix_output() {
-        let output = Ref::new(LegacyValue::Empty);
-        let output_address = output.addr();
+        let output = ValueCell::new(LegacyValue::Empty);
+        let original_output = output.clone();
         let function = resource_read_function(output.clone(), ResourceDelivery::Snapshot);
         let mut services = RecordingReadServices::new([matrix(2, 2, vec![1.0, 2.0, 3.0, 4.0])]);
 
         function.solve_result_with(&mut services).unwrap();
 
-        assert_eq!(output.addr(), output_address);
+        assert!(output.same_cell(&original_output));
         assert!(matches!(
             &*output.borrow(),
             LegacyValue::MatrixF64(Matrix::DMatrix(value))
@@ -369,8 +386,8 @@ mod tests {
 
     #[test]
     fn resource_read_subsequent_same_representation_update_uses_stable_contract() {
-        let output = Ref::new(LegacyValue::Empty);
-        let output_address = output.addr();
+        let output = ValueCell::new(LegacyValue::Empty);
+        let original_output = output.clone();
         let function = resource_read_function(output.clone(), ResourceDelivery::Snapshot);
         let mut services = RecordingReadServices::new([
             LegacyValue::F64(Ref::new(1.0)),
@@ -380,13 +397,13 @@ mod tests {
         function.solve_result_with(&mut services).unwrap();
         function.solve_result_with(&mut services).unwrap();
 
-        assert_eq!(output.addr(), output_address);
+        assert!(output.same_cell(&original_output));
         assert!(matches!(&*output.borrow(), LegacyValue::F64(value) if *value.borrow() == 2.0));
     }
 
     #[test]
     fn resource_read_rejects_representation_change_after_initialization() {
-        let output = Ref::new(LegacyValue::Empty);
+        let output = ValueCell::new(LegacyValue::Empty);
         let function = resource_read_function(output.clone(), ResourceDelivery::Snapshot);
         let mut services =
             RecordingReadServices::new([LegacyValue::F64(Ref::new(1.0)), matrix(1, 1, vec![2.0])]);
@@ -400,7 +417,7 @@ mod tests {
 
     #[test]
     fn resource_read_rejects_shape_change_after_initialization() {
-        let output = Ref::new(LegacyValue::Empty);
+        let output = ValueCell::new(LegacyValue::Empty);
         let function = resource_read_function(output.clone(), ResourceDelivery::Snapshot);
         let mut services = RecordingReadServices::new([
             matrix(1, 2, vec![1.0, 2.0]),
@@ -421,7 +438,7 @@ mod tests {
 
     #[test]
     fn resource_read_rejects_empty_initial_provider_result() {
-        let output = Ref::new(LegacyValue::Empty);
+        let output = ValueCell::new(LegacyValue::Empty);
         let function = resource_read_function(output.clone(), ResourceDelivery::Live);
         let mut services = RecordingReadServices::new([LegacyValue::Empty]);
 
@@ -434,20 +451,54 @@ mod tests {
 
     #[test]
     fn resource_read_live_binding_observes_initialized_cell() {
-        let output = Ref::new(LegacyValue::Empty);
-        let output_address = output.addr();
+        let output = ValueCell::new(LegacyValue::Empty);
         let function = resource_read_function(output.clone(), ResourceDelivery::Live);
         let mut services = RecordingReadServices::new([matrix(2, 1, vec![1.0, 2.0])]);
 
         function.solve_result_with(&mut services).unwrap();
 
         assert_eq!(services.live_bindings, 1);
-        assert_eq!(services.bound_targets[0].addr(), output_address);
+        assert!(services.bound_targets[0].same_cell(&output));
         assert!(matches!(
             &*services.bound_targets[0].borrow(),
             LegacyValue::MatrixF64(Matrix::DMatrix(value))
                 if value.borrow().shape() == (2, 1)
         ));
+    }
+
+    #[test]
+    fn repeated_live_bindings_share_one_updated_output_cell() {
+        let output = ValueCell::new(LegacyValue::Empty);
+        let function = resource_read_function(output.clone(), ResourceDelivery::Live);
+        let mut services = RecordingReadServices::new([
+            LegacyValue::F64(Ref::new(1.0)),
+            LegacyValue::F64(Ref::new(2.0)),
+        ]);
+
+        function.solve_result_with(&mut services).unwrap();
+        function.solve_result_with(&mut services).unwrap();
+
+        assert_eq!(services.bound_targets.len(), 2);
+        assert!(services.bound_targets[0].same_cell(&output));
+        assert!(services.bound_targets[1].same_cell(&output));
+        assert!(services.bound_targets[0].same_cell(&services.bound_targets[1]));
+        assert!(matches!(
+            &*services.bound_targets[0].borrow(),
+            LegacyValue::F64(value) if *value.borrow() == 2.0
+        ));
+    }
+
+    #[test]
+    fn resource_read_transaction_state_uses_the_same_legacy_handle() {
+        let output = ValueCell::new(LegacyValue::F64(Ref::new(1.0)));
+        let function = resource_read_function(output.clone(), ResourceDelivery::Snapshot);
+
+        let state = function.transaction_state_values().unwrap();
+
+        let [LegacyValue::MutableReference(reference)] = state.as_slice() else {
+            panic!("resource read must expose one mutable-reference compatibility root")
+        };
+        assert!(reference.same_handle(&output.legacy_ref()));
     }
 
     #[test]
@@ -505,7 +556,7 @@ mod tests {
 
     #[test]
     fn resource_write_failure_propagates_without_changing_its_output() {
-        let output = Ref::new(LegacyValue::Empty);
+        let output = ValueCell::new(LegacyValue::Empty);
         let function = ExternalResourceWriteFunction {
             request: resource_request(ResourceIntent::Assign),
             input: LegacyValue::F64(Ref::new(43.0)),

--- a/src/engine/src/function/external/resource_read.rs
+++ b/src/engine/src/function/external/resource_read.rs
@@ -4,7 +4,7 @@ use mech_core::{
     ExternalInteraction, InitialSolvePolicy, InputPortLayout, LegacyValue, MResult, MechError,
     MechErrorKind, MechExecutionServices, MechFunctionImpl, NoMechExecutionServices,
     ObservationContract, ObservationReplayPolicy, OperationContractDeclaration, OutputConstruction,
-    OutputPortPolicy, ReactiveSolveStatus, ResourceDelivery, ShapeRule, ValRef,
+    OutputPortPolicy, ReactiveSolveStatus, ResourceDelivery, ShapeRule, ValRef, ValueCell,
 };
 use std::sync::LazyLock;
 
@@ -78,7 +78,8 @@ impl ExternalResourceReadFunction {
             return Ok(());
         }
 
-        apply_stable_value_update(self.output.clone(), result).map(|_| ())
+        apply_stable_value_update(ValueCell::from_legacy_ref(self.output.clone()), result)
+            .map(|_| ())
     }
 
     fn solve_with_services(&self, services: &mut dyn MechExecutionServices) -> MResult<()> {

--- a/src/engine/src/function/external/resource_read.rs
+++ b/src/engine/src/function/external/resource_read.rs
@@ -4,7 +4,7 @@ use mech_core::{
     ExternalInteraction, InitialSolvePolicy, InputPortLayout, LegacyValue, MResult, MechError,
     MechErrorKind, MechExecutionServices, MechFunctionImpl, NoMechExecutionServices,
     ObservationContract, ObservationReplayPolicy, OperationContractDeclaration, OutputConstruction,
-    OutputPortPolicy, ReactiveSolveStatus, ResourceDelivery, ShapeRule, ValRef, ValueCell,
+    OutputPortPolicy, ReactiveSolveStatus, ResourceDelivery, ShapeRule, ValueCell,
 };
 use std::sync::LazyLock;
 
@@ -33,7 +33,7 @@ use mech_core::{ApplicationRequirement, BytecodeCompilerContext, MechFunctionCom
 pub struct ExternalResourceReadFunction {
     pub interpreter_id: u64,
     pub request: ExecutionResourceRequest,
-    pub output: ValRef,
+    pub output: ValueCell,
     pub initial_solve_policy: InitialSolvePolicy,
     pub semantic_contract: Option<&'static OperationContractDeclaration>,
 }
@@ -78,8 +78,7 @@ impl ExternalResourceReadFunction {
             return Ok(());
         }
 
-        apply_stable_value_update(ValueCell::from_legacy_ref(self.output.clone()), result)
-            .map(|_| ())
+        apply_stable_value_update(self.output.clone(), result).map(|_| ())
     }
 
     fn solve_with_services(&self, services: &mut dyn MechExecutionServices) -> MResult<()> {
@@ -138,7 +137,9 @@ impl MechFunctionImpl for ExternalResourceReadFunction {
     }
 
     fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
-        Ok(vec![LegacyValue::MutableReference(self.output.clone())])
+        Ok(vec![LegacyValue::MutableReference(
+            self.output.legacy_ref(),
+        )])
     }
 
     fn to_string(&self) -> String {

--- a/src/engine/src/function/external/resource_write.rs
+++ b/src/engine/src/function/external/resource_write.rs
@@ -3,7 +3,7 @@ use mech_core::{
     ExternalInteraction, IdempotencyRequirement, InitialSolvePolicy, InputPortLayout,
     InputPortPolicy, LegacyValue, MResult, MechError, MechErrorKind, MechExecutionServices,
     MechFunctionImpl, NoMechExecutionServices, OperationContractDeclaration,
-    ReactiveDependencyScope, ReactiveSolveStatus, ResourceIntent, ValRef,
+    ReactiveDependencyScope, ReactiveSolveStatus, ResourceIntent, ValueCell,
 };
 use std::sync::LazyLock;
 
@@ -30,7 +30,7 @@ use mech_core::{ApplicationRequirement, BytecodeCompilerContext, MechFunctionCom
 pub struct ExternalResourceWriteFunction {
     pub request: ExecutionResourceRequest,
     pub input: LegacyValue,
-    pub output: ValRef,
+    pub output: ValueCell,
     pub initial_solve_policy: InitialSolvePolicy,
     pub semantic_contract: Option<&'static OperationContractDeclaration>,
 }
@@ -123,7 +123,9 @@ impl MechFunctionImpl for ExternalResourceWriteFunction {
     }
 
     fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
-        Ok(vec![LegacyValue::MutableReference(self.output.clone())])
+        Ok(vec![LegacyValue::MutableReference(
+            self.output.legacy_ref(),
+        )])
     }
 
     fn to_string(&self) -> String {
@@ -201,7 +203,7 @@ mod tests {
                 delivery: mech_core::ResourceDelivery::Snapshot,
             },
             input: LegacyValue::F64(Ref::new(1.0)),
-            output: Ref::new(LegacyValue::F64(Ref::new(2.0))),
+            output: ValueCell::new(LegacyValue::F64(Ref::new(2.0))),
             initial_solve_policy: InitialSolvePolicy::Solve,
             semantic_contract: None,
         };

--- a/src/engine/src/integrity.rs
+++ b/src/engine/src/integrity.rs
@@ -346,7 +346,7 @@ fn constraint_evaluation(
     }
 }
 
-fn format_operand(operand: Option<&ValRef>) -> Option<String> {
+fn format_operand(operand: Option<&ValueCell>) -> Option<String> {
     let operand = operand?;
     let value = operand.try_borrow().ok()?;
     resolve_value(&value)
@@ -578,7 +578,7 @@ mod tests {
             .integrity_constraints
             .get_mut(&hash_str(name))
             .unwrap()
-            .result = Ref::new(result);
+            .result = ValueCell::new(result);
     }
 
     #[test]

--- a/src/engine/src/interpreter/mod.rs
+++ b/src/engine/src/interpreter/mod.rs
@@ -226,10 +226,10 @@ impl SymbolTableCellCheckpoint {
             })?;
             let snapshot = table.snapshot();
             for value in table.symbols.values() {
-                journal.capture_val_ref(value)?;
+                journal.capture_value_cell(value)?;
             }
             for value in table.mutable_variables.values() {
-                journal.capture_val_ref(value)?;
+                journal.capture_value_cell(value)?;
             }
             snapshot
         };
@@ -322,7 +322,7 @@ impl UserFunctionsCheckpoint {
                 symbols_target: definition.symbols.clone(),
                 symbols: symbol_snapshot,
                 symbol_dictionary_target,
-                out_target: definition.out.clone(),
+                out_target: definition.out.legacy_ref(),
                 plan_target: definition.plan.clone(),
                 plan,
             });
@@ -382,6 +382,7 @@ impl UserFunctionsCheckpoint {
     fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
         let mut values = Vec::new();
         let mut seen_refs = HashSet::new();
+        let mut seen_cells = Vec::new();
         for definition in &self.definitions {
             if seen_refs.insert(definition.out_target.addr()) {
                 values.push(LegacyValue::MutableReference(definition.out_target.clone()));
@@ -395,8 +396,12 @@ impl UserFunctionsCheckpoint {
                 .values()
                 .chain(symbols.mutable_variables.values())
             {
-                if seen_refs.insert(value.addr()) {
-                    values.push(LegacyValue::MutableReference(value.clone()));
+                if !seen_cells
+                    .iter()
+                    .any(|seen: &ValueCell| seen.same_cell(value))
+                {
+                    seen_cells.push(value.clone());
+                    values.push(LegacyValue::MutableReference(value.legacy_ref()));
                 }
             }
             drop(symbols);
@@ -504,12 +509,12 @@ impl ProgramStateCheckpoint {
 
         #[cfg(feature = "invariant_define")]
         for constraint in state.integrity_constraints.values() {
-            journal.capture_val_ref(&constraint.result)?;
+            journal.capture_value_cell(&constraint.result)?;
             if let Some(lhs) = &constraint.lhs {
-                journal.capture_val_ref(lhs)?;
+                journal.capture_value_cell(lhs)?;
             }
             if let Some(rhs) = &constraint.rhs {
-                journal.capture_val_ref(rhs)?;
+                journal.capture_value_cell(rhs)?;
             }
         }
 

--- a/src/engine/src/interpreter/tests/checkpoint.rs
+++ b/src/engine/src/interpreter/tests/checkpoint.rs
@@ -5,7 +5,7 @@ mod checkpoint_tests {
         FunctionDefinition, FunctionExport, FunctionExposure, FunctionExtensionEntry,
         FunctionSpecializer, Interpreter, LegacyValue, MResult, MechFunction, MechSourceCode,
         ModuleManifestCatalog, OperationId, ProgramState, ReactiveCellId, Ref,
-        RuntimeContextBinding, ValRef, ValueStateBorrowConflict, hash_str,
+        RuntimeContextBinding, ValueCell, ValueStateBorrowConflict, hash_str,
         internal_pattern_value_identifier,
     };
     use std::collections::HashMap;
@@ -42,7 +42,7 @@ mod checkpoint_tests {
         )
     }
 
-    fn index_payload(value: &Ref<LegacyValue>) -> usize {
+    fn index_payload(value: &ValueCell) -> usize {
         let value = value.borrow();
         let LegacyValue::Index(index) = &*value else {
             panic!("expected retained index value, got {value:?}")
@@ -50,7 +50,7 @@ mod checkpoint_tests {
         *index.borrow()
     }
 
-    fn install_scalar(interpreter: &Interpreter, name: &str, value: f64) -> (ValRef, Ref<f64>) {
+    fn install_scalar(interpreter: &Interpreter, name: &str, value: f64) -> (ValueCell, Ref<f64>) {
         let backing = Ref::new(value);
         let id = hash_str(name);
         let symbols = interpreter.symbols();
@@ -362,7 +362,7 @@ mod checkpoint_tests {
         assert!(state.user_functions.resolve_name(added_name).is_none());
         let restored = state.user_functions.resolve_name(function_name).unwrap();
         assert_eq!(restored.symbols.addr(), original_symbols.addr());
-        assert_eq!(restored.out.addr(), original_out.addr());
+        assert!(restored.out.same_cell(&original_out));
         assert_eq!(restored.plan.0.addr(), original_plan.0.addr());
         assert_eq!(
             restored.symbols.borrow().dictionary.addr(),
@@ -377,7 +377,7 @@ mod checkpoint_tests {
             .get(&symbol_id)
             .unwrap()
             .clone();
-        assert_eq!(restored_symbol.addr(), symbol.addr());
+        assert!(restored_symbol.same_cell(&symbol));
         assert_eq!(index_payload(&restored_symbol), 20);
         assert_eq!(
             restored
@@ -435,7 +435,7 @@ mod checkpoint_tests {
     fn interpreter_checkpoint_restores_private_state_and_recursive_child_identity() {
         let mut root = Interpreter::new(1, 100);
         let (symbol_cell, symbol_backing) = install_scalar(&root, "kept", 1.0);
-        let symbol_cell_address = symbol_cell.addr();
+        let original_symbol_cell = symbol_cell.clone();
         let symbol_backing_address = symbol_backing.addr();
         let symbol_backing_identity = ReactiveCellId::new(symbol_backing.id());
         root.out = f64_value(&symbol_backing);
@@ -483,9 +483,9 @@ mod checkpoint_tests {
             );
         }
         #[cfg(feature = "invariant_define")]
-        let invariant_result = Ref::new(LegacyValue::Bool(Ref::new(true)));
+        let invariant_result = ValueCell::new(LegacyValue::Bool(Ref::new(true)));
         #[cfg(feature = "invariant_define")]
-        let invariant_rhs = Ref::new(LegacyValue::F64(Ref::new(2.0)));
+        let invariant_rhs = ValueCell::new(LegacyValue::F64(Ref::new(2.0)));
         #[cfg(feature = "invariant_define")]
         {
             let invariant_id = hash_str("checkpoint-invariant");
@@ -668,11 +668,8 @@ mod checkpoint_tests {
                 constraint.operator,
                 Some(FormulaOperator::Comparison(ComparisonOp::LessThanEqual,)),
             );
-            assert_eq!(constraint.result.addr(), invariant_result.addr());
-            assert_eq!(
-                constraint.rhs.as_ref().unwrap().addr(),
-                invariant_rhs.addr()
-            );
+            assert!(constraint.result.same_cell(&invariant_result));
+            assert!(constraint.rhs.as_ref().unwrap().same_cell(&invariant_rhs));
             if let LegacyValue::Bool(value) = &*constraint.result.borrow() {
                 assert!(*value.borrow());
             } else {
@@ -692,7 +689,7 @@ mod checkpoint_tests {
         assert_eq!(*root.inline_eval_counter.borrow(), 4);
         assert_eq!(*root.persistent_user_function_plan_depth.borrow(), 2);
         assert_eq!(*root.deferred_expression_solve_depth.borrow(), 3);
-        assert_eq!(symbol_cell.addr(), symbol_cell_address);
+        assert!(symbol_cell.same_cell(&original_symbol_cell));
         assert_eq!(symbol_backing.addr(), symbol_backing_address);
         assert_eq!(
             ReactiveCellId::new(symbol_backing.id()),

--- a/src/engine/src/program/compiler_planning.rs
+++ b/src/engine/src/program/compiler_planning.rs
@@ -389,7 +389,9 @@ impl CompilerPlanningProgram {
         let id = hash_str(name);
         let symbols = self.interpreter.symbols();
         let mut symbols = symbols.borrow_mut();
-        symbols.symbols.insert(id, value);
+        symbols
+            .symbols
+            .insert(id, ValueCell::from_legacy_ref(value));
         symbols.dictionary.borrow_mut().insert(id, name.to_owned());
         Ok(())
     }
@@ -764,7 +766,7 @@ fn compile_bytecode(program: &mut CompilerPlanningProgram) -> MResult<CompilerPl
     let retained_integrity_metadata = if !state.integrity_constraints.is_empty() {
         let mut metadata = Vec::with_capacity(state.integrity_constraints.len());
         for constraint in state.integrity_constraints.values() {
-            let result = LegacyValue::MutableReference(constraint.result.clone());
+            let result = LegacyValue::MutableReference(constraint.result.legacy_ref());
             let result_register = context.resolve_value_register(&result)?;
             context.record_integrity_constraint(constraint.name.clone(), result_register)?;
             let name = LegacyValue::String(Ref::new(constraint.name.clone()));
@@ -805,12 +807,12 @@ fn compile_bytecode(program: &mut CompilerPlanningProgram) -> MResult<CompilerPl
             let lhs = constraint
                 .lhs
                 .as_ref()
-                .map(|value| LegacyValue::MutableReference(value.clone()))
+                .map(|value| LegacyValue::MutableReference(value.legacy_ref()))
                 .unwrap_or(LegacyValue::Empty);
             let rhs = constraint
                 .rhs
                 .as_ref()
-                .map(|value| LegacyValue::MutableReference(value.clone()))
+                .map(|value| LegacyValue::MutableReference(value.legacy_ref()))
                 .unwrap_or(LegacyValue::Empty);
             metadata.push(RetainedIntegrityMarkerMetadata {
                 result_register,
@@ -944,8 +946,6 @@ mod tests {
     use super::*;
     #[cfg(feature = "functions")]
     use mech_core::FunctionCatalogBuilder;
-    #[cfg(feature = "native")]
-    use mech_core::Ref;
     #[cfg(all(
         feature = "semantic-compiler",
         feature = "source",
@@ -954,6 +954,8 @@ mod tests {
         feature = "f64"
     ))]
     use mech_core::{BytecodeInstruction, ParsedProgram, Register};
+    #[cfg(feature = "native")]
+    use mech_core::{Ref, ValueCell};
     use std::collections::BTreeMap;
 
     #[cfg(feature = "functions")]
@@ -1070,7 +1072,7 @@ mod tests {
             .borrow()
             .get(hash_str("target"))
             .unwrap();
-        assert_eq!(descriptor.lhs.as_ref().unwrap().addr(), target.addr());
+        assert!(descriptor.lhs.as_ref().unwrap().same_cell(&target));
         assert!(descriptor.rhs.is_some());
         if let LegacyValue::F64(value) = &*target.borrow() {
             *value.borrow_mut() = 3.0;
@@ -1208,14 +1210,14 @@ mod live_input_tests {
     #[cfg(feature = "f64")]
     #[test]
     fn stable_value_update_preserves_f64_reference() {
-        let sink = Ref::new(LegacyValue::F64(Ref::new(1.0)));
-        let outer_pointer = sink.as_ptr();
+        let sink = ValueCell::new(LegacyValue::F64(Ref::new(1.0)));
+        let original_cell = sink.clone();
         let inner_pointer = match &*sink.borrow() {
             LegacyValue::F64(value) => value.as_ptr(),
             other => panic!("expected f64, got {other:?}"),
         };
         apply_stable_value_update(sink.clone(), LegacyValue::F64(Ref::new(9.0))).unwrap();
-        assert_eq!(outer_pointer, sink.as_ptr());
+        assert!(sink.same_cell(&original_cell));
         match &*sink.borrow() {
             LegacyValue::F64(value) => {
                 assert_eq!(inner_pointer, value.as_ptr());
@@ -1228,14 +1230,14 @@ mod live_input_tests {
     #[cfg(feature = "i64")]
     #[test]
     fn stable_value_update_preserves_i64_reference() {
-        let sink = Ref::new(LegacyValue::I64(Ref::new(1)));
-        let outer_pointer = sink.as_ptr();
+        let sink = ValueCell::new(LegacyValue::I64(Ref::new(1)));
+        let original_cell = sink.clone();
         let inner_pointer = match &*sink.borrow() {
             LegacyValue::I64(value) => value.as_ptr(),
             other => panic!("expected i64, got {other:?}"),
         };
         apply_stable_value_update(sink.clone(), LegacyValue::I64(Ref::new(9))).unwrap();
-        assert_eq!(outer_pointer, sink.as_ptr());
+        assert!(sink.same_cell(&original_cell));
         match &*sink.borrow() {
             LegacyValue::I64(value) => {
                 assert_eq!(inner_pointer, value.as_ptr());
@@ -1248,14 +1250,14 @@ mod live_input_tests {
     #[cfg(feature = "bool")]
     #[test]
     fn stable_value_update_preserves_bool_reference() {
-        let sink = Ref::new(LegacyValue::Bool(Ref::new(false)));
-        let outer_pointer = sink.as_ptr();
+        let sink = ValueCell::new(LegacyValue::Bool(Ref::new(false)));
+        let original_cell = sink.clone();
         let inner_pointer = match &*sink.borrow() {
             LegacyValue::Bool(value) => value.as_ptr(),
             other => panic!("expected bool, got {other:?}"),
         };
         apply_stable_value_update(sink.clone(), LegacyValue::Bool(Ref::new(true))).unwrap();
-        assert_eq!(outer_pointer, sink.as_ptr());
+        assert!(sink.same_cell(&original_cell));
         match &*sink.borrow() {
             LegacyValue::Bool(value) => {
                 assert_eq!(inner_pointer, value.as_ptr());
@@ -1268,8 +1270,8 @@ mod live_input_tests {
     #[cfg(any(feature = "string", feature = "variable_define"))]
     #[test]
     fn stable_value_update_preserves_string_reference() {
-        let sink = Ref::new(LegacyValue::String(Ref::new("old".to_string())));
-        let outer_pointer = sink.as_ptr();
+        let sink = ValueCell::new(LegacyValue::String(Ref::new("old".to_string())));
+        let original_cell = sink.clone();
         let inner_pointer = match &*sink.borrow() {
             LegacyValue::String(value) => value.as_ptr(),
             other => panic!("expected string, got {other:?}"),
@@ -1279,7 +1281,7 @@ mod live_input_tests {
             LegacyValue::String(Ref::new("new".to_string())),
         )
         .unwrap();
-        assert_eq!(outer_pointer, sink.as_ptr());
+        assert!(sink.same_cell(&original_cell));
         match &*sink.borrow() {
             LegacyValue::String(value) => {
                 assert_eq!(inner_pointer, value.as_ptr());
@@ -1291,14 +1293,14 @@ mod live_input_tests {
 
     #[test]
     fn stable_value_update_preserves_index_reference() {
-        let sink = Ref::new(LegacyValue::Index(Ref::new(1)));
-        let outer_pointer = sink.as_ptr();
+        let sink = ValueCell::new(LegacyValue::Index(Ref::new(1)));
+        let original_cell = sink.clone();
         let inner_pointer = match &*sink.borrow() {
             LegacyValue::Index(value) => value.as_ptr(),
             other => panic!("expected index, got {other:?}"),
         };
         apply_stable_value_update(sink.clone(), LegacyValue::Index(Ref::new(9))).unwrap();
-        assert_eq!(outer_pointer, sink.as_ptr());
+        assert!(sink.same_cell(&original_cell));
         match &*sink.borrow() {
             LegacyValue::Index(value) => {
                 assert_eq!(inner_pointer, value.as_ptr());
@@ -1311,7 +1313,7 @@ mod live_input_tests {
     #[cfg(all(feature = "f64", any(feature = "string", feature = "variable_define")))]
     #[test]
     fn stable_value_update_rejects_incompatible_kind() {
-        let sink = Ref::new(LegacyValue::F64(Ref::new(1.0)));
+        let sink = ValueCell::new(LegacyValue::F64(Ref::new(1.0)));
         let inner_pointer = match &*sink.borrow() {
             LegacyValue::F64(value) => value.as_ptr(),
             other => panic!("expected f64, got {other:?}"),
@@ -1345,15 +1347,15 @@ mod live_input_tests {
             2,
             vec![5.0, 6.0, 7.0, 8.0],
         )));
-        let sink = Ref::new(LegacyValue::MatrixF64(sink_matrix));
-        let outer_pointer = sink.as_ptr();
+        let sink = ValueCell::new(LegacyValue::MatrixF64(sink_matrix));
+        let original_cell = sink.clone();
         let inner_pointer = match &*sink.borrow() {
             LegacyValue::MatrixF64(value) => value.addr(),
             other => panic!("expected f64 matrix, got {other:?}"),
         };
         apply_stable_value_update(sink.clone(), LegacyValue::MatrixF64(source_matrix.clone()))
             .unwrap();
-        assert_eq!(outer_pointer, sink.as_ptr());
+        assert!(sink.same_cell(&original_cell));
         match &*sink.borrow() {
             LegacyValue::MatrixF64(value) => {
                 assert_eq!(inner_pointer, value.addr());
@@ -1366,11 +1368,11 @@ mod live_input_tests {
     #[cfg(feature = "f64")]
     #[test]
     fn stable_value_update_preserves_typed_scalar_reference() {
-        let sink = Ref::new(LegacyValue::Typed(
+        let sink = ValueCell::new(LegacyValue::Typed(
             Box::new(LegacyValue::F64(Ref::new(1.0))),
             ValueKind::F64,
         ));
-        let outer_pointer = sink.as_ptr();
+        let original_cell = sink.clone();
         let inner_pointer = match &*sink.borrow() {
             LegacyValue::Typed(inner, annotation) => {
                 assert_eq!(annotation, &ValueKind::F64);
@@ -1388,7 +1390,7 @@ mod live_input_tests {
         )
         .unwrap();
 
-        assert_eq!(outer_pointer, sink.as_ptr());
+        assert!(sink.same_cell(&original_cell));
         match &*sink.borrow() {
             LegacyValue::Typed(inner, annotation) => {
                 assert_eq!(annotation, &ValueKind::F64);
@@ -1407,11 +1409,11 @@ mod live_input_tests {
     #[cfg(feature = "f64")]
     #[test]
     fn stable_value_update_rejects_different_typed_annotation() {
-        let sink = Ref::new(LegacyValue::Typed(
+        let sink = ValueCell::new(LegacyValue::Typed(
             Box::new(LegacyValue::F64(Ref::new(1.0))),
             ValueKind::F64,
         ));
-        let outer_pointer = sink.as_ptr();
+        let original_cell = sink.clone();
         let inner_pointer = match &*sink.borrow() {
             LegacyValue::Typed(inner, _) => match inner.as_ref() {
                 LegacyValue::F64(value) => value.as_ptr(),
@@ -1428,7 +1430,7 @@ mod live_input_tests {
             format!("{:?}", result.unwrap_err()).contains("StableValueUpdateContractViolation")
         );
 
-        assert_eq!(outer_pointer, sink.as_ptr());
+        assert!(sink.same_cell(&original_cell));
         match &*sink.borrow() {
             LegacyValue::Typed(inner, annotation) => {
                 assert_eq!(annotation, &ValueKind::F64);
@@ -1447,7 +1449,7 @@ mod live_input_tests {
     #[cfg(feature = "f64")]
     #[test]
     fn stable_value_update_rejects_typed_to_untyped() {
-        let sink = Ref::new(LegacyValue::Typed(
+        let sink = ValueCell::new(LegacyValue::Typed(
             Box::new(LegacyValue::F64(Ref::new(1.0))),
             ValueKind::F64,
         ));
@@ -1483,7 +1485,8 @@ mod live_input_tests {
     #[test]
     fn empty_stable_assignment_bytecode_compile_returns_error() {
         let assignment =
-            compile_stable_value_update(Ref::new(LegacyValue::Empty), LegacyValue::Empty).unwrap();
+            compile_stable_value_update(ValueCell::new(LegacyValue::Empty), LegacyValue::Empty)
+                .unwrap();
         let mut ctx = CompileCtx::new();
         let error = assignment.compile(&mut ctx).unwrap_err();
         let rendered = format!("{error:?}");
@@ -1495,7 +1498,7 @@ mod live_input_tests {
 
     #[test]
     fn stable_value_update_accepts_empty_to_empty() {
-        let sink = Ref::new(LegacyValue::Empty);
+        let sink = ValueCell::new(LegacyValue::Empty);
         compile_stable_value_update(sink.clone(), LegacyValue::Empty).unwrap();
         apply_stable_value_update(sink.clone(), LegacyValue::Empty).unwrap();
         assert_eq!(&*sink.borrow(), &LegacyValue::Empty);
@@ -1504,7 +1507,7 @@ mod live_input_tests {
     #[cfg(feature = "f64")]
     #[test]
     fn stable_value_update_rejects_empty_to_value() {
-        let sink = Ref::new(LegacyValue::Empty);
+        let sink = ValueCell::new(LegacyValue::Empty);
         let result = apply_stable_value_update(sink.clone(), LegacyValue::F64(Ref::new(1.0)));
         assert!(
             format!("{:?}", result.unwrap_err()).contains("StableValueUpdateContractViolation")
@@ -1518,8 +1521,8 @@ mod live_input_tests {
         let sink_matrix = MechMatrix::from_vec((1..=25).map(|x| x as f64).collect(), 5, 5);
         let source_matrix = MechMatrix::from_vec((1..=36).map(|x| x as f64).collect(), 6, 6);
         let expected = sink_matrix.clone();
-        let sink = Ref::new(LegacyValue::MatrixF64(sink_matrix));
-        let outer_pointer = sink.as_ptr();
+        let sink = ValueCell::new(LegacyValue::MatrixF64(sink_matrix));
+        let original_cell = sink.clone();
         let inner_pointer = match &*sink.borrow() {
             LegacyValue::MatrixF64(value) => value.addr(),
             other => panic!("expected f64 matrix, got {other:?}"),
@@ -1529,7 +1532,7 @@ mod live_input_tests {
             .unwrap_err();
         assert_eq!(error.kind_name(), "StableValueUpdateContractViolation");
 
-        assert_eq!(outer_pointer, sink.as_ptr());
+        assert!(sink.same_cell(&original_cell));
         match &*sink.borrow() {
             LegacyValue::MatrixF64(value) => {
                 assert_eq!(inner_pointer, value.addr());
@@ -1554,7 +1557,7 @@ mod live_input_tests {
             vec![7.0, 8.0, 9.0, 10.0, 11.0, 12.0],
         )));
         let expected = sink_matrix.clone();
-        let sink = Ref::new(LegacyValue::MatrixF64(sink_matrix));
+        let sink = ValueCell::new(LegacyValue::MatrixF64(sink_matrix));
         let inner_pointer = match &*sink.borrow() {
             LegacyValue::MatrixF64(value) => value.addr(),
             other => panic!("expected f64 matrix, got {other:?}"),
@@ -1578,7 +1581,7 @@ mod live_input_tests {
     #[test]
     fn stable_value_update_rejects_matrix_value_sink() {
         let matrix_value = MechMatrix::from_vec(vec![LegacyValue::F64(Ref::new(1.0))], 1, 1);
-        let sink = Ref::new(LegacyValue::MatrixValue(matrix_value));
+        let sink = ValueCell::new(LegacyValue::MatrixValue(matrix_value));
         let result = apply_stable_value_update(sink.clone(), LegacyValue::F64(Ref::new(9.0)));
         let rendered = format!("{:?}", result.unwrap_err());
         assert!(
@@ -1590,7 +1593,7 @@ mod live_input_tests {
     #[cfg(all(feature = "matrix", feature = "f64"))]
     #[test]
     fn stable_value_update_rejects_matrix_value_source() {
-        let sink = Ref::new(LegacyValue::F64(Ref::new(1.0)));
+        let sink = ValueCell::new(LegacyValue::F64(Ref::new(1.0)));
         let matrix_value = MechMatrix::from_vec(vec![LegacyValue::F64(Ref::new(9.0))], 1, 1);
         let result =
             apply_stable_value_update(sink.clone(), LegacyValue::MatrixValue(matrix_value));
@@ -1605,8 +1608,8 @@ mod live_input_tests {
     #[test]
     fn stable_value_update_preserves_matrix_index_reference() {
         let matrix = MechMatrix::from_vec(vec![1usize, 2, 3, 4], 2, 2);
-        let sink = Ref::new(LegacyValue::MatrixIndex(matrix));
-        let outer_pointer = sink.as_ptr();
+        let sink = ValueCell::new(LegacyValue::MatrixIndex(matrix));
+        let original_cell = sink.clone();
         let inner_pointer = match &*sink.borrow() {
             LegacyValue::MatrixIndex(value) => value.addr(),
             other => panic!("expected index matrix, got {other:?}"),
@@ -1616,7 +1619,7 @@ mod live_input_tests {
             LegacyValue::MatrixIndex(MechMatrix::from_vec(vec![5usize, 6, 7, 8], 2, 2)),
         )
         .unwrap();
-        assert_eq!(outer_pointer, sink.as_ptr());
+        assert!(sink.same_cell(&original_cell));
         match &*sink.borrow() {
             LegacyValue::MatrixIndex(value) => {
                 assert_eq!(inner_pointer, value.addr());
@@ -1717,7 +1720,7 @@ mod live_input_tests {
             let inner_pointer = composite_addr(&current);
             let nested = nested_f64(&current);
             let nested_pointer = nested.as_ref().map(Ref::addr);
-            let sink = Ref::new(current);
+            let sink = ValueCell::new(current);
 
             compile_stable_value_update(sink.clone(), incoming)
                 .unwrap()
@@ -1744,7 +1747,7 @@ mod live_input_tests {
             ("left", LegacyValue::F64(Ref::new(2.0))),
             ("right", LegacyValue::F64(Ref::new(3.0))),
         ])));
-        let aliased = Ref::new(aliased);
+        let aliased = ValueCell::new(aliased);
         let error = match compile_stable_value_update(aliased, distinct)
             .unwrap()
             .stage_register()

--- a/src/engine/src/program/state.rs
+++ b/src/engine/src/program/state.rs
@@ -1,7 +1,7 @@
 use crate::*;
 #[cfg(feature = "assign")]
 pub fn compile_stable_value_update(
-    sink: ValRef,
+    sink: ValueCell,
     source: LegacyValue,
 ) -> MResult<Box<dyn MechFunction>> {
     {
@@ -9,16 +9,16 @@ pub fn compile_stable_value_update(
         validate_stable_value_update(&current, &source)?;
     }
 
-    crate::AssignValue {}.specialize(&[LegacyValue::MutableReference(sink), source])
+    crate::AssignValue {}.specialize(&[LegacyValue::MutableReference(sink.legacy_ref()), source])
 }
 #[cfg(feature = "assign")]
-pub fn apply_stable_value_update(sink: ValRef, source: LegacyValue) -> MResult<LegacyValue> {
+pub fn apply_stable_value_update(sink: ValueCell, source: LegacyValue) -> MResult<LegacyValue> {
     {
         let current = sink.borrow();
         validate_stable_value_update(&current, &source)?;
     }
-    let update =
-        crate::AssignValue {}.specialize(&[LegacyValue::MutableReference(sink.clone()), source])?;
+    let update = crate::AssignValue {}
+        .specialize(&[LegacyValue::MutableReference(sink.legacy_ref()), source])?;
     update.solve_result()?;
     Ok(sink.borrow().clone())
 }
@@ -167,13 +167,13 @@ impl ProgramState {
     }
 
     #[cfg(feature = "symbol_table")]
-    pub fn get_symbol(&self, id: u64) -> Option<Ref<LegacyValue>> {
+    pub fn get_symbol(&self, id: u64) -> Option<ValueCell> {
         let syms = self.symbol_table.borrow();
         syms.get(id)
     }
 
     #[cfg(feature = "symbol_table")]
-    pub fn get_mutable_symbol(&self, id: u64) -> Option<ValRef> {
+    pub fn get_mutable_symbol(&self, id: u64) -> Option<ValueCell> {
         let syms = self.symbol_table.borrow();
         syms.get_mutable(id)
     }
@@ -201,7 +201,7 @@ impl ProgramState {
 
     /// Look up symbol in environment first, then in global symbol table.
     #[cfg(feature = "symbol_table")]
-    pub fn get_env_symbol(&self, id: u64) -> Option<Ref<LegacyValue>> {
+    pub fn get_env_symbol(&self, id: u64) -> Option<ValueCell> {
         if let Some(env) = &self.environment {
             let env_brrw = env.borrow();
             match env_brrw.get(id) {
@@ -223,7 +223,13 @@ impl ProgramState {
     }
 
     #[cfg(feature = "symbol_table")]
-    pub fn save_symbol(&self, id: u64, name: String, value: LegacyValue, mutable: bool) -> ValRef {
+    pub fn save_symbol(
+        &self,
+        id: u64,
+        name: String,
+        value: LegacyValue,
+        mutable: bool,
+    ) -> ValueCell {
         let mut symbols_brrw = self.symbol_table.borrow_mut();
         let val_ref = symbols_brrw.insert(id, value, mutable);
         let mut dict_brrw = symbols_brrw.dictionary.borrow_mut();
@@ -238,7 +244,7 @@ impl ProgramState {
         name: String,
         value: LegacyValue,
         mutable: bool,
-    ) -> ValRef {
+    ) -> ValueCell {
         if let Some(env) = &self.environment {
             let mut env_brrw = env.borrow_mut();
             let val_ref = env_brrw.insert(id, value, mutable);

--- a/src/engine/src/statements/context.rs
+++ b/src/engine/src/statements/context.rs
@@ -1,9 +1,9 @@
 use crate::{
     ContextBase, ContextDeclaration, ContextSend, ExecutionResourceRequest,
     ExternalResourceReadFunction, ExternalResourceWriteFunction, GenericError, Identifier,
-    InitialSolvePolicy, InterpreterExecution, LegacyValue, MResult, MechError, Ref,
-    ResourceDelivery, ResourceIntent, UndefinedContextError, ValRef, Var,
-    execute_specialized_function, expression,
+    InitialSolvePolicy, InterpreterExecution, LegacyValue, MResult, MechError, ResourceDelivery,
+    ResourceIntent, UndefinedContextError, ValueCell, Var, execute_specialized_function,
+    expression,
 };
 #[cfg(feature = "variable_assign")]
 use crate::{Environment, VariableAssign};
@@ -67,7 +67,7 @@ fn resource_request(
 pub(crate) fn context_read(
     variable: &Var,
     interpreter: &InterpreterExecution<'_>,
-) -> MResult<ValRef> {
+) -> MResult<ValueCell> {
     let context = variable.context.as_ref().ok_or_else(|| {
         MechError::new(
             GenericError {
@@ -86,7 +86,7 @@ pub(crate) fn context_read(
         ResourceDelivery::Live,
         interpreter,
     )?;
-    let output = Ref::new(LegacyValue::Empty);
+    let output = ValueCell::new(LegacyValue::Empty);
     let function = ExternalResourceReadFunction {
         interpreter_id: interpreter.id,
         request,
@@ -128,7 +128,7 @@ pub(crate) fn context_assign(
     let function = ExternalResourceWriteFunction {
         request,
         input,
-        output: Ref::new(LegacyValue::Empty),
+        output: ValueCell::new(LegacyValue::Empty),
         initial_solve_policy: InitialSolvePolicy::PreserveSpecializedOutput,
         semantic_contract: None,
     };
@@ -165,7 +165,7 @@ pub fn context_send(send: &ContextSend, p: &InterpreterExecution<'_>) -> MResult
     let function = ExternalResourceWriteFunction {
         request,
         input,
-        output: Ref::new(LegacyValue::Empty),
+        output: ValueCell::new(LegacyValue::Empty),
         initial_solve_policy: InitialSolvePolicy::PreserveSpecializedOutput,
         semantic_contract: None,
     };

--- a/src/engine/src/statements/integrity.rs
+++ b/src/engine/src/statements/integrity.rs
@@ -5,7 +5,7 @@ use super::variable_define::detach_variable_value;
 #[cfg(feature = "invariant_define")]
 use crate::{
     ComparisonOp, Expression, Factor, FormulaOperator, IntegrityConstraint, InterpreterExecution,
-    InvariantDefine, LegacyValue, Literal, MResult, MechError, OperationId, Ref, Token, ValRef,
+    InvariantDefine, LegacyValue, Literal, MResult, MechError, OperationId, Ref, Token, ValueCell,
     expression, literal,
 };
 
@@ -79,10 +79,10 @@ fn tokens_to_string(tokens: &[Token]) -> String {
 }
 
 #[cfg(feature = "invariant_define")]
-fn value_to_ref(value: LegacyValue) -> ValRef {
+fn value_to_cell(value: LegacyValue) -> ValueCell {
     match value {
-        LegacyValue::MutableReference(r) => r.clone(),
-        other => Ref::new(other),
+        LegacyValue::MutableReference(reference) => ValueCell::from_legacy_ref(reference),
+        other => ValueCell::new(other),
     }
 }
 
@@ -90,7 +90,11 @@ fn value_to_ref(value: LegacyValue) -> ValRef {
 fn integrity_constraint_operands(
     inv_def: &InvariantDefine,
     p: &InterpreterExecution<'_>,
-) -> (Option<ValRef>, Option<FormulaOperator>, Option<ValRef>) {
+) -> (
+    Option<ValueCell>,
+    Option<FormulaOperator>,
+    Option<ValueCell>,
+) {
     let factor = match &inv_def.expression {
         Expression::Formula(factor) => factor,
         _ => return (None, None, None),
@@ -133,7 +137,10 @@ fn transparent_factor(factor: &Factor) -> &Factor {
 }
 
 #[cfg(feature = "invariant_define")]
-fn integrity_constraint_operand(factor: &Factor, p: &InterpreterExecution<'_>) -> Option<ValRef> {
+fn integrity_constraint_operand(
+    factor: &Factor,
+    p: &InterpreterExecution<'_>,
+) -> Option<ValueCell> {
     let expression = match transparent_factor(factor) {
         Factor::Expression(expression) => expression.as_ref(),
         _ => return None,
@@ -147,7 +154,7 @@ fn integrity_constraint_operand(factor: &Factor, p: &InterpreterExecution<'_>) -
             | Literal::Boolean(_)
             | Literal::Number(_)
             | Literal::String(_)),
-        ) => literal(literal_node, p).ok().map(value_to_ref),
+        ) => literal(literal_node, p).ok().map(value_to_cell),
         _ => None,
     }
 }

--- a/src/engine/src/statements/tests/context.rs
+++ b/src/engine/src/statements/tests/context.rs
@@ -1,6 +1,6 @@
 use crate::{
     ExecutionHostFunctionRequest, ExecutionResourceRequest, GenericError, Interpreter, LegacyValue,
-    MResult, MechError, MechExecutionServices, ResourceDelivery, ResourceIntent, ValRef,
+    MResult, MechError, MechExecutionServices, ResourceDelivery, ResourceIntent, ValueCell,
 };
 
 #[derive(Default)]
@@ -44,7 +44,7 @@ impl MechExecutionServices for RecordingContextServices {
         &mut self,
         _interpreter_id: u64,
         _request: &ExecutionResourceRequest,
-        _target: ValRef,
+        _target: ValueCell,
     ) -> MResult<()> {
         Err(MechError::new(
             GenericError {

--- a/src/engine/tests/resident_ekf_contract.rs
+++ b/src/engine/tests/resident_ekf_contract.rs
@@ -115,8 +115,9 @@ fn resident_source_has_no_erased_or_legacy_turn_dependencies() {
                 "RuntimeExecutionTransaction",
                 "ValueStateJournal",
                 "ReactiveTurnJournal",
-                "ValRef",
                 "ReactiveCellId",
+                "ValueCell",
+                "MutableReference",
             ] {
                 assert!(
                     !source.contains(forbidden),

--- a/src/runtime/src/runtime/execution_session.rs
+++ b/src/runtime/src/runtime/execution_session.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use mech_core::{
     ExecutionHostFunctionRequest, ExecutionResourceRequest, LegacyValue, MResult, MechError,
-    MechExecutionServices, ResourceIntent, ValRef,
+    MechExecutionServices, ResourceIntent, ValueCell,
 };
 
 pub(crate) struct RuntimeExecutionSession<'a> {
@@ -597,7 +597,7 @@ impl MechExecutionServices for RuntimeExecutionSession<'_> {
         &mut self,
         _interpreter_id: u64,
         _request: &ExecutionResourceRequest,
-        _target: ValRef,
+        _target: ValueCell,
     ) -> MResult<()> {
         Err(MechError::new(
             RuntimeInvalidOperationError {

--- a/src/runtime/src/runtime/input_tests/snapshot_boundaries.rs
+++ b/src/runtime/src/runtime/input_tests/snapshot_boundaries.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use mech_core::{
-    LegacyValue, MResult, MechMap, Ref, ValRef, ValueSnapshotBorrowConflict,
+    LegacyValue, MResult, MechMap, Ref, ValueSnapshotBorrowConflict,
     ValueSnapshotCollectionCollision,
 };
 
@@ -25,18 +25,18 @@ const SNAPSHOT_RESOURCE: &str = "snapshot://boundary";
 const SNAPSHOT_PATH: &str = "value";
 
 thread_local! {
-    static HOST_RESULT_CYCLE: RefCell<Option<ValRef>> =
+    static HOST_RESULT_CYCLE: RefCell<Option<Ref<LegacyValue>>> =
         const { RefCell::new(None) };
 }
 
-fn cyclic_node() -> ValRef {
+fn cyclic_node() -> Ref<LegacyValue> {
     let node = Ref::new(LegacyValue::Empty);
     *node.borrow_mut() = LegacyValue::MutableReference(node.clone());
     node
 }
 
 fn thread_local_cycle(
-    slot: &'static std::thread::LocalKey<RefCell<Option<ValRef>>>,
+    slot: &'static std::thread::LocalKey<RefCell<Option<Ref<LegacyValue>>>>,
 ) -> LegacyValue {
     let node = cyclic_node();
     slot.with(|stored| {
@@ -45,7 +45,9 @@ fn thread_local_cycle(
     LegacyValue::MutableReference(node)
 }
 
-fn clear_thread_local_cycle(slot: &'static std::thread::LocalKey<RefCell<Option<ValRef>>>) {
+fn clear_thread_local_cycle(
+    slot: &'static std::thread::LocalKey<RefCell<Option<Ref<LegacyValue>>>>,
+) {
     slot.with(|stored| {
         if let Some(node) = stored.borrow_mut().take() {
             *node.borrow_mut() = LegacyValue::Empty;
@@ -140,7 +142,7 @@ impl HostCallPolicy for CountingHostPolicy {
 #[derive(Debug)]
 struct SnapshotBoundaryProvider {
     cycle_reads: Arc<AtomicBool>,
-    cycle: ValRef,
+    cycle: Ref<LegacyValue>,
     preflight_calls: Arc<AtomicUsize>,
     prepare_calls: Arc<AtomicUsize>,
 }

--- a/src/runtime/src/runtime/program/compiler.rs
+++ b/src/runtime/src/runtime/program/compiler.rs
@@ -19,7 +19,7 @@ use mech_compute::{
 use mech_core::{
     ApplicationRequirement, ExecutionHostFunctionRequest, ExecutionResourceRequest, LegacyValue,
     MResult, MechError, MechErrorKind, MechExecutionServices, MechSourceCode,
-    ModuleManifestCatalog, OperationContractDeclaration, Ref, ResourceIntent,
+    ModuleManifestCatalog, OperationContractDeclaration, Ref, ResourceIntent, ValueCell,
 };
 #[cfg(feature = "compute")]
 use mech_core::{Body, MechCode, Program, Section, SectionElement};
@@ -2186,7 +2186,7 @@ impl MechExecutionServices for CompilerPlanningServices<'_> {
         &mut self,
         _interpreter_id: u64,
         _request: &ExecutionResourceRequest,
-        _target: Ref<LegacyValue>,
+        _target: ValueCell,
     ) -> MResult<()> {
         Ok(())
     }


### PR DESCRIPTION
## Summary

- introduces opaque `ValueCell` handles with address-free debug output and explicit identity checks
- migrates symbol tables, program state, snapshots, journals, execution resources, external functions, and live runtime boundaries from `ValRef` to `ValueCell`
- removes the `ValRef` alias and symbol-table address reverse index while retaining the `MutableReference` compatibility payload only at legacy variant boundaries
- uses explicit `Ref<LegacyValue>` for legacy graph traversal and keeps `ValueCell` and `MutableReference` out of resident execution source

## Stack

- Base: #782
- PR0 #781 now treats retirement authorizations as shrinkable ceilings while preserving exact-mode behavior
- PR1 #782 and this PR were rebased on the corrected PR0 head
- All three PRs remain draft; this PR must not merge before PR1

## Commits

1. `refactor(core): add opaque ValueCell handles`
2. `refactor(core): move program state and journals to ValueCell`
3. `refactor(runtime): retire ValRef from live execution boundaries`

## Validation

Passed:

- `cargo +nightly-2026-03-03 fmt --all -- --check`
- core library test suite: 319 tests
- engine full-compiler test suite: 282 tests, plus integration targets
- runtime full-compiler test suite: 465 tests
- `python3 scripts/check-value-system-contract.py --mode retirement`: 16 `LegacyValue` occurrences removed, zero unreviewed audited occurrences
- value execution boundary, compiler planning quarantine, bytecode v1, production resident routing, function-system source, and function-system consumer checks
- source checks: zero `ValRef` occurrences, zero symbol address/id calls, no new `MutableReference` alias-use paths, and exactly one retained `MutableReference` alias declaration
- resident source checks: zero `ValueCell` and zero `MutableReference` references
- `git diff --check`
- frozen value-system and function-system inventory JSON files unchanged

Exact mode is intentionally reserved for the frozen pre-retirement inventory. No frozen architecture inventory changes are included in this PR.
