### PR TITLE
[PR3] refactor(compiler): make ValueCell register ownership explicit

### DIFF
--- a/src/core/src/function/mod.rs
+++ b/src/core/src/function/mod.rs
@@ -558,6 +558,12 @@ impl ReactiveRegisterCommit for ReactiveRegisterNoopCommit {
 
 #[cfg(feature = "semantic-compiler")]
 pub trait MechFunctionCompiler {
+    /// Returns explicit cells whose identity must remain associated with the
+    /// legacy values consumed by other compiler implementations in this plan.
+    fn compiler_owned_value_cells(&self) -> Vec<ValueCell> {
+        Vec::new()
+    }
+
     /// Reserves registers whose initializer must come from declaration-time
     /// state before other plan nodes observe their live reactive values.
     fn reserve_bytecode_registers(&self, _ctx: &mut dyn BytecodeCompilerContext) -> MResult<()> {
@@ -677,6 +683,10 @@ impl MechFunctionImpl for SemanticMechFunction {
 
 #[cfg(feature = "semantic-compiler")]
 impl MechFunctionCompiler for SemanticMechFunction {
+    fn compiler_owned_value_cells(&self) -> Vec<ValueCell> {
+        self.function.compiler_owned_value_cells()
+    }
+
     fn reserve_bytecode_registers(&self, ctx: &mut dyn BytecodeCompilerContext) -> MResult<()> {
         self.function.reserve_bytecode_registers(ctx)
     }

--- a/src/core/src/program/compiler/api.rs
+++ b/src/core/src/program/compiler/api.rs
@@ -1,9 +1,12 @@
-use crate::{ApplicationRequirement, EncodedConstant, LegacyValue, MResult, ValueKind};
+use crate::{
+    ApplicationRequirement, EncodedConstant, LegacyValue, MResult, MechError, MechErrorKind,
+    ValueCell, ValueKind,
+};
 
 #[cfg(feature = "no_std")]
 use alloc::{boxed::Box, vec::Vec};
 
-use super::{CompileConst, Register};
+use super::{CompileConst, Register, compile_annotated_constant};
 
 /// Canonical producer identity used when assigning bytecode registers.
 ///
@@ -204,6 +207,140 @@ pub trait BytecodeCompilerContext {
     fn emit_resource_send(&mut self, requirement: u32, destination: Register, source: Register);
 }
 
+/// A compiler could not inspect the payload of an explicit value cell because
+/// another owner held an incompatible borrow.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ValueCellCompilerBorrowConflict {
+    pub phase: &'static str,
+}
+
+impl MechErrorKind for ValueCellCompilerBorrowConflict {
+    fn name(&self) -> &str {
+        "ValueCellCompilerBorrowConflict"
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "value cell payload is already mutably borrowed during {}",
+            self.phase,
+        )
+    }
+}
+
+fn value_cell_borrow_conflict(phase: &'static str) -> MechError {
+    MechError::new(ValueCellCompilerBorrowConflict { phase }, None).with_compiler_loc()
+}
+
+/// Resolves and, when necessary, initializes the register owned by `cell`.
+///
+/// The cell is the outer register owner even when its current payload is a
+/// reactive composite. Composite children continue to use their canonical
+/// value identities so their live topology is retained.
+pub fn compile_value_cell_register(
+    cell: &ValueCell,
+    context: &mut dyn BytecodeCompilerContext,
+) -> MResult<Register> {
+    let reference = cell.legacy_ref();
+    let value = cell
+        .try_borrow()
+        .map_err(|_| value_cell_borrow_conflict("value-cell register compilation"))?;
+    compile_value_register_for_ptr(&value, reference.addr(), context)
+}
+
+/// Recovers the explicit cell carried by a legacy compiler ABI value.
+///
+/// This is a normalization bridge for compiler planning. Ordinary compiler
+/// ownership should remain explicit after this boundary.
+#[doc(hidden)]
+pub fn compiler_value_cell_from_legacy(value: &LegacyValue) -> Option<ValueCell> {
+    value
+        .exact_ref_any()?
+        .downcast_ref::<crate::Ref<LegacyValue>>()
+        .cloned()
+        .map(ValueCell::from_legacy_ref)
+}
+
+fn compile_annotation_layers(
+    value: &LegacyValue,
+    mut identity: BytecodeRegisterIdentity,
+    mut register: Register,
+    annotations: &[ValueKind],
+    context: &mut dyn BytecodeCompilerContext,
+) -> MResult<Register> {
+    for index in (0..annotations.len()).rev() {
+        let annotation = &annotations[index];
+        identity = BytecodeRegisterIdentity::Typed {
+            inner: Box::new(identity),
+            annotation: annotation.clone(),
+        };
+        let (typed_register, initialize) =
+            context.register_for_identity_with_initialization_status(&identity);
+        context.record_register_kind(typed_register, annotation.clone())?;
+        if initialize {
+            let template = compile_annotated_constant(value, &annotations[index..], context)?;
+            context.record_register_constant_metadata(typed_register, template)?;
+            context.emit_composite_pack(typed_register, template, vec![register]);
+        }
+        register = typed_register;
+    }
+    Ok(register)
+}
+
+/// Compiles a compiler-only typed view whose underlying identity is `cell`.
+///
+/// Annotation layers are ordered from outermost to innermost. This bridge is
+/// intentionally hidden from ordinary API documentation; it exists so source
+/// planning can preserve typed views without recreating MutableReference.
+#[doc(hidden)]
+pub fn compile_annotated_value_cell_register(
+    cell: &ValueCell,
+    annotations: &[ValueKind],
+    context: &mut dyn BytecodeCompilerContext,
+) -> MResult<Register> {
+    let reference = cell.legacy_ref();
+    let value = cell
+        .try_borrow()
+        .map_err(|_| value_cell_borrow_conflict("annotated value-cell register compilation"))?
+        .clone();
+    let identity = BytecodeRegisterIdentity::Cell(reference.addr());
+    let register = compile_value_register_for_ptr(&value, reference.addr(), context)?;
+    compile_annotation_layers(&value, identity, register, annotations, context)
+}
+
+/// Compiles typed views of an immediate legacy value without reconstructing
+/// legacy wrappers in engine planning.
+#[doc(hidden)]
+pub fn compile_annotated_value_register(
+    value: &LegacyValue,
+    annotations: &[ValueKind],
+    fallback: usize,
+    context: &mut dyn BytecodeCompilerContext,
+) -> MResult<Register> {
+    let identity = bytecode_register_identity(value, fallback);
+    let register = compile_value_register(value, fallback, context)?;
+    compile_annotation_layers(value, identity, register, annotations, context)
+}
+
+/// Resolves the register owned by a cell whose payload will be supplied by an
+/// executable instruction.
+///
+/// The current payload contributes semantic kind information only. No
+/// planning-time `ConstLoad` or `CompositePack` is emitted, and a provisional
+/// initializer for the same cell is discarded.
+pub fn compile_runtime_produced_value_cell_register(
+    cell: &ValueCell,
+    context: &mut dyn BytecodeCompilerContext,
+) -> MResult<Register> {
+    let reference = cell.legacy_ref();
+    let value = cell
+        .try_borrow()
+        .map_err(|_| value_cell_borrow_conflict("runtime-produced value-cell compilation"))?;
+    let (register, _) = context.register_for_ptr_with_initialization_status(reference.addr());
+    context.record_register_kind(register, value.kind())?;
+    context.record_runtime_produced_register(register)?;
+    Ok(register)
+}
+
 /// Resolves and, when necessary, initializes the register for one logical
 /// value. Composite values are reconstructed from child registers so their
 /// reactive topology is never replaced by a planning-time constant snapshot.
@@ -212,6 +349,9 @@ pub fn compile_value_register(
     fallback: usize,
     context: &mut dyn BytecodeCompilerContext,
 ) -> MResult<Register> {
+    // MutableReference remains a supported legacy compiler ABI. New compiler
+    // ownership paths should retain ValueCell and use
+    // `compile_value_cell_register` instead of manufacturing this wrapper.
     if let LegacyValue::MutableReference(reference) = value {
         return compile_value_register(&reference.borrow(), reference.addr(), {
             context.override_next_register_kind(value.kind())?;
@@ -287,6 +427,8 @@ pub fn compile_runtime_produced_register(
     fallback: usize,
     context: &mut dyn BytecodeCompilerContext,
 ) -> MResult<Register> {
+    // MutableReference remains a supported legacy compiler ABI. New external
+    // producers should call `compile_runtime_produced_value_cell_register`.
     if let LegacyValue::MutableReference(reference) = value {
         context.override_next_register_kind(value.kind())?;
         return compile_runtime_produced_register(&reference.borrow(), reference.addr(), context);

--- a/src/core/src/program/compiler/constants.rs
+++ b/src/core/src/program/compiler/constants.rs
@@ -1390,6 +1390,55 @@ fn encode_typed_constant(
 }
 
 #[cfg(feature = "semantic-compiler")]
+fn wrap_annotated_constant(
+    child: Option<EncodedConstant>,
+    annotation: &ValueKind,
+    source_kind: &ValueKind,
+) -> MResult<EncodedConstant> {
+    let declared_runtime_type = runtime_type_from_value_kind(annotation)?;
+    let RuntimeType::Option(declared_inner_type) = &declared_runtime_type else {
+        return Err(unsupported_constant(
+            declared_runtime_type,
+            source_kind.clone(),
+            "typed constant annotation does not match its source value kind; only Option wrappers are canonical",
+        ));
+    };
+    let Some(child) = child else {
+        return Ok(encoded_constant(declared_runtime_type, 1, vec![0]));
+    };
+    if !runtime_type_matches_annotation(&child.runtime_type, declared_inner_type) {
+        return Err(unsupported_constant(
+            declared_runtime_type,
+            source_kind.clone(),
+            "typed option child does not match its declared inner type",
+        ));
+    }
+    let runtime_type = RuntimeType::Option(Box::new(child.runtime_type.clone()));
+    let mut bytes = vec![1];
+    append_child_payload(&mut bytes, &child)?;
+    Ok(encoded_constant(runtime_type, 4, bytes))
+}
+
+#[cfg(feature = "semantic-compiler")]
+pub(super) fn compile_annotated_constant(
+    value: &LegacyValue,
+    annotations: &[ValueKind],
+    context: &mut dyn BytecodeCompilerContext,
+) -> MResult<u32> {
+    let mut codec = ConstantCodecContext::new();
+    let encoded = encode_constant_value(value, &mut codec)?;
+    if annotations.is_empty() {
+        return context.intern_constant(encoded);
+    }
+    let source_kind = value.kind();
+    let mut child = (encoded.runtime_type != RuntimeType::Empty).then_some(encoded);
+    for annotation in annotations.iter().rev() {
+        child = Some(wrap_annotated_constant(child, annotation, &source_kind)?);
+    }
+    context.intern_constant(child.expect("annotations produce an encoded constant"))
+}
+
+#[cfg(feature = "semantic-compiler")]
 impl CompileConst for LegacyValue {
     fn compile_const(&self, ctx: &mut dyn BytecodeCompilerContext) -> MResult<u32> {
         let mut codec = ConstantCodecContext::new();

--- a/src/core/src/program/compiler/context.rs
+++ b/src/core/src/program/compiler/context.rs
@@ -1289,6 +1289,177 @@ mod tests {
     }
 
     #[test]
+    fn value_cell_registers_follow_outer_cell_identity() {
+        let shared = crate::ValueCell::new(LegacyValue::F64(crate::Ref::new(7.0)));
+        let alias = shared.clone();
+        let distinct = crate::ValueCell::new(LegacyValue::F64(crate::Ref::new(7.0)));
+        let mut context = CompileCtx::new();
+
+        let shared_register = crate::compile_value_cell_register(&shared, &mut context).unwrap();
+        let alias_register = crate::compile_value_cell_register(&alias, &mut context).unwrap();
+        let distinct_register =
+            crate::compile_value_cell_register(&distinct, &mut context).unwrap();
+
+        assert_eq!(shared_register, alias_register);
+        assert_ne!(shared_register, distinct_register);
+        let compiled = context.finish_program(shared_register).unwrap();
+        assert_eq!(
+            compiled
+                .program
+                .instructions
+                .iter()
+                .filter(|instruction| matches!(
+                    instruction,
+                    BytecodeInstruction::ConstLoad { dst, .. } if *dst == shared_register
+                ))
+                .count(),
+            1,
+        );
+    }
+
+    #[test]
+    fn runtime_produced_value_cell_emits_no_planning_initializer() {
+        let cell = crate::ValueCell::new(LegacyValue::F64(crate::Ref::new(7.0)));
+        let mut context = CompileCtx::new();
+
+        let register =
+            crate::compile_runtime_produced_value_cell_register(&cell, &mut context).unwrap();
+        let compiled = context.finish_program(register).unwrap();
+
+        assert!(compiled.program.constants.is_empty());
+        assert!(
+            !compiled
+                .program
+                .instructions
+                .iter()
+                .any(|instruction| matches!(
+                    instruction,
+                    BytecodeInstruction::ConstLoad { dst, .. }
+                        | BytecodeInstruction::CompositePack { dst, .. }
+                        if *dst == register
+                ))
+        );
+    }
+
+    #[test]
+    fn runtime_produced_value_cell_discards_a_provisional_initializer() {
+        let cell = crate::ValueCell::new(LegacyValue::F64(crate::Ref::new(7.0)));
+        let mut context = CompileCtx::new();
+        let seeded = crate::compile_value_cell_register(&cell, &mut context).unwrap();
+
+        let produced =
+            crate::compile_runtime_produced_value_cell_register(&cell, &mut context).unwrap();
+        let compiled = context.finish_program(produced).unwrap();
+
+        assert_eq!(seeded, produced);
+        assert!(compiled.program.constants.is_empty());
+        assert!(
+            !compiled
+                .program
+                .instructions
+                .iter()
+                .any(|instruction| matches!(
+                    instruction,
+                    BytecodeInstruction::ConstLoad { dst, .. }
+                        | BytecodeInstruction::CompositePack { dst, .. }
+                        if *dst == produced
+                ))
+        );
+    }
+
+    #[test]
+    fn value_cell_composites_keep_outer_and_child_identities() {
+        let scalar = crate::Ref::new(7.0);
+        let child = LegacyValue::F64(scalar.clone());
+        let cell = crate::ValueCell::new(LegacyValue::Tuple(crate::Ref::new(
+            crate::MechTuple::from_vec(vec![
+                LegacyValue::F64(scalar.clone()),
+                LegacyValue::F64(scalar),
+            ]),
+        )));
+        let mut context = CompileCtx::new();
+        let child_register = context.resolve_value_register(&child).unwrap();
+        let outer_register = crate::compile_value_cell_register(&cell, &mut context).unwrap();
+        let compiled = context.finish_program(outer_register).unwrap();
+
+        assert_ne!(outer_register, child_register);
+        assert!(
+            compiled
+                .program
+                .instructions
+                .iter()
+                .any(|instruction| matches!(
+                    instruction,
+                    BytecodeInstruction::CompositePack { dst, children, .. }
+                        if *dst == outer_register
+                            && children == &[child_register, child_register]
+                ))
+        );
+    }
+
+    #[test]
+    fn annotated_value_cell_views_preserve_annotations_and_cell_identity() {
+        let cell = crate::ValueCell::new(LegacyValue::F64(crate::Ref::new(7.0)));
+        let option_f64 = crate::ValueKind::Option(Box::new(crate::ValueKind::F64));
+        let nested_option = crate::ValueKind::Option(Box::new(option_f64.clone()));
+        let mut context = CompileCtx::new();
+
+        let cell_register = crate::compile_value_cell_register(&cell, &mut context).unwrap();
+        let f64_view = crate::compile_annotated_value_cell_register(
+            &cell,
+            core::slice::from_ref(&option_f64),
+            &mut context,
+        )
+        .unwrap();
+        let f64_view_again = crate::compile_annotated_value_cell_register(
+            &cell,
+            core::slice::from_ref(&option_f64),
+            &mut context,
+        )
+        .unwrap();
+        let nested_view = crate::compile_annotated_value_cell_register(
+            &cell,
+            &[nested_option, option_f64],
+            &mut context,
+        )
+        .unwrap();
+        let compiled = context.finish_program(f64_view).unwrap();
+
+        assert_eq!(f64_view, f64_view_again);
+        assert_ne!(f64_view, cell_register);
+        assert_ne!(f64_view, nested_view);
+        assert!(
+            compiled
+                .program
+                .instructions
+                .iter()
+                .any(|instruction| matches!(
+                    instruction,
+                    BytecodeInstruction::CompositePack { dst, children, .. }
+                        if *dst == f64_view && children == &[cell_register]
+                ))
+        );
+    }
+
+    #[test]
+    fn value_cell_compiler_borrow_conflicts_are_structured() {
+        let cell = crate::ValueCell::new(LegacyValue::F64(crate::Ref::new(7.0)));
+        let _borrow = cell.borrow_mut();
+        let mut context = CompileCtx::new();
+
+        let error = crate::compile_value_cell_register(&cell, &mut context).unwrap_err();
+
+        assert_eq!(error.kind_name(), "ValueCellCompilerBorrowConflict");
+        assert_eq!(
+            error
+                .kind_as::<crate::ValueCellCompilerBorrowConflict>()
+                .unwrap()
+                .phase,
+            "value-cell register compilation",
+        );
+    }
+
+    #[test]
     fn runtime_producer_keeps_a_seed_constant_used_by_another_register() {
         let produced_value = LegacyValue::F64(crate::Ref::new(7.0));
         let retained_value = LegacyValue::F64(crate::Ref::new(7.0));

--- a/src/core/src/program/compiler/context.rs
+++ b/src/core/src/program/compiler/context.rs
@@ -9,7 +9,7 @@ use crate::{
     BytecodeProgram, BytecodeRegisterIdentity, BytecodeValidationError, ChangeDetectionPolicy,
     ComputePlacement, DeliveryMode, EncodedConstant, ExternalInteraction, InputPortLayout,
     InputPortPolicy, LegacyValue, MResult, MechError, OperationContractDeclaration,
-    OutputConstruction, OutputPortPolicy, ParsedProgram, Register, ShapeRule, ValueKind,
+    OutputConstruction, OutputPortPolicy, ParsedProgram, Register, ShapeRule, ValueCell, ValueKind,
     compare_application_requirements, compile_value_register, hash_str,
     value_kind_from_runtime_type, write_bytecode,
 };
@@ -139,8 +139,10 @@ impl PartialOrd for CanonicalRequirement {
 #[derive(Debug)]
 pub struct CompileCtx {
     reg_map: HashMap<BytecodeRegisterIdentity, Register>,
+    retained_value_cell_identities: BTreeMap<usize, BytecodeRegisterIdentity>,
     symbols: BTreeMap<u64, Register>,
     symbol_ptrs: BTreeMap<u64, usize>,
+    retained_symbol_cells: BTreeMap<String, ValueCell>,
     dictionary: BTreeMap<u64, String>,
     runtime_function_names: BTreeMap<u64, String>,
     mutable_symbols: BTreeSet<u64>,
@@ -171,8 +173,10 @@ impl Default for CompileCtx {
     fn default() -> Self {
         Self {
             reg_map: HashMap::new(),
+            retained_value_cell_identities: BTreeMap::new(),
             symbols: BTreeMap::new(),
             symbol_ptrs: BTreeMap::new(),
+            retained_symbol_cells: BTreeMap::new(),
             dictionary: BTreeMap::new(),
             runtime_function_names: BTreeMap::new(),
             mutable_symbols: BTreeSet::new(),
@@ -208,6 +212,80 @@ impl CompileCtx {
 
     pub fn clear(&mut self) {
         *self = Self::default();
+    }
+
+    /// Retains the explicit outer cell that owns a source symbol until its
+    /// legacy declaration step supplies the canonical producer register.
+    pub fn retain_compiler_symbol_cell(&mut self, name: &str, cell: &ValueCell) -> MResult<()> {
+        if let Some(existing) = self.retained_symbol_cells.get(name) {
+            if !existing.same_cell(cell) {
+                return invalid(format!(
+                    "compiler symbol {name:?} has conflicting retained value cells",
+                ));
+            }
+            return Ok(());
+        }
+        self.retained_symbol_cells
+            .insert(name.to_owned(), cell.clone());
+        self.retain_compiler_value_cell(cell)?;
+        Ok(())
+    }
+
+    /// Retains the relationship between an explicit outer cell and the legacy
+    /// value identity still used by downstream compiler ABI consumers.
+    pub fn retain_compiler_value_cell(&mut self, cell: &ValueCell) -> MResult<()> {
+        let address = cell.legacy_ref().addr();
+        let value = cell.try_borrow().map_err(|_| {
+            MechError::new(
+                crate::ValueCellCompilerBorrowConflict {
+                    phase: "compiler value-cell retention",
+                },
+                None,
+            )
+            .with_compiler_loc()
+        })?;
+        let identity = crate::bytecode_register_identity(&value, address);
+        if let Some(existing) = self.retained_value_cell_identities.get(&address) {
+            if existing != &identity {
+                return invalid("retained compiler value cell changed identity before compilation");
+            }
+            return Ok(());
+        }
+        self.retained_value_cell_identities
+            .insert(address, identity);
+        Ok(())
+    }
+
+    /// Associates retained symbols that enter planning as host/compiler inputs
+    /// with the legacy value registers already used by compiled plan nodes.
+    /// Source declarations are associated directly by `define_symbol`.
+    pub fn associate_retained_symbol_cells_with_existing_value_registers(&mut self) -> MResult<()> {
+        let retained = self
+            .retained_symbol_cells
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        for cell in retained {
+            let address = cell.legacy_ref().addr();
+            let outer_identity = BytecodeRegisterIdentity::Cell(address);
+            if self.reg_map.contains_key(&outer_identity) {
+                continue;
+            }
+            let value = cell.try_borrow().map_err(|_| {
+                MechError::new(
+                    crate::ValueCellCompilerBorrowConflict {
+                        phase: "compiler symbol cell association",
+                    },
+                    None,
+                )
+                .with_compiler_loc()
+            })?;
+            let value_identity = crate::bytecode_register_identity(&value, address);
+            if let Some(register) = self.reg_map.get(&value_identity).copied() {
+                self.reg_map.insert(outer_identity, register);
+            }
+        }
+        Ok(())
     }
 
     /// Resolve an interpreted value to the register that carries its identity.
@@ -618,6 +696,7 @@ impl CompileCtx {
                         "conflicting bytecode symbol definition for {name:?}",
                     ));
                 }
+                self.associate_retained_symbol_cell(name, register)?;
                 return Ok(());
             }
 
@@ -627,6 +706,7 @@ impl CompileCtx {
             if mutable {
                 self.mutable_symbols.insert(symbol_id);
             }
+            self.associate_retained_symbol_cell(name, register)?;
         }
 
         if let Some(kind) = self.register_kinds.get(&register).cloned()
@@ -645,6 +725,24 @@ impl CompileCtx {
             root_visible,
             ordinal,
         });
+        Ok(())
+    }
+
+    fn associate_retained_symbol_cell(&mut self, name: &str, register: Register) -> MResult<()> {
+        let Some(cell) = self.retained_symbol_cells.get(name) else {
+            return Ok(());
+        };
+        let address = cell.legacy_ref().addr();
+        let identity = BytecodeRegisterIdentity::Cell(address);
+        if let Some(existing) = self.reg_map.get(&identity) {
+            if *existing != register {
+                return invalid(format!(
+                    "compiler symbol {name:?} retained cell already owns register {existing}, incoming register {register}",
+                ));
+            }
+            return Ok(());
+        }
+        self.reg_map.insert(identity, register);
         Ok(())
     }
 
@@ -681,7 +779,20 @@ impl BytecodeCompilerContext for CompileCtx {
     }
 
     fn register_for_ptr_with_initialization_status(&mut self, pointer: usize) -> (Register, bool) {
-        self.register_for_identity(BytecodeRegisterIdentity::Cell(pointer))
+        let outer_identity = BytecodeRegisterIdentity::Cell(pointer);
+        if let Some(&register) = self.reg_map.get(&outer_identity) {
+            return (register, false);
+        }
+        if let Some(value_identity) = self.retained_value_cell_identities.get(&pointer).cloned() {
+            if let Some(&register) = self.reg_map.get(&value_identity) {
+                self.reg_map.insert(outer_identity, register);
+                return (register, false);
+            }
+            let (register, initialize) = self.register_for_identity(outer_identity);
+            self.reg_map.insert(value_identity, register);
+            return (register, initialize);
+        }
+        self.register_for_identity(outer_identity)
     }
 
     fn register_for_identity_with_initialization_status(
@@ -1797,6 +1908,58 @@ mod tests {
         }
 
         assert_eq!(compile(false), compile(true));
+    }
+
+    #[test]
+    fn retained_symbol_cells_reuse_their_declared_registers() {
+        let cell = ValueCell::new(LegacyValue::F64(crate::Ref::new(7.0)));
+        let mut context = CompileCtx::new();
+        context
+            .retain_compiler_symbol_cell("answer", &cell)
+            .unwrap();
+        let register = context.register_for_ptr_with_initialization_status(17).0;
+        context
+            .record_register_kind(register, ValueKind::F64)
+            .unwrap();
+        context
+            .define_symbol(17, register, "answer", false)
+            .unwrap();
+
+        let resolved = crate::compile_value_cell_register(&cell, &mut context).unwrap();
+
+        assert_eq!(resolved, register);
+        assert_eq!(context.next_register, 1);
+    }
+
+    #[test]
+    fn retained_input_cells_reuse_existing_legacy_value_registers() {
+        let cell = ValueCell::new(LegacyValue::F64(crate::Ref::new(7.0)));
+        let legacy = LegacyValue::MutableReference(cell.legacy_ref());
+        let mut context = CompileCtx::new();
+        context.retain_compiler_symbol_cell("input", &cell).unwrap();
+        let legacy_register = context.resolve_value_register(&legacy).unwrap();
+
+        context
+            .associate_retained_symbol_cells_with_existing_value_registers()
+            .unwrap();
+        let cell_register = crate::compile_value_cell_register(&cell, &mut context).unwrap();
+
+        assert_eq!(cell_register, legacy_register);
+        assert_eq!(context.next_register, 1);
+    }
+
+    #[test]
+    fn retained_producer_cells_share_their_register_with_legacy_consumers() {
+        let cell = ValueCell::new(LegacyValue::F64(crate::Ref::new(7.0)));
+        let legacy_value = cell.borrow().clone();
+        let mut context = CompileCtx::new();
+        context.retain_compiler_value_cell(&cell).unwrap();
+
+        let cell_register = crate::compile_value_cell_register(&cell, &mut context).unwrap();
+        let legacy_register = context.resolve_value_register(&legacy_value).unwrap();
+
+        assert_eq!(cell_register, legacy_register);
+        assert_eq!(context.next_register, 1);
     }
 
     #[test]

--- a/src/core/src/value.rs
+++ b/src/core/src/value.rs
@@ -4,7 +4,11 @@ use crate::matrix::Matrix;
 #[cfg(feature = "complex")]
 use crate::types::complex_numbers::C64;
 use crate::*;
-#[cfg(any(feature = "functions", feature = "matrix"))]
+#[cfg(any(
+    feature = "functions",
+    feature = "matrix",
+    feature = "semantic-compiler"
+))]
 use core::any::Any;
 #[cfg(feature = "no_std")]
 use core::hash::BuildHasherDefault;
@@ -1420,7 +1424,7 @@ impl LegacyValue {
     }
 
     /// Returns the exact `Ref<_>` stored by this value, if it has one.
-    #[cfg(feature = "functions")]
+    #[cfg(any(feature = "functions", feature = "semantic-compiler"))]
     pub(crate) fn exact_ref_any(&self) -> Option<&dyn Any> {
         match self {
             #[cfg(feature = "u8")]

--- a/src/engine/src/function/external/host_call.rs
+++ b/src/engine/src/function/external/host_call.rs
@@ -81,6 +81,10 @@ impl MechFunctionImpl for ExternalHostCallFunction {
 
 #[cfg(feature = "semantic-compiler")]
 impl MechFunctionCompiler for ExternalHostCallFunction {
+    fn compiler_owned_value_cells(&self) -> Vec<ValueCell> {
+        vec![self.output.clone()]
+    }
+
     fn compile(&self, context: &mut dyn BytecodeCompilerContext) -> MResult<Register> {
         let output = super::compile_external_output(&self.output, context)?;
         let arguments = self

--- a/src/engine/src/function/external/mod.rs
+++ b/src/engine/src/function/external/mod.rs
@@ -8,7 +8,9 @@ pub use resource_write::*;
 
 #[cfg(feature = "semantic-compiler")]
 use mech_core::{
-    BytecodeCompilerContext, LegacyValue, MResult, Register, ValueCell, compile_value_register,
+    BytecodeCompilerContext, LegacyValue, MResult, Register, ValueCell,
+    compile_runtime_produced_value_cell_register, compile_value_cell_register,
+    compile_value_register,
 };
 
 #[cfg(feature = "semantic-compiler")]
@@ -16,9 +18,7 @@ pub(super) fn compile_external_output(
     output: &ValueCell,
     context: &mut dyn BytecodeCompilerContext,
 ) -> MResult<Register> {
-    let reference = output.legacy_ref();
-    let value = reference.borrow();
-    compile_external_value_with_fallback(&value, reference.addr(), context)
+    compile_value_cell_register(output, context)
 }
 
 #[cfg(feature = "semantic-compiler")]
@@ -26,9 +26,7 @@ pub(super) fn compile_runtime_produced_external_output(
     output: &ValueCell,
     context: &mut dyn BytecodeCompilerContext,
 ) -> MResult<Register> {
-    let reference = output.legacy_ref();
-    let value = reference.borrow();
-    mech_core::compile_runtime_produced_register(&value, reference.addr(), context)
+    compile_runtime_produced_value_cell_register(output, context)
 }
 
 #[cfg(feature = "semantic-compiler")]
@@ -36,16 +34,7 @@ pub(super) fn compile_external_value(
     value: &LegacyValue,
     context: &mut dyn BytecodeCompilerContext,
 ) -> MResult<Register> {
-    compile_external_value_with_fallback(value, std::ptr::from_ref(value).addr(), context)
-}
-
-#[cfg(feature = "semantic-compiler")]
-fn compile_external_value_with_fallback(
-    value: &LegacyValue,
-    fallback: usize,
-    context: &mut dyn BytecodeCompilerContext,
-) -> MResult<Register> {
-    compile_value_register(value, fallback, context)
+    compile_value_register(value, std::ptr::from_ref(value).addr(), context)
 }
 
 #[cfg(all(test, feature = "semantic-compiler", feature = "f64"))]

--- a/src/engine/src/function/external/resource_read.rs
+++ b/src/engine/src/function/external/resource_read.rs
@@ -149,6 +149,10 @@ impl MechFunctionImpl for ExternalResourceReadFunction {
 
 #[cfg(feature = "semantic-compiler")]
 impl MechFunctionCompiler for ExternalResourceReadFunction {
+    fn compiler_owned_value_cells(&self) -> Vec<ValueCell> {
+        vec![self.output.clone()]
+    }
+
     fn compile(&self, context: &mut dyn BytecodeCompilerContext) -> MResult<Register> {
         let output = super::compile_runtime_produced_external_output(&self.output, context)?;
         let requirement =

--- a/src/engine/src/function/external/resource_write.rs
+++ b/src/engine/src/function/external/resource_write.rs
@@ -135,6 +135,10 @@ impl MechFunctionImpl for ExternalResourceWriteFunction {
 
 #[cfg(feature = "semantic-compiler")]
 impl MechFunctionCompiler for ExternalResourceWriteFunction {
+    fn compiler_owned_value_cells(&self) -> Vec<ValueCell> {
+        vec![self.output.clone()]
+    }
+
     fn compile(&self, context: &mut dyn BytecodeCompilerContext) -> MResult<Register> {
         self.validate()?;
         let output = super::compile_external_output(&self.output, context)?;

--- a/src/engine/src/program/compiler_planning.rs
+++ b/src/engine/src/program/compiler_planning.rs
@@ -1,3 +1,4 @@
+use super::compiler_value_source::CompilerValueSource;
 use crate::*;
 use std::collections::BTreeSet;
 use std::sync::Arc;
@@ -128,7 +129,7 @@ pub struct CompilerPlanningProgram {
 
 struct PublishedPlanningOutput {
     name: Option<String>,
-    value: LegacyValue,
+    source: CompilerValueSource,
 }
 
 impl CompilerPlanningProgram {
@@ -297,11 +298,17 @@ impl CompilerPlanningProgram {
         self.plan_tree_with_services(&tree, &mut services)
     }
 
+    /// Returns a host-inspection snapshot of a root symbol.
+    ///
+    /// Compiler ownership paths must use `compiler_root_symbol_cell` instead.
     pub fn compiler_root_symbol_value(&self, name: &str) -> MResult<LegacyValue> {
         let mut values = self.compiler_root_symbol_values(&[name])?;
         Ok(values.remove(0).1)
     }
 
+    /// Returns host-inspection snapshots of selected root symbols.
+    ///
+    /// These cloned values do not carry compiler register ownership.
     pub fn compiler_root_symbol_values(
         &self,
         names: &[&str],
@@ -324,12 +331,39 @@ impl CompilerPlanningProgram {
         Ok(values)
     }
 
+    /// Returns host-inspection snapshots of every root symbol.
     pub fn compiler_root_symbol_values_all(&self) -> Vec<(String, LegacyValue)> {
         let symbols = self.interpreter.symbols();
         let symbols_brrw = symbols.borrow();
         let mut values = symbol_rows(&symbols_brrw, &[]);
         values.sort_by(|left, right| left.0.cmp(&right.0));
         values
+    }
+
+    /// Returns the original compiler-owned cell for one root symbol.
+    pub fn compiler_root_symbol_cell(&self, name: &str) -> MResult<ValueCell> {
+        let mut cells = self.compiler_root_symbol_cells(&[name])?;
+        Ok(cells.remove(0).1)
+    }
+
+    /// Returns the original compiler-owned cells for selected root symbols.
+    pub fn compiler_root_symbol_cells(&self, names: &[&str]) -> MResult<Vec<(String, ValueCell)>> {
+        let symbols = self.interpreter.symbols();
+        let symbols_brrw = symbols.borrow();
+        let mut cells = Vec::with_capacity(names.len());
+        for name in names {
+            let symbol_id = hash_str(name);
+            let Some(cell) = symbols_brrw.get(symbol_id) else {
+                return Err(MechError::new(
+                    ProgramOutputNotFound {
+                        name: (*name).to_string(),
+                    },
+                    None,
+                ));
+            };
+            cells.push(((*name).to_string(), cell));
+        }
+        Ok(cells)
     }
 
     /// Resolves stable formatted-document output addresses inside the
@@ -356,28 +390,36 @@ impl CompilerPlanningProgram {
     /// Dependency-only planning never calls this method, so multi-root
     /// products publish each requested root exactly once in caller order.
     pub fn publish_compiler_root_output(&mut self, value: LegacyValue) {
-        self.published_outputs
-            .push(PublishedPlanningOutput { name: None, value });
+        self.published_outputs.push(PublishedPlanningOutput {
+            name: None,
+            source: CompilerValueSource::from_legacy(value),
+        });
     }
 
     /// Retain a document-addressed output whose ordinal is part of the host
     /// rendering contract, even when its register aliases a named symbol.
     pub fn publish_compiler_document_output(&mut self, value: LegacyValue) {
-        self.published_outputs
-            .push(PublishedPlanningOutput { name: None, value });
+        self.published_outputs.push(PublishedPlanningOutput {
+            name: None,
+            source: CompilerValueSource::from_legacy(value),
+        });
     }
 
     /// Retain every named root symbol as a live artifact output for an
     /// interactive host. The ordinary result remains first, while explicit
     /// names may alias one shared register without losing lexical identity.
     pub fn publish_compiler_root_symbols(&mut self) {
+        let symbols = self.interpreter.symbols();
+        let symbols_brrw = symbols.borrow();
+        let mut cells = symbol_cell_rows(&symbols_brrw, &[]);
+        cells.sort_by(|left, right| left.0.cmp(&right.0));
         self.published_outputs
             .extend(
-                self.compiler_root_symbol_values_all()
+                cells
                     .into_iter()
-                    .map(|(name, value)| PublishedPlanningOutput {
+                    .map(|(name, cell)| PublishedPlanningOutput {
                         name: Some(name),
-                        value,
+                        source: CompilerValueSource::Cell(cell),
                     }),
             );
     }
@@ -385,13 +427,11 @@ impl CompilerPlanningProgram {
     /// Installs one compiler-resolved source import in the ephemeral planning
     /// symbol table. This coordinate is consumed during compilation and is not
     /// retained by the runtime artifact.
-    pub fn install_compiler_symbol(&mut self, name: &str, value: Ref<LegacyValue>) -> MResult<()> {
+    pub fn install_compiler_symbol(&mut self, name: &str, value: ValueCell) -> MResult<()> {
         let id = hash_str(name);
         let symbols = self.interpreter.symbols();
         let mut symbols = symbols.borrow_mut();
-        symbols
-            .symbols
-            .insert(id, ValueCell::from_legacy_ref(value));
+        symbols.symbols.insert(id, value);
         symbols.dictionary.borrow_mut().insert(id, name.to_owned());
         Ok(())
     }
@@ -695,12 +735,12 @@ fn preserve_compiled_resource_send_operations(
 /// explicit without exposing it through `ProgramArtifact`.
 #[cfg(all(feature = "semantic-compiler", feature = "invariant_define"))]
 struct RetainedIntegrityMarkerMetadata {
-    result_register: Register,
+    result: ValueCell,
     name: LegacyValue,
     expression: LegacyValue,
     operator: LegacyValue,
-    lhs: LegacyValue,
-    rhs: LegacyValue,
+    lhs: Option<ValueCell>,
+    rhs: Option<ValueCell>,
 }
 
 #[cfg(feature = "semantic-compiler")]
@@ -766,8 +806,8 @@ fn compile_bytecode(program: &mut CompilerPlanningProgram) -> MResult<CompilerPl
     let retained_integrity_metadata = if !state.integrity_constraints.is_empty() {
         let mut metadata = Vec::with_capacity(state.integrity_constraints.len());
         for constraint in state.integrity_constraints.values() {
-            let result = LegacyValue::MutableReference(constraint.result.legacy_ref());
-            let result_register = context.resolve_value_register(&result)?;
+            let result_register =
+                mech_core::compile_value_cell_register(&constraint.result, &mut context)?;
             context.record_integrity_constraint(constraint.name.clone(), result_register)?;
             let name = LegacyValue::String(Ref::new(constraint.name.clone()));
             let expression = LegacyValue::String(Ref::new(constraint.expression.clone()));
@@ -804,23 +844,13 @@ fn compile_bytecode(program: &mut CompilerPlanningProgram) -> MResult<CompilerPl
                 }
                 None => LegacyValue::Empty,
             };
-            let lhs = constraint
-                .lhs
-                .as_ref()
-                .map(|value| LegacyValue::MutableReference(value.legacy_ref()))
-                .unwrap_or(LegacyValue::Empty);
-            let rhs = constraint
-                .rhs
-                .as_ref()
-                .map(|value| LegacyValue::MutableReference(value.legacy_ref()))
-                .unwrap_or(LegacyValue::Empty);
             metadata.push(RetainedIntegrityMarkerMetadata {
-                result_register,
+                result: constraint.result.clone(),
                 name,
                 expression,
                 operator,
-                lhs,
-                rhs,
+                lhs: constraint.lhs.clone(),
+                rhs: constraint.rhs.clone(),
             });
         }
         metadata
@@ -836,13 +866,22 @@ fn compile_bytecode(program: &mut CompilerPlanningProgram) -> MResult<CompilerPl
     if let Some(marker_output) = retained_integrity_marker_output.as_ref() {
         let marker_register = context.resolve_value_register(marker_output)?;
         for marker in &retained_integrity_metadata {
+            let result = mech_core::compile_value_cell_register(&marker.result, &mut context)?;
+            let lhs = match &marker.lhs {
+                Some(cell) => mech_core::compile_value_cell_register(cell, &mut context)?,
+                None => context.resolve_value_register(&LegacyValue::Empty)?,
+            };
+            let rhs = match &marker.rhs {
+                Some(cell) => mech_core::compile_value_cell_register(cell, &mut context)?,
+                None => context.resolve_value_register(&LegacyValue::Empty)?,
+            };
             let metadata = vec![
-                marker.result_register,
+                result,
                 context.resolve_value_register(&marker.name)?,
                 context.resolve_value_register(&marker.expression)?,
                 context.resolve_value_register(&marker.operator)?,
-                context.resolve_value_register(&marker.lhs)?,
-                context.resolve_value_register(&marker.rhs)?,
+                lhs,
+                rhs,
             ];
             context.emit_integrity_marker(
                 hash_str("integrity/constraint"),
@@ -856,7 +895,7 @@ fn compile_bytecode(program: &mut CompilerPlanningProgram) -> MResult<CompilerPl
     for output in &program.published_outputs {
         resolved_outputs.push((
             output.name.clone(),
-            context.resolve_value_register(&output.value)?,
+            output.source.compile_register(&mut context)?,
         ));
     }
     let mut published_outputs = Vec::with_capacity(resolved_outputs.len());
@@ -933,6 +972,35 @@ fn symbol_rows(
     rows
 }
 
+fn symbol_cell_rows(
+    symbol_table: &mech_core::SymbolTable,
+    names: &[String],
+) -> Vec<(String, ValueCell)> {
+    let dictionary = symbol_table.dictionary.borrow();
+    let mut rows = Vec::new();
+
+    if !names.is_empty() {
+        for target_name in names {
+            for (id, name) in dictionary.iter() {
+                if name == target_name {
+                    if let Some(cell) = symbol_table.symbols.get(id) {
+                        rows.push((name.clone(), cell.clone()));
+                    }
+                    break;
+                }
+            }
+        }
+    } else {
+        for (id, cell) in symbol_table.symbols.iter() {
+            if let Some(name) = dictionary.get(id) {
+                rows.push((name.clone(), cell.clone()));
+            }
+        }
+    }
+
+    rows
+}
+
 #[cfg(test)]
 fn test_mech_program(config: CompilerPlanningConfig) -> CompilerPlanningProgram {
     CompilerPlanningProgram::with_function_catalog(
@@ -946,6 +1014,8 @@ mod tests {
     use super::*;
     #[cfg(feature = "functions")]
     use mech_core::FunctionCatalogBuilder;
+    #[cfg(feature = "native")]
+    use mech_core::Ref;
     #[cfg(all(
         feature = "semantic-compiler",
         feature = "source",
@@ -954,8 +1024,6 @@ mod tests {
         feature = "f64"
     ))]
     use mech_core::{BytecodeInstruction, ParsedProgram, Register};
-    #[cfg(feature = "native")]
-    use mech_core::{Ref, ValueCell};
     use std::collections::BTreeMap;
 
     #[cfg(feature = "functions")]
@@ -1796,6 +1864,101 @@ mod root_symbol_snapshot_tests {
             .unwrap();
         let names: Vec<_> = rows.iter().map(|(name, _)| name.as_str()).collect();
         assert_eq!(names, vec!["c", "a", "b"]);
+    }
+
+    #[test]
+    fn root_symbol_cells_preserve_order_and_original_identity() {
+        let mut program = test_mech_program(CompilerPlanningConfig::default());
+        program.plan_source_for_test("a := 1.0\nb := 2.0").unwrap();
+        let symbols = program.interpreter.symbols();
+        let a = symbols.borrow().get(hash_str("a")).unwrap();
+
+        let rows = program.compiler_root_symbol_cells(&["b", "a"]).unwrap();
+
+        assert_eq!(rows[0].0, "b");
+        assert_eq!(rows[1].0, "a");
+        assert!(rows[1].1.same_cell(&a));
+        assert!(
+            program
+                .compiler_root_symbol_cell("a")
+                .unwrap()
+                .same_cell(&a)
+        );
+    }
+
+    #[test]
+    fn root_symbol_publication_retains_cells_and_lexical_aliases() {
+        let mut program = test_mech_program(CompilerPlanningConfig::default());
+        let shared = ValueCell::new(LegacyValue::F64(Ref::new(7.0)));
+        program
+            .install_compiler_symbol("left", shared.clone())
+            .unwrap();
+        program
+            .install_compiler_symbol("right", shared.clone())
+            .unwrap();
+
+        program.publish_compiler_root_symbols();
+
+        let alias_outputs = program
+            .published_outputs
+            .iter()
+            .filter(|output| matches!(output.name.as_deref(), Some("left" | "right")))
+            .collect::<Vec<_>>();
+        assert_eq!(alias_outputs.len(), 2);
+        for output in alias_outputs {
+            let CompilerValueSource::Cell(cell) = &output.source else {
+                panic!("root symbols must publish explicit cells")
+            };
+            assert!(cell.same_cell(&shared));
+        }
+        let compiled = compile_bytecode(&mut program).unwrap();
+        let left = compiled
+            .published_output_names
+            .iter()
+            .position(|name| name.as_deref() == Some("left"))
+            .unwrap();
+        let right = compiled
+            .published_output_names
+            .iter()
+            .position(|name| name.as_deref() == Some("right"))
+            .unwrap();
+        assert_ne!(left, right);
+        assert_eq!(
+            compiled.published_outputs[left],
+            compiled.published_outputs[right]
+        );
+    }
+
+    #[test]
+    fn later_source_read_of_typed_symbol_compiles_without_losing_cell_identity() {
+        let mut program = test_mech_program(CompilerPlanningConfig::default());
+        let optional = ValueCell::new(LegacyValue::Typed(
+            Box::new(LegacyValue::F64(Ref::new(7.0))),
+            ValueKind::Option(Box::new(ValueKind::F64)),
+        ));
+        program
+            .install_compiler_symbol("optional", optional.clone())
+            .unwrap();
+
+        let result = program
+            .plan_source_for_test("answer := optional\nanswer")
+            .unwrap();
+        let LegacyValue::MutableReference(result_reference) = &result else {
+            panic!("a later symbol read must return its mutable cell")
+        };
+        let result_cell = ValueCell::from_legacy_ref(result_reference.clone());
+        let payload = result_cell.borrow();
+        let LegacyValue::Typed(inner, annotation) = &*payload else {
+            panic!("the later symbol read must retain its typed payload")
+        };
+        assert_eq!(annotation, &ValueKind::Option(Box::new(ValueKind::F64)));
+        assert!(matches!(inner.as_ref(), LegacyValue::F64(_)));
+        drop(payload);
+
+        program.publish_compiler_root_output(result);
+        let compiled = compile_bytecode(&mut program).unwrap();
+
+        assert_eq!(compiled.published_outputs.len(), 1);
     }
 
     #[test]

--- a/src/engine/src/program/compiler_planning.rs
+++ b/src/engine/src/program/compiler_planning.rs
@@ -756,6 +756,31 @@ fn compile_bytecode(program: &mut CompilerPlanningProgram) -> MResult<CompilerPl
     let plan = state.plan.borrow();
     let mut context = CompileCtx::new();
 
+    {
+        let symbols = state.symbol_table.borrow();
+        for (name, cell) in symbol_cell_rows(&symbols, &[]) {
+            context.retain_compiler_symbol_cell(&name, &cell)?;
+        }
+    }
+    for output in &program.published_outputs {
+        output.source.retain_cells(&mut context)?;
+    }
+    #[cfg(feature = "invariant_define")]
+    for constraint in state.integrity_constraints.values() {
+        context.retain_compiler_value_cell(&constraint.result)?;
+        if let Some(lhs) = &constraint.lhs {
+            context.retain_compiler_value_cell(lhs)?;
+        }
+        if let Some(rhs) = &constraint.rhs {
+            context.retain_compiler_value_cell(rhs)?;
+        }
+    }
+    for step in plan.iter() {
+        for cell in step.compiler_owned_value_cells() {
+            context.retain_compiler_value_cell(&cell)?;
+        }
+    }
+
     // State declarations retain their declaration-time initializer even when
     // source execution has already advanced the corresponding reactive cell.
     for step in plan.iter() {
@@ -775,6 +800,8 @@ fn compile_bytecode(program: &mut CompilerPlanningProgram) -> MResult<CompilerPl
         context.end_plan_node();
         compile_result?;
     }
+
+    context.associate_retained_symbol_cells_with_existing_value_registers()?;
 
     for region in &state.compute_regions {
         let start = u32::try_from(region.plan_nodes.start).map_err(|_| {

--- a/src/engine/src/program/compiler_value_source.rs
+++ b/src/engine/src/program/compiler_value_source.rs
@@ -1,0 +1,207 @@
+use mech_core::{
+    BytecodeCompilerContext, BytecodeRegisterIdentity, LegacyValue, MResult, Register, ValueCell,
+    ValueKind, bytecode_composite_children, bytecode_register_identity,
+    compile_annotated_value_cell_register, compile_annotated_value_register,
+    compile_value_cell_register, compile_value_register, compiler_value_cell_from_legacy,
+};
+
+/// Short-lived source-planning ownership retained until artifact compilation.
+///
+/// This type is deliberately engine-private and non-serialized. `Cell` keeps
+/// location identity explicit, `Typed` preserves every source annotation, and
+/// `Immediate` carries values that do not denote a compiler-owned location.
+#[derive(Clone, Debug)]
+pub(super) enum CompilerValueSource {
+    Cell(ValueCell),
+    Typed {
+        source: Box<CompilerValueSource>,
+        annotation: ValueKind,
+    },
+    Immediate(LegacyValue),
+}
+
+impl CompilerValueSource {
+    pub(super) fn from_legacy(value: LegacyValue) -> Self {
+        // Cell ownership follows the actual outer value; register identity may
+        // transparently inspect the payload and must not reorder that boundary.
+        if let Some(cell) = compiler_value_cell_from_legacy(&value) {
+            return Self::Cell(cell);
+        }
+
+        let fallback = core::ptr::from_ref(&value).addr();
+        if let BytecodeRegisterIdentity::Typed { annotation, .. } =
+            bytecode_register_identity(&value, fallback)
+        {
+            let mut children = bytecode_composite_children(&value)
+                .expect("typed compiler values expose their wrapped value");
+            let inner = children
+                .pop()
+                .expect("typed compiler values have exactly one wrapped value");
+            return Self::Typed {
+                source: Box::new(Self::from_legacy(inner)),
+                annotation,
+            };
+        }
+        Self::Immediate(value)
+    }
+
+    pub(super) fn compile_register(
+        &self,
+        context: &mut dyn BytecodeCompilerContext,
+    ) -> MResult<Register> {
+        let mut annotations = Vec::new();
+        if let Some(cell) = self.typed_cell(&mut annotations) {
+            return compile_annotated_value_cell_register(cell, &annotations, context);
+        }
+        annotations.clear();
+        if let Some(value) = self.typed_immediate(&mut annotations) {
+            return compile_annotated_value_register(
+                value,
+                &annotations,
+                core::ptr::from_ref(value).addr(),
+                context,
+            );
+        }
+
+        match self {
+            Self::Cell(cell) => compile_value_cell_register(cell, context),
+            Self::Immediate(value) => {
+                compile_value_register(value, core::ptr::from_ref(value).addr(), context)
+            }
+            Self::Typed { .. } => unreachable!("typed compiler sources were resolved above"),
+        }
+    }
+
+    fn typed_cell<'a>(&'a self, annotations: &mut Vec<ValueKind>) -> Option<&'a ValueCell> {
+        match self {
+            Self::Cell(cell) => Some(cell),
+            Self::Typed { source, annotation } => {
+                annotations.push(annotation.clone());
+                source.typed_cell(annotations)
+            }
+            Self::Immediate(_) => None,
+        }
+    }
+
+    fn typed_immediate<'a>(&'a self, annotations: &mut Vec<ValueKind>) -> Option<&'a LegacyValue> {
+        match self {
+            Self::Immediate(value) => Some(value),
+            Self::Typed { source, annotation } => {
+                annotations.push(annotation.clone());
+                source.typed_immediate(annotations)
+            }
+            Self::Cell(_) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::CompileCtx;
+    use mech_core::{BytecodeInstruction, Ref};
+
+    #[test]
+    fn mutable_reference_normalization_retains_the_original_cell() {
+        let reference = Ref::new(LegacyValue::F64(Ref::new(7.0)));
+        let source =
+            CompilerValueSource::from_legacy(LegacyValue::MutableReference(reference.clone()));
+
+        let CompilerValueSource::Cell(cell) = source else {
+            panic!("mutable references must normalize to explicit cells")
+        };
+        assert!(cell.same_cell(&ValueCell::from_legacy_ref(reference)));
+    }
+
+    #[test]
+    fn typed_cell_sources_preserve_annotations_and_underlying_identity() {
+        let reference = Ref::new(LegacyValue::F64(Ref::new(7.0)));
+        let annotation = ValueKind::Option(Box::new(ValueKind::F64));
+        let source = CompilerValueSource::from_legacy(LegacyValue::Typed(
+            Box::new(LegacyValue::MutableReference(reference.clone())),
+            annotation,
+        ));
+        let cell = ValueCell::from_legacy_ref(reference);
+        let mut context = CompileCtx::new();
+
+        let cell_register = compile_value_cell_register(&cell, &mut context).unwrap();
+        let typed_register = source.compile_register(&mut context).unwrap();
+        let typed_register_again = source.compile_register(&mut context).unwrap();
+        let compiled = context.finish_program(typed_register).unwrap();
+
+        assert_eq!(typed_register, typed_register_again);
+        assert_ne!(typed_register, cell_register);
+        assert!(
+            compiled
+                .program
+                .instructions
+                .iter()
+                .any(|instruction| matches!(
+                    instruction,
+                    BytecodeInstruction::CompositePack { dst, children, .. }
+                        if *dst == typed_register && children == &[cell_register]
+                ))
+        );
+    }
+
+    #[test]
+    fn mutable_reference_to_typed_payload_retains_the_outer_cell_and_register() {
+        let annotation = ValueKind::Option(Box::new(ValueKind::F64));
+        let reference = Ref::new(LegacyValue::Typed(
+            Box::new(LegacyValue::F64(Ref::new(7.0))),
+            annotation.clone(),
+        ));
+        let cell = ValueCell::from_legacy_ref(reference.clone());
+        let source =
+            CompilerValueSource::from_legacy(LegacyValue::MutableReference(reference.clone()));
+
+        let CompilerValueSource::Cell(normalized) = &source else {
+            panic!("an outer mutable reference must normalize before its typed payload")
+        };
+        assert!(normalized.same_cell(&cell));
+
+        let payload = normalized.borrow();
+        let LegacyValue::Typed(inner, retained_annotation) = &*payload else {
+            panic!("the typed payload must remain inside the retained cell")
+        };
+        assert_eq!(retained_annotation, &annotation);
+        assert!(matches!(inner.as_ref(), LegacyValue::F64(_)));
+        drop(payload);
+
+        let mut context = CompileCtx::new();
+        let cell_register = compile_value_cell_register(&cell, &mut context).unwrap();
+        let source_register = source.compile_register(&mut context).unwrap();
+        assert_eq!(source_register, cell_register);
+    }
+
+    #[test]
+    fn mutable_reference_normalization_preserves_nested_typed_payloads() {
+        let inner_annotation = ValueKind::Option(Box::new(ValueKind::F64));
+        let outer_annotation = ValueKind::Option(Box::new(inner_annotation.clone()));
+        let reference = Ref::new(LegacyValue::Typed(
+            Box::new(LegacyValue::Typed(
+                Box::new(LegacyValue::F64(Ref::new(7.0))),
+                inner_annotation.clone(),
+            )),
+            outer_annotation.clone(),
+        ));
+        let source =
+            CompilerValueSource::from_legacy(LegacyValue::MutableReference(reference.clone()));
+
+        let CompilerValueSource::Cell(normalized) = source else {
+            panic!("an outer mutable reference must retain its complete payload")
+        };
+        assert!(normalized.same_cell(&ValueCell::from_legacy_ref(reference)));
+
+        let payload = normalized.borrow();
+        let LegacyValue::Typed(inner, retained_outer_annotation) = &*payload else {
+            panic!("the outer typed payload must remain intact")
+        };
+        assert_eq!(retained_outer_annotation, &outer_annotation);
+        let LegacyValue::Typed(value, retained_inner_annotation) = inner.as_ref() else {
+            panic!("the nested typed payload must remain intact")
+        };
+        assert_eq!(retained_inner_annotation, &inner_annotation);
+        assert!(matches!(value.as_ref(), LegacyValue::F64(_)));
+    }
+}

--- a/src/engine/src/program/compiler_value_source.rs
+++ b/src/engine/src/program/compiler_value_source.rs
@@ -5,6 +5,8 @@ use mech_core::{
     compile_value_cell_register, compile_value_register, compiler_value_cell_from_legacy,
 };
 
+use crate::CompileCtx;
+
 /// Short-lived source-planning ownership retained until artifact compilation.
 ///
 /// This type is deliberately engine-private and non-serialized. `Cell` keeps
@@ -69,6 +71,14 @@ impl CompilerValueSource {
                 compile_value_register(value, core::ptr::from_ref(value).addr(), context)
             }
             Self::Typed { .. } => unreachable!("typed compiler sources were resolved above"),
+        }
+    }
+
+    pub(super) fn retain_cells(&self, context: &mut CompileCtx) -> MResult<()> {
+        match self {
+            Self::Cell(cell) => context.retain_compiler_value_cell(cell),
+            Self::Typed { source, .. } => source.retain_cells(context),
+            Self::Immediate(_) => Ok(()),
         }
     }
 

--- a/src/engine/src/program/mod.rs
+++ b/src/engine/src/program/mod.rs
@@ -16,6 +16,8 @@ pub use document_outputs::{
 #[cfg(feature = "semantic-compiler")]
 mod compiler_planning;
 #[cfg(feature = "semantic-compiler")]
+mod compiler_value_source;
+#[cfg(feature = "semantic-compiler")]
 pub use compiler_planning::{
     CompiledResourceSendOperation, CompilerPlanningConfig, CompilerPlanningLimits,
     CompilerPlanningProgram, ProgramArtifactCompilationProduct, ProgramCompilationProduct,

--- a/src/runtime/src/runtime/program/compiler.rs
+++ b/src/runtime/src/runtime/program/compiler.rs
@@ -19,7 +19,7 @@ use mech_compute::{
 use mech_core::{
     ApplicationRequirement, ExecutionHostFunctionRequest, ExecutionResourceRequest, LegacyValue,
     MResult, MechError, MechErrorKind, MechExecutionServices, MechSourceCode,
-    ModuleManifestCatalog, OperationContractDeclaration, Ref, ResourceIntent, ValueCell,
+    ModuleManifestCatalog, OperationContractDeclaration, ResourceIntent, ValueCell,
 };
 #[cfg(feature = "compute")]
 use mech_core::{Body, MechCode, Program, Section, SectionElement};
@@ -339,10 +339,10 @@ struct CompilerExportValue {
 }
 
 impl CompilerExportValue {
-    fn fresh_reference(&self) -> MResult<Ref<LegacyValue>> {
+    fn fresh_cell(&self) -> MResult<ValueCell> {
         self.value
             .try_deep_snapshot()
-            .map(Ref::new)
+            .map(ValueCell::new)
             .map_err(|_| unsupported_compiler_import(self))
     }
 }
@@ -527,7 +527,8 @@ impl<'a> ProgramCompilerView<'a> {
     )> {
         let mut program = self.new_program();
         for (name, value) in inputs {
-            program.install_compiler_symbol(name, Ref::new(value.clone().into_mech_value()?))?;
+            program
+                .install_compiler_symbol(name, ValueCell::new(value.clone().into_mech_value()?))?;
         }
         let document_output_ids = root_document_output_ids(tree);
         let index = SourceIndex::from_program(tree);
@@ -743,7 +744,8 @@ impl<'a> ProgramCompilerView<'a> {
     ) -> MResult<BTreeMap<String, RuntimeHostInputValue>> {
         let mut program = self.new_program();
         for (name, value) in inputs {
-            program.install_compiler_symbol(name, Ref::new(value.clone().into_mech_value()?))?;
+            program
+                .install_compiler_symbol(name, ValueCell::new(value.clone().into_mech_value()?))?;
         }
         let index = SourceIndex::from_program(tree);
         index.validate_address_targets()?;
@@ -2073,7 +2075,7 @@ fn install_environment(
     environment: &HashMap<String, CompilerExportValue>,
 ) -> MResult<()> {
     for (name, value) in environment {
-        program.install_compiler_symbol(name, value.fresh_reference()?)?;
+        program.install_compiler_symbol(name, value.fresh_cell()?)?;
     }
     Ok(())
 }


### PR DESCRIPTION
## Stack

- Targets PR2: #784 (`codex/explicit-value-cells`)
- Keep this PR draft until the preceding stack is ready

## Summary

- adds direct `ValueCell` compiler APIs for initialized and runtime-produced registers
- retains typed annotations and composite child identities without reconstructing legacy mutable-reference signals
- introduces an engine-private `CompilerValueSource` for cells, typed sources, and immediate values
- publishes root symbols and integrity operands as explicit cells
- migrates external host/resource outputs to the direct-cell compiler path
- preserves the existing function, machinery, bytecode-v1, and runtime ABIs

## Local validation

- value-system retirement contract passed: 4,909 live `LegacyValue` occurrences, 19 removed, 0 unreviewed
- `cargo check -p mech-core --features semantic-compiler`
- `cargo check -p mech-engine --all-features`
- `cargo test -p mech-core --all-features --lib` (359 passed)

No value-system or function-system contract inventory JSON was regenerated.