### PR TITLE
[PR4] refactor(compiler): lower matrix literals through canonical IR

### DIFF
--- a/src/core/src/program/bytecode/aggregates.rs
+++ b/src/core/src/program/bytecode/aggregates.rs
@@ -7,7 +7,9 @@
     feature = "enum"
 ))]
 use crate::Ref;
-use crate::{BytecodeValidationError, LegacyValue, MResult, MechError, ValueKind};
+#[cfg(feature = "matrix")]
+use crate::ToValue;
+use crate::{AsValueKind, BytecodeValidationError, LegacyValue, MResult, MechError, ValueKind};
 
 #[cfg(feature = "no_std")]
 use alloc::{boxed::Box, format, vec, vec::Vec};
@@ -86,12 +88,42 @@ fn duplicate_hashed_child(kind: &str) -> MechError {
     .with_compiler_loc()
 }
 
+impl ValueKind {
+    /// Returns the element kind and declared dimensions of an exact matrix
+    /// kind without erasing its shape as the general collection helper does.
+    pub fn matrix_parts(&self) -> Option<(&ValueKind, &[usize])> {
+        match self {
+            ValueKind::Matrix(element, dimensions) => {
+                Some((element.as_ref(), dimensions.as_slice()))
+            }
+            _ => None,
+        }
+    }
+
+    pub fn is_any(&self) -> bool {
+        self == &<LegacyValue as AsValueKind>::as_value_kind()
+    }
+
+    pub fn option_inner(&self) -> Option<&ValueKind> {
+        match self {
+            ValueKind::Option(inner) => Some(inner.as_ref()),
+            _ => None,
+        }
+    }
+}
+
 fn compiled_kind(kind: ValueKind) -> ValueKind {
+    if let Some((inner, shape)) = kind
+        .matrix_parts()
+        .map(|(inner, shape)| (inner.clone(), shape.to_vec()))
+    {
+        return ValueKind::Matrix(Box::new(compiled_kind(inner)), shape);
+    }
+    if let Some(inner) = kind.option_inner().cloned() {
+        return ValueKind::Option(Box::new(compiled_kind(inner)));
+    }
     match kind {
         ValueKind::Reference(inner) => compiled_kind(*inner),
-        ValueKind::Matrix(inner, shape) => {
-            ValueKind::Matrix(Box::new(compiled_kind(*inner)), shape)
-        }
         ValueKind::Record(fields) => ValueKind::Record(
             fields
                 .into_iter()
@@ -115,7 +147,6 @@ fn compiled_kind(kind: ValueKind) -> ValueKind {
         ValueKind::Set(element, max_len) => {
             ValueKind::Set(Box::new(compiled_kind(*element)), max_len)
         }
-        ValueKind::Option(inner) => ValueKind::Option(Box::new(compiled_kind(*inner))),
         ValueKind::Kind(inner) => ValueKind::Kind(Box::new(compiled_kind(*inner))),
         kind => kind,
     }
@@ -138,12 +169,81 @@ fn wrong_child_kind(index: usize, expected: &ValueKind, actual: &ValueKind) -> M
     .with_compiler_loc()
 }
 
+#[cfg(feature = "matrix")]
+fn matrix_template_schema(template: &LegacyValue) -> MResult<Option<(ValueKind, usize, usize)>> {
+    let Some(kind) = template.legacy_kind_literal() else {
+        return Ok(None);
+    };
+    let Some((element_kind, dimensions)) = kind.matrix_parts() else {
+        return Ok(None);
+    };
+    let [rows, columns] = dimensions else {
+        return Err(MechError::new(
+            BytecodeValidationError {
+                reason: format!(
+                    "Matrix CompositePack template requires exactly two dimensions, found {}",
+                    dimensions.len(),
+                ),
+            },
+            None,
+        )
+        .with_compiler_loc());
+    };
+    Ok(Some((element_kind.clone(), *rows, *columns)))
+}
+
+#[cfg(feature = "matrix")]
+fn validate_matrix_child(
+    index: usize,
+    element_kind: &ValueKind,
+    child: &LegacyValue,
+) -> MResult<()> {
+    if let Some(reference) = child.legacy_mutable_reference() {
+        return validate_matrix_child(index, element_kind, &reference.borrow());
+    }
+
+    let expected = compiled_kind(element_kind.clone());
+    let actual = compiled_kind(child.kind());
+    let compatible = if child.is_legacy_index_all() || child.legacy_kind_literal().is_some() {
+        false
+    } else if child.is_legacy_empty() {
+        expected.is_any() || expected.option_inner().is_some()
+    } else if let Some(empty_kind) = child.legacy_empty_kind() {
+        empty_kind.option_inner().is_some() && compiled_kind(empty_kind.clone()) == expected
+    } else if expected.is_any() {
+        true
+    } else if let Some(inner) = expected.option_inner() {
+        actual == expected || &actual == inner
+    } else {
+        actual == expected
+    };
+    if compatible {
+        Ok(())
+    } else {
+        Err(wrong_child_kind(index, element_kind, &child.kind()))
+    }
+}
+
 /// Validates the exact child schema shared by bytecode reading, contract
 /// planning, and runtime reconstruction.
 pub fn validate_bytecode_composite_children(
     template: &LegacyValue,
     children: &[LegacyValue],
 ) -> MResult<()> {
+    #[cfg(feature = "matrix")]
+    if let Some((element_kind, rows, columns)) = matrix_template_schema(template)? {
+        let expected = rows
+            .checked_mul(columns)
+            .ok_or_else(|| wrong_arity("Matrix", usize::MAX, children.len()))?;
+        if children.len() != expected {
+            return Err(wrong_arity("Matrix", expected, children.len()));
+        }
+        for (index, child) in children.iter().enumerate() {
+            validate_matrix_child(index, &element_kind, child)?;
+        }
+        return Ok(());
+    }
+
     let expected = bytecode_composite_children(template).ok_or_else(|| {
         MechError::new(
             BytecodeValidationError {
@@ -175,6 +275,16 @@ pub fn rebuild_bytecode_composite(
     children: Vec<LegacyValue>,
 ) -> MResult<LegacyValue> {
     validate_bytecode_composite_children(template, &children)?;
+    #[cfg(feature = "matrix")]
+    if let Some((_, rows, columns)) = matrix_template_schema(template)? {
+        let mut column_major = Vec::with_capacity(children.len());
+        for column in 0..columns {
+            for row in 0..rows {
+                column_major.push(children[row * columns + column].clone());
+            }
+        }
+        return Ok(crate::matrix::Matrix::from_vec(column_major, rows, columns).to_value());
+    }
     match template {
         #[cfg(feature = "tuple")]
         LegacyValue::Tuple(value) => {
@@ -358,5 +468,121 @@ pub fn rebuild_bytecode_composite(
             None,
         )
         .with_compiler_loc()),
+    }
+}
+
+#[cfg(all(test, feature = "matrix", feature = "f64", feature = "string"))]
+mod tests {
+    use super::*;
+    use crate::Ref;
+
+    fn f64_value(value: f64) -> LegacyValue {
+        LegacyValue::F64(Ref::new(value))
+    }
+
+    fn matrix_template(element: ValueKind, rows: usize, columns: usize) -> LegacyValue {
+        LegacyValue::Kind(ValueKind::Matrix(Box::new(element), vec![rows, columns]))
+    }
+
+    #[test]
+    fn matrix_kind_template_rebuilds_logical_row_major_order() {
+        let rebuilt = rebuild_bytecode_composite(
+            &matrix_template(ValueKind::F64, 2, 3),
+            (1..=6).map(|value| f64_value(value as f64)).collect(),
+        )
+        .unwrap();
+        let LegacyValue::MatrixValue(matrix) = rebuilt else {
+            panic!("matrix-kind template must rebuild a generic matrix");
+        };
+        let logical = (1..=2)
+            .flat_map(|row| (1..=3).map(move |column| (row, column)))
+            .map(|(row, column)| {
+                let LegacyValue::F64(value) = matrix.index2d(row, column) else {
+                    panic!("rebuilt matrix element must be f64");
+                };
+                *value.borrow()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(logical, vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    }
+
+    #[test]
+    fn matrix_kind_template_rejects_wrong_count_kind_and_controls() {
+        assert!(
+            rebuild_bytecode_composite(
+                &matrix_template(ValueKind::F64, 1, 2),
+                vec![f64_value(1.0)],
+            )
+            .is_err()
+        );
+        assert!(
+            rebuild_bytecode_composite(
+                &matrix_template(ValueKind::F64, 1, 1),
+                vec![LegacyValue::String(Ref::new("wrong".into()))],
+            )
+            .is_err()
+        );
+        assert!(
+            rebuild_bytecode_composite(
+                &matrix_template(ValueKind::F64, 1, 1),
+                vec![LegacyValue::Empty],
+            )
+            .is_err()
+        );
+        assert!(
+            rebuild_bytecode_composite(
+                &matrix_template(ValueKind::Any, 1, 1),
+                vec![LegacyValue::IndexAll],
+            )
+            .is_err()
+        );
+        assert!(
+            rebuild_bytecode_composite(
+                &matrix_template(ValueKind::Any, 1, 1),
+                vec![LegacyValue::Kind(ValueKind::F64)],
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn matrix_any_and_option_schemas_accept_their_legacy_compatibility_values() {
+        let heterogeneous = vec![f64_value(1.0), LegacyValue::String(Ref::new("two".into()))];
+        assert!(
+            rebuild_bytecode_composite(&matrix_template(ValueKind::Any, 1, 2), heterogeneous,)
+                .is_ok()
+        );
+
+        let option = ValueKind::Option(Box::new(ValueKind::F64));
+        let values = vec![
+            f64_value(1.0),
+            LegacyValue::Typed(Box::new(f64_value(2.0)), option.clone()),
+            LegacyValue::Empty,
+            LegacyValue::EmptyKind(option.clone()),
+        ];
+        let rebuilt = rebuild_bytecode_composite(&matrix_template(option, 2, 2), values).unwrap();
+        let LegacyValue::MatrixValue(matrix) = rebuilt else {
+            panic!("2x2 option matrix should retain generic matrix storage");
+        };
+        assert_eq!(matrix.as_vec().len(), 4);
+    }
+
+    #[test]
+    fn matrix_schema_checks_the_current_mutable_reference_payload() {
+        let valid = LegacyValue::MutableReference(Ref::new(f64_value(1.0)));
+        assert!(
+            validate_bytecode_composite_children(&matrix_template(ValueKind::F64, 1, 1), &[valid],)
+                .is_ok()
+        );
+
+        let invalid =
+            LegacyValue::MutableReference(Ref::new(LegacyValue::String(Ref::new("wrong".into()))));
+        assert!(
+            validate_bytecode_composite_children(
+                &matrix_template(ValueKind::F64, 1, 1),
+                &[invalid],
+            )
+            .is_err()
+        );
     }
 }

--- a/src/core/src/program/compiler/api.rs
+++ b/src/core/src/program/compiler/api.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "matrix")]
+use crate::BytecodeValidationError;
 use crate::{
     ApplicationRequirement, EncodedConstant, LegacyValue, MResult, MechError, MechErrorKind,
     ValueCell, ValueKind,
@@ -6,6 +8,10 @@ use crate::{
 #[cfg(feature = "no_std")]
 use alloc::{boxed::Box, vec::Vec};
 
+#[cfg(feature = "matrix")]
+use super::CompiledMatrixLiteralElement;
+#[cfg(feature = "matrix")]
+use super::constants::compile_kind_constant;
 use super::{CompileConst, CompiledMatrixLiteral, Register, compile_annotated_constant};
 
 /// Canonical producer identity used when assigning bytecode registers.
@@ -119,6 +125,13 @@ pub trait BytecodeCompilerContext {
     /// the producer instruction.
     fn record_runtime_produced_register(&mut self, _register: Register) -> MResult<()> {
         Ok(())
+    }
+
+    /// Reports whether an executable producer already owns this register.
+    /// Such values may be observed through the compiler API without being
+    /// reclassified as source matrix-literal construction.
+    fn register_is_runtime_produced(&self, _register: Register) -> bool {
+        false
     }
 
     /// Records deterministic, in-memory construction metadata for a generic
@@ -368,7 +381,21 @@ pub fn compile_value_register(
 
     let (register, initialize) =
         context.register_for_value_with_initialization_status(value, fallback);
-    context.record_register_kind(register, value.kind())?;
+    let kind = value.kind();
+    context.record_register_kind(register, kind.clone())?;
+    // Observing a value whose register is owned by an executable producer is
+    // not a second source construction. In particular, do not manufacture a
+    // matrix-literal sidecar for a runtime-produced generic matrix.
+    if !initialize && context.register_is_runtime_produced(register) {
+        return Ok(register);
+    }
+    #[cfg(feature = "matrix")]
+    if let Some(matrix) = value
+        .exact_matrix_any()
+        .and_then(|matrix| matrix.downcast_ref::<crate::matrix::Matrix<LegacyValue>>())
+    {
+        return compile_matrix_literal_register(matrix, kind, register, initialize, context);
+    }
     if !initialize {
         return Ok(register);
     }
@@ -401,7 +428,20 @@ pub fn compile_value_register_for_ptr(
     context: &mut dyn BytecodeCompilerContext,
 ) -> MResult<Register> {
     let (register, initialize) = context.register_for_ptr_with_initialization_status(pointer);
-    context.record_register_kind(register, value.kind())?;
+    let kind = value.kind();
+    context.record_register_kind(register, kind.clone())?;
+    // An executable producer supersedes the planning-time payload stored in
+    // this cell, so observing that payload is not matrix-literal registration.
+    if !initialize && context.register_is_runtime_produced(register) {
+        return Ok(register);
+    }
+    #[cfg(feature = "matrix")]
+    if let Some(matrix) = value
+        .exact_matrix_any()
+        .and_then(|matrix| matrix.downcast_ref::<crate::matrix::Matrix<LegacyValue>>())
+    {
+        return compile_matrix_literal_register(matrix, kind, register, initialize, context);
+    }
     if !initialize {
         return Ok(register);
     }
@@ -420,6 +460,267 @@ pub fn compile_value_register_for_ptr(
         context.emit_const_load(register, constant);
     }
     Ok(register)
+}
+
+#[cfg(feature = "matrix")]
+fn compile_matrix_literal_register(
+    matrix: &crate::matrix::Matrix<LegacyValue>,
+    output_kind: ValueKind,
+    register: Register,
+    initialize: bool,
+    context: &mut dyn BytecodeCompilerContext,
+) -> MResult<Register> {
+    let Some((_, declared_dimensions)) = output_kind.matrix_parts() else {
+        return compiler_invariant(format!(
+            "generic matrix literal register {register} does not have a matrix output kind",
+        ));
+    };
+    let rows = matrix.rows();
+    let columns = matrix.cols();
+    if declared_dimensions != [rows, columns] {
+        return compiler_invariant(format!(
+            "generic matrix literal register {register} declares dimensions {:?}, found {rows}x{columns}",
+            declared_dimensions,
+        ));
+    }
+    let rows_u32 = u32::try_from(rows).map_err(|_| {
+        compiler_invariant::<()>(format!(
+            "generic matrix literal row count {rows} exceeds u32",
+        ))
+        .unwrap_err()
+    })?;
+    let columns_u32 = u32::try_from(columns).map_err(|_| {
+        compiler_invariant::<()>(format!(
+            "generic matrix literal column count {columns} exceeds u32",
+        ))
+        .unwrap_err()
+    })?;
+
+    let mut values = Vec::with_capacity(rows.saturating_mul(columns));
+    for row in 0..rows {
+        for column in 0..columns {
+            values.push(matrix.index2d(row + 1, column + 1));
+        }
+    }
+
+    let mut elements = Vec::with_capacity(values.len());
+    let mut children = Vec::with_capacity(values.len());
+    for value in &values {
+        let child = compile_value_register(value, core::ptr::from_ref(value).addr(), context)?;
+        children.push(child);
+        elements.push(if value.is_legacy_empty() {
+            CompiledMatrixLiteralElement::Empty { register: child }
+        } else {
+            CompiledMatrixLiteralElement::Value { register: child }
+        });
+    }
+
+    let literal =
+        CompiledMatrixLiteral::new(register, rows_u32, columns_u32, elements.into_boxed_slice())?;
+    context.record_matrix_literal(literal)?;
+
+    if initialize {
+        let template = compile_kind_constant(&output_kind, context)?;
+        context.record_register_constant_metadata(register, template)?;
+        context.emit_composite_pack(register, template, children);
+    }
+    Ok(register)
+}
+
+#[cfg(feature = "matrix")]
+fn compiler_invariant<T>(reason: impl Into<String>) -> MResult<T> {
+    Err(MechError::new(
+        BytecodeValidationError {
+            reason: reason.into(),
+        },
+        None,
+    )
+    .with_compiler_loc())
+}
+
+#[cfg(all(test, feature = "matrix", feature = "f64"))]
+mod tests {
+    use super::*;
+    use crate::{
+        BytecodeInstruction, CompileCtx, CompiledBytecode, Ref, decode_encoded_constants,
+        matrix::Matrix,
+    };
+
+    fn f64_value(value: f64) -> LegacyValue {
+        LegacyValue::F64(Ref::new(value))
+    }
+
+    fn compiled_matrix(values: Vec<LegacyValue>, rows: usize, columns: usize) -> CompiledBytecode {
+        let value = LegacyValue::MatrixValue(Matrix::from_vec(values, rows, columns));
+        let mut context = CompileCtx::new();
+        let output =
+            compile_value_register(&value, core::ptr::from_ref(&value).addr(), &mut context)
+                .unwrap();
+        context.finish_program(output).unwrap()
+    }
+
+    fn register_f64(compiled: &CompiledBytecode, register: Register) -> f64 {
+        let constant = compiled
+            .program
+            .instructions
+            .iter()
+            .find_map(|instruction| match instruction {
+                BytecodeInstruction::ConstLoad { dst, constant } if *dst == register => {
+                    Some(*constant)
+                }
+                _ => None,
+            })
+            .unwrap();
+        let values = decode_encoded_constants(&compiled.program.constants).unwrap();
+        let LegacyValue::F64(value) = &values[constant as usize] else {
+            panic!("matrix element register must contain an f64 constant");
+        };
+        *value.borrow()
+    }
+
+    #[test]
+    fn generic_matrix_compilation_records_empty_and_repeated_elements() {
+        let empty = compiled_matrix(Vec::new(), 0, 0);
+        let descriptor = empty.matrix_literals.get(&empty.return_register).unwrap();
+        assert_eq!((descriptor.rows, descriptor.columns), (0, 0));
+        assert!(descriptor.elements.is_empty());
+
+        let shared = f64_value(1.0);
+        let compiled = compiled_matrix(vec![shared.clone(), LegacyValue::Empty, shared], 1, 3);
+        let descriptor = compiled
+            .matrix_literals
+            .get(&compiled.return_register)
+            .unwrap();
+        assert!(matches!(
+            descriptor.elements[1],
+            CompiledMatrixLiteralElement::Empty { .. }
+        ));
+        assert_eq!(
+            descriptor.elements[0].register(),
+            descriptor.elements[2].register()
+        );
+    }
+
+    #[test]
+    fn generic_matrix_compilation_uses_canonical_row_major_order_and_kind_template() {
+        // Matrix storage is column-major; the logical value is
+        // [1, 2, 3]
+        // [4, 5, 6].
+        let compiled = compiled_matrix(
+            [1.0, 4.0, 2.0, 5.0, 3.0, 6.0]
+                .into_iter()
+                .map(f64_value)
+                .collect(),
+            2,
+            3,
+        );
+        let descriptor = compiled
+            .matrix_literals
+            .get(&compiled.return_register)
+            .unwrap();
+        let values = descriptor
+            .elements
+            .iter()
+            .map(|element| register_f64(&compiled, element.register()))
+            .collect::<Vec<_>>();
+        assert_eq!(values, vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+        let templates = decode_encoded_constants(&compiled.program.constants).unwrap();
+        let template = compiled
+            .program
+            .instructions
+            .iter()
+            .find_map(|instruction| match instruction {
+                BytecodeInstruction::CompositePack {
+                    dst,
+                    template,
+                    children,
+                } if *dst == compiled.return_register => {
+                    assert_eq!(children.len(), 6);
+                    Some(*template)
+                }
+                _ => None,
+            })
+            .expect("generic matrix compilation must emit one CompositePack");
+        assert_eq!(
+            templates[template as usize],
+            LegacyValue::Kind(ValueKind::Matrix(Box::new(ValueKind::F64), vec![2, 3]))
+        );
+        assert_eq!(
+            compiled
+                .program
+                .instructions
+                .iter()
+                .filter(|instruction| matches!(
+                    instruction,
+                    BytecodeInstruction::CompositePack { .. }
+                ))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn nonempty_generic_matrix_is_not_an_ordinary_constant() {
+        let value = LegacyValue::MatrixValue(Matrix::from_vec(vec![f64_value(1.0)], 1, 1));
+        let mut context = CompileCtx::new();
+        assert!(value.compile_const(&mut context).is_err());
+    }
+
+    #[test]
+    fn reused_matrix_register_rejects_a_conflicting_descriptor_without_reemitting() {
+        let left = f64_value(1.0);
+        let right = f64_value(2.0);
+        let first =
+            LegacyValue::MatrixValue(Matrix::from_vec(vec![left.clone(), right.clone()], 1, 2));
+        let conflicting = LegacyValue::MatrixValue(Matrix::from_vec(vec![right, left], 1, 2));
+        let mut context = CompileCtx::new();
+        let pointer = 0x4d41_5452_4958usize;
+        let output = compile_value_register_for_ptr(&first, pointer, &mut context).unwrap();
+        let error = compile_value_register_for_ptr(&conflicting, pointer, &mut context)
+            .expect_err("reusing a matrix output must validate its complete descriptor");
+        assert!(error.kind_message().contains("conflicting descriptors"));
+
+        let compiled = context.finish_program(output).unwrap();
+        assert_eq!(
+            compiled
+                .program
+                .instructions
+                .iter()
+                .filter(|instruction| matches!(
+                    instruction,
+                    BytecodeInstruction::CompositePack { dst, .. } if *dst == output
+                ))
+                .count(),
+            1,
+            "descriptor validation must not emit another construction instruction",
+        );
+    }
+
+    #[test]
+    fn runtime_produced_generic_matrix_can_be_observed_without_a_literal_sidecar() {
+        let value = LegacyValue::MatrixValue(Matrix::from_vec(Vec::new(), 0, 0));
+        let pointer = core::ptr::from_ref(&value).addr();
+        let mut context = CompileCtx::new();
+        let produced = compile_runtime_produced_register(&value, pointer, &mut context).unwrap();
+        let observed = compile_value_register(&value, pointer, &mut context).unwrap();
+        let compiled = context.finish_program(observed).unwrap();
+
+        assert_eq!(observed, produced);
+        assert!(!compiled.matrix_literals.contains_key(&observed));
+        assert!(
+            compiled
+                .program
+                .instructions
+                .iter()
+                .all(|instruction| !matches!(
+                    instruction,
+                    BytecodeInstruction::ConstLoad { dst, .. }
+                        | BytecodeInstruction::CompositePack { dst, .. }
+                        if *dst == observed
+                ))
+        );
+    }
 }
 
 /// Resolves the register for a value whose payload will be produced by an

--- a/src/core/src/program/compiler/api.rs
+++ b/src/core/src/program/compiler/api.rs
@@ -6,7 +6,7 @@ use crate::{
 #[cfg(feature = "no_std")]
 use alloc::{boxed::Box, vec::Vec};
 
-use super::{CompileConst, Register, compile_annotated_constant};
+use super::{CompileConst, CompiledMatrixLiteral, Register, compile_annotated_constant};
 
 /// Canonical producer identity used when assigning bytecode registers.
 ///
@@ -118,6 +118,13 @@ pub trait BytecodeCompilerContext {
     /// use this hook to discard that provisional initializer before emitting
     /// the producer instruction.
     fn record_runtime_produced_register(&mut self, _register: Register) -> MResult<()> {
+        Ok(())
+    }
+
+    /// Records deterministic, in-memory construction metadata for a generic
+    /// matrix literal. Contexts that do not build semantic artifacts may
+    /// ignore it.
+    fn record_matrix_literal(&mut self, _literal: CompiledMatrixLiteral) -> MResult<()> {
         Ok(())
     }
 

--- a/src/core/src/program/compiler/constants.rs
+++ b/src/core/src/program/compiler/constants.rs
@@ -476,6 +476,18 @@ pub trait CompileConst {
 }
 
 #[cfg(all(feature = "semantic-compiler", feature = "matrix"))]
+pub(super) fn compile_kind_constant(
+    kind: &ValueKind,
+    ctx: &mut dyn BytecodeCompilerContext,
+) -> MResult<u32> {
+    ctx.intern_constant(encoded_constant(
+        RuntimeType::Kind(semantic_kind_from_value_kind(kind)?),
+        1,
+        Vec::new(),
+    ))
+}
+
+#[cfg(all(feature = "semantic-compiler", feature = "matrix"))]
 struct CapturingConstantContext {
     constant: Option<EncodedConstant>,
 }

--- a/src/core/src/program/compiler/construction.rs
+++ b/src/core/src/program/compiler/construction.rs
@@ -1,0 +1,122 @@
+use crate::{BytecodeValidationError, MResult, MechError, Register};
+
+/// One source element in a generic matrix-literal construction.
+///
+/// This metadata is compiler-local and register based. `Empty` preserves the
+/// source pseudo-value distinction until canonical artifact lowering resolves
+/// it against the declared element schema.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CompiledMatrixLiteralElement {
+    Empty { register: Register },
+    Value { register: Register },
+}
+
+impl CompiledMatrixLiteralElement {
+    pub const fn register(self) -> Register {
+        match self {
+            Self::Empty { register } | Self::Value { register } => register,
+        }
+    }
+}
+
+/// Deterministic compiler sidecar for one generic matrix construction.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CompiledMatrixLiteral {
+    pub output: Register,
+    pub rows: u32,
+    pub columns: u32,
+    pub elements: Box<[CompiledMatrixLiteralElement]>,
+}
+
+impl CompiledMatrixLiteral {
+    pub fn new(
+        output: Register,
+        rows: u32,
+        columns: u32,
+        elements: Box<[CompiledMatrixLiteralElement]>,
+    ) -> MResult<Self> {
+        let expected = rows.checked_mul(columns).ok_or_else(|| {
+            invalid::<()>(format!(
+                "matrix literal dimensions {rows}x{columns} overflow element cardinality",
+            ))
+            .unwrap_err()
+        })?;
+        if usize::try_from(expected).ok() != Some(elements.len()) {
+            return invalid(format!(
+                "matrix literal dimensions {rows}x{columns} require {expected} elements, found {}",
+                elements.len(),
+            ));
+        }
+        if elements.iter().any(|element| element.register() == output) {
+            return invalid(format!(
+                "matrix literal output register {output} cannot also be an element register",
+            ));
+        }
+        Ok(Self {
+            output,
+            rows,
+            columns,
+            elements,
+        })
+    }
+}
+
+fn invalid<T>(reason: impl Into<String>) -> MResult<T> {
+    Err(MechError::new(
+        BytecodeValidationError {
+            reason: reason.into(),
+        },
+        None,
+    )
+    .with_compiler_loc())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checked_matrix_literal_accepts_repeated_inputs() {
+        let literal = CompiledMatrixLiteral::new(
+            2,
+            1,
+            2,
+            vec![
+                CompiledMatrixLiteralElement::Value { register: 1 },
+                CompiledMatrixLiteralElement::Value { register: 1 },
+            ]
+            .into_boxed_slice(),
+        )
+        .unwrap();
+
+        assert_eq!(literal.elements[0].register(), 1);
+        assert_eq!(literal.elements[1].register(), 1);
+    }
+
+    #[test]
+    fn checked_matrix_literal_rejects_invalid_cardinality_and_output_cycles() {
+        let cardinality = CompiledMatrixLiteral::new(
+            2,
+            2,
+            2,
+            vec![CompiledMatrixLiteralElement::Value { register: 1 }].into_boxed_slice(),
+        )
+        .unwrap_err();
+        assert!(cardinality.kind_message().contains("require 4 elements"));
+
+        let cycle = CompiledMatrixLiteral::new(
+            2,
+            1,
+            1,
+            vec![CompiledMatrixLiteralElement::Value { register: 2 }].into_boxed_slice(),
+        )
+        .unwrap_err();
+        assert!(cycle.kind_message().contains("cannot also be an element"));
+    }
+
+    #[test]
+    fn checked_matrix_literal_rejects_dimension_overflow() {
+        let error = CompiledMatrixLiteral::new(u32::MAX, u32::MAX, 2, Box::new([])).unwrap_err();
+        assert!(error.kind_message().contains("overflow"));
+    }
+}

--- a/src/core/src/program/compiler/context.rs
+++ b/src/core/src/program/compiler/context.rs
@@ -7,11 +7,11 @@ use std::sync::LazyLock;
 use crate::{
     AccessMode, AliasPolicy, ApplicationRequirement, BytecodeCompilerContext, BytecodeInstruction,
     BytecodeProgram, BytecodeRegisterIdentity, BytecodeValidationError, ChangeDetectionPolicy,
-    ComputePlacement, DeliveryMode, EncodedConstant, ExternalInteraction, InputPortLayout,
-    InputPortPolicy, LegacyValue, MResult, MechError, OperationContractDeclaration,
-    OutputConstruction, OutputPortPolicy, ParsedProgram, Register, ShapeRule, ValueCell, ValueKind,
-    compare_application_requirements, compile_value_register, hash_str,
-    value_kind_from_runtime_type, write_bytecode,
+    CompiledMatrixLiteral, ComputePlacement, DeliveryMode, EncodedConstant, ExternalInteraction,
+    InputPortLayout, InputPortPolicy, LegacyValue, MResult, MechError,
+    OperationContractDeclaration, OutputConstruction, OutputPortPolicy, ParsedProgram, Register,
+    ShapeRule, ValueCell, ValueKind, compare_application_requirements, compile_value_register,
+    hash_str, value_kind_from_runtime_type, write_bytecode,
 };
 
 static PURE_COMPOSITE_PACK_CONTRACT: LazyLock<OperationContractDeclaration> =
@@ -114,6 +114,9 @@ pub struct CompiledBytecode {
     /// register space. This is compilation sidecar metadata, not an
     /// executable instruction.
     pub register_state_initializers: Vec<Option<u32>>,
+    /// Generic matrix constructions keyed by their destination register.
+    /// This semantic sidecar is intentionally not serialized in bytecode v1.
+    pub matrix_literals: BTreeMap<Register, CompiledMatrixLiteral>,
     /// Exact first-definition order, unlike the canonically sorted symbol map.
     pub symbol_definitions: Vec<CompiledSymbolDefinition>,
     pub return_register: Register,
@@ -157,6 +160,8 @@ pub struct CompileCtx {
     register_kinds: BTreeMap<Register, ValueKind>,
     register_collection_cardinalities: BTreeMap<Register, usize>,
     register_state_initializers: BTreeMap<Register, u32>,
+    matrix_literals: BTreeMap<Register, CompiledMatrixLiteral>,
+    runtime_produced_registers: BTreeSet<Register>,
     next_register_kind_override: Option<ValueKind>,
     symbol_definitions: Vec<CompiledSymbolDefinition>,
     current_node_kind: Option<CompiledNodeKind>,
@@ -191,6 +196,8 @@ impl Default for CompileCtx {
             register_kinds: BTreeMap::new(),
             register_collection_cardinalities: BTreeMap::new(),
             register_state_initializers: BTreeMap::new(),
+            matrix_literals: BTreeMap::new(),
+            runtime_produced_registers: BTreeSet::new(),
             next_register_kind_override: None,
             symbol_definitions: Vec::new(),
             current_node_kind: None,
@@ -648,6 +655,7 @@ impl CompileCtx {
             register_kinds,
             register_collection_cardinalities,
             register_state_initializers,
+            matrix_literals: self.matrix_literals.clone(),
             symbol_definitions: self.symbol_definitions.clone(),
             return_register,
             integrity_constraints: self.integrity_constraints.clone(),
@@ -881,10 +889,51 @@ impl BytecodeCompilerContext for CompileCtx {
             ));
         }
         let Some((index, constant)) = initializers.first().copied() else {
+            self.matrix_literals.remove(&register);
+            self.runtime_produced_registers.insert(register);
             return Ok(());
         };
         self.remove_instruction(index);
         self.remove_constant_if_unreferenced(constant);
+        self.matrix_literals.remove(&register);
+        self.runtime_produced_registers.insert(register);
+        Ok(())
+    }
+
+    fn record_matrix_literal(&mut self, literal: CompiledMatrixLiteral) -> MResult<()> {
+        if literal.output >= self.next_register {
+            return invalid(format!(
+                "matrix literal output register {} is outside register count {}",
+                literal.output, self.next_register,
+            ));
+        }
+        if let Some(element) = literal
+            .elements
+            .iter()
+            .find(|element| element.register() >= self.next_register)
+        {
+            return invalid(format!(
+                "matrix literal element register {} is outside register count {}",
+                element.register(),
+                self.next_register,
+            ));
+        }
+        if self.runtime_produced_registers.contains(&literal.output) {
+            return invalid(format!(
+                "runtime-produced register {} has no executable matrix literal construction",
+                literal.output,
+            ));
+        }
+        if let Some(existing) = self.matrix_literals.get(&literal.output) {
+            if existing != &literal {
+                return invalid(format!(
+                    "matrix literal output register {} has conflicting descriptors",
+                    literal.output,
+                ));
+            }
+            return Ok(());
+        }
+        self.matrix_literals.insert(literal.output, literal);
         Ok(())
     }
 
@@ -1371,6 +1420,87 @@ mod tests {
         assert_eq!(
             context.register_for_ptr_with_initialization_status(100),
             (0, true),
+        );
+    }
+
+    #[test]
+    fn matrix_literal_descriptors_are_deterministic_and_emit_no_instructions() {
+        let mut context = CompileCtx::new();
+        let registers = allocate_registers(&mut context, 3);
+        let literal = CompiledMatrixLiteral::new(
+            registers[2],
+            1,
+            2,
+            vec![
+                crate::CompiledMatrixLiteralElement::Value {
+                    register: registers[0],
+                },
+                crate::CompiledMatrixLiteralElement::Value {
+                    register: registers[1],
+                },
+            ]
+            .into_boxed_slice(),
+        )
+        .unwrap();
+
+        context.record_matrix_literal(literal.clone()).unwrap();
+        context.record_matrix_literal(literal.clone()).unwrap();
+        assert!(context.instructions.is_empty());
+
+        let conflicting = CompiledMatrixLiteral::new(
+            registers[2],
+            1,
+            2,
+            vec![
+                crate::CompiledMatrixLiteralElement::Value {
+                    register: registers[1],
+                },
+                crate::CompiledMatrixLiteralElement::Value {
+                    register: registers[0],
+                },
+            ]
+            .into_boxed_slice(),
+        )
+        .unwrap();
+        let error = context.record_matrix_literal(conflicting).unwrap_err();
+        assert!(error.kind_message().contains("conflicting descriptors"));
+
+        let compiled = context.finish_program(registers[2]).unwrap();
+        assert_eq!(compiled.matrix_literals.get(&registers[2]), Some(&literal));
+    }
+
+    #[test]
+    fn matrix_literal_descriptor_requires_allocated_non_runtime_registers() {
+        let mut context = CompileCtx::new();
+        let registers = allocate_registers(&mut context, 2);
+        let unallocated_output = CompiledMatrixLiteral::new(2, 0, 0, Box::new([])).unwrap();
+        assert!(
+            context
+                .record_matrix_literal(unallocated_output)
+                .unwrap_err()
+                .kind_message()
+                .contains("outside register count")
+        );
+
+        context
+            .record_runtime_produced_register(registers[1])
+            .unwrap();
+        let runtime_output = CompiledMatrixLiteral::new(
+            registers[1],
+            1,
+            1,
+            vec![crate::CompiledMatrixLiteralElement::Value {
+                register: registers[0],
+            }]
+            .into_boxed_slice(),
+        )
+        .unwrap();
+        assert!(
+            context
+                .record_matrix_literal(runtime_output)
+                .unwrap_err()
+                .kind_message()
+                .contains("no executable matrix literal construction")
         );
     }
 

--- a/src/core/src/program/compiler/context.rs
+++ b/src/core/src/program/compiler/context.rs
@@ -900,6 +900,10 @@ impl BytecodeCompilerContext for CompileCtx {
         Ok(())
     }
 
+    fn register_is_runtime_produced(&self, register: Register) -> bool {
+        self.runtime_produced_registers.contains(&register)
+    }
+
     fn record_matrix_literal(&mut self, literal: CompiledMatrixLiteral) -> MResult<()> {
         if literal.output >= self.next_register {
             return invalid(format!(

--- a/src/core/src/program/compiler/mod.rs
+++ b/src/core/src/program/compiler/mod.rs
@@ -1,9 +1,11 @@
 pub mod api;
 mod constants;
+mod construction;
 pub mod context;
 
 pub use self::api::*;
 pub use self::constants::*;
+pub use self::construction::*;
 pub use self::context::*;
 
 pub type Register = u32;

--- a/src/core/src/structures/matrix.rs
+++ b/src/core/src/structures/matrix.rs
@@ -1640,6 +1640,12 @@ macro_rules! impl_to_value_for_matrix {
 }
 
 impl_to_value_for_matrix!(LegacyValue, MatrixValue);
+#[cfg(feature = "matrixd")]
+impl ToValue for Ref<DMatrix<LegacyValue>> {
+    fn to_value(&self) -> LegacyValue {
+        Matrix::DMatrix(self.clone()).to_value()
+    }
+}
 #[cfg(feature = "f64")]
 impl_to_value_for_matrix!(f64, MatrixF64);
 #[cfg(feature = "f32")]

--- a/src/core/src/value_snapshot.rs
+++ b/src/core/src/value_snapshot.rs
@@ -5,6 +5,40 @@ use core::fmt::Debug;
 
 use crate::{LegacyValue, MResult, MechError, MechErrorKind, Ref};
 
+impl LegacyValue {
+    /// Returns an exact legacy kind literal without formatting or reparsing.
+    pub fn legacy_kind_literal(&self) -> Option<&crate::ValueKind> {
+        match self {
+            LegacyValue::Kind(kind) => Some(kind),
+            _ => None,
+        }
+    }
+
+    pub fn is_legacy_empty(&self) -> bool {
+        matches!(self, LegacyValue::Empty)
+    }
+
+    pub fn legacy_empty_kind(&self) -> Option<&crate::ValueKind> {
+        match self {
+            LegacyValue::EmptyKind(kind) => Some(kind),
+            _ => None,
+        }
+    }
+
+    pub fn is_legacy_index_all(&self) -> bool {
+        matches!(self, LegacyValue::IndexAll)
+    }
+
+    /// Returns the exact compatibility cell stored by an outer legacy mutable
+    /// reference. Callers must keep the resulting borrow local.
+    pub fn legacy_mutable_reference(&self) -> Option<&Ref<LegacyValue>> {
+        match self {
+            LegacyValue::MutableReference(reference) => Some(reference),
+            _ => None,
+        }
+    }
+}
+
 #[cfg(feature = "enum")]
 use crate::MechEnum;
 #[cfg(feature = "map")]
@@ -457,6 +491,21 @@ impl ValueSnapshotCloneContext {
     }
 
     fn snapshot_value(&mut self, source: &LegacyValue) -> MResult<LegacyValue> {
+        if let Some(reference) = source.legacy_mutable_reference() {
+            return self.snapshot_mutable_reference(reference);
+        }
+        if let Some(kind) = source.legacy_kind_literal() {
+            return Ok(LegacyValue::Kind(kind.clone()));
+        }
+        if source.is_legacy_index_all() {
+            return Ok(LegacyValue::IndexAll);
+        }
+        if let Some(kind) = source.legacy_empty_kind() {
+            return Ok(LegacyValue::EmptyKind(kind.clone()));
+        }
+        if source.is_legacy_empty() {
+            return Ok(LegacyValue::Empty);
+        }
         match source {
             #[cfg(feature = "u8")]
             LegacyValue::U8(value) => Ok(LegacyValue::U8(self.snapshot_leaf(value, "u8")?)),
@@ -670,15 +719,11 @@ impl ValueSnapshotCloneContext {
             LegacyValue::Index(value) => {
                 Ok(LegacyValue::Index(self.snapshot_leaf(value, "index")?))
             }
-            LegacyValue::MutableReference(value) => self.snapshot_mutable_reference(value),
             LegacyValue::Typed(value, kind) => Ok(LegacyValue::Typed(
                 Box::new(self.snapshot_value(value)?),
                 kind.clone(),
             )),
-            LegacyValue::Kind(kind) => Ok(LegacyValue::Kind(kind.clone())),
-            LegacyValue::IndexAll => Ok(LegacyValue::IndexAll),
-            LegacyValue::EmptyKind(kind) => Ok(LegacyValue::EmptyKind(kind.clone())),
-            LegacyValue::Empty => Ok(LegacyValue::Empty),
+            _ => unreachable!("legacy pseudo-values are normalized before snapshot matching"),
         }
     }
 }

--- a/src/engine/src/artifact/compiler.rs
+++ b/src/engine/src/artifact/compiler.rs
@@ -20,7 +20,8 @@ use mech_core::{
 
 #[cfg(feature = "semantic-compiler")]
 use crate::{
-    CompiledBytecode, CompiledInstructionRole, CompiledNodeKind, CompiledSymbolDefinition,
+    CompiledBytecode, CompiledInstructionRole, CompiledMatrixLiteralElement, CompiledNodeKind,
+    CompiledSymbolDefinition,
 };
 #[cfg(feature = "semantic-compiler")]
 use mech_core::snapshot::SnapshotValidationContext;
@@ -31,9 +32,9 @@ use mech_core::{
     DimensionEnvironmentBuilder, DimensionExpr, ExternalInteraction, FunctionCatalog,
     InputPortLayout, InputPortPolicy, KindId, LegacyEmptyPolicy, LegacyExtentRole,
     LegacyExtentSite, LegacyNominalResolution, LegacyReferencePolicy, LegacyResolvedExtent,
-    LegacySemanticContext, LegacySnapshotContext, NamedKindPathResolver, NominalKind,
+    LegacySemanticContext, LegacySnapshotContext, LegacyValue, NamedKindPathResolver, NominalKind,
     OperationContractError, OutputConstruction, OutputPortPolicy, Register, SchemaBody,
-    SchemaHandle, SchemaTableBuilder, SemanticModelError, ShapeRule, ValueKind,
+    SchemaHandle, SchemaTableBuilder, SemanticModelError, ShapeRule, Value, ValueKind,
     schema_from_legacy_value_kind, snapshot_from_legacy,
 };
 
@@ -41,9 +42,10 @@ use mech_core::{
 use super::ComputeRegionDeclaration;
 use super::{
     ApplicationRequirementTable, ArtifactBuildError, ArtifactSource, BindingDeclaration,
-    InitializerReference, InputDeclaration, IntegrityConstraintDeclaration,
-    InteractiveSymbolBinding, NodeDeclaration, OperationReference, OutputDeclaration,
-    ProducerReference, ProgramArtifact, ProgramArtifactDraft, SlotDeclaration, SlotRole,
+    CompilerIrError, ExpressionIR, InitializerReference, InputDeclaration,
+    IntegrityConstraintDeclaration, InteractiveSymbolBinding, MatrixLiteralIR, NodeDeclaration,
+    OperationReference, OutputDeclaration, ProducerReference, ProgramArtifact,
+    ProgramArtifactDraft, SlotDeclaration, SlotRole,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -52,6 +54,15 @@ pub enum SourceValue {
     Input(u32),
     State(u32),
     NodeOutput { node: u32, output_ordinal: u16 },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct SourceMatrixLiteral {
+    rows: u64,
+    columns: u64,
+    // `None` is the compiler-only empty expression; `Some` retains a source
+    // identity until artifact slots have been allocated.
+    elements: Box<[Option<SourceValue>]>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -104,6 +115,32 @@ static COMPILER_STATE_HOLD_CONTRACT: LazyLock<OperationContractDeclaration> =
         .into_boxed_slice(),
         interaction: ExternalInteraction::Pure,
     });
+
+#[cfg(feature = "semantic-compiler")]
+fn matrix_literal_contract(element_count: usize) -> OperationContractDeclaration {
+    OperationContractDeclaration {
+        inputs: InputPortLayout::Fixed(
+            (0..element_count)
+                .map(|_| InputPortPolicy {
+                    access: AccessMode::Read,
+                    delivery: DeliveryMode::Signal,
+                })
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        ),
+        outputs: vec![OutputPortPolicy {
+            access: AccessMode::Write,
+            delivery: DeliveryMode::Signal,
+            construction: OutputConstruction::FullWrite {
+                shape: ShapeRule::Declared,
+            },
+            alias: AliasPolicy::NoAlias,
+            change_detection: ChangeDetectionPolicy::AlwaysChanged,
+        }]
+        .into_boxed_slice(),
+        interaction: ExternalInteraction::Pure,
+    }
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SourceOutput {
@@ -212,8 +249,24 @@ pub fn compile_source_program(
 pub fn compile_source_program_with_contracts(
     graph: &SourceProgram,
     context: &mut ArtifactBuildContext<'_>,
-    node_contracts: &[Option<&'static OperationContractDeclaration>],
+    node_contracts: &[Option<&OperationContractDeclaration>],
 ) -> Result<ProgramArtifact, ArtifactBuildError> {
+    compile_source_program_with_metadata(graph, context, node_contracts, &[])
+}
+
+fn compile_source_program_with_metadata(
+    graph: &SourceProgram,
+    context: &mut ArtifactBuildContext<'_>,
+    node_contracts: &[Option<&OperationContractDeclaration>],
+    node_matrix_literals: &[Option<SourceMatrixLiteral>],
+) -> Result<ProgramArtifact, ArtifactBuildError> {
+    if !node_matrix_literals.is_empty() && node_matrix_literals.len() != graph.nodes.len() {
+        return Err(ArtifactBuildError::CompiledMetadataLengthMismatch {
+            table: "node_matrix_literals",
+            expected: graph.nodes.len(),
+            actual: node_matrix_literals.len(),
+        });
+    }
     let input_count = checked_u32(graph.inputs.len(), "InputId")?;
     let state_count = checked_u32(graph.states.len(), "CellSlotId")?;
     let mut next_slot = input_count.checked_add(state_count).ok_or(
@@ -315,13 +368,50 @@ pub fn compile_source_program_with_contracts(
     for (node_index, declaration) in graph.nodes.iter().enumerate() {
         let node = NodeId(checked_u32(node_index, "NodeId")?);
         let input_start = checked_u32(bindings.len(), "BindingId")?;
-        for (ordinal, source) in declaration.inputs.iter().enumerate() {
+        let matrix_ir = node_matrix_literals
+            .get(node_index)
+            .and_then(Option::as_ref)
+            .map(|literal| {
+                resolve_source_matrix_literal(literal, &input_slots, &state_slots, &output_slots)
+            })
+            .transpose()?;
+        let resolved_inputs = if let Some(matrix_ir) = &matrix_ir {
+            if matrix_ir.elements.len() != declaration.inputs.len() {
+                return Err(ArtifactBuildError::CompiledMetadataLengthMismatch {
+                    table: "matrix_literal_elements",
+                    expected: declaration.inputs.len(),
+                    actual: matrix_ir.elements.len(),
+                });
+            }
+            matrix_ir
+                .elements
+                .iter()
+                .enumerate()
+                .map(|(index, expression)| match expression {
+                    ExpressionIR::Constant(constant) => Ok(ArtifactSource::Constant(*constant)),
+                    ExpressionIR::Slot(slot) => Ok(ArtifactSource::Slot(*slot)),
+                    ExpressionIR::Empty => {
+                        Err(CompilerIrError::DynamicEmptyMatrixLiteralUnsupported { index }.into())
+                    }
+                    ExpressionIR::MatrixLiteral(_) | ExpressionIR::Selection(_) => {
+                        Err(CompilerIrError::UnresolvedMatrixLiteralElement { index }.into())
+                    }
+                })
+                .collect::<Result<Vec<_>, ArtifactBuildError>>()?
+        } else {
+            declaration
+                .inputs
+                .iter()
+                .map(|source| resolve_source(*source, &input_slots, &state_slots, &output_slots))
+                .collect::<Result<Vec<_>, ArtifactBuildError>>()?
+        };
+        for (ordinal, source) in resolved_inputs.into_iter().enumerate() {
             let id = BindingId(checked_u32(bindings.len(), "BindingId")?);
             bindings.push(BindingDeclaration::Input {
                 id,
                 node,
                 port_ordinal: checked_u16(ordinal, "input port ordinal")?,
-                source: resolve_source(*source, &input_slots, &state_slots, &output_slots)?,
+                source,
             });
         }
         let input_end = checked_u32(bindings.len(), "BindingId")?;
@@ -467,6 +557,82 @@ pub fn compile_source_program_with_contracts(
 struct RegisterSemantic {
     source: SourceValue,
     schema: SchemaId,
+}
+
+#[cfg(feature = "semantic-compiler")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RegisterMatrixLiteralElement {
+    Empty,
+    Constant(ConstantId),
+    Register(Register),
+}
+
+#[cfg(feature = "semantic-compiler")]
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct RegisterMatrixLiteral {
+    rows: u64,
+    columns: u64,
+    elements: Box<[RegisterMatrixLiteralElement]>,
+}
+
+#[cfg(feature = "semantic-compiler")]
+impl RegisterMatrixLiteral {
+    fn constant_ir(&self) -> Option<MatrixLiteralIR> {
+        let elements = self
+            .elements
+            .iter()
+            .map(|element| match element {
+                RegisterMatrixLiteralElement::Empty => Some(ExpressionIR::Empty),
+                RegisterMatrixLiteralElement::Constant(constant) => {
+                    Some(ExpressionIR::Constant(*constant))
+                }
+                RegisterMatrixLiteralElement::Register(_) => None,
+            })
+            .collect::<Option<Vec<_>>>()?;
+        Some(MatrixLiteralIR {
+            rows: self.rows,
+            columns: self.columns,
+            elements: elements.into_boxed_slice(),
+        })
+    }
+
+    fn contains_empty(&self) -> bool {
+        self.elements
+            .iter()
+            .any(|element| matches!(element, RegisterMatrixLiteralElement::Empty))
+    }
+}
+
+#[cfg(feature = "semantic-compiler")]
+fn source_matrix_literal_from_registers(
+    literal: &RegisterMatrixLiteral,
+    registers: &[Option<RegisterSemantic>],
+    instruction: u32,
+) -> Result<SourceMatrixLiteral, ArtifactBuildError> {
+    let elements = literal
+        .elements
+        .iter()
+        .map(|element| match element {
+            RegisterMatrixLiteralElement::Empty => Ok(None),
+            RegisterMatrixLiteralElement::Constant(constant) => {
+                Ok(Some(SourceValue::Constant(*constant)))
+            }
+            RegisterMatrixLiteralElement::Register(input_register) => {
+                register(registers, *input_register)?
+                    .map(|semantic| Some(semantic.source))
+                    .ok_or(ArtifactBuildError::MissingRegisterSource {
+                        instruction,
+                        register: *input_register,
+                        role: "matrix literal input",
+                    })
+            }
+        })
+        .collect::<Result<Vec<_>, ArtifactBuildError>>()?;
+    Ok(SourceMatrixLiteral {
+        rows: literal.rows,
+        columns: literal.columns,
+        elements: elements.into_boxed_slice(),
+    })
 }
 
 #[cfg(feature = "semantic-compiler")]
@@ -678,6 +844,328 @@ pub(crate) fn compile_legacy_bytecode_program_artifact_with_outputs(
 }
 
 #[cfg(feature = "semantic-compiler")]
+fn matrix_literal_mismatch(output: Register, reason: &'static str) -> ArtifactBuildError {
+    ArtifactBuildError::MatrixLiteralMetadataMismatch { output, reason }
+}
+
+#[cfg(feature = "semantic-compiler")]
+fn validate_compiled_matrix_literals(
+    compiled: &CompiledBytecode,
+    constants: &[LegacyValue],
+) -> Result<BTreeMap<Register, usize>, ArtifactBuildError> {
+    let mut instructions = BTreeMap::new();
+    for (key, literal) in &compiled.matrix_literals {
+        if *key != literal.output {
+            return Err(matrix_literal_mismatch(
+                *key,
+                "sidecar key does not match output",
+            ));
+        }
+        let output = literal.output;
+        if output >= compiled.program.register_count {
+            return Err(matrix_literal_mismatch(
+                output,
+                "output register is out of range",
+            ));
+        }
+        if literal
+            .elements
+            .iter()
+            .any(|element| element.register() >= compiled.program.register_count)
+        {
+            return Err(matrix_literal_mismatch(
+                output,
+                "element register is out of range",
+            ));
+        }
+
+        let writers = compiled
+            .program
+            .instructions
+            .iter()
+            .enumerate()
+            .filter(|(_, instruction)| instruction_destination(instruction) == Some(output))
+            .collect::<Vec<_>>();
+        let [
+            (
+                instruction_index,
+                BytecodeInstruction::CompositePack {
+                    template, children, ..
+                },
+            ),
+        ] = writers.as_slice()
+        else {
+            return Err(matrix_literal_mismatch(
+                output,
+                "output must have exactly one CompositePack writer",
+            ));
+        };
+        let descriptor_children = literal
+            .elements
+            .iter()
+            .map(|element| element.register())
+            .collect::<Vec<_>>();
+        if children != &descriptor_children {
+            return Err(matrix_literal_mismatch(
+                output,
+                "CompositePack children do not match the sidecar",
+            ));
+        }
+        let Some(template_value) = constants.get(*template as usize) else {
+            return Err(matrix_literal_mismatch(
+                output,
+                "CompositePack template constant is out of range",
+            ));
+        };
+        let Some(template_kind) = template_value.legacy_kind_literal() else {
+            return Err(matrix_literal_mismatch(
+                output,
+                "CompositePack template is not a matrix kind",
+            ));
+        };
+        let Some((template_element, template_dimensions)) = template_kind.matrix_parts() else {
+            return Err(matrix_literal_mismatch(
+                output,
+                "CompositePack template is not a matrix kind",
+            ));
+        };
+        let [template_rows, template_columns] = template_dimensions else {
+            return Err(matrix_literal_mismatch(
+                output,
+                "CompositePack matrix template is not rank two",
+            ));
+        };
+        let Some(Some(output_kind)) = compiled.register_kinds.get(output as usize) else {
+            return Err(matrix_literal_mismatch(
+                output,
+                "output register kind is not a matrix",
+            ));
+        };
+        let (output_kind, _) = normalize_legacy_binding_kind(output_kind.clone());
+        let Some((output_element, output_dimensions)) = output_kind.matrix_parts() else {
+            return Err(matrix_literal_mismatch(
+                output,
+                "output register kind is not a matrix",
+            ));
+        };
+        if &output_kind != template_kind {
+            return Err(matrix_literal_mismatch(
+                output,
+                "output register kind does not match the matrix template",
+            ));
+        }
+        if template_element.is_any() || output_element.is_any() {
+            let mut expected = None;
+            for (index, element) in literal.elements.iter().enumerate() {
+                let CompiledMatrixLiteralElement::Value { register } = element else {
+                    continue;
+                };
+                let Some(Some(kind)) = compiled.register_kinds.get(*register as usize) else {
+                    return Err(matrix_literal_mismatch(
+                        output,
+                        "matrix element register has no value kind",
+                    ));
+                };
+                let (kind, _) = normalize_legacy_binding_kind(kind.clone());
+                match &expected {
+                    None => expected = Some(kind),
+                    Some(expected) if expected == &kind => {}
+                    Some(_) => {
+                        return Err(CompilerIrError::HeterogeneousMatrixLiteral { index }.into());
+                    }
+                }
+            }
+        }
+        let [output_rows, output_columns] = output_dimensions else {
+            return Err(matrix_literal_mismatch(
+                output,
+                "output register matrix kind is not rank two",
+            ));
+        };
+        let literal_rows = usize::try_from(literal.rows).map_err(|_| {
+            matrix_literal_mismatch(output, "matrix literal row count exceeds usize")
+        })?;
+        let literal_columns = usize::try_from(literal.columns).map_err(|_| {
+            matrix_literal_mismatch(output, "matrix literal column count exceeds usize")
+        })?;
+        if [*template_rows, *template_columns] != [literal_rows, literal_columns]
+            || [*output_rows, *output_columns] != [literal_rows, literal_columns]
+        {
+            return Err(matrix_literal_mismatch(
+                output,
+                "matrix kind dimensions do not match the sidecar",
+            ));
+        }
+        for element in &literal.elements {
+            let register = element.register();
+            let constant = compiled
+                .program
+                .instructions
+                .iter()
+                .find_map(|instruction| match instruction {
+                    BytecodeInstruction::ConstLoad { dst, constant } if *dst == register => {
+                        Some(*constant)
+                    }
+                    _ => None,
+                });
+            match element {
+                CompiledMatrixLiteralElement::Empty { .. } => {
+                    if !constant
+                        .and_then(|constant| constants.get(constant as usize))
+                        .is_some_and(LegacyValue::is_legacy_empty)
+                    {
+                        return Err(matrix_literal_mismatch(
+                            output,
+                            "empty element does not reference an Empty constant",
+                        ));
+                    }
+                }
+                CompiledMatrixLiteralElement::Value { .. } => {
+                    if constant
+                        .and_then(|constant| constants.get(constant as usize))
+                        .is_some_and(LegacyValue::is_legacy_empty)
+                    {
+                        return Err(matrix_literal_mismatch(
+                            output,
+                            "value element references an Empty constant",
+                        ));
+                    }
+                }
+            }
+        }
+        instructions.insert(output, *instruction_index);
+    }
+
+    let empty_registers = compiled
+        .matrix_literals
+        .values()
+        .flat_map(|literal| literal.elements.iter())
+        .filter_map(|element| match element {
+            CompiledMatrixLiteralElement::Empty { register } => Some(*register),
+            CompiledMatrixLiteralElement::Value { .. } => None,
+        })
+        .collect::<BTreeSet<_>>();
+    for register in empty_registers {
+        for (instruction_index, instruction) in compiled.program.instructions.iter().enumerate() {
+            match instruction {
+                BytecodeInstruction::ConstLoad { dst, .. } if *dst == register => {}
+                BytecodeInstruction::CompositePack { dst, children, .. } => {
+                    for (index, child) in children.iter().enumerate() {
+                        if *child != register {
+                            continue;
+                        }
+                        let allowed = compiled
+                            .matrix_literals
+                            .get(dst)
+                            .and_then(|literal| literal.elements.get(index))
+                            .is_some_and(|element| {
+                                matches!(
+                                    element,
+                                    CompiledMatrixLiteralElement::Empty { register: empty }
+                                        if *empty == register
+                                )
+                            });
+                        if !allowed {
+                            return Err(ArtifactBuildError::UnresolvedEmptyRegister { register });
+                        }
+                    }
+                }
+                _ if instruction_input_registers(instruction).contains(&register) => {
+                    let _ = instruction_index;
+                    return Err(ArtifactBuildError::UnresolvedEmptyRegister { register });
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(instructions)
+}
+
+#[cfg(feature = "semantic-compiler")]
+fn instruction_input_registers(instruction: &BytecodeInstruction) -> Vec<Register> {
+    match instruction {
+        BytecodeInstruction::ConstLoad { .. }
+        | BytecodeInstruction::RuntimeNullary { .. }
+        | BytecodeInstruction::ResourceRead { .. } => Vec::new(),
+        BytecodeInstruction::CompositePack { children, .. }
+        | BytecodeInstruction::RuntimeVariadic {
+            arguments: children,
+            ..
+        }
+        | BytecodeInstruction::HostCall {
+            arguments: children,
+            ..
+        } => children.clone(),
+        BytecodeInstruction::RuntimeUnary { src, .. }
+        | BytecodeInstruction::ResourceWrite { src, .. }
+        | BytecodeInstruction::ResourceSend { src, .. }
+        | BytecodeInstruction::Return { src } => vec![*src],
+        BytecodeInstruction::RuntimeBinary { lhs, rhs, .. } => vec![*lhs, *rhs],
+        BytecodeInstruction::RuntimeTernary { a, b, c, .. } => vec![*a, *b, *c],
+        BytecodeInstruction::RuntimeQuaternary { a, b, c, d, .. } => vec![*a, *b, *c, *d],
+    }
+}
+
+#[cfg(feature = "semantic-compiler")]
+fn constant_for_register(
+    register: Register,
+    register_schemas: &[Option<SchemaId>],
+    constants: &BTreeMap<(u32, SchemaId), ConstantId>,
+    instructions: &[BytecodeInstruction],
+) -> Option<ConstantId> {
+    let schema = register_schemas.get(register as usize).copied().flatten()?;
+    let encoded = instructions
+        .iter()
+        .find_map(|instruction| match instruction {
+            BytecodeInstruction::ConstLoad { dst, constant } if *dst == register => Some(*constant),
+            BytecodeInstruction::CompositePack { dst, template, .. } if *dst == register => {
+                Some(*template)
+            }
+            _ => None,
+        })?;
+    constants.get(&(encoded, schema)).copied()
+}
+
+#[cfg(feature = "semantic-compiler")]
+fn extend_constant_store_with_matrix_literals(
+    schemas: &SchemaTable,
+    constants: &ConstantStore,
+    matrices: BTreeMap<Register, Value>,
+) -> Result<
+    (
+        ConstantStore,
+        BTreeMap<ConstantId, ConstantId>,
+        BTreeMap<Register, ConstantId>,
+    ),
+    ArtifactBuildError,
+> {
+    let mut builder = ConstantStoreBuilder::new(schemas);
+    let mut existing = BTreeMap::new();
+    for raw in 0..constants.len() {
+        let old = ConstantId::new(checked_u32(raw, "ConstantId")?);
+        let value = constants
+            .get(old)
+            .ok_or(ArtifactBuildError::UnknownConstant { constant: old })?;
+        existing.insert(old, builder.insert(value.clone())?);
+    }
+    let mut matrix_handles = BTreeMap::new();
+    for (register, value) in matrices {
+        matrix_handles.insert(register, builder.insert(value)?);
+    }
+    let build = builder.finish()?;
+    let existing = existing
+        .into_iter()
+        .map(|(old, handle)| Ok((old, build.resolve(handle)?)))
+        .collect::<Result<BTreeMap<_, _>, ArtifactBuildError>>()?;
+    let matrices = matrix_handles
+        .into_iter()
+        .map(|(register, handle)| Ok((register, build.resolve(handle)?)))
+        .collect::<Result<BTreeMap<_, _>, ArtifactBuildError>>()?;
+    let (store, _) = build.into_parts();
+    Ok((store, existing, matrices))
+}
+
+#[cfg(feature = "semantic-compiler")]
 fn compile_executable_program_artifact_with_identity(
     compiled: &CompiledBytecode,
     published_outputs: &[Register],
@@ -724,6 +1212,8 @@ fn compile_executable_program_artifact_with_identity(
     validate_compiled_instruction_roles(compiled, catalog)?;
 
     let legacy_constants = mech_core::decode_encoded_constants(&compiled.program.constants)?;
+    let matrix_literal_instructions =
+        validate_compiled_matrix_literals(compiled, &legacy_constants)?;
 
     struct PendingRegisterSchema {
         handle: SchemaHandle,
@@ -863,7 +1353,11 @@ fn compile_executable_program_artifact_with_identity(
     for instruction in &compiled.program.instructions {
         let (register, constant) = match instruction {
             BytecodeInstruction::ConstLoad { dst, constant } => (*dst, *constant),
-            BytecodeInstruction::CompositePack { dst, template, .. } => (*dst, *template),
+            BytecodeInstruction::CompositePack { dst, template, .. }
+                if !compiled.matrix_literals.contains_key(dst) =>
+            {
+                (*dst, *template)
+            }
             _ => continue,
         };
         let register_index = register as usize;
@@ -955,11 +1449,71 @@ fn compile_executable_program_artifact_with_identity(
         constant_handles.insert((constant, schema), constant_builder.insert(value)?);
     }
     let constant_build = constant_builder.finish()?;
-    let constants = constant_handles
+    let mut constants = constant_handles
         .into_iter()
         .map(|(key, handle)| Ok((key, constant_build.resolve(handle)?)))
         .collect::<Result<BTreeMap<_, _>, ArtifactBuildError>>()?;
-    let (constant_store, _) = constant_build.into_parts();
+    let (base_constant_store, _) = constant_build.into_parts();
+
+    let mut register_matrix_literals = BTreeMap::<Register, RegisterMatrixLiteral>::new();
+    let mut folded_matrix_values = BTreeMap::<Register, Value>::new();
+    for literal in compiled.matrix_literals.values() {
+        let elements = literal
+            .elements
+            .iter()
+            .map(|element| match element {
+                CompiledMatrixLiteralElement::Empty { .. } => RegisterMatrixLiteralElement::Empty,
+                CompiledMatrixLiteralElement::Value { register }
+                    if register_constant_roles[*register as usize]
+                        == Some(CompilerConstantRole::Snapshot) =>
+                {
+                    constant_for_register(
+                        *register,
+                        &register_schemas,
+                        &constants,
+                        &compiled.program.instructions,
+                    )
+                    .map(RegisterMatrixLiteralElement::Constant)
+                    .unwrap_or(RegisterMatrixLiteralElement::Register(*register))
+                }
+                CompiledMatrixLiteralElement::Value { register } => {
+                    RegisterMatrixLiteralElement::Register(*register)
+                }
+            })
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        let source_literal = RegisterMatrixLiteral {
+            rows: u64::from(literal.rows),
+            columns: u64::from(literal.columns),
+            elements,
+        };
+        let instruction = matrix_literal_instructions[&literal.output];
+        if let Some(ir) = source_literal.constant_ir()
+            && compiled.instruction_source_nodes[instruction].is_none()
+        {
+            let schema = register_schemas[literal.output as usize].ok_or(
+                ArtifactBuildError::MissingRegisterKind {
+                    instruction: checked_u32(instruction, "instruction")?,
+                    register: literal.output,
+                },
+            )?;
+            folded_matrix_values.insert(
+                literal.output,
+                ir.resolve_constant(schema, &schemas, &base_constant_store)?,
+            );
+        }
+        register_matrix_literals.insert(literal.output, source_literal);
+    }
+
+    let (constant_store, constant_remap, folded_matrix_constants) =
+        extend_constant_store_with_matrix_literals(
+            &schemas,
+            &base_constant_store,
+            folded_matrix_values,
+        )?;
+    for constant in constants.values_mut() {
+        *constant = constant_remap[constant];
+    }
     let explicit_state_initializers = compiled
         .register_state_initializers
         .iter()
@@ -1067,8 +1621,10 @@ fn compile_executable_program_artifact_with_identity(
         let Some(schema) = register_schemas[register as usize] else {
             continue;
         };
-        inferred_state_initializers[register as usize] =
-            constants.get(&(constant, schema)).copied();
+        inferred_state_initializers[register as usize] = folded_matrix_constants
+            .get(&register)
+            .copied()
+            .or_else(|| constants.get(&(constant, schema)).copied());
     }
 
     let mut register_state_indexes = vec![None::<u32>; compiled.program.register_count as usize];
@@ -1110,7 +1666,8 @@ fn compile_executable_program_artifact_with_identity(
     let mut registers = vec![None::<RegisterSemantic>; compiled.program.register_count as usize];
     let mut nodes = Vec::<SourceNode>::new();
     let mut source_node_origins = Vec::<Option<u32>>::new();
-    let mut node_contracts = Vec::<Option<&'static OperationContractDeclaration>>::new();
+    let mut node_contracts = Vec::<Option<OperationContractDeclaration>>::new();
+    let mut node_matrix_literals = Vec::<Option<SourceMatrixLiteral>>::new();
     let mut lowered_declared_source_nodes = std::collections::BTreeSet::new();
 
     // A mutable declaration remains semantic state even when source contains
@@ -1136,12 +1693,142 @@ fn compile_executable_program_artifact_with_identity(
             inputs: vec![SourceValue::State(state)].into_boxed_slice(),
             outputs: vec![SourceNodeOutput::State(state)].into_boxed_slice(),
         });
-        node_contracts.push(Some(&COMPILER_STATE_HOLD_CONTRACT));
+        node_contracts.push(Some((*COMPILER_STATE_HOLD_CONTRACT).clone()));
+        node_matrix_literals.push(None);
     }
 
     for (instruction_index, instruction) in compiled.program.instructions.iter().enumerate() {
         let instruction_id = checked_u32(instruction_index, "instruction")?;
         let role = compiled.instruction_roles[instruction_index];
+        if let BytecodeInstruction::CompositePack { dst, .. } = instruction
+            && let Some(literal) = compiled.matrix_literals.get(dst)
+        {
+            let kind = match role {
+                Some(CompiledInstructionRole::Node(kind)) => kind,
+                Some(role) => {
+                    return Err(ArtifactBuildError::UnexpectedInstructionRole {
+                        instruction: instruction_id,
+                        role: instruction_role_name(role),
+                    });
+                }
+                None => {
+                    return Err(ArtifactBuildError::MissingInstructionRole {
+                        instruction: instruction_id,
+                    });
+                }
+            };
+            if kind != CompiledNodeKind::Combinational {
+                return Err(matrix_literal_mismatch(
+                    *dst,
+                    "matrix literal CompositePack is not combinational",
+                ));
+            }
+            let schema =
+                register_schemas[*dst as usize].ok_or(ArtifactBuildError::MissingRegisterKind {
+                    instruction: instruction_id,
+                    register: *dst,
+                })?;
+            if register_constant_roles[*dst as usize] == Some(CompilerConstantRole::ExternalInput) {
+                let input = input_indexes[*dst as usize].ok_or(
+                    ArtifactBuildError::MissingRegisterSource {
+                        instruction: instruction_id,
+                        register: *dst,
+                        role: "external input",
+                    },
+                )?;
+                set_register(
+                    &mut registers,
+                    *dst,
+                    Some(RegisterSemantic {
+                        source: SourceValue::Input(input),
+                        schema,
+                    }),
+                )?;
+                continue;
+            }
+            if let Some(constant) = folded_matrix_constants.get(dst).copied() {
+                let source = register_state_indexes[*dst as usize]
+                    .map(SourceValue::State)
+                    .unwrap_or(SourceValue::Constant(constant));
+                set_register(
+                    &mut registers,
+                    *dst,
+                    Some(RegisterSemantic { source, schema }),
+                )?;
+                continue;
+            }
+
+            let register_literal = &register_matrix_literals[dst];
+            if register_literal.contains_empty() {
+                let index = register_literal
+                    .elements
+                    .iter()
+                    .position(|element| matches!(element, RegisterMatrixLiteralElement::Empty))
+                    .expect("compiled matrix literals contain no nested expressions");
+                return Err(
+                    super::CompilerIrError::DynamicEmptyMatrixLiteralUnsupported { index }.into(),
+                );
+            }
+            let node_index = checked_u32(nodes.len(), "NodeId")?;
+            let state_index = if register_state_indexes[*dst as usize].is_some()
+                && mutable_declaration_instructions[*dst as usize]
+                    .is_some_and(|marker| instruction_index > marker)
+            {
+                let state = register_state_indexes[*dst as usize].ok_or(
+                    ArtifactBuildError::MissingRegisterSource {
+                        instruction: instruction_id,
+                        register: *dst,
+                        role: "state declaration",
+                    },
+                )?;
+                states[state as usize].producer_node = node_index;
+                Some(state)
+            } else {
+                None
+            };
+            let source_literal =
+                source_matrix_literal_from_registers(register_literal, &registers, instruction_id)?;
+            let inputs = source_literal
+                .elements
+                .iter()
+                .filter_map(|element| *element)
+                .collect::<Vec<_>>();
+            if let Some(source_node) = compiled.instruction_source_nodes[instruction_index]
+                && !lowered_declared_source_nodes.insert(source_node)
+            {
+                return Err(ArtifactBuildError::DeclaredSourceNodeLoweringUnsupported {
+                    source_node,
+                });
+            }
+            nodes.push(SourceNode {
+                operation: OperationReference {
+                    module_path: vec!["matrix".to_owned()].into_boxed_slice(),
+                    operation_name: "literal".to_owned(),
+                },
+                requirement: None,
+                inputs: inputs.into_boxed_slice(),
+                outputs: match state_index {
+                    Some(state) => vec![SourceNodeOutput::State(state)],
+                    None => vec![SourceNodeOutput::Derived { schema }],
+                }
+                .into_boxed_slice(),
+            });
+            source_node_origins.push(compiled.instruction_source_nodes[instruction_index]);
+            node_contracts.push(Some(matrix_literal_contract(literal.elements.len())));
+            node_matrix_literals.push(Some(source_literal));
+            let source = state_index
+                .map(SourceValue::State)
+                .unwrap_or(SourceValue::NodeOutput {
+                    node: node_index,
+                    output_ordinal: 0,
+                });
+            set_register(
+                &mut registers,
+                *dst,
+                Some(RegisterSemantic { source, schema }),
+            )?;
+            continue;
+        }
         match instruction {
             BytecodeInstruction::ConstLoad { dst, constant } => {
                 if let Some(role) = role {
@@ -1436,7 +2123,8 @@ fn compile_executable_program_artifact_with_identity(
                     .into_boxed_slice(),
                 });
                 source_node_origins.push(compiled.instruction_source_nodes[instruction_index]);
-                node_contracts.push(declaration);
+                node_contracts.push(declaration.cloned());
+                node_matrix_literals.push(None);
                 if schema.is_none() {
                     set_register(&mut registers, dst, None)?;
                     continue;
@@ -1576,8 +2264,13 @@ fn compile_executable_program_artifact_with_identity(
         });
     }
 
-    let (inputs, mut nodes, mut outputs, mut constraints) =
-        prune_unused_inputs(inputs, nodes, outputs, constraints)?;
+    let (inputs, mut nodes, mut outputs, mut constraints) = prune_unused_inputs(
+        inputs,
+        nodes,
+        outputs,
+        constraints,
+        &mut node_matrix_literals,
+    )?;
     let constant_store = prune_unused_constants(
         &schemas,
         &constant_store,
@@ -1597,10 +2290,15 @@ fn compile_executable_program_artifact_with_identity(
         outputs: outputs.into_boxed_slice(),
         constraints: constraints.into_boxed_slice(),
     };
-    let artifact = compile_source_program_with_contracts(
+    let node_contract_refs = node_contracts
+        .iter()
+        .map(Option::as_ref)
+        .collect::<Vec<_>>();
+    let artifact = compile_source_program_with_metadata(
         &source,
         &mut ArtifactBuildContext::new(&schemas, &constant_store),
-        &node_contracts,
+        &node_contract_refs,
+        &node_matrix_literals,
     )?;
     let compute_regions = compiled
         .compute_regions
@@ -1752,6 +2450,7 @@ fn prune_unused_inputs(
     mut nodes: Vec<SourceNode>,
     mut outputs: Vec<SourceOutput>,
     mut constraints: Vec<SourceIntegrityConstraint>,
+    node_matrix_literals: &mut [Option<SourceMatrixLiteral>],
 ) -> Result<
     (
         Vec<SourceInput>,
@@ -1799,6 +2498,13 @@ fn prune_unused_inputs(
     for node in &mut nodes {
         for source in &mut node.inputs {
             remap_value(source);
+        }
+    }
+    for literal in node_matrix_literals.iter_mut().flatten() {
+        for element in &mut literal.elements {
+            if let Some(source) = element {
+                remap_value(source);
+            }
         }
     }
     for output in &mut outputs {
@@ -2406,6 +3112,30 @@ fn instruction_semantics(
     Ok(Some(semantics))
 }
 
+fn resolve_source_matrix_literal(
+    literal: &SourceMatrixLiteral,
+    inputs: &[CellSlotId],
+    states: &[CellSlotId],
+    outputs: &BTreeMap<(u32, u16), CellSlotId>,
+) -> Result<MatrixLiteralIR, ArtifactBuildError> {
+    let elements = literal
+        .elements
+        .iter()
+        .map(|element| match element {
+            None => Ok(ExpressionIR::Empty),
+            Some(source) => Ok(match resolve_source(*source, inputs, states, outputs)? {
+                ArtifactSource::Constant(constant) => ExpressionIR::Constant(constant),
+                ArtifactSource::Slot(slot) => ExpressionIR::Slot(slot),
+            }),
+        })
+        .collect::<Result<Vec<_>, ArtifactBuildError>>()?;
+    Ok(MatrixLiteralIR {
+        rows: literal.rows,
+        columns: literal.columns,
+        elements: elements.into_boxed_slice(),
+    })
+}
+
 fn resolve_source(
     source: SourceValue,
     inputs: &[CellSlotId],
@@ -2444,4 +3174,42 @@ fn checked_u32(value: usize, identity: &'static str) -> Result<u32, ArtifactBuil
 
 fn checked_u16(value: usize, identity: &'static str) -> Result<u16, ArtifactBuildError> {
     u16::try_from(value).map_err(|_| ArtifactBuildError::ArtifactIdentityExhausted { identity })
+}
+
+#[cfg(all(test, feature = "semantic-compiler"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matrix_ir_slots_use_resolved_artifact_identity_not_register_numbers() {
+        let mut registers = vec![None; 10];
+        registers[9] = Some(RegisterSemantic {
+            source: SourceValue::Input(0),
+            schema: SchemaId::new(0),
+        });
+        let register_literal = RegisterMatrixLiteral {
+            rows: 1,
+            columns: 1,
+            elements: vec![RegisterMatrixLiteralElement::Register(9)].into_boxed_slice(),
+        };
+
+        let source_literal =
+            source_matrix_literal_from_registers(&register_literal, &registers, 0).unwrap();
+        let ir = resolve_source_matrix_literal(
+            &source_literal,
+            &[CellSlotId::new(0)],
+            &[],
+            &BTreeMap::new(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            ir.elements.as_ref(),
+            [ExpressionIR::Slot(CellSlotId::new(0))]
+        );
+        assert_ne!(
+            ir.elements.as_ref(),
+            [ExpressionIR::Slot(CellSlotId::new(9))]
+        );
+    }
 }

--- a/src/engine/src/artifact/compiler.rs
+++ b/src/engine/src/artifact/compiler.rs
@@ -884,7 +884,13 @@ fn validate_compiled_matrix_literals(
             .instructions
             .iter()
             .enumerate()
-            .filter(|(_, instruction)| instruction_destination(instruction) == Some(output))
+            .filter(|(index, instruction)| {
+                instruction_destination(instruction) == Some(output)
+                    && !matches!(
+                        compiled.instruction_roles[*index],
+                        Some(CompiledInstructionRole::DeclarationMarker)
+                    )
+            })
             .collect::<Vec<_>>();
         let [
             (

--- a/src/engine/src/artifact/ir.rs
+++ b/src/engine/src/artifact/ir.rs
@@ -1,7 +1,7 @@
-use mech_core::snapshot::SnapshotValidationContext;
+use mech_core::snapshot::{OptionDraft, SnapshotValidationContext};
 use mech_core::{
-    CellSlotId, ConstantId, ConstantStore, DimensionExpr, LegacyValue, SchemaBody, SchemaDraft,
-    SchemaId, SchemaTable, SnapshotValueError, Value, ValueDataDraft, ValueDraft,
+    CellSlotId, ConstantId, ConstantStore, DimensionExpr, SchemaBody, SchemaDraft, SchemaId,
+    SchemaTable, SnapshotValueError, Value, ValueDataDraft, ValueDraft,
 };
 
 use super::snapshot::data_draft;
@@ -35,40 +35,36 @@ pub enum SelectionIR {
 
 #[derive(Debug)]
 pub enum CompilerIrError {
-    PseudoValueNotCompilerIr,
     UnknownSchema {
         schema: SchemaId,
     },
     UnknownConstant {
         constant: ConstantId,
     },
-    MatrixSchemaRequired {
-        schema: SchemaId,
-    },
+    MatrixLiteralSchemaNotMatrix,
     DynamicMatrixSchemaUnsupported {
-        schema: SchemaId,
-    },
-    MatrixLiteralRankMismatch {
         schema: SchemaId,
     },
     MatrixLiteralShapeMismatch {
         expected_rows: u64,
         expected_columns: u64,
-        found_rows: u64,
-        found_columns: u64,
+        actual_elements: usize,
+    },
+    MatrixLiteralSchemaShapeMismatch {
+        ir_rows: u64,
+        ir_columns: u64,
     },
     MatrixLiteralCardinalityOverflow,
-    MatrixLiteralElementCount {
-        expected: u64,
-        found: usize,
-    },
-    LegacyMatrixLiteralRank {
-        rank: usize,
-    },
-    MatrixLiteralElementNotConstant {
+    EmptyMatrixLiteralElementRequiresOption {
         index: usize,
     },
     HeterogeneousMatrixLiteral {
+        index: usize,
+    },
+    UnresolvedMatrixLiteralElement {
+        index: usize,
+    },
+    DynamicEmptyMatrixLiteralUnsupported {
         index: usize,
     },
     MatrixLiteralElementUnsupported {
@@ -83,59 +79,15 @@ impl From<SnapshotValueError> for CompilerIrError {
     }
 }
 
-/// Moves legacy parser pseudo-values into compiler-only IR.
-///
-/// Ordinary runtime values must be inserted into `ConstantStore` first and
-/// represented by `ExpressionIR::Constant`; they are deliberately rejected
-/// here.
-pub fn compiler_ir_from_legacy_pseudo_value(
-    value: &LegacyValue,
-) -> Result<ExpressionIR, CompilerIrError> {
-    match value {
-        LegacyValue::Empty => Ok(ExpressionIR::Empty),
-        // Retained only for legacy pseudo-value compatibility. Production
-        // source-to-artifact integration will migrate independently.
-        LegacyValue::IndexAll => Ok(ExpressionIR::Selection(SelectionIR::All)),
-        _ => Err(CompilerIrError::PseudoValueNotCompilerIr),
-    }
-}
-
-/// Moves the legacy heterogeneous matrix container into compiler-only literal
-/// IR. Elements have already been lowered to expressions; only the source
-/// matrix's deterministic rank-2 shape is retained.
-#[cfg(feature = "matrix")]
-pub fn matrix_literal_ir_from_legacy(
-    value: &LegacyValue,
-    elements: Box<[ExpressionIR]>,
-) -> Result<MatrixLiteralIR, CompilerIrError> {
-    let LegacyValue::MatrixValue(matrix) = value else {
-        return Err(CompilerIrError::PseudoValueNotCompilerIr);
-    };
-    let shape = matrix.shape();
-    let [rows, columns] = shape.as_slice() else {
-        return Err(CompilerIrError::LegacyMatrixLiteralRank { rank: shape.len() });
-    };
-    let rows =
-        u64::try_from(*rows).map_err(|_| CompilerIrError::MatrixLiteralCardinalityOverflow)?;
-    let columns =
-        u64::try_from(*columns).map_err(|_| CompilerIrError::MatrixLiteralCardinalityOverflow)?;
-    let expected = rows
-        .checked_mul(columns)
-        .ok_or(CompilerIrError::MatrixLiteralCardinalityOverflow)?;
-    if usize::try_from(expected).ok() != Some(elements.len()) {
-        return Err(CompilerIrError::MatrixLiteralElementCount {
-            expected,
-            found: elements.len(),
-        });
-    }
-    Ok(MatrixLiteralIR {
-        rows,
-        columns,
-        elements,
-    })
-}
-
 impl MatrixLiteralIR {
+    pub fn contains_slots(&self) -> bool {
+        self.elements.iter().any(expression_contains_slot)
+    }
+
+    pub fn contains_empty(&self) -> bool {
+        self.elements.iter().any(expression_contains_empty)
+    }
+
     /// Resolves a fully constant, homogeneous matrix literal into one final
     /// immutable matrix snapshot.
     ///
@@ -158,31 +110,33 @@ impl MatrixLiteralIR {
             dimensions,
         } = schema_definition.body()
         else {
-            return Err(CompilerIrError::MatrixSchemaRequired { schema });
+            return Err(CompilerIrError::MatrixLiteralSchemaNotMatrix);
         };
+        let expected_elements = self
+            .rows
+            .checked_mul(self.columns)
+            .ok_or(CompilerIrError::MatrixLiteralCardinalityOverflow)?;
+        if usize::try_from(expected_elements).ok() != Some(self.elements.len()) {
+            return Err(CompilerIrError::MatrixLiteralShapeMismatch {
+                expected_rows: self.rows,
+                expected_columns: self.columns,
+                actual_elements: self.elements.len(),
+            });
+        }
         let [
             DimensionExpr::Constant(expected_rows),
             DimensionExpr::Constant(expected_columns),
         ] = dimensions.as_ref()
         else {
-            return Err(CompilerIrError::MatrixLiteralRankMismatch { schema });
+            return Err(CompilerIrError::MatrixLiteralSchemaShapeMismatch {
+                ir_rows: self.rows,
+                ir_columns: self.columns,
+            });
         };
         if (*expected_rows, *expected_columns) != (self.rows, self.columns) {
-            return Err(CompilerIrError::MatrixLiteralShapeMismatch {
-                expected_rows: *expected_rows,
-                expected_columns: *expected_columns,
-                found_rows: self.rows,
-                found_columns: self.columns,
-            });
-        }
-        let expected = self
-            .rows
-            .checked_mul(self.columns)
-            .ok_or(CompilerIrError::MatrixLiteralCardinalityOverflow)?;
-        if usize::try_from(expected).ok() != Some(self.elements.len()) {
-            return Err(CompilerIrError::MatrixLiteralElementCount {
-                expected,
-                found: self.elements.len(),
+            return Err(CompilerIrError::MatrixLiteralSchemaShapeMismatch {
+                ir_rows: self.rows,
+                ir_columns: self.columns,
             });
         }
 
@@ -193,23 +147,66 @@ impl MatrixLiteralIR {
         .finalize()
         .map_err(|error| CompilerIrError::Snapshot(error.into()))?;
         let expected_key = element_schema.key();
+        let option_element = match element_schema.body() {
+            SchemaBody::Option(element) => Some(
+                SchemaDraft {
+                    dimension_parameters: Box::new([]),
+                    body: (**element).clone(),
+                }
+                .finalize()
+                .map_err(|error| CompilerIrError::Snapshot(error.into()))?,
+            ),
+            _ => None,
+        };
         let mut values = Vec::with_capacity(self.elements.len());
         for (index, expression) in self.elements.iter().enumerate() {
-            let ExpressionIR::Constant(constant) = expression else {
-                return Err(CompilerIrError::MatrixLiteralElementNotConstant { index });
-            };
-            let value = constants
-                .get(*constant)
-                .ok_or(CompilerIrError::UnknownConstant {
-                    constant: *constant,
-                })?;
-            if value.schema_key() != expected_key {
-                return Err(CompilerIrError::HeterogeneousMatrixLiteral { index });
+            match expression {
+                ExpressionIR::Empty => {
+                    if option_element.is_none() {
+                        return Err(CompilerIrError::EmptyMatrixLiteralElementRequiresOption {
+                            index,
+                        });
+                    }
+                    values.push(ValueDataDraft::Option(OptionDraft {
+                        present: false,
+                        value: None,
+                    }));
+                }
+                ExpressionIR::Constant(constant) => {
+                    let value =
+                        constants
+                            .get(*constant)
+                            .ok_or(CompilerIrError::UnknownConstant {
+                                constant: *constant,
+                            })?;
+                    if value.schema_key() == expected_key {
+                        values.push(
+                            data_draft(value.data(), element_schema.body()).ok_or(
+                                CompilerIrError::MatrixLiteralElementUnsupported { index },
+                            )?,
+                        );
+                    } else if let Some(option_element) = &option_element {
+                        if value.schema_key() != option_element.key() {
+                            return Err(CompilerIrError::HeterogeneousMatrixLiteral { index });
+                        }
+                        values.push(ValueDataDraft::Option(OptionDraft {
+                            present: true,
+                            value: Some(Box::new(
+                                data_draft(value.data(), option_element.body()).ok_or(
+                                    CompilerIrError::MatrixLiteralElementUnsupported { index },
+                                )?,
+                            )),
+                        }));
+                    } else {
+                        return Err(CompilerIrError::HeterogeneousMatrixLiteral { index });
+                    }
+                }
+                ExpressionIR::Slot(_)
+                | ExpressionIR::MatrixLiteral(_)
+                | ExpressionIR::Selection(_) => {
+                    return Err(CompilerIrError::UnresolvedMatrixLiteralElement { index });
+                }
             }
-            values.push(
-                data_draft(value.data(), element_schema.body())
-                    .ok_or(CompilerIrError::MatrixLiteralElementUnsupported { index })?,
-            );
         }
 
         Ok(ValueDraft {
@@ -218,5 +215,38 @@ impl MatrixLiteralIR {
             data: ValueDataDraft::Matrix(values.into_boxed_slice()),
         }
         .finalize(&SnapshotValidationContext::new(schemas))?)
+    }
+}
+
+fn expression_contains_slot(expression: &ExpressionIR) -> bool {
+    match expression {
+        ExpressionIR::Slot(_) => true,
+        ExpressionIR::MatrixLiteral(literal) => literal.contains_slots(),
+        ExpressionIR::Selection(selection) => {
+            selection_contains(selection, expression_contains_slot)
+        }
+        ExpressionIR::Empty | ExpressionIR::Constant(_) => false,
+    }
+}
+
+fn expression_contains_empty(expression: &ExpressionIR) -> bool {
+    match expression {
+        ExpressionIR::Empty => true,
+        ExpressionIR::MatrixLiteral(literal) => literal.contains_empty(),
+        ExpressionIR::Selection(selection) => {
+            selection_contains(selection, expression_contains_empty)
+        }
+        ExpressionIR::Constant(_) | ExpressionIR::Slot(_) => false,
+    }
+}
+
+fn selection_contains(selection: &SelectionIR, predicate: fn(&ExpressionIR) -> bool) -> bool {
+    match selection {
+        SelectionIR::All => false,
+        SelectionIR::Index(index) => predicate(index),
+        SelectionIR::Range { start, end, step } => [start, end, step]
+            .into_iter()
+            .flatten()
+            .any(|expression| predicate(expression)),
     }
 }

--- a/src/engine/src/artifact/model.rs
+++ b/src/engine/src/artifact/model.rs
@@ -10,6 +10,8 @@ use mech_core::{
     SchemaTable, SemanticModelError, SnapshotValueError, validate_declaration,
 };
 
+use super::CompilerIrError;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ComputeRegionDeclaration {
     pub id: ComputeRegionId,
@@ -291,7 +293,7 @@ impl ProgramArtifactDraft {
 
     pub(super) fn attach_contracts(
         mut self,
-        declarations: &[Option<&'static OperationContractDeclaration>],
+        declarations: &[Option<&OperationContractDeclaration>],
     ) -> Result<Self, ArtifactBuildError> {
         if declarations.len() != self.nodes.len() {
             return Err(ArtifactBuildError::CompiledMetadataLengthMismatch {
@@ -443,6 +445,13 @@ pub enum ArtifactBuildError {
         table: &'static str,
         expected: usize,
         actual: usize,
+    },
+    MatrixLiteralMetadataMismatch {
+        output: u32,
+        reason: &'static str,
+    },
+    UnresolvedEmptyRegister {
+        register: u32,
     },
     InvalidDeclarationMarker {
         instruction: u32,
@@ -642,6 +651,7 @@ pub enum ArtifactBuildError {
     LegacySnapshot(LegacySnapshotError),
     CoreBytecode(MechError),
     OperationContract(OperationContractError),
+    CompilerIr(CompilerIrError),
 }
 
 impl From<SnapshotValueError> for ArtifactBuildError {
@@ -671,5 +681,11 @@ impl From<OperationContractError> for ArtifactBuildError {
 impl From<MechError> for ArtifactBuildError {
     fn from(error: MechError) -> Self {
         Self::CoreBytecode(error)
+    }
+}
+
+impl From<CompilerIrError> for ArtifactBuildError {
+    fn from(error: CompilerIrError) -> Self {
+        Self::CompilerIr(error)
     }
 }

--- a/src/engine/src/expressions/tests/comprehensions.rs
+++ b/src/engine/src/expressions/tests/comprehensions.rs
@@ -161,3 +161,41 @@ fn matrix_comprehension_bytecode_reuses_repeated_child_registers() {
                 && arguments[0] == arguments[1]
     )));
 }
+
+#[cfg(all(feature = "matrix_comprehensions", feature = "semantic-compiler"))]
+#[test]
+fn empty_matrix_comprehension_keeps_legacy_seed_without_a_literal_sidecar() {
+    let function = ValueMatrixComprehension {
+        arguments: Vec::new(),
+        out: Ref::new(LegacyValue::MatrixValue(Matrix::from_vec(Vec::new(), 0, 0))),
+    };
+    let mut context = CompileCtx::new();
+    let output = function.compile(&mut context).unwrap();
+    let compiled = context.finish_program(output).unwrap();
+
+    assert!(!compiled.matrix_literals.contains_key(&output));
+    assert!(
+        compiled
+            .program
+            .instructions
+            .iter()
+            .any(|instruction| matches!(
+                instruction,
+                BytecodeInstruction::RuntimeVariadic { function, dst, arguments }
+                    if *function == hash_str("matrix/comprehension")
+                        && *dst == output
+                        && arguments.is_empty()
+            ))
+    );
+    assert!(
+        compiled
+            .program
+            .instructions
+            .iter()
+            .any(|instruction| matches!(
+                instruction,
+                BytecodeInstruction::CompositePack { dst, children, .. }
+                    if *dst == output && children.is_empty()
+            ))
+    );
+}

--- a/src/engine/src/function/catalog.rs
+++ b/src/engine/src/function/catalog.rs
@@ -19,6 +19,8 @@ pub fn install_intrinsic_resident(
     #[cfg(feature = "resident-artifact")]
     crate::resident::composite::install(builder)?;
     #[cfg(feature = "resident-artifact")]
+    crate::resident::matrix_literal::install(builder)?;
+    #[cfg(feature = "resident-artifact")]
     crate::resident::numeric::install(builder)?;
     #[cfg(feature = "resident-artifact")]
     crate::resident::set::install(builder)?;

--- a/src/engine/src/intrinsics/constructors.rs
+++ b/src/engine/src/intrinsics/constructors.rs
@@ -294,7 +294,23 @@ impl MechFunctionFactory for ValueMatrixComprehension {
 impl MechFunctionCompiler for ValueMatrixComprehension {
     fn compile(&self, ctx: &mut dyn BytecodeCompilerContext) -> MResult<Register> {
         let output = self.out.borrow().clone();
-        let destination = compile_value_register(&output, self.out.addr(), ctx)?;
+        let output_kind = output.kind();
+        let destination = if output_kind
+            .matrix_parts()
+            .is_some_and(|(element, _)| element.is_any())
+        {
+            let (destination, initialize) =
+                ctx.register_for_ptr_with_initialization_status(self.out.addr());
+            ctx.record_register_kind(destination, output_kind)?;
+            if initialize {
+                let template = output.compile_const(ctx)?;
+                ctx.record_register_constant_metadata(destination, template)?;
+                ctx.emit_composite_pack(destination, template, Vec::new());
+            }
+            destination
+        } else {
+            compile_value_register(&output, self.out.addr(), ctx)?
+        };
         let arguments = self
             .arguments
             .iter()

--- a/src/engine/src/intrinsics/define.rs
+++ b/src/engine/src/intrinsics/define.rs
@@ -712,7 +712,14 @@ impl MechFunctionImpl for VariableDefineEmpty {
 #[cfg(feature = "semantic-compiler")]
 impl MechFunctionCompiler for VariableDefineEmpty {
     fn reserve_bytecode_registers(&self, ctx: &mut dyn BytecodeCompilerContext) -> MResult<()> {
-        if *self.mutable.borrow() {
+        if self
+            .initial
+            .exact_matrix_any()
+            .and_then(|matrix| matrix.downcast_ref::<Matrix<LegacyValue>>())
+            .is_some()
+        {
+            compile_value_register_for_ptr(&self.initial, self.var.addr(), ctx)?;
+        } else if *self.mutable.borrow() {
             compile_register_initial!(self.var, self.initial, ctx);
         }
         Ok(())
@@ -733,7 +740,15 @@ impl MechFunctionCompiler for VariableDefineEmpty {
             self.root_visible,
         )?;
         let name = "VariableDefineEmpty".to_string();
-        compile_binop!(name, self.var, self.name, self.mutable, ctx);
+        let name_register = compile_register_brrw!(self.name, ctx);
+        let mutable_register = compile_register_brrw!(self.mutable, ctx);
+        ctx.emit_declaration_binary(
+            hash_str(&name),
+            variable_register,
+            name_register,
+            mutable_register,
+        );
+        Ok(variable_register)
     }
 }
 

--- a/src/engine/src/intrinsics/horzcat.rs
+++ b/src/engine/src/intrinsics/horzcat.rs
@@ -44,6 +44,22 @@ static PURE_HORIZONTAL_UNARY_BUILD_CONTRACT: LazyLock<OperationContractDeclarati
         ))
     });
 
+#[cfg(all(feature = "semantic-compiler", feature = "matrixd"))]
+fn heterogeneous_horizontal_literal(arguments: &[LegacyValue]) -> Box<dyn MechFunction> {
+    let inputs = arguments
+        .iter()
+        .cloned()
+        .map(|argument| HorizontalConcatenateInput::Scalar(Ref::new(argument)))
+        .collect();
+    let out = Ref::new(DMatrix::from_vec(1, arguments.len(), arguments.to_vec()));
+    Box::new(HorizontalConcatenateNArgs { e0: inputs, out })
+}
+
+#[cfg(all(feature = "semantic-compiler", feature = "matrixd"))]
+fn same_or_option_element_kind(left: &ValueKind, right: &ValueKind) -> bool {
+    left == right || left.option_inner() == Some(right) || right.option_inner() == Some(left)
+}
+
 // Horizontal Concatenate -----------------------------------------------------
 
 #[cfg(any(
@@ -854,7 +870,7 @@ where
 #[cfg(feature = "matrixd")]
 impl<T> MechFunctionImpl for HorizontalConcatenateNArgs<T>
 where
-    T: Debug + Clone + Sync + Send + PartialEq + 'static,
+    T: Debug + Clone + PartialEq + 'static,
     Ref<DMatrix<T>>: ToValue,
 {
     fn solve_result(&self) -> MResult<()> {
@@ -891,8 +907,21 @@ where
 impl<T> MechFunctionCompiler for HorizontalConcatenateNArgs<T>
 where
     T: ConstElem + CompileConst + AsValueKind,
+    Ref<DMatrix<T>>: ToValue,
 {
+    fn reserve_bytecode_registers(&self, ctx: &mut dyn BytecodeCompilerContext) -> MResult<()> {
+        if T::as_value_kind().is_any() {
+            let output = self.out.to_value();
+            compile_value_register(&output, self.out.addr(), ctx)?;
+        }
+        Ok(())
+    }
+
     fn compile(&self, ctx: &mut dyn BytecodeCompilerContext) -> MResult<Register> {
+        if T::as_value_kind().is_any() {
+            let output = self.out.to_value();
+            return compile_value_register(&output, self.out.addr(), ctx);
+        }
         let mut registers = [0, 0];
         registers[0] = compile_register!(self.out, ctx);
 
@@ -6766,6 +6795,22 @@ pub(crate) fn impl_horzcat_fxn(arguments: &[LegacyValue]) -> MResult<Box<dyn Mec
         })
         .unwrap_or_else(|| kinds[0].clone());
 
+    #[cfg(all(feature = "semantic-compiler", feature = "matrixd"))]
+    if arguments
+        .iter()
+        .all(|argument| argument.is_scalar() || argument.is_legacy_empty())
+        && kinds.iter().zip(arguments).any(|(kind, argument)| {
+            if argument.is_legacy_empty() {
+                return false;
+            }
+            !ValueKind::is_compatible(target_kind.clone(), kind.clone())
+                && !ValueKind::is_compatible(kind.clone(), target_kind.clone())
+                && !same_or_option_element_kind(kind, &target_kind)
+        })
+    {
+        return Ok(heterogeneous_horizontal_literal(arguments));
+    }
+
     #[cfg(feature = "f64")]
     {
         if ValueKind::is_compatible(target_kind.clone(), ValueKind::F64) {
@@ -6876,6 +6921,14 @@ pub(crate) fn impl_horzcat_fxn(arguments: &[LegacyValue]) -> MResult<Box<dyn Mec
         if ValueKind::is_compatible(target_kind.clone(), ValueKind::C64) {
             return impl_horzcat_arms!(C64, arguments, C64::default());
         }
+    }
+
+    #[cfg(all(feature = "semantic-compiler", feature = "matrixd"))]
+    if arguments
+        .iter()
+        .all(|argument| argument.is_scalar() || argument.is_legacy_empty())
+    {
+        return Ok(heterogeneous_horizontal_literal(arguments));
     }
 
     Err(MechError::new(

--- a/src/engine/src/program/bytecode_plan_topology_tests.rs
+++ b/src/engine/src/program/bytecode_plan_topology_tests.rs
@@ -740,6 +740,7 @@ fn compiled_fixture(
         instruction_roles,
         register_collection_cardinalities: vec![None; register_kinds.len()],
         register_state_initializers: vec![None; register_kinds.len()],
+        matrix_literals: BTreeMap::new(),
         register_kinds,
         symbol_definitions: Vec::new(),
         return_register,

--- a/src/engine/src/program/bytecode_plan_topology_tests.rs
+++ b/src/engine/src/program/bytecode_plan_topology_tests.rs
@@ -9,7 +9,6 @@ use crate::{
     CompileCtx, CompiledBytecode, CompiledInstructionRole, CompiledIntegrityConstraint,
     CompiledNodeKind, CompiledSymbolDefinition,
 };
-#[cfg(feature = "native-plan")]
 use mech_core::snapshot::SequenceView;
 use mech_core::{
     AccessMode, AliasPolicy, ApplicationRequirement, BytecodeCompilerContext, BytecodeInstruction,
@@ -242,6 +241,58 @@ fn compile_artifact_fixture(source: &str) -> MResult<(ProgramArtifact, ProgramAr
     assert_frozen_v1_topology_parity(&source_artifact, &bytecode_artifact);
     assert_eq!(source_artifact.revision(), bytecode_artifact.revision());
     Ok((source_artifact, bytecode_artifact))
+}
+
+fn output_initializer(artifact: &ProgramArtifact) -> &mech_core::Value {
+    let output = &artifact.outputs()[0];
+    let slot = &artifact.slots()[output.source.get() as usize];
+    let Some(InitializerReference::Constant(constant)) = slot.initializer else {
+        panic!("static source output must have a canonical constant initializer");
+    };
+    artifact.constants().get(constant).unwrap()
+}
+
+#[test]
+fn generic_source_matrix_literals_fold_without_legacy_artifact_nodes() -> MResult<()> {
+    let (empty, _) = compile_artifact_fixture("x := []\nx")?;
+    let empty_value = output_initializer(&empty);
+    let ValueData::Matrix(_) = empty_value.data() else {
+        panic!("empty source literal must become a canonical matrix constant");
+    };
+    assert!(matches!(
+        empty.schemas().get(empty_value.schema()).unwrap().body(),
+        SchemaBody::Matrix { dimensions, .. }
+            if dimensions.as_ref()
+                == [DimensionExpr::Constant(0), DimensionExpr::Constant(0)]
+    ));
+    assert!(empty.nodes().iter().all(|node| {
+        node.operation.module_path.as_ref() != ["matrix"]
+            || node.operation.operation_name != "literal"
+    }));
+
+    let (optional, _) = compile_artifact_fixture("x := [1.0 _]\nx")?;
+    let ValueData::Matrix(matrix) = output_initializer(&optional).data() else {
+        panic!("optional source literal must become a canonical matrix constant");
+    };
+    let SequenceView::Values(elements) = matrix.elements() else {
+        panic!("optional matrix elements must retain canonical option values");
+    };
+    assert!(matches!(elements[0], ValueData::Option(Some(_))));
+    assert!(matches!(elements[1], ValueData::Option(None)));
+    Ok(())
+}
+
+#[test]
+fn heterogeneous_source_matrix_literal_fails_structurally() -> MResult<()> {
+    let mut program = source_program();
+    program.plan_source_for_test("x := [1.0 \"x\"]\nx")?;
+    let error = program.compile_program_product().unwrap_err();
+    assert_eq!(error.kind_name(), "ProgramArtifactCompilationError");
+    assert!(
+        error.kind_message().contains("HeterogeneousMatrixLiteral"),
+        "{error:?}"
+    );
+    Ok(())
 }
 
 #[test]

--- a/src/engine/src/resident/matrix_literal.rs
+++ b/src/engine/src/resident/matrix_literal.rs
@@ -1,0 +1,666 @@
+use mech_core::{
+    AccessMode, AliasPolicy, BoundResidentKernel, ChangeDetectionPolicy, DeliveryMode,
+    DimensionExpr, ExternalInteraction, FloatWidth, FunctionCatalogBuilder, MResult,
+    OutputConstruction, ResidentKernelBindError, ResidentKernelBindRequest, ResidentKernelError,
+    ResidentKernelInputs, ResidentShape, ResidentValueKind, ResidentValueMut, ResidentValueRef,
+    ResolvedOperationContract, SchemaBody, ShapeRule,
+};
+use std::sync::Arc;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct MatrixLiteralPlan {
+    rows: usize,
+    columns: usize,
+    kind: ResidentValueKind,
+}
+
+pub(crate) fn install(builder: &mut FunctionCatalogBuilder) -> MResult<()> {
+    builder.insert_resident_factory(["matrix"], "literal", bind_matrix_literal)?;
+    Ok(())
+}
+
+fn resident_element_kind(element: &SchemaBody) -> Option<ResidentValueKind> {
+    match element {
+        SchemaBody::Bool => Some(ResidentValueKind::Bool),
+        SchemaBody::Index => Some(ResidentValueKind::Index),
+        SchemaBody::FloatingPoint(FloatWidth::W64) => Some(ResidentValueKind::F64),
+        SchemaBody::String => Some(ResidentValueKind::String),
+        SchemaBody::Atom(_)
+        | SchemaBody::Enum { .. }
+        | SchemaBody::Option(_)
+        | SchemaBody::Tuple(_)
+        | SchemaBody::Record(_)
+        | SchemaBody::Table { .. }
+        | SchemaBody::Set { .. }
+        | SchemaBody::Map { .. }
+        | SchemaBody::ReifiedType => Some(ResidentValueKind::Snapshot),
+        SchemaBody::UnsignedInteger(_)
+        | SchemaBody::SignedInteger(_)
+        | SchemaBody::FloatingPoint(FloatWidth::W32)
+        | SchemaBody::Complex(_)
+        | SchemaBody::Rational64
+        | SchemaBody::Id
+        | SchemaBody::Matrix { .. } => None,
+    }
+}
+
+fn bind_matrix_literal(
+    request: &ResidentKernelBindRequest<'_>,
+) -> Result<BoundResidentKernel, ResidentKernelBindError> {
+    let ResolvedOperationContract::Declared(contract) = request.contract else {
+        return Err(ResidentKernelBindError::UnsupportedContract);
+    };
+    let Some(output_schema) = request.schemas.get(request.output.schema_id) else {
+        return Err(ResidentKernelBindError::UnsupportedLayout);
+    };
+    let SchemaBody::Matrix {
+        element,
+        dimensions,
+    } = output_schema.body()
+    else {
+        return Err(ResidentKernelBindError::UnsupportedLayout);
+    };
+    let [
+        DimensionExpr::Constant(rows),
+        DimensionExpr::Constant(columns),
+    ] = dimensions.as_ref()
+    else {
+        return Err(ResidentKernelBindError::UnsupportedLayout);
+    };
+    let rows = usize::try_from(*rows).map_err(|_| ResidentKernelBindError::UnsupportedLayout)?;
+    let columns =
+        usize::try_from(*columns).map_err(|_| ResidentKernelBindError::UnsupportedLayout)?;
+    let count = rows
+        .checked_mul(columns)
+        .ok_or(ResidentKernelBindError::UnsupportedLayout)?;
+    let rows_u32 = u32::try_from(rows).map_err(|_| ResidentKernelBindError::UnsupportedLayout)?;
+    let columns_u32 =
+        u32::try_from(columns).map_err(|_| ResidentKernelBindError::UnsupportedLayout)?;
+    let kind = resident_element_kind(element).ok_or(ResidentKernelBindError::UnsupportedLayout)?;
+    if request.inputs.len() != count
+        || request.output.kind != kind
+        || request.output.shape
+            != (ResidentShape {
+                rows: rows_u32,
+                columns: columns_u32,
+            })
+        || request.inputs.iter().any(|input| {
+            input.kind != kind
+                || input.shape != ResidentShape::SCALAR
+                || request.schemas.get(input.schema_id).is_none_or(|schema| {
+                    !schema.dimension_parameters().is_empty() || schema.body() != element.as_ref()
+                })
+        })
+    {
+        return Err(ResidentKernelBindError::UnsupportedLayout);
+    }
+    if contract.interaction != ExternalInteraction::Pure
+        || contract.inputs.len() != request.inputs.len()
+        || contract.outputs.len() != 1
+        || contract
+            .inputs
+            .iter()
+            .zip(request.inputs)
+            .any(|(contract, input)| {
+                contract.schema != input.schema_id
+                    || contract.access != AccessMode::Read
+                    || contract.delivery != DeliveryMode::Signal
+            })
+    {
+        return Err(ResidentKernelBindError::UnsupportedContract);
+    }
+    let output = &contract.outputs[0];
+    if output.schema != request.output.schema_id
+        || output.access != AccessMode::Write
+        || output.delivery != DeliveryMode::Signal
+        || output.construction
+            != (OutputConstruction::FullWrite {
+                shape: ShapeRule::Declared,
+            })
+        || output.alias != AliasPolicy::NoAlias
+        || output.change_detection != ChangeDetectionPolicy::AlwaysChanged
+    {
+        return Err(ResidentKernelBindError::UnsupportedContract);
+    }
+    Ok(
+        BoundResidentKernel::new(matrix_literal, Box::new([])).with_retained_state(Arc::new(
+            MatrixLiteralPlan {
+                rows,
+                columns,
+                kind,
+            },
+        )),
+    )
+}
+
+fn target_index(source: usize, rows: usize, columns: usize) -> usize {
+    let row = source / columns;
+    let column = source % columns;
+    column * rows + row
+}
+
+fn matrix_literal(
+    kernel: &BoundResidentKernel,
+    inputs: &dyn ResidentKernelInputs,
+    output: ResidentValueMut<'_>,
+) -> Result<bool, ResidentKernelError> {
+    let plan = kernel
+        .retained_state::<MatrixLiteralPlan>()
+        .ok_or(ResidentKernelError::InvalidInput)?;
+    let count = plan
+        .rows
+        .checked_mul(plan.columns)
+        .ok_or(ResidentKernelError::InvalidShape)?;
+    if inputs.len() != count || output.kind() != plan.kind || output.len() != count {
+        return Err(ResidentKernelError::InvalidShape);
+    }
+    if count == 0 {
+        return Ok(true);
+    }
+
+    match output {
+        ResidentValueMut::Bool(target) if plan.kind == ResidentValueKind::Bool => {
+            for source in 0..count {
+                let Some(ResidentValueRef::Bool([value])) = inputs.get(source) else {
+                    return Err(ResidentKernelError::InvalidInput);
+                };
+                if *value > 1 {
+                    return Err(ResidentKernelError::InvalidInput);
+                }
+                target[target_index(source, plan.rows, plan.columns)] = *value;
+            }
+        }
+        ResidentValueMut::Index(target) if plan.kind == ResidentValueKind::Index => {
+            for source in 0..count {
+                let Some(ResidentValueRef::Index([value])) = inputs.get(source) else {
+                    return Err(ResidentKernelError::InvalidInput);
+                };
+                target[target_index(source, plan.rows, plan.columns)] = *value;
+            }
+        }
+        ResidentValueMut::F64(target) if plan.kind == ResidentValueKind::F64 => {
+            for source in 0..count {
+                let Some(ResidentValueRef::F64([value])) = inputs.get(source) else {
+                    return Err(ResidentKernelError::InvalidInput);
+                };
+                target[target_index(source, plan.rows, plan.columns)] = *value;
+            }
+        }
+        ResidentValueMut::String(target) if plan.kind == ResidentValueKind::String => {
+            for source in 0..count {
+                let Some(ResidentValueRef::String([value])) = inputs.get(source) else {
+                    return Err(ResidentKernelError::InvalidInput);
+                };
+                target[target_index(source, plan.rows, plan.columns)] = value.clone();
+            }
+        }
+        ResidentValueMut::Snapshot(target) if plan.kind == ResidentValueKind::Snapshot => {
+            for source in 0..count {
+                let Some(ResidentValueRef::Snapshot([Some(value)])) = inputs.get(source) else {
+                    return Err(ResidentKernelError::InvalidInput);
+                };
+                target[target_index(source, plan.rows, plan.columns)] = Some(value.clone());
+            }
+        }
+        _ => return Err(ResidentKernelError::InvalidOutput),
+    }
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mech_core::{
+        DeclaredOperationContract, ResidentPortLayout, ResolvedInputPort, ResolvedOutputPort,
+        SchemaDraft, SchemaId, SchemaTable, SchemaTableBuilder, ValueDataDraft, ValueDraft,
+        snapshot::{F64Bits, SnapshotValidationContext},
+    };
+
+    struct Inputs<'a>(Vec<ResidentValueRef<'a>>);
+
+    impl ResidentKernelInputs for Inputs<'_> {
+        fn len(&self) -> usize {
+            self.0.len()
+        }
+
+        fn get(&self, index: usize) -> Option<ResidentValueRef<'_>> {
+            self.0.get(index).copied()
+        }
+    }
+
+    fn schema(body: SchemaBody) -> mech_core::Schema {
+        SchemaDraft {
+            dimension_parameters: Box::new([]),
+            body,
+        }
+        .finalize()
+        .unwrap()
+    }
+
+    fn f64_schemas(rows: u64, columns: u64) -> (SchemaTable, SchemaId, SchemaId) {
+        schemas_for(SchemaBody::FloatingPoint(FloatWidth::W64), rows, columns)
+    }
+
+    fn schemas_for(
+        element_body: SchemaBody,
+        rows: u64,
+        columns: u64,
+    ) -> (SchemaTable, SchemaId, SchemaId) {
+        let mut builder = SchemaTableBuilder::new();
+        let scalar = builder.insert(schema(element_body.clone())).unwrap();
+        let matrix = builder
+            .insert(schema(SchemaBody::Matrix {
+                element: Box::new(element_body),
+                dimensions: vec![
+                    DimensionExpr::Constant(rows),
+                    DimensionExpr::Constant(columns),
+                ]
+                .into_boxed_slice(),
+            }))
+            .unwrap();
+        let build = builder.finish().unwrap();
+        let scalar = build.resolve(scalar).unwrap();
+        let matrix = build.resolve(matrix).unwrap();
+        let (schemas, _) = build.into_parts();
+        (schemas, scalar, matrix)
+    }
+
+    fn layout(
+        schemas: &SchemaTable,
+        schema: SchemaId,
+        kind: ResidentValueKind,
+        shape: ResidentShape,
+    ) -> ResidentPortLayout {
+        ResidentPortLayout {
+            schema_id: schema,
+            schema_key: schemas.entry(schema).unwrap().key(),
+            kind,
+            shape,
+        }
+    }
+
+    fn contract(input: SchemaId, output: SchemaId, count: usize) -> ResolvedOperationContract {
+        ResolvedOperationContract::Declared(DeclaredOperationContract {
+            inputs: (0..count)
+                .map(|_| ResolvedInputPort {
+                    schema: input,
+                    access: AccessMode::Read,
+                    delivery: DeliveryMode::Signal,
+                })
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+            outputs: vec![ResolvedOutputPort {
+                schema: output,
+                access: AccessMode::Write,
+                delivery: DeliveryMode::Signal,
+                construction: OutputConstruction::FullWrite {
+                    shape: ShapeRule::Declared,
+                },
+                alias: AliasPolicy::NoAlias,
+                change_detection: ChangeDetectionPolicy::AlwaysChanged,
+            }]
+            .into_boxed_slice(),
+            interaction: ExternalInteraction::Pure,
+        })
+    }
+
+    #[test]
+    fn f64_literal_writes_logical_rows_into_column_major_storage() {
+        let (schemas, scalar, matrix) = f64_schemas(2, 3);
+        let contract = contract(scalar, matrix, 6);
+        let inputs = vec![
+            layout(
+                &schemas,
+                scalar,
+                ResidentValueKind::F64,
+                ResidentShape::SCALAR,
+            );
+            6
+        ];
+        let kernel = bind_matrix_literal(&ResidentKernelBindRequest {
+            contract: &contract,
+            schemas: &schemas,
+            inputs: &inputs,
+            output: layout(
+                &schemas,
+                matrix,
+                ResidentValueKind::F64,
+                ResidentShape {
+                    rows: 2,
+                    columns: 3,
+                },
+            ),
+        })
+        .unwrap();
+        let values = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let inputs = Inputs(
+            values
+                .iter()
+                .map(|value| ResidentValueRef::F64(core::slice::from_ref(value)))
+                .collect(),
+        );
+        let mut output = [0.0; 6];
+        assert!(
+            kernel
+                .execute(&inputs, ResidentValueMut::F64(&mut output))
+                .unwrap()
+        );
+        assert_eq!(output, [1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+    }
+
+    #[test]
+    fn scalar_resident_families_execute_one_by_one_literals() {
+        let (schemas, scalar, matrix) = f64_schemas(1, 1);
+        let kernel = bind_matrix_literal(&ResidentKernelBindRequest {
+            contract: &contract(scalar, matrix, 1),
+            schemas: &schemas,
+            inputs: &[layout(
+                &schemas,
+                scalar,
+                ResidentValueKind::F64,
+                ResidentShape::SCALAR,
+            )],
+            output: layout(
+                &schemas,
+                matrix,
+                ResidentValueKind::F64,
+                ResidentShape {
+                    rows: 1,
+                    columns: 1,
+                },
+            ),
+        })
+        .unwrap();
+        let source = [3.5];
+        let mut output = [0.0];
+        kernel
+            .execute(
+                &Inputs(vec![ResidentValueRef::F64(&source)]),
+                ResidentValueMut::F64(&mut output),
+            )
+            .unwrap();
+        assert_eq!(output, source);
+
+        let (schemas, scalar, matrix) = schemas_for(SchemaBody::Bool, 1, 1);
+        let kernel = bind_matrix_literal(&ResidentKernelBindRequest {
+            contract: &contract(scalar, matrix, 1),
+            schemas: &schemas,
+            inputs: &[layout(
+                &schemas,
+                scalar,
+                ResidentValueKind::Bool,
+                ResidentShape::SCALAR,
+            )],
+            output: layout(
+                &schemas,
+                matrix,
+                ResidentValueKind::Bool,
+                ResidentShape {
+                    rows: 1,
+                    columns: 1,
+                },
+            ),
+        })
+        .unwrap();
+        let source = [1];
+        let mut output = [0];
+        kernel
+            .execute(
+                &Inputs(vec![ResidentValueRef::Bool(&source)]),
+                ResidentValueMut::Bool(&mut output),
+            )
+            .unwrap();
+        assert_eq!(output, source);
+
+        let (schemas, scalar, matrix) = schemas_for(SchemaBody::Index, 1, 1);
+        let kernel = bind_matrix_literal(&ResidentKernelBindRequest {
+            contract: &contract(scalar, matrix, 1),
+            schemas: &schemas,
+            inputs: &[layout(
+                &schemas,
+                scalar,
+                ResidentValueKind::Index,
+                ResidentShape::SCALAR,
+            )],
+            output: layout(
+                &schemas,
+                matrix,
+                ResidentValueKind::Index,
+                ResidentShape {
+                    rows: 1,
+                    columns: 1,
+                },
+            ),
+        })
+        .unwrap();
+        let source = [42];
+        let mut output = [0];
+        kernel
+            .execute(
+                &Inputs(vec![ResidentValueRef::Index(&source)]),
+                ResidentValueMut::Index(&mut output),
+            )
+            .unwrap();
+        assert_eq!(output, source);
+
+        let (schemas, scalar, matrix) = schemas_for(SchemaBody::String, 1, 1);
+        let kernel = bind_matrix_literal(&ResidentKernelBindRequest {
+            contract: &contract(scalar, matrix, 1),
+            schemas: &schemas,
+            inputs: &[layout(
+                &schemas,
+                scalar,
+                ResidentValueKind::String,
+                ResidentShape::SCALAR,
+            )],
+            output: layout(
+                &schemas,
+                matrix,
+                ResidentValueKind::String,
+                ResidentShape {
+                    rows: 1,
+                    columns: 1,
+                },
+            ),
+        })
+        .unwrap();
+        let source = ["matrix".to_owned()];
+        let mut output = [String::new()];
+        kernel
+            .execute(
+                &Inputs(vec![ResidentValueRef::String(&source)]),
+                ResidentValueMut::String(&mut output),
+            )
+            .unwrap();
+        assert_eq!(output, source);
+    }
+
+    #[test]
+    fn binder_rejects_wrong_counts_schemas_shapes_and_nested_matrices() {
+        let (schemas, scalar, matrix) = f64_schemas(1, 1);
+        let scalar_layout = layout(
+            &schemas,
+            scalar,
+            ResidentValueKind::F64,
+            ResidentShape::SCALAR,
+        );
+        let output_layout = layout(
+            &schemas,
+            matrix,
+            ResidentValueKind::F64,
+            ResidentShape {
+                rows: 1,
+                columns: 1,
+            },
+        );
+        assert!(matches!(
+            bind_matrix_literal(&ResidentKernelBindRequest {
+                contract: &contract(scalar, matrix, 0),
+                schemas: &schemas,
+                inputs: &[],
+                output: output_layout.clone(),
+            }),
+            Err(ResidentKernelBindError::UnsupportedLayout)
+        ));
+        assert!(matches!(
+            bind_matrix_literal(&ResidentKernelBindRequest {
+                contract: &contract(matrix, matrix, 1),
+                schemas: &schemas,
+                inputs: &[layout(
+                    &schemas,
+                    matrix,
+                    ResidentValueKind::F64,
+                    ResidentShape::SCALAR,
+                )],
+                output: output_layout.clone(),
+            }),
+            Err(ResidentKernelBindError::UnsupportedLayout)
+        ));
+        assert!(matches!(
+            bind_matrix_literal(&ResidentKernelBindRequest {
+                contract: &contract(scalar, matrix, 1),
+                schemas: &schemas,
+                inputs: &[scalar_layout],
+                output: layout(
+                    &schemas,
+                    matrix,
+                    ResidentValueKind::F64,
+                    ResidentShape {
+                        rows: 1,
+                        columns: 2,
+                    },
+                ),
+            }),
+            Err(ResidentKernelBindError::UnsupportedLayout)
+        ));
+
+        let nested = SchemaBody::Matrix {
+            element: Box::new(SchemaBody::FloatingPoint(FloatWidth::W64)),
+            dimensions: vec![DimensionExpr::Constant(1), DimensionExpr::Constant(1)]
+                .into_boxed_slice(),
+        };
+        let (schemas, scalar, matrix) = schemas_for(nested, 1, 1);
+        assert!(matches!(
+            bind_matrix_literal(&ResidentKernelBindRequest {
+                contract: &contract(scalar, matrix, 1),
+                schemas: &schemas,
+                inputs: &[layout(
+                    &schemas,
+                    scalar,
+                    ResidentValueKind::Snapshot,
+                    ResidentShape::SCALAR,
+                )],
+                output: layout(
+                    &schemas,
+                    matrix,
+                    ResidentValueKind::Snapshot,
+                    ResidentShape {
+                        rows: 1,
+                        columns: 1,
+                    },
+                ),
+            }),
+            Err(ResidentKernelBindError::UnsupportedLayout)
+        ));
+    }
+
+    #[test]
+    fn zero_by_zero_literal_requires_empty_input_and_output() {
+        let (schemas, scalar, matrix) = f64_schemas(0, 0);
+        let contract = contract(scalar, matrix, 0);
+        let kernel = bind_matrix_literal(&ResidentKernelBindRequest {
+            contract: &contract,
+            schemas: &schemas,
+            inputs: &[],
+            output: layout(
+                &schemas,
+                matrix,
+                ResidentValueKind::F64,
+                ResidentShape {
+                    rows: 0,
+                    columns: 0,
+                },
+            ),
+        })
+        .unwrap();
+        let mut output = [];
+        assert!(
+            kernel
+                .execute(&Inputs(Vec::new()), ResidentValueMut::F64(&mut output))
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn snapshot_elements_are_cloned_and_missing_values_are_rejected() {
+        let mut builder = SchemaTableBuilder::new();
+        let element = builder
+            .insert(schema(SchemaBody::Tuple(
+                vec![SchemaBody::FloatingPoint(FloatWidth::W64)].into_boxed_slice(),
+            )))
+            .unwrap();
+        let matrix = builder
+            .insert(schema(SchemaBody::Matrix {
+                element: Box::new(SchemaBody::Tuple(
+                    vec![SchemaBody::FloatingPoint(FloatWidth::W64)].into_boxed_slice(),
+                )),
+                dimensions: vec![DimensionExpr::Constant(1), DimensionExpr::Constant(1)]
+                    .into_boxed_slice(),
+            }))
+            .unwrap();
+        let build = builder.finish().unwrap();
+        let element = build.resolve(element).unwrap();
+        let matrix = build.resolve(matrix).unwrap();
+        let (schemas, _) = build.into_parts();
+        let value = ValueDraft {
+            schema: element,
+            shape_values: Box::new([]),
+            data: ValueDataDraft::Tuple(
+                vec![ValueDataDraft::F64(F64Bits::from_f64(1.0))].into_boxed_slice(),
+            ),
+        }
+        .finalize(&SnapshotValidationContext::new(&schemas))
+        .unwrap();
+        let contract = contract(element, matrix, 1);
+        let kernel = bind_matrix_literal(&ResidentKernelBindRequest {
+            contract: &contract,
+            schemas: &schemas,
+            inputs: &[layout(
+                &schemas,
+                element,
+                ResidentValueKind::Snapshot,
+                ResidentShape::SCALAR,
+            )],
+            output: layout(
+                &schemas,
+                matrix,
+                ResidentValueKind::Snapshot,
+                ResidentShape {
+                    rows: 1,
+                    columns: 1,
+                },
+            ),
+        })
+        .unwrap();
+        let source = [Some(value.clone())];
+        let mut output = [None];
+        assert!(
+            kernel
+                .execute(
+                    &Inputs(vec![ResidentValueRef::Snapshot(&source)]),
+                    ResidentValueMut::Snapshot(&mut output),
+                )
+                .unwrap()
+        );
+        assert_eq!(output[0].as_ref().unwrap().schema(), value.schema());
+
+        let missing = [None];
+        assert_eq!(
+            kernel.execute(
+                &Inputs(vec![ResidentValueRef::Snapshot(&missing)]),
+                ResidentValueMut::Snapshot(&mut output),
+            ),
+            Err(ResidentKernelError::InvalidInput)
+        );
+    }
+}

--- a/src/engine/src/resident/mod.rs
+++ b/src/engine/src/resident/mod.rs
@@ -10,6 +10,8 @@ mod full_write;
 pub(crate) mod general;
 mod kernel;
 #[cfg(feature = "resident-artifact")]
+pub(crate) mod matrix_literal;
+#[cfg(feature = "resident-artifact")]
 pub(crate) mod numeric;
 #[cfg(feature = "resident-artifact")]
 pub(crate) mod set;

--- a/src/engine/tests/program_artifact_contract.rs
+++ b/src/engine/tests/program_artifact_contract.rs
@@ -2,6 +2,7 @@
 
 use mech_engine::*;
 
+use mech_core::matrix::Matrix;
 use mech_core::{
     AccessMode, AliasPolicy, ApplicationRequirement, ApplicationRequirementId, BytecodeProgram,
     CanonicalNominalPath, ChangeDetectionPolicy, ConstantHandle, ConstantStoreBuilder,
@@ -11,14 +12,14 @@ use mech_core::{
     InputPortLayout, InputPortPolicy, IntegerWidth, KindExpr, LegacyOpaqueOperationContract,
     LegacyValue, NominalKey, NominalKind, ObservationContract, ObservationReplayPolicy,
     OperationContractDeclaration, OperationContractId, OperationContractTable,
-    OperationContractTableBuilder, OutputConstruction, OutputPortPolicy, RegionPolicy,
+    OperationContractTableBuilder, OutputConstruction, OutputPortPolicy, Ref, RegionPolicy,
     ResolvedInputPort, ResolvedOperationContract, ResolvedOutputPort, ResourceDelivery,
     ResourceIntent, SchemaBody, SchemaDraft, SchemaField, SchemaHandle, SchemaTableBuilder,
-    ShapeContractReference, ShapeRule, Value, ValueDataDraft, ValueDraft,
+    ShapeContractReference, ShapeRule, Value, ValueData, ValueDataDraft, ValueDraft,
     snapshot::{
         Complex32Bits, Complex64Bits, ConstantStoreBuild, EnumDraft, F32Bits, F64Bits,
-        MapEntryDraft, NamedValueDraft, OptionDraft, ReifiedTypeDraft, SnapshotValidationContext,
-        TableColumnDraft,
+        MapEntryDraft, NamedValueDraft, OptionDraft, ReifiedTypeDraft, SequenceView,
+        SnapshotValidationContext, TableColumnDraft,
     },
     write_bytecode_with_artifact,
 };
@@ -629,7 +630,7 @@ fn pure_state_rmw_contract(base_input: u16) -> OperationContractDeclaration {
 fn build_both_with_contracts(
     data: &FixtureData,
     graph: SourceProgram,
-    declarations: &[Option<&'static OperationContractDeclaration>],
+    declarations: &[Option<&OperationContractDeclaration>],
 ) -> (ProgramArtifact, ProgramArtifact) {
     let mut source_context = ArtifactBuildContext::new(&data.schemas, &data.constants);
     let source =
@@ -693,14 +694,10 @@ fn synthetic_ekf_contract_fixture_is_fully_declared_and_round_trips_contract_ids
     let declarations = graph
         .nodes
         .iter()
-        .map(|node| {
-            Some(Box::leak(Box::new(pure_full_write_contract(
-                node.inputs.len(),
-                node.outputs.len(),
-            ))) as &'static OperationContractDeclaration)
-        })
+        .map(|node| pure_full_write_contract(node.inputs.len(), node.outputs.len()))
         .collect::<Vec<_>>();
-    let (source, bytecode) = build_both_with_contracts(&data, graph, &declarations);
+    let declaration_refs = declarations.iter().map(Some).collect::<Vec<_>>();
+    let (source, bytecode) = build_both_with_contracts(&data, graph, &declaration_refs);
 
     assert!(
         source
@@ -862,25 +859,13 @@ fn state_reads_depend_on_the_latest_preceding_writer() {
         .into_boxed_slice(),
         ..SourceProgram::default()
     };
-    let write = Box::leak(Box::new(pure_state_rmw_contract(1)));
-    let read = Box::leak(Box::new(pure_full_write_contract(1, 1)));
+    let write = pure_state_rmw_contract(1);
+    let read = pure_full_write_contract(1, 1);
     let mut context = ArtifactBuildContext::new(&data.schemas, &data.constants);
     assert!(matches!(
-        compile_source_program_with_contracts(&graph, &mut context, &[Some(write), Some(read)],),
+        compile_source_program_with_contracts(&graph, &mut context, &[Some(&write), Some(&read)],),
         Err(ArtifactBuildError::CombinationalCycle)
     ));
-}
-
-#[test]
-fn compiler_pseudo_values_never_enter_snapshot_constants() {
-    assert_eq!(
-        compiler_ir_from_legacy_pseudo_value(&LegacyValue::Empty).unwrap(),
-        ExpressionIR::Empty
-    );
-    assert_eq!(
-        compiler_ir_from_legacy_pseudo_value(&LegacyValue::IndexAll).unwrap(),
-        ExpressionIR::Selection(SelectionIR::All)
-    );
 }
 
 #[test]
@@ -919,7 +904,296 @@ fn matrix_literal_resolution_is_homogeneous_and_structured() {
     };
     assert!(matches!(
         unresolved.resolve_constant(data.schema.matrix2, &data.schemas, &data.constants),
-        Err(CompilerIrError::MatrixLiteralElementNotConstant { index: 0 })
+        Err(CompilerIrError::UnresolvedMatrixLiteralElement { index: 0 })
+    ));
+
+    let malformed_shape = MatrixLiteralIR {
+        rows: 2,
+        columns: 2,
+        elements: vec![ExpressionIR::Constant(data.constant.one); 3].into_boxed_slice(),
+    };
+    assert!(matches!(
+        malformed_shape.resolve_constant(data.schema.matrix2, &data.schemas, &data.constants),
+        Err(CompilerIrError::MatrixLiteralShapeMismatch {
+            actual_elements: 3,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn matrix_literal_resolution_canonicalizes_optional_elements() {
+    let mut schemas = SchemaTableBuilder::new();
+    let f64_schema = schemas
+        .insert(schema(SchemaBody::FloatingPoint(FloatWidth::W64)))
+        .unwrap();
+    let option_schema = schemas
+        .insert(schema(SchemaBody::Option(Box::new(
+            SchemaBody::FloatingPoint(FloatWidth::W64),
+        ))))
+        .unwrap();
+    let matrix_schema = schemas
+        .insert(schema(SchemaBody::Matrix {
+            element: Box::new(SchemaBody::Option(Box::new(SchemaBody::FloatingPoint(
+                FloatWidth::W64,
+            )))),
+            dimensions: vec![DimensionExpr::Constant(1), DimensionExpr::Constant(3)]
+                .into_boxed_slice(),
+        }))
+        .unwrap();
+    let build = schemas.finish().unwrap();
+    let f64_schema = build.resolve(f64_schema).unwrap();
+    let option_schema = build.resolve(option_schema).unwrap();
+    let matrix_schema = build.resolve(matrix_schema).unwrap();
+    let (schemas, _) = build.into_parts();
+    let validation = SnapshotValidationContext::new(&schemas);
+    let mut constants = ConstantStoreBuilder::new(&schemas);
+    let bare = constants
+        .insert(scalar_value(&schemas, f64_schema, 1.0))
+        .unwrap();
+    let wrapped = constants
+        .insert(
+            ValueDraft {
+                schema: option_schema,
+                shape_values: Box::new([]),
+                data: ValueDataDraft::Option(OptionDraft {
+                    present: true,
+                    value: Some(Box::new(ValueDataDraft::F64(F64Bits::from_f64(2.0)))),
+                }),
+            }
+            .finalize(&validation)
+            .unwrap(),
+        )
+        .unwrap();
+    let build = constants.finish().unwrap();
+    let bare = build.resolve(bare).unwrap();
+    let wrapped = build.resolve(wrapped).unwrap();
+    let (constants, _) = build.into_parts();
+
+    let literal = MatrixLiteralIR {
+        rows: 1,
+        columns: 3,
+        elements: vec![
+            ExpressionIR::Empty,
+            ExpressionIR::Constant(bare),
+            ExpressionIR::Constant(wrapped),
+        ]
+        .into_boxed_slice(),
+    };
+    let value = literal
+        .resolve_constant(matrix_schema, &schemas, &constants)
+        .unwrap();
+    let ValueData::Matrix(matrix) = value.data() else {
+        panic!("optional matrix literal must resolve to matrix data");
+    };
+    let SequenceView::Values(elements) = matrix.elements() else {
+        panic!("option matrix elements must use canonical value storage");
+    };
+    assert!(matches!(elements[0], ValueData::Option(None)));
+    assert!(matches!(elements[1], ValueData::Option(Some(_))));
+    assert!(matches!(elements[2], ValueData::Option(Some(_))));
+
+    let data = fixture_data();
+    let empty_f64 = MatrixLiteralIR {
+        rows: 2,
+        columns: 1,
+        elements: vec![
+            ExpressionIR::Empty,
+            ExpressionIR::Constant(data.constant.one),
+        ]
+        .into_boxed_slice(),
+    };
+    assert!(matches!(
+        empty_f64.resolve_constant(data.schema.vector2, &data.schemas, &data.constants),
+        Err(CompilerIrError::EmptyMatrixLiteralElementRequiresOption { index: 0 })
+    ));
+}
+
+#[test]
+fn matrix_literal_dynamic_classification_is_recursive() {
+    let literal = MatrixLiteralIR {
+        rows: 1,
+        columns: 2,
+        elements: vec![
+            ExpressionIR::Selection(SelectionIR::Index(Box::new(ExpressionIR::Slot(
+                CellSlotId::new(0),
+            )))),
+            ExpressionIR::MatrixLiteral(MatrixLiteralIR {
+                rows: 1,
+                columns: 1,
+                elements: vec![ExpressionIR::Empty].into_boxed_slice(),
+            }),
+        ]
+        .into_boxed_slice(),
+    };
+    assert!(literal.contains_slots());
+    assert!(literal.contains_empty());
+}
+
+fn compiled_generic_matrix(
+    values: Vec<LegacyValue>,
+    rows: usize,
+    columns: usize,
+) -> CompiledBytecode {
+    let matrix = LegacyValue::MatrixValue(Matrix::from_vec(values, rows, columns));
+    let mut context = CompileCtx::new();
+    let output = context.resolve_value_register(&matrix).unwrap();
+    context.finish_program(output).unwrap()
+}
+
+#[test]
+fn compiled_matrix_sidecars_fold_static_literals_through_canonical_ir() {
+    let compiled = compiled_generic_matrix(
+        [1.0, 3.0, 2.0, 4.0]
+            .into_iter()
+            .map(|value| LegacyValue::F64(Ref::new(value)))
+            .collect(),
+        2,
+        2,
+    );
+    let artifact = compile_executable_program_artifact(&compiled, &empty_function_catalog())
+        .expect("a valid static matrix sidecar must compile");
+    assert!(artifact.nodes().iter().all(|node| {
+        node.operation.module_path.as_ref() != ["matrix"]
+            || node.operation.operation_name != "literal"
+    }));
+    let output = &artifact.outputs()[0];
+    let slot = &artifact.slots()[output.source.get() as usize];
+    let Some(InitializerReference::Constant(constant)) = slot.initializer else {
+        panic!("a folded matrix output must be initialized by one canonical constant");
+    };
+    let value = artifact.constants().get(constant).unwrap();
+    let ValueData::Matrix(matrix) = value.data() else {
+        panic!("the folded output constant must be matrix data");
+    };
+    let SequenceView::F64(values) = matrix.elements() else {
+        panic!("the folded homogeneous f64 matrix must use f64 storage");
+    };
+    assert_eq!(
+        values
+            .iter()
+            .map(|value| value.to_f64())
+            .collect::<Vec<_>>(),
+        vec![1.0, 2.0, 3.0, 4.0]
+    );
+}
+
+#[test]
+fn compiled_matrix_sidecars_emit_fixed_row_major_dynamic_bindings() {
+    let mut compiled = compiled_generic_matrix(
+        vec![
+            LegacyValue::F64(Ref::new(1.0)),
+            LegacyValue::F64(Ref::new(2.0)),
+        ],
+        1,
+        2,
+    );
+    let literal = compiled
+        .matrix_literals
+        .get(&compiled.return_register)
+        .unwrap();
+    let first = literal.elements[0].register();
+    compiled.symbol_definitions.push(CompiledSymbolDefinition {
+        id: mech_core::hash_str("live"),
+        name: "live".to_owned(),
+        register: first,
+        mutable: false,
+        root_visible: true,
+        ordinal: 0,
+    });
+    let artifact = compile_executable_program_artifact_with_outputs_and_external_inputs(
+        &compiled,
+        &[],
+        &empty_function_catalog(),
+        &BTreeSet::from(["live".to_owned()]),
+    )
+    .expect("a live matrix element must lower to matrix/literal");
+    let node = artifact
+        .nodes()
+        .iter()
+        .find(|node| {
+            node.operation.module_path.as_ref() == ["matrix"]
+                && node.operation.operation_name == "literal"
+        })
+        .expect("dynamic matrix lowering must emit one matrix/literal node");
+    let bindings =
+        &artifact.bindings()[node.input_bindings.start as usize..node.input_bindings.end as usize];
+    assert_eq!(
+        bindings.len(),
+        2,
+        "the kind template is not an artifact input"
+    );
+    let BindingDeclaration::Input {
+        port_ordinal: 0,
+        source: ArtifactSource::Slot(first_slot),
+        ..
+    } = &bindings[0]
+    else {
+        panic!("the live first element must bind from an artifact slot");
+    };
+    assert_ne!(
+        first_slot.get(),
+        first,
+        "the fixture must distinguish bytecode register and artifact slot identities",
+    );
+    assert!(matches!(
+        bindings[1],
+        BindingDeclaration::Input {
+            port_ordinal: 1,
+            source: ArtifactSource::Constant(_),
+            ..
+        }
+    ));
+}
+
+#[test]
+fn compiled_matrix_sidecar_disagreement_fails_before_lowering() {
+    let mut compiled = compiled_generic_matrix(
+        vec![
+            LegacyValue::F64(Ref::new(1.0)),
+            LegacyValue::F64(Ref::new(2.0)),
+        ],
+        1,
+        2,
+    );
+    compiled
+        .matrix_literals
+        .get_mut(&compiled.return_register)
+        .unwrap()
+        .elements
+        .swap(0, 1);
+    assert!(matches!(
+        compile_executable_program_artifact(&compiled, &empty_function_catalog()),
+        Err(ArtifactBuildError::MatrixLiteralMetadataMismatch { .. })
+    ));
+}
+
+#[test]
+fn dynamic_matrix_sidecars_reject_empty_pseudo_values() {
+    let mut compiled = compiled_generic_matrix(
+        vec![LegacyValue::Empty, LegacyValue::F64(Ref::new(2.0))],
+        1,
+        2,
+    );
+    let second = compiled.matrix_literals[&compiled.return_register].elements[1].register();
+    compiled.symbol_definitions.push(CompiledSymbolDefinition {
+        id: mech_core::hash_str("live"),
+        name: "live".to_owned(),
+        register: second,
+        mutable: false,
+        root_visible: true,
+        ordinal: 0,
+    });
+    assert!(matches!(
+        compile_executable_program_artifact_with_outputs_and_external_inputs(
+            &compiled,
+            &[],
+            &empty_function_catalog(),
+            &BTreeSet::from(["live".to_owned()]),
+        ),
+        Err(ArtifactBuildError::CompilerIr(
+            CompilerIrError::DynamicEmptyMatrixLiteralUnsupported { index: 0 }
+        ))
     ));
 }
 

--- a/src/engine/tests/program_artifact_contract.rs
+++ b/src/engine/tests/program_artifact_contract.rs
@@ -1197,6 +1197,73 @@ fn dynamic_matrix_sidecars_reject_empty_pseudo_values() {
     ));
 }
 
+#[cfg(feature = "resident-artifact")]
+#[test]
+fn dynamic_matrix_literal_artifacts_execute_and_update_resident_output() {
+    use mech_engine::__resident::{ActivationFacts, CapturedSignalInput, activate};
+
+    let mut compiled = compiled_generic_matrix(
+        [1.0, 3.0, 2.0, 4.0]
+            .into_iter()
+            .map(|value| LegacyValue::F64(Ref::new(value)))
+            .collect(),
+        2,
+        2,
+    );
+    let first = compiled.matrix_literals[&compiled.return_register].elements[0].register();
+    compiled.symbol_definitions.push(CompiledSymbolDefinition {
+        id: mech_core::hash_str("live"),
+        name: "live".to_owned(),
+        register: first,
+        mutable: false,
+        root_visible: true,
+        ordinal: 0,
+    });
+    let mut catalog = mech_core::FunctionCatalogBuilder::new();
+    install_intrinsic_resident(&mut catalog).unwrap();
+    let catalog = catalog.build().unwrap();
+    let artifact = compile_executable_program_artifact_with_outputs_and_external_inputs(
+        &compiled,
+        &[],
+        &catalog,
+        &BTreeSet::from(["live".to_owned()]),
+    )
+    .unwrap();
+    let mut instance = activate(
+        mech_core::ReactiveInstanceId::new(1, 0),
+        &artifact,
+        &catalog,
+        &ActivationFacts::default(),
+    )
+    .unwrap();
+    for (live, expected) in [
+        (9.0, vec![9.0, 2.0, 3.0, 4.0]),
+        (7.0, vec![7.0, 2.0, 3.0, 4.0]),
+    ] {
+        let live = [live];
+        instance
+            .turn_without_summary(&[CapturedSignalInput {
+                slot: instance.plan.inputs[0].slot,
+                value: mech_core::ResidentValueRef::F64(&live),
+            }])
+            .unwrap();
+        let output = instance.copied_output(0).unwrap();
+        let ValueData::Matrix(matrix) = output.data() else {
+            panic!("resident matrix/literal output must remain canonical matrix data");
+        };
+        let SequenceView::F64(values) = matrix.elements() else {
+            panic!("resident f64 literal must preserve f64 matrix storage");
+        };
+        assert_eq!(
+            values
+                .iter()
+                .map(|value| value.to_f64())
+                .collect::<Vec<_>>(),
+            expected
+        );
+    }
+}
+
 #[test]
 fn matrix_literal_resolution_accepts_homogeneous_aggregate_elements() {
     let mut schemas = SchemaTableBuilder::new();


### PR DESCRIPTION
## Summary

- records generic matrix construction as deterministic compiler sidecar metadata
- uses an existing `Kind(Matrix)` constant as the legacy bytecode `CompositePack` template
- lowers the sidecar into production `MatrixLiteralIR` during `ProgramArtifact` construction
- folds static matrix literals into canonical `Value` constants
- lowers dynamic exact-schema literals to a declared `matrix/literal` resident operation
- resolves static `_` elements as absent options without giving `Empty` a runtime representation
- preserves the existing interpreter, function ABI, bytecode framing, and frozen fixtures

## Review revisions

- matrix literal operation contracts are owned for the duration of compilation; no dynamic declaration is leaked to manufacture a `'static` reference
- matrix, option, empty, index-all, and mutable-reference semantics are inspected structurally rather than through display-string formatting or parsing
- reused matrix registers revalidate the complete sidecar descriptor while `CompositePack` is emitted only for the initializing producer; conflicting reuse returns a structured error
- dynamic matrix elements retain source/register identity until artifact slot allocation; `MatrixLiteralIR` is built only from the real resolved `CellSlotId` values
- regressions cover conflicting reused descriptors and prove that artifact slot IDs are not fabricated from bytecode register numbers

## Behavior

| Source/compiler case | Result |
|---|---|
| `[]` | Canonical 0×0 matrix constant |
| Static homogeneous literal | Canonical matrix constant |
| Static literal with `_` and option-compatible elements | Canonical option-element matrix |
| Static heterogeneous literal | Structured error |
| Dynamic exact-schema generic literal | `matrix/literal` node |
| Dynamic literal containing `_` | Structured unsupported error |
| Ordinary tuple/record composite | Existing `core/composite-pack` path |
| Nonempty `MatrixValue::compile_const` | Still rejected |

## Non-goals

- no `MatrixValue` deletion
- no function ABI migration
- no selection migration
- no machinery sweep
- no bytecode opcode or version change
- no architecture JSON regeneration

## Evidence

- Base SHA: `a66ce415f9f93c759100f010a0db9f8caf819d02`
- Final head SHA: `f41b6a6adbc59741bdc64b957c11dd0694bd4df5`
- exactly four PR commits
- `src/core/src/value.rs`: unchanged
- `cargo +nightly-2026-03-03 fmt --all -- --check`: passed
- `git diff --check`: passed
- warning policy: passed
- `cargo test --locked -p mech-core --lib --all-features`: passed, 373 tests
- `cargo test --locked -p mech-engine --test program_artifact_contract --no-default-features --features full_compiler`: passed, 27 tests
- `cargo test --locked -p mech-engine --lib --no-default-features --features full_compiler`: passed, 293 tests
- `cargo test --locked -p mech-runtime --lib --no-default-features --features full_compiler`: passed, 465 tests
- runtime-only stdlib compilation: passed
- `cargo test --locked -p mech-engine --lib --all-features resident::matrix_literal::tests:: -- --nocapture`: passed, 5 tests
- `cargo test --locked -p mech-engine --lib --all-features`: 362 passed and 3 inherited fixed-storage selector-layout tests failed in the unchanged access/assignment implementation; the requested `full_compiler` configuration passes those selector cases, and PR4 changes none of `src/engine/src/intrinsics/access/**` or `src/engine/src/intrinsics/assign/**`
- `cargo test --locked -p mech-engine --lib --all-features explicit_all_selector_preserves -- --nocapture`: reproduced the same 3 inherited full-feature selector-layout failures and 3 companion passes
- `python3 scripts/check-value-system-contract.py --mode retirement`: passed; `LegacyValue` reviewed 4,928, live 4,906, removed 22; `ValueKind` reviewed/live 1,181; `Kind` reviewed/live 162; zero unreviewed audited occurrences
- production routing, compiler quarantine, execution boundary, bytecode-v1, artifact, operation, and resident activation contract checks: passed
- function-system source and consumer checks: passed
- frozen value-system/function-system JSON, bytecode framing files, prohibited paths, and contract declarations: unchanged
- final tree equality check against the fully validated pre-rebase tree: unchanged

The repository impact-selected CI is used for the PR; no `ci:full` label is applied.

- GitHub CI run `33077419620`: passed all selected checks, including Static contracts, Linux, Windows, browser canary, all 14 owner shards, and the PR gate

