### PR TITLE
[PR5] refactor(functions): route runtime factories through opaque ports

### DIFF
--- a/machines/compare/src/eq.rs
+++ b/machines/compare/src/eq.rs
@@ -119,23 +119,16 @@ impl MechFunctionFactory for AtomEq {
         FunctionValueRepresentation::Atom,
     );
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, lhs, rhs) = invocation.expect_binary()?;
+        let lhs: Ref<MechAtom> = lhs.try_ref()?;
+        let rhs: Ref<MechAtom> = rhs.try_ref()?;
+        let out: Ref<bool> = out.try_ref()?;
+        Ok(Box::new(AtomEq { lhs, rhs, out }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Binary(out, arg1, arg2) => {
-                let lhs: Ref<MechAtom> = arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let rhs: Ref<MechAtom> = arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                let out: Ref<bool> = out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(AtomEq { lhs, rhs, out }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 2,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 #[cfg(feature = "atom")]
@@ -184,23 +177,16 @@ impl MechFunctionFactory for TableEq {
         FunctionValueRepresentation::Table,
     );
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, lhs, rhs) = invocation.expect_binary()?;
+        let lhs: Ref<MechTable> = lhs.try_ref()?;
+        let rhs: Ref<MechTable> = rhs.try_ref()?;
+        let out: Ref<bool> = out.try_ref()?;
+        Ok(Box::new(TableEq { lhs, rhs, out }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Binary(out, arg1, arg2) => {
-                let lhs: Ref<MechTable> = arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let rhs: Ref<MechTable> = arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                let out: Ref<bool> = out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(TableEq { lhs, rhs, out }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 2,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 #[cfg(feature = "table")]
@@ -279,3 +265,91 @@ fn impl_eq_fxn(lhs_value: LegacyValue, rhs_value: LegacyValue) -> MResult<Box<dy
 
 #[cfg(feature = "source")]
 impl_mech_binop_fxn!(CompareEqual, impl_eq_fxn, "compare/eq");
+
+#[cfg(all(
+    test,
+    feature = "runtime",
+    feature = "f64",
+    feature = "bool",
+    feature = "matrix2",
+    feature = "atom",
+    feature = "table"
+))]
+mod invocation_port_tests {
+    use super::*;
+    use nalgebra::Matrix2;
+
+    fn binary_args<T, O>(out: &Ref<O>, lhs: &Ref<T>, rhs: &Ref<T>) -> FunctionArgs
+    where
+        Ref<T>: ToValue,
+        Ref<O>: ToValue,
+    {
+        FunctionArgs::Binary(out.to_value(), lhs.to_value(), rhs.to_value())
+    }
+
+    #[test]
+    fn scalar_legacy_and_invocation_entries_are_equivalent() {
+        let lhs = Ref::new(3.0_f64);
+        let rhs = Ref::new(3.0_f64);
+        let legacy_out = Ref::new(false);
+        let invocation_out = Ref::new(false);
+
+        let legacy = EQSS::<f64>::new(binary_args(&legacy_out, &lhs, &rhs)).unwrap();
+        let invocation = EQSS::<f64>::new_invocation(
+            binary_args(&invocation_out, &lhs, &rhs).into(),
+        )
+        .unwrap();
+        legacy.solve_result().unwrap();
+        invocation.solve_result().unwrap();
+
+        assert!(*legacy_out.borrow());
+        assert_eq!(*legacy_out.borrow(), *invocation_out.borrow());
+    }
+
+    #[test]
+    fn fixed_matrix_atom_and_table_factories_use_exact_ports() {
+        let lhs = Ref::new(Matrix2::new(1.0_f64, 2.0, 3.0, 4.0));
+        let rhs = Ref::new(Matrix2::new(1.0_f64, 0.0, 3.0, 5.0));
+        let out = Ref::new(Matrix2::from_element(false));
+        let function = EQM2M2::<f64>::new_invocation(binary_args(&out, &lhs, &rhs).into()).unwrap();
+        function.solve_result().unwrap();
+        assert_eq!(*out.borrow(), Matrix2::new(true, false, true, false));
+
+        let atom_lhs = Ref::new(MechAtom::from_name("same"));
+        let atom_rhs = Ref::new(MechAtom::from_name("same"));
+        let atom_out = Ref::new(false);
+        let atom = AtomEq::new_invocation(binary_args(&atom_out, &atom_lhs, &atom_rhs).into())
+            .unwrap();
+        atom.solve_result().unwrap();
+        assert!(*atom_out.borrow());
+
+        let table_lhs = Ref::new(MechTable::from_parts(0, 0, Vec::new(), Vec::new()));
+        let table_rhs = Ref::new(MechTable::from_parts(0, 0, Vec::new(), Vec::new()));
+        let table_out = Ref::new(false);
+        let table =
+            TableEq::new_invocation(binary_args(&table_out, &table_lhs, &table_rhs).into())
+                .unwrap();
+        table.solve_result().unwrap();
+        assert!(*table_out.borrow());
+    }
+
+    #[test]
+    fn comparison_ports_reject_wrong_types_and_layouts() {
+        let out = Ref::new(false);
+        let lhs = Ref::new(1.0_f64);
+        let rhs = Ref::new(1_i8);
+        let type_error = EQSS::<f64>::new_invocation(
+            FunctionArgs::Binary(out.to_value(), lhs.to_value(), rhs.to_value()).into(),
+        )
+        .err()
+        .expect("wrong exact input representation must fail");
+        assert_eq!(type_error.kind_name(), "FunctionArgumentTypeMismatch");
+
+        let arity_error = EQSS::<f64>::new_invocation(
+            FunctionArgs::Unary(out.to_value(), lhs.to_value()).into(),
+        )
+        .err()
+        .expect("wrong layout must fail");
+        assert_eq!(arity_error.kind_name(), "IncorrectNumberOfArguments");
+    }
+}

--- a/machines/compare/src/lib.rs
+++ b/machines/compare/src/lib.rs
@@ -177,9 +177,9 @@ macro_rules! impl_compare_binop {
             #[cfg(feature = "semantic-compiler")]
             T: ConstElem + CompileConst,
             Ref<$out_type>: ToValue,
-            $arg1_type: FunctionRuntimeType,
-            $arg2_type: FunctionRuntimeType,
-            $out_type: FunctionRuntimeType,
+            $arg1_type: FunctionRuntimeType + FunctionPortBacking,
+            $arg2_type: FunctionRuntimeType + FunctionPortBacking,
+            $out_type: FunctionRuntimeType + FunctionPortBacking,
         {
             const SIGNATURE: RuntimeFunctionSignature = RuntimeFunctionSignature::binary(
                 <$out_type as FunctionRuntimeType>::REPRESENTATION,
@@ -187,26 +187,18 @@ macro_rules! impl_compare_binop {
                 <$arg2_type as FunctionRuntimeType>::REPRESENTATION,
             );
 
+            fn new_invocation(
+                invocation: FunctionInvocation,
+            ) -> MResult<Box<dyn MechFunction>> {
+                let (out, lhs, rhs) = invocation.expect_binary()?;
+                let lhs: Ref<$arg1_type> = lhs.try_ref()?;
+                let rhs: Ref<$arg2_type> = rhs.try_ref()?;
+                let out: Ref<$out_type> = out.try_ref()?;
+                Ok(Box::new(Self { lhs, rhs, out }))
+            }
+
             fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-                match args {
-                    FunctionArgs::Binary(out, arg1, arg2) => {
-                        let lhs: Ref<$arg1_type> =
-                            arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                        let rhs: Ref<$arg2_type> =
-                            arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                        let out: Ref<$out_type> =
-                            out.try_function_ref(FunctionArgumentRole::Output)?;
-                        Ok(Box::new(Self { lhs, rhs, out }))
-                    }
-                    _ => Err(MechError::new(
-                        IncorrectNumberOfArguments {
-                            expected: 2,
-                            found: args.len(),
-                        },
-                        None,
-                    )
-                    .with_compiler_loc()),
-                }
+                Self::new_invocation(args.into())
             }
         }
         impl<T> MechFunctionImpl for $struct_name<T>

--- a/machines/compare/src/neq.rs
+++ b/machines/compare/src/neq.rs
@@ -119,23 +119,16 @@ impl MechFunctionFactory for AtomNeq {
         FunctionValueRepresentation::Atom,
     );
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, lhs, rhs) = invocation.expect_binary()?;
+        let lhs: Ref<MechAtom> = lhs.try_ref()?;
+        let rhs: Ref<MechAtom> = rhs.try_ref()?;
+        let out: Ref<bool> = out.try_ref()?;
+        Ok(Box::new(AtomNeq { lhs, rhs, out }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Binary(out, arg1, arg2) => {
-                let lhs: Ref<MechAtom> = arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let rhs: Ref<MechAtom> = arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                let out: Ref<bool> = out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(AtomNeq { lhs, rhs, out }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 2,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 #[cfg(feature = "atom")]
@@ -184,23 +177,16 @@ impl MechFunctionFactory for TableNeq {
         FunctionValueRepresentation::Table,
     );
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, lhs, rhs) = invocation.expect_binary()?;
+        let lhs: Ref<MechTable> = lhs.try_ref()?;
+        let rhs: Ref<MechTable> = rhs.try_ref()?;
+        let out: Ref<bool> = out.try_ref()?;
+        Ok(Box::new(TableNeq { lhs, rhs, out }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Binary(out, arg1, arg2) => {
-                let lhs: Ref<MechTable> = arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let rhs: Ref<MechTable> = arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                let out: Ref<bool> = out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(TableNeq { lhs, rhs, out }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 2,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 #[cfg(feature = "table")]

--- a/machines/logic/src/lib.rs
+++ b/machines/logic/src/lib.rs
@@ -202,26 +202,18 @@ macro_rules! impl_logic_binop {
                 <$arg2_type as FunctionRuntimeType>::REPRESENTATION,
             );
 
+            fn new_invocation(
+                invocation: FunctionInvocation,
+            ) -> MResult<Box<dyn MechFunction>> {
+                let (out, lhs, rhs) = invocation.expect_binary()?;
+                let lhs: Ref<$arg1_type> = lhs.try_ref()?;
+                let rhs: Ref<$arg2_type> = rhs.try_ref()?;
+                let out: Ref<$out_type> = out.try_ref()?;
+                Ok(Box::new(Self { lhs, rhs, out }))
+            }
+
             fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-                match args {
-                    FunctionArgs::Binary(out, arg1, arg2) => {
-                        let lhs: Ref<$arg1_type> =
-                            arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                        let rhs: Ref<$arg2_type> =
-                            arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                        let out: Ref<$out_type> =
-                            out.try_function_ref(FunctionArgumentRole::Output)?;
-                        Ok(Box::new(Self { lhs, rhs, out }))
-                    }
-                    _ => Err(MechError::new(
-                        IncorrectNumberOfArguments {
-                            expected: 2,
-                            found: args.len(),
-                        },
-                        None,
-                    )
-                    .with_compiler_loc()),
-                }
+                Self::new_invocation(args.into())
             }
         }
         impl MechFunctionImpl for $struct_name {
@@ -263,4 +255,103 @@ macro_rules! impl_logic_fxns {
     ($lib:ident) => {
         impl_fxns!($lib, bool, bool, impl_logic_binop);
     };
+}
+
+#[cfg(all(
+    test,
+    feature = "runtime",
+    feature = "and",
+    feature = "not",
+    feature = "bool",
+    feature = "matrix2",
+    feature = "matrixd"
+))]
+mod invocation_port_tests {
+    use super::*;
+    use nalgebra::{DMatrix, Matrix2};
+
+    fn binary_args<T>(out: &Ref<T>, lhs: &Ref<T>, rhs: &Ref<T>) -> FunctionArgs
+    where
+        Ref<T>: ToValue,
+    {
+        FunctionArgs::Binary(out.to_value(), lhs.to_value(), rhs.to_value())
+    }
+
+    #[test]
+    fn scalar_binary_and_unary_factories_use_invocation_ports() {
+        let lhs = Ref::new(true);
+        let rhs = Ref::new(false);
+        let binary_out = Ref::new(true);
+        let binary = crate::and::AndSS::new_invocation(
+            binary_args(&binary_out, &lhs, &rhs).into(),
+        )
+        .unwrap();
+        binary.solve_result().unwrap();
+        assert!(!*binary_out.borrow());
+
+        let unary_out = Ref::new(false);
+        let unary = crate::not::NotS::<bool>::new_invocation(
+            FunctionArgs::Unary(unary_out.to_value(), lhs.to_value()).into(),
+        )
+        .unwrap();
+        unary.solve_result().unwrap();
+        assert!(!*unary_out.borrow());
+    }
+
+    #[test]
+    fn fixed_and_dynamic_matrix_factories_preserve_storage() {
+        let fixed_lhs = Ref::new(Matrix2::new(true, true, false, false));
+        let fixed_rhs = Ref::new(Matrix2::new(true, false, true, false));
+        let fixed_out = Ref::new(Matrix2::from_element(false));
+        let fixed = crate::and::AndM2M2::new_invocation(
+            binary_args(&fixed_out, &fixed_lhs, &fixed_rhs).into(),
+        )
+        .unwrap();
+        fixed.solve_result().unwrap();
+        assert_eq!(
+            *fixed_out.borrow(),
+            Matrix2::new(true, false, false, false)
+        );
+
+        let dynamic_lhs = Ref::new(DMatrix::from_row_slice(
+            2,
+            2,
+            &[true, true, false, false],
+        ));
+        let dynamic_rhs = Ref::new(DMatrix::from_row_slice(
+            2,
+            2,
+            &[true, false, true, false],
+        ));
+        let dynamic_out = Ref::new(DMatrix::from_element(2, 2, false));
+        let dynamic = crate::and::AndMDMD::new_invocation(
+            binary_args(&dynamic_out, &dynamic_lhs, &dynamic_rhs).into(),
+        )
+        .unwrap();
+        dynamic.solve_result().unwrap();
+        assert_eq!(
+            *dynamic_out.borrow(),
+            DMatrix::from_row_slice(2, 2, &[true, false, false, false])
+        );
+    }
+
+    #[test]
+    fn logic_ports_reject_wrong_types_and_layouts() {
+        let out = Ref::new(false);
+        let scalar = Ref::new(true);
+        let matrix = Ref::new(Matrix2::from_element(true));
+        let type_error = crate::and::AndSS::new_invocation(
+            FunctionArgs::Binary(out.to_value(), matrix.to_value(), scalar.to_value()).into(),
+        )
+        .err()
+        .expect("wrong exact input representation must fail");
+        assert_eq!(type_error.kind_name(), "FunctionArgumentTypeMismatch");
+
+        let arity_error = crate::and::AndSS::new_invocation(
+            FunctionArgs::Unary(out.to_value(), scalar.to_value()).into(),
+        )
+        .err()
+        .expect("wrong layout must fail");
+        assert_eq!(arity_error.kind_name(), "IncorrectNumberOfArguments");
+    }
 }

--- a/machines/logic/src/not.rs
+++ b/machines/logic/src/not.rs
@@ -21,31 +21,24 @@ where
     #[cfg(feature = "semantic-compiler")]
     T: CompileConst + ConstElem,
     Ref<T>: ToValue,
-    T: FunctionRuntimeType,
+    T: FunctionRuntimeType + FunctionPortBacking,
 {
     const SIGNATURE: RuntimeFunctionSignature =
         RuntimeFunctionSignature::unary(T::REPRESENTATION, T::REPRESENTATION);
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, arg) = invocation.expect_unary()?;
+        let arg: Ref<T> = arg.try_ref()?;
+        let out: Ref<T> = out.try_ref()?;
+        Ok(Box::new(Self {
+            arg,
+            out,
+            _marker: PhantomData::default(),
+        }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Unary(out, arg) => {
-                let arg: Ref<T> = arg.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let out: Ref<T> = out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(Self {
-                    arg,
-                    out,
-                    _marker: PhantomData::default(),
-                }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 1,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 impl<T> MechFunctionImpl for NotS<T>
@@ -112,31 +105,24 @@ where
     #[cfg(feature = "semantic-compiler")]
     MatA: CompileConst + ConstElem,
     Ref<MatA>: ToValue,
-    MatA: FunctionRuntimeType,
+    MatA: FunctionRuntimeType + FunctionPortBacking,
 {
     const SIGNATURE: RuntimeFunctionSignature =
         RuntimeFunctionSignature::unary(MatA::REPRESENTATION, MatA::REPRESENTATION);
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, arg) = invocation.expect_unary()?;
+        let arg: Ref<MatA> = arg.try_ref()?;
+        let out: Ref<MatA> = out.try_ref()?;
+        Ok(Box::new(Self {
+            arg,
+            out,
+            _marker: PhantomData::default(),
+        }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Unary(out, arg) => {
-                let arg: Ref<MatA> = arg.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let out: Ref<MatA> = out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(Self {
-                    arg,
-                    out,
-                    _marker: PhantomData::default(),
-                }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 1,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 impl<T, MatA> MechFunctionImpl for NotV<T, MatA>

--- a/machines/math/src/ops/div.rs
+++ b/machines/math/src/ops/div.rs
@@ -136,9 +136,9 @@ macro_rules! impl_checked_div_binop {
                 + One
                 + RuntimeCheckedDiv,
             Ref<$out_type>: ToValue,
-            $arg1_type: FunctionRuntimeType,
-            $arg2_type: FunctionRuntimeType,
-            $out_type: FunctionRuntimeType,
+            $arg1_type: FunctionRuntimeType + FunctionPortBacking,
+            $arg2_type: FunctionRuntimeType + FunctionPortBacking,
+            $out_type: FunctionRuntimeType + FunctionPortBacking,
         {
             const SIGNATURE: RuntimeFunctionSignature = RuntimeFunctionSignature::binary(
                 <$out_type as FunctionRuntimeType>::REPRESENTATION,
@@ -146,26 +146,18 @@ macro_rules! impl_checked_div_binop {
                 <$arg2_type as FunctionRuntimeType>::REPRESENTATION,
             );
 
+            fn new_invocation(
+                invocation: FunctionInvocation,
+            ) -> MResult<Box<dyn MechFunction>> {
+                let (out, lhs, rhs) = invocation.expect_binary()?;
+                let lhs: Ref<$arg1_type> = lhs.try_ref()?;
+                let rhs: Ref<$arg2_type> = rhs.try_ref()?;
+                let out: Ref<$out_type> = out.try_ref()?;
+                Ok(Box::new(Self { lhs, rhs, out }))
+            }
+
             fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-                match args {
-                    FunctionArgs::Binary(out, arg1, arg2) => {
-                        let lhs: Ref<$arg1_type> =
-                            arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                        let rhs: Ref<$arg2_type> =
-                            arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                        let out: Ref<$out_type> =
-                            out.try_function_ref(FunctionArgumentRole::Output)?;
-                        Ok(Box::new(Self { lhs, rhs, out }))
-                    }
-                    _ => Err(MechError::new(
-                        IncorrectNumberOfArguments {
-                            expected: 2,
-                            found: args.len(),
-                        },
-                        None,
-                    )
-                    .with_compiler_loc()),
-                }
+                Self::new_invocation(args.into())
             }
         }
         impl<T> MechFunctionImpl for $struct_name<T>

--- a/machines/math/src/ops/mod.rs
+++ b/machines/math/src/ops/mod.rs
@@ -355,9 +355,9 @@ macro_rules! impl_checked_arithmetic_binop {
             #[cfg(feature = "semantic-compiler")]
             T: ConstElem + CompileConst,
             Ref<$out_type>: ToValue,
-            $arg1_type: FunctionRuntimeType,
-            $arg2_type: FunctionRuntimeType,
-            $out_type: FunctionRuntimeType,
+            $arg1_type: FunctionRuntimeType + FunctionPortBacking,
+            $arg2_type: FunctionRuntimeType + FunctionPortBacking,
+            $out_type: FunctionRuntimeType + FunctionPortBacking,
         {
             const SIGNATURE: RuntimeFunctionSignature = RuntimeFunctionSignature::binary(
                 <$out_type as FunctionRuntimeType>::REPRESENTATION,
@@ -365,26 +365,18 @@ macro_rules! impl_checked_arithmetic_binop {
                 <$arg2_type as FunctionRuntimeType>::REPRESENTATION,
             );
 
+            fn new_invocation(
+                invocation: FunctionInvocation,
+            ) -> MResult<Box<dyn MechFunction>> {
+                let (out, lhs, rhs) = invocation.expect_binary()?;
+                let lhs: Ref<$arg1_type> = lhs.try_ref()?;
+                let rhs: Ref<$arg2_type> = rhs.try_ref()?;
+                let out: Ref<$out_type> = out.try_ref()?;
+                Ok(Box::new(Self { lhs, rhs, out }))
+            }
+
             fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-                match args {
-                    FunctionArgs::Binary(out, arg1, arg2) => {
-                        let lhs: Ref<$arg1_type> =
-                            arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                        let rhs: Ref<$arg2_type> =
-                            arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                        let out: Ref<$out_type> =
-                            out.try_function_ref(FunctionArgumentRole::Output)?;
-                        Ok(Box::new(Self { lhs, rhs, out }))
-                    }
-                    _ => Err(MechError::new(
-                        IncorrectNumberOfArguments {
-                            expected: 2,
-                            found: args.len(),
-                        },
-                        None,
-                    )
-                    .with_compiler_loc()),
-                }
+                Self::new_invocation(args.into())
             }
         }
 

--- a/machines/math/src/ops/modulus.rs
+++ b/machines/math/src/ops/modulus.rs
@@ -101,9 +101,9 @@ macro_rules! impl_binop2 {
             #[cfg(feature = "semantic-compiler")]
             T: CompileConst + ConstElem,
             Ref<$out_type>: ToValue,
-            $arg1_type: FunctionRuntimeType,
-            $arg2_type: FunctionRuntimeType,
-            $out_type: FunctionRuntimeType,
+            $arg1_type: FunctionRuntimeType + FunctionPortBacking,
+            $arg2_type: FunctionRuntimeType + FunctionPortBacking,
+            $out_type: FunctionRuntimeType + FunctionPortBacking,
         {
             const SIGNATURE: RuntimeFunctionSignature = RuntimeFunctionSignature::binary(
                 <$out_type as FunctionRuntimeType>::REPRESENTATION,
@@ -111,26 +111,18 @@ macro_rules! impl_binop2 {
                 <$arg2_type as FunctionRuntimeType>::REPRESENTATION,
             );
 
+            fn new_invocation(
+                invocation: FunctionInvocation,
+            ) -> MResult<Box<dyn MechFunction>> {
+                let (out, lhs, rhs) = invocation.expect_binary()?;
+                let lhs: Ref<$arg1_type> = lhs.try_ref()?;
+                let rhs: Ref<$arg2_type> = rhs.try_ref()?;
+                let out: Ref<$out_type> = out.try_ref()?;
+                Ok(Box::new(Self { lhs, rhs, out }))
+            }
+
             fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-                match args {
-                    FunctionArgs::Binary(out, arg1, arg2) => {
-                        let lhs: Ref<$arg1_type> =
-                            arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                        let rhs: Ref<$arg2_type> =
-                            arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                        let out: Ref<$out_type> =
-                            out.try_function_ref(FunctionArgumentRole::Output)?;
-                        Ok(Box::new(Self { lhs, rhs, out }))
-                    }
-                    _ => Err(MechError::new(
-                        IncorrectNumberOfArguments {
-                            expected: 2,
-                            found: 0,
-                        },
-                        None,
-                    )
-                    .with_compiler_loc()),
-                }
+                Self::new_invocation(args.into())
             }
         }
         impl<T> MechFunctionImpl for $struct_name<T>

--- a/machines/math/src/ops/negate.rs
+++ b/machines/math/src/ops/negate.rs
@@ -26,31 +26,24 @@ where
     #[cfg(feature = "semantic-compiler")]
     O: CompileConst + ConstElem,
     Ref<O>: ToValue,
-    O: FunctionRuntimeType,
+    O: FunctionRuntimeType + FunctionPortBacking,
 {
     const SIGNATURE: RuntimeFunctionSignature =
         RuntimeFunctionSignature::unary(O::REPRESENTATION, O::REPRESENTATION);
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, arg) = invocation.expect_unary()?;
+        let arg: Ref<O> = arg.try_ref()?;
+        let out: Ref<O> = out.try_ref()?;
+        Ok(Box::new(Self {
+            arg,
+            out,
+            _marker: PhantomData,
+        }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Unary(out, arg) => {
-                let arg: Ref<O> = arg.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let out: Ref<O> = out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(Self {
-                    arg,
-                    out,
-                    _marker: PhantomData,
-                }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 1,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 impl<O> MechFunctionImpl for NegateV<O>
@@ -125,31 +118,24 @@ where
     #[cfg(feature = "semantic-compiler")]
     O: CompileConst + ConstElem,
     Ref<O>: ToValue,
-    O: FunctionRuntimeType,
+    O: FunctionRuntimeType + FunctionPortBacking,
 {
     const SIGNATURE: RuntimeFunctionSignature =
         RuntimeFunctionSignature::unary(O::REPRESENTATION, O::REPRESENTATION);
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, arg) = invocation.expect_unary()?;
+        let arg: Ref<O> = arg.try_ref()?;
+        let out: Ref<O> = out.try_ref()?;
+        Ok(Box::new(Self {
+            arg,
+            out,
+            _marker: PhantomData,
+        }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Unary(out, arg) => {
-                let arg: Ref<O> = arg.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let out: Ref<O> = out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(Self {
-                    arg,
-                    out,
-                    _marker: PhantomData,
-                }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 1,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 impl<O> MechFunctionImpl for NegateS<O>
@@ -206,6 +192,19 @@ where
 #[cfg(all(test, feature = "i8"))]
 mod checked_arithmetic_tests {
     use super::*;
+
+    #[test]
+    fn unary_scalar_factory_uses_exact_invocation_ports() {
+        let input = Ref::new(7_i8);
+        let output = Ref::new(0_i8);
+        let function = NegateS::<i8>::new_invocation(
+            FunctionArgs::Unary(output.to_value(), input.to_value()).into(),
+        )
+        .unwrap();
+
+        function.solve_result().unwrap();
+        assert_eq!(*output.borrow(), -7);
+    }
 
     #[test]
     fn integer_negation_rejects_reactive_overflow_and_retains_output() {

--- a/machines/math/src/ops/pow.rs
+++ b/machines/math/src/ops/pow.rs
@@ -154,9 +154,9 @@ macro_rules! impl_powop {
             #[cfg(feature = "semantic-compiler")]
             T: CompileConst + ConstElem,
             Ref<$out_type>: ToValue,
-            $arg1_type: FunctionRuntimeType,
-            $arg2_type: FunctionRuntimeType,
-            $out_type: FunctionRuntimeType,
+            $arg1_type: FunctionRuntimeType + FunctionPortBacking,
+            $arg2_type: FunctionRuntimeType + FunctionPortBacking,
+            $out_type: FunctionRuntimeType + FunctionPortBacking,
         {
             const SIGNATURE: RuntimeFunctionSignature = RuntimeFunctionSignature::binary(
                 <$out_type as FunctionRuntimeType>::REPRESENTATION,
@@ -164,26 +164,18 @@ macro_rules! impl_powop {
                 <$arg2_type as FunctionRuntimeType>::REPRESENTATION,
             );
 
+            fn new_invocation(
+                invocation: FunctionInvocation,
+            ) -> MResult<Box<dyn MechFunction>> {
+                let (out, lhs, rhs) = invocation.expect_binary()?;
+                let lhs: Ref<$arg1_type> = lhs.try_ref()?;
+                let rhs: Ref<$arg2_type> = rhs.try_ref()?;
+                let out: Ref<$out_type> = out.try_ref()?;
+                Ok(Box::new(Self { lhs, rhs, out }))
+            }
+
             fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-                match args {
-                    FunctionArgs::Binary(out, arg1, arg2) => {
-                        let lhs: Ref<$arg1_type> =
-                            arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                        let rhs: Ref<$arg2_type> =
-                            arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                        let out: Ref<$out_type> =
-                            out.try_function_ref(FunctionArgumentRole::Output)?;
-                        Ok(Box::new(Self { lhs, rhs, out }))
-                    }
-                    _ => Err(MechError::new(
-                        IncorrectNumberOfArguments {
-                            expected: 2,
-                            found: 0,
-                        },
-                        None,
-                    )
-                    .with_compiler_loc()),
-                }
+                Self::new_invocation(args.into())
             }
         }
         impl<T> MechFunctionImpl for $struct_name<T>
@@ -260,6 +252,21 @@ impl_math_fxns_pow!(Pow);
 mod checked_arithmetic_tests {
     use super::*;
 
+    #[cfg(all(feature = "rational", feature = "i32"))]
+    #[test]
+    fn rational_factory_extracts_each_exact_port() {
+        let lhs = Ref::new(R64::new(3, 2));
+        let rhs = Ref::new(2_i32);
+        let out = Ref::new(R64::default());
+        let function = PowRational::new_invocation(
+            FunctionArgs::Binary(out.to_value(), lhs.to_value(), rhs.to_value()).into(),
+        )
+        .unwrap();
+
+        function.solve_result().unwrap();
+        assert_eq!(*out.borrow(), R64::new(9, 4));
+    }
+
     #[test]
     fn integer_exponentiation_rejects_reactive_overflow_and_retains_output() {
         let rhs = Ref::new(1_u8);
@@ -294,23 +301,16 @@ impl MechFunctionFactory for PowRational {
         FunctionValueRepresentation::I32,
     );
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, lhs, rhs) = invocation.expect_binary()?;
+        let lhs: Ref<R64> = lhs.try_ref()?;
+        let rhs: Ref<i32> = rhs.try_ref()?;
+        let out: Ref<R64> = out.try_ref()?;
+        Ok(Box::new(Self { lhs, rhs, out }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Binary(out, arg1, arg2) => {
-                let lhs: Ref<R64> = arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let rhs: Ref<i32> = arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                let out: Ref<R64> = out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(Self { lhs, rhs, out }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 2,
-                    found: 0,
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 #[cfg(all(feature = "rational", feature = "i32"))]

--- a/machines/math/src/trig/atan2.rs
+++ b/machines/math/src/trig/atan2.rs
@@ -62,33 +62,30 @@ macro_rules! impl_two_arg_fxn {
             arg2: Ref<$kind2>,
             out: Ref<$out_kind>,
         }
-        impl MechFunctionFactory for $struct_name {
+        impl MechFunctionFactory for $struct_name
+        where
+            $kind1: FunctionPortBacking,
+            $kind2: FunctionPortBacking,
+            $out_kind: FunctionPortBacking,
+        {
             const SIGNATURE: RuntimeFunctionSignature = RuntimeFunctionSignature::binary(
                 <$out_kind as FunctionRuntimeType>::REPRESENTATION,
                 <$kind1 as FunctionRuntimeType>::REPRESENTATION,
                 <$kind2 as FunctionRuntimeType>::REPRESENTATION,
             );
 
+            fn new_invocation(
+                invocation: FunctionInvocation,
+            ) -> MResult<Box<dyn MechFunction>> {
+                let (out, arg1, arg2) = invocation.expect_binary()?;
+                let arg1: Ref<$kind1> = arg1.try_ref()?;
+                let arg2: Ref<$kind2> = arg2.try_ref()?;
+                let out: Ref<$out_kind> = out.try_ref()?;
+                Ok(Box::new($struct_name { arg1, arg2, out }))
+            }
+
             fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-                match args {
-                    FunctionArgs::Binary(out, arg1, arg2) => {
-                        let arg1: Ref<$kind1> =
-                            arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                        let arg2: Ref<$kind2> =
-                            arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                        let out: Ref<$out_kind> =
-                            out.try_function_ref(FunctionArgumentRole::Output)?;
-                        Ok(Box::new($struct_name { arg1, arg2, out }))
-                    }
-                    _ => Err(MechError::new(
-                        IncorrectNumberOfArguments {
-                            expected: 2,
-                            found: args.len(),
-                        },
-                        None,
-                    )
-                    .with_compiler_loc()),
-                }
+                Self::new_invocation(args.into())
             }
         }
         impl MechFunctionImpl for $struct_name {
@@ -191,6 +188,25 @@ impl_two_arg_fxn!(Atan2F32, f32, f32, f32, atan2f_op);
 
 #[cfg(feature = "f64")]
 impl_two_arg_fxn!(Atan2F64, f64, f64, f64, atan2_op);
+
+#[cfg(all(test, feature = "runtime", feature = "f64"))]
+mod invocation_port_tests {
+    use super::*;
+
+    #[test]
+    fn scalar_atan2_factory_uses_exact_invocation_ports() {
+        let lhs = Ref::new(1.0_f64);
+        let rhs = Ref::new(1.0_f64);
+        let out = Ref::new(0.0_f64);
+        let function = Atan2F64::new_invocation(
+            FunctionArgs::Binary(out.to_value(), lhs.to_value(), rhs.to_value()).into(),
+        )
+        .unwrap();
+
+        function.solve_result().unwrap();
+        assert!((*out.borrow() - core::f64::consts::FRAC_PI_4).abs() < f64::EPSILON);
+    }
+}
 
 #[macro_export]
 macro_rules! impl_binop_atan2 {

--- a/src/core/src/function/argument.rs
+++ b/src/core/src/function/argument.rs
@@ -1,13 +1,413 @@
 #[cfg(feature = "no_std")]
-use alloc::string::{String, ToString};
+use alloc::{
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
 #[cfg(not(feature = "no_std"))]
-use std::string::{String, ToString};
+use std::{
+    string::{String, ToString},
+    vec::Vec,
+};
 
-use core::any::type_name;
+use core::{any::type_name, fmt};
 
 #[cfg(feature = "matrix")]
 use crate::structures::Matrix;
-use crate::{LegacyValue, MResult, MechError, MechErrorKind, ReactiveCellId, Ref};
+use crate::{
+    FunctionArgs, FunctionRuntimeType, IncorrectNumberOfArguments, LegacyValue, MResult, MechError,
+    MechErrorKind, ReactiveCellId, Ref, RuntimeFunctionInputs, RuntimeFunctionSignature,
+};
+
+mod function_port_backing {
+    pub trait Sealed {}
+}
+
+/// An exact runtime backing type that may be extracted through a function port.
+///
+/// This sealed marker deliberately excludes [`LegacyValue`], [`crate::ValueCell`],
+/// and reference wrappers around either type. Universal legacy values remain
+/// available only through the legacy factory boundary.
+pub trait FunctionPortBacking:
+    function_port_backing::Sealed + FunctionRuntimeType + 'static
+{
+}
+
+impl<T> FunctionPortBacking for T where
+    T: function_port_backing::Sealed + FunctionRuntimeType + 'static
+{
+}
+
+macro_rules! scalar_function_port_backing {
+    ($type:ty, $feature:literal) => {
+        #[cfg(feature = $feature)]
+        impl function_port_backing::Sealed for $type {}
+    };
+}
+
+scalar_function_port_backing!(u8, "u8");
+scalar_function_port_backing!(u16, "u16");
+scalar_function_port_backing!(u32, "u32");
+scalar_function_port_backing!(u64, "u64");
+scalar_function_port_backing!(u128, "u128");
+scalar_function_port_backing!(i8, "i8");
+scalar_function_port_backing!(i16, "i16");
+scalar_function_port_backing!(i32, "i32");
+scalar_function_port_backing!(i64, "i64");
+scalar_function_port_backing!(i128, "i128");
+scalar_function_port_backing!(f32, "f32");
+scalar_function_port_backing!(f64, "f64");
+scalar_function_port_backing!(bool, "bool");
+scalar_function_port_backing!(String, "string");
+
+impl function_port_backing::Sealed for usize {}
+
+#[cfg(feature = "complex")]
+impl function_port_backing::Sealed for crate::C64 {}
+
+#[cfg(feature = "rational")]
+impl function_port_backing::Sealed for crate::R64 {}
+
+#[cfg(feature = "atom")]
+impl function_port_backing::Sealed for crate::MechAtom {}
+
+#[cfg(feature = "enum")]
+impl function_port_backing::Sealed for crate::MechEnum {}
+
+#[cfg(feature = "record")]
+impl function_port_backing::Sealed for crate::MechRecord {}
+
+#[cfg(feature = "map")]
+impl function_port_backing::Sealed for crate::MechMap {}
+
+#[cfg(feature = "set")]
+impl function_port_backing::Sealed for crate::MechSet {}
+
+#[cfg(feature = "table")]
+impl function_port_backing::Sealed for crate::MechTable {}
+
+#[cfg(feature = "tuple")]
+impl function_port_backing::Sealed for crate::MechTuple {}
+
+#[cfg(feature = "matrix")]
+impl<T: FunctionPortBacking> function_port_backing::Sealed for Matrix<T> {}
+
+macro_rules! exact_matrix_function_port_backing {
+    ($type:ident, $feature:literal) => {
+        #[cfg(feature = $feature)]
+        impl<T: FunctionPortBacking> function_port_backing::Sealed for crate::$type<T> {}
+    };
+}
+
+exact_matrix_function_port_backing!(Matrix1, "matrix1");
+exact_matrix_function_port_backing!(Matrix2, "matrix2");
+exact_matrix_function_port_backing!(Matrix3, "matrix3");
+exact_matrix_function_port_backing!(Matrix4, "matrix4");
+exact_matrix_function_port_backing!(Matrix2x3, "matrix2x3");
+exact_matrix_function_port_backing!(Matrix3x2, "matrix3x2");
+exact_matrix_function_port_backing!(RowVector2, "row_vector2");
+exact_matrix_function_port_backing!(RowVector3, "row_vector3");
+exact_matrix_function_port_backing!(RowVector4, "row_vector4");
+exact_matrix_function_port_backing!(RowDVector, "row_vectord");
+exact_matrix_function_port_backing!(Vector2, "vector2");
+exact_matrix_function_port_backing!(Vector3, "vector3");
+exact_matrix_function_port_backing!(Vector4, "vector4");
+exact_matrix_function_port_backing!(DVector, "vectord");
+exact_matrix_function_port_backing!(DMatrix, "matrixd");
+
+#[derive(Clone)]
+pub struct FunctionInvocation {
+    args: FunctionArgs,
+}
+
+#[derive(Clone, Copy)]
+pub struct FunctionInputPort<'a> {
+    invocation: &'a FunctionInvocation,
+    index: usize,
+}
+
+#[derive(Clone, Copy)]
+pub struct FunctionOutputPort<'a> {
+    invocation: &'a FunctionInvocation,
+}
+
+pub struct FunctionInputPorts<'a> {
+    invocation: &'a FunctionInvocation,
+    next: usize,
+}
+
+impl From<FunctionArgs> for FunctionInvocation {
+    fn from(args: FunctionArgs) -> Self {
+        Self { args }
+    }
+}
+
+impl FunctionInvocation {
+    pub fn input_count(&self) -> usize {
+        self.legacy_args().input_count()
+    }
+
+    pub fn output(&self) -> FunctionOutputPort<'_> {
+        FunctionOutputPort { invocation: self }
+    }
+
+    pub fn input(&self, index: usize) -> Option<FunctionInputPort<'_>> {
+        self.args.input_value(index).map(|_| FunctionInputPort {
+            invocation: self,
+            index,
+        })
+    }
+
+    pub fn inputs(&self) -> FunctionInputPorts<'_> {
+        FunctionInputPorts {
+            invocation: self,
+            next: 0,
+        }
+    }
+
+    pub fn expect_nullary(&self) -> MResult<FunctionOutputPort<'_>> {
+        if matches!(self.args, FunctionArgs::Nullary(_)) {
+            Ok(self.output())
+        } else {
+            Err(self.layout_error(0))
+        }
+    }
+
+    pub fn expect_unary(&self) -> MResult<(FunctionOutputPort<'_>, FunctionInputPort<'_>)> {
+        if matches!(self.args, FunctionArgs::Unary(_, _)) {
+            Ok((self.output(), self.input(0).expect("unary input")))
+        } else {
+            Err(self.layout_error(1))
+        }
+    }
+
+    pub fn expect_binary(
+        &self,
+    ) -> MResult<(
+        FunctionOutputPort<'_>,
+        FunctionInputPort<'_>,
+        FunctionInputPort<'_>,
+    )> {
+        if matches!(self.args, FunctionArgs::Binary(_, _, _)) {
+            Ok((
+                self.output(),
+                self.input(0).expect("binary left input"),
+                self.input(1).expect("binary right input"),
+            ))
+        } else {
+            Err(self.layout_error(2))
+        }
+    }
+
+    pub fn expect_ternary(
+        &self,
+    ) -> MResult<(
+        FunctionOutputPort<'_>,
+        FunctionInputPort<'_>,
+        FunctionInputPort<'_>,
+        FunctionInputPort<'_>,
+    )> {
+        if matches!(self.args, FunctionArgs::Ternary(_, _, _, _)) {
+            Ok((
+                self.output(),
+                self.input(0).expect("ternary first input"),
+                self.input(1).expect("ternary second input"),
+                self.input(2).expect("ternary third input"),
+            ))
+        } else {
+            Err(self.layout_error(3))
+        }
+    }
+
+    pub fn expect_quaternary(
+        &self,
+    ) -> MResult<(
+        FunctionOutputPort<'_>,
+        FunctionInputPort<'_>,
+        FunctionInputPort<'_>,
+        FunctionInputPort<'_>,
+        FunctionInputPort<'_>,
+    )> {
+        if matches!(self.args, FunctionArgs::Quaternary(_, _, _, _, _)) {
+            Ok((
+                self.output(),
+                self.input(0).expect("quaternary first input"),
+                self.input(1).expect("quaternary second input"),
+                self.input(2).expect("quaternary third input"),
+                self.input(3).expect("quaternary fourth input"),
+            ))
+        } else {
+            Err(self.layout_error(4))
+        }
+    }
+
+    pub fn expect_variadic(&self) -> MResult<(FunctionOutputPort<'_>, FunctionInputPorts<'_>)> {
+        if matches!(self.args, FunctionArgs::Variadic(_, _)) {
+            Ok((self.output(), self.inputs()))
+        } else {
+            Err(self.layout_error(self.input_count()))
+        }
+    }
+
+    pub(crate) fn normalize_for_signature(self, signature: RuntimeFunctionSignature) -> Self {
+        if !matches!(signature.inputs, RuntimeFunctionInputs::Variadic { .. }) {
+            return self;
+        }
+        let args = match self.args {
+            FunctionArgs::Nullary(output) => FunctionArgs::Variadic(output, Vec::new()),
+            FunctionArgs::Unary(output, first) => FunctionArgs::Variadic(output, vec![first]),
+            FunctionArgs::Binary(output, first, second) => {
+                FunctionArgs::Variadic(output, vec![first, second])
+            }
+            FunctionArgs::Ternary(output, first, second, third) => {
+                FunctionArgs::Variadic(output, vec![first, second, third])
+            }
+            FunctionArgs::Quaternary(output, first, second, third, fourth) => {
+                FunctionArgs::Variadic(output, vec![first, second, third, fourth])
+            }
+            args @ FunctionArgs::Variadic(_, _) => args,
+        };
+        Self { args }
+    }
+
+    pub(crate) fn legacy_args(&self) -> &FunctionArgs {
+        &self.args
+    }
+
+    pub(crate) fn into_legacy_args(self) -> FunctionArgs {
+        self.args
+    }
+
+    fn layout_error(&self, expected: usize) -> MechError {
+        MechError::new(
+            IncorrectNumberOfArguments {
+                expected,
+                found: self.input_count(),
+            },
+            None,
+        )
+        .with_compiler_loc()
+    }
+
+    fn layout_name(&self) -> &'static str {
+        match self.args {
+            FunctionArgs::Nullary(_) => "Nullary",
+            FunctionArgs::Unary(_, _) => "Unary",
+            FunctionArgs::Binary(_, _, _) => "Binary",
+            FunctionArgs::Ternary(_, _, _, _) => "Ternary",
+            FunctionArgs::Quaternary(_, _, _, _, _) => "Quaternary",
+            FunctionArgs::Variadic(_, _) => "Variadic",
+        }
+    }
+}
+
+impl fmt::Debug for FunctionInvocation {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("FunctionInvocation")
+            .field("layout", &self.layout_name())
+            .field("input_count", &self.input_count())
+            .finish()
+    }
+}
+
+impl FunctionInputPort<'_> {
+    pub const fn index(self) -> usize {
+        self.index
+    }
+
+    /// Extracts the exact typed input backing without exposing legacy values.
+    ///
+    /// ```compile_fail
+    /// use mech_core::{FunctionArgs, FunctionInvocation, LegacyValue, Ref};
+    ///
+    /// let legacy_cell = Ref::new(LegacyValue::Empty);
+    /// let invocation = FunctionInvocation::from(FunctionArgs::Unary(
+    ///     LegacyValue::Empty,
+    ///     LegacyValue::MutableReference(legacy_cell),
+    /// ));
+    /// let (_, input) = invocation.expect_unary().unwrap();
+    /// let _: Ref<LegacyValue> = input.try_ref::<LegacyValue>().unwrap();
+    /// ```
+    pub fn try_ref<T: FunctionPortBacking>(self) -> MResult<Ref<T>> {
+        require_function_ref(
+            self.invocation
+                .args
+                .input_value(self.index)
+                .expect("function input port index remains valid"),
+            FunctionArgumentRole::Input(self.index),
+        )
+    }
+}
+
+impl fmt::Debug for FunctionInputPort<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("FunctionInputPort")
+            .field("index", &self.index)
+            .finish()
+    }
+}
+
+impl FunctionOutputPort<'_> {
+    /// Extracts the exact typed output backing without exposing legacy values.
+    ///
+    /// ```compile_fail
+    /// use mech_core::{FunctionArgs, FunctionInvocation, LegacyValue, Ref};
+    ///
+    /// let legacy_cell = Ref::new(LegacyValue::Empty);
+    /// let invocation = FunctionInvocation::from(FunctionArgs::Nullary(
+    ///     LegacyValue::MutableReference(legacy_cell),
+    /// ));
+    /// let output = invocation.expect_nullary().unwrap();
+    /// let _: Ref<LegacyValue> = output.try_ref::<LegacyValue>().unwrap();
+    /// ```
+    pub fn try_ref<T: FunctionPortBacking>(self) -> MResult<Ref<T>> {
+        require_function_ref(
+            self.invocation.args.output_value(),
+            FunctionArgumentRole::Output,
+        )
+    }
+}
+
+impl fmt::Debug for FunctionOutputPort<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("FunctionOutputPort(Output)")
+    }
+}
+
+impl<'a> Iterator for FunctionInputPorts<'a> {
+    type Item = FunctionInputPort<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let port = self.invocation.input(self.next)?;
+        self.next += 1;
+        Some(port)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.len();
+        (remaining, Some(remaining))
+    }
+}
+
+impl ExactSizeIterator for FunctionInputPorts<'_> {
+    fn len(&self) -> usize {
+        self.invocation.input_count().saturating_sub(self.next)
+    }
+}
+
+impl core::iter::FusedIterator for FunctionInputPorts<'_> {}
+
+impl fmt::Debug for FunctionInputPorts<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("FunctionInputPorts")
+            .field("next", &self.next)
+            .field("remaining", &self.len())
+            .finish()
+    }
+}
 
 /// Identifies the argument whose exact runtime representation was rejected.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -215,6 +615,269 @@ pub fn require_function_ref<T: 'static>(
 mod tests {
     use super::*;
     use crate::ToValue;
+
+    #[cfg(feature = "f64")]
+    fn scalar(value: f64) -> (Ref<f64>, LegacyValue) {
+        let reference = Ref::new(value);
+        let value = reference.to_value();
+        (reference, value)
+    }
+
+    #[cfg(feature = "f64")]
+    #[test]
+    fn fixed_invocation_layouts_preserve_output_and_input_order() {
+        let (output, output_value) = scalar(10.0);
+        let (first, first_value) = scalar(1.0);
+        let (second, second_value) = scalar(2.0);
+        let (third, third_value) = scalar(3.0);
+        let (fourth, fourth_value) = scalar(4.0);
+
+        let nullary = FunctionInvocation::from(FunctionArgs::Nullary(output_value.clone()));
+        assert!(
+            nullary
+                .expect_nullary()
+                .unwrap()
+                .try_ref::<f64>()
+                .unwrap()
+                .same_handle(&output)
+        );
+
+        let unary = FunctionInvocation::from(FunctionArgs::Unary(
+            output_value.clone(),
+            first_value.clone(),
+        ));
+        let (unary_output, unary_first) = unary.expect_unary().unwrap();
+        assert!(unary_output.try_ref::<f64>().unwrap().same_handle(&output));
+        assert!(unary_first.try_ref::<f64>().unwrap().same_handle(&first));
+
+        let binary = FunctionInvocation::from(FunctionArgs::Binary(
+            output_value.clone(),
+            first_value.clone(),
+            second_value.clone(),
+        ));
+        let (binary_output, binary_first, binary_second) = binary.expect_binary().unwrap();
+        assert!(binary_output.try_ref::<f64>().unwrap().same_handle(&output));
+        assert!(binary_first.try_ref::<f64>().unwrap().same_handle(&first));
+        assert!(binary_second.try_ref::<f64>().unwrap().same_handle(&second));
+
+        let ternary = FunctionInvocation::from(FunctionArgs::Ternary(
+            output_value.clone(),
+            first_value.clone(),
+            second_value.clone(),
+            third_value.clone(),
+        ));
+        let (ternary_output, ternary_first, ternary_second, ternary_third) =
+            ternary.expect_ternary().unwrap();
+        assert!(
+            ternary_output
+                .try_ref::<f64>()
+                .unwrap()
+                .same_handle(&output)
+        );
+        assert!(ternary_first.try_ref::<f64>().unwrap().same_handle(&first));
+        assert!(
+            ternary_second
+                .try_ref::<f64>()
+                .unwrap()
+                .same_handle(&second)
+        );
+        assert!(ternary_third.try_ref::<f64>().unwrap().same_handle(&third));
+
+        let quaternary = FunctionInvocation::from(FunctionArgs::Quaternary(
+            output_value,
+            first_value,
+            second_value,
+            third_value,
+            fourth_value,
+        ));
+        let (
+            quaternary_output,
+            quaternary_first,
+            quaternary_second,
+            quaternary_third,
+            quaternary_fourth,
+        ) = quaternary.expect_quaternary().unwrap();
+        assert!(
+            quaternary_output
+                .try_ref::<f64>()
+                .unwrap()
+                .same_handle(&output)
+        );
+        assert!(
+            quaternary_first
+                .try_ref::<f64>()
+                .unwrap()
+                .same_handle(&first)
+        );
+        assert!(
+            quaternary_second
+                .try_ref::<f64>()
+                .unwrap()
+                .same_handle(&second)
+        );
+        assert!(
+            quaternary_third
+                .try_ref::<f64>()
+                .unwrap()
+                .same_handle(&third)
+        );
+        assert!(
+            quaternary_fourth
+                .try_ref::<f64>()
+                .unwrap()
+                .same_handle(&fourth)
+        );
+    }
+
+    #[cfg(feature = "f64")]
+    #[test]
+    fn variadic_invocation_is_an_exact_borrowed_cursor() {
+        let (_, output) = scalar(10.0);
+        let (first, first_value) = scalar(1.0);
+        let (second, second_value) = scalar(2.0);
+        let (third, third_value) = scalar(3.0);
+        let invocation = FunctionInvocation::from(FunctionArgs::Variadic(
+            output,
+            vec![first_value, second_value, third_value],
+        ));
+
+        let (_, mut inputs) = invocation.expect_variadic().unwrap();
+        assert_eq!(inputs.len(), 3);
+        assert!(
+            inputs
+                .next()
+                .unwrap()
+                .try_ref::<f64>()
+                .unwrap()
+                .same_handle(&first)
+        );
+        assert_eq!(inputs.len(), 2);
+        assert!(
+            inputs
+                .next()
+                .unwrap()
+                .try_ref::<f64>()
+                .unwrap()
+                .same_handle(&second)
+        );
+        assert!(
+            inputs
+                .next()
+                .unwrap()
+                .try_ref::<f64>()
+                .unwrap()
+                .same_handle(&third)
+        );
+        assert!(inputs.next().is_none());
+        assert!(inputs.next().is_none());
+        assert_eq!(invocation.inputs().size_hint(), (3, Some(3)));
+        assert_eq!(
+            core::mem::size_of::<FunctionInputPorts<'_>>(),
+            core::mem::size_of::<&FunctionInvocation>() + core::mem::size_of::<usize>()
+        );
+    }
+
+    #[cfg(feature = "f64")]
+    #[test]
+    fn input_lookup_and_layout_checks_remain_exact() {
+        let (_, output) = scalar(10.0);
+        let (_, first) = scalar(1.0);
+        let (_, second) = scalar(2.0);
+        let invocation =
+            FunctionInvocation::from(FunctionArgs::Variadic(output, vec![first, second]));
+
+        assert_eq!(invocation.input(0).unwrap().index(), 0);
+        assert_eq!(invocation.input(1).unwrap().index(), 1);
+        assert!(invocation.input(2).is_none());
+
+        let error = invocation.expect_binary().unwrap_err();
+        assert_eq!(error.kind_name(), "IncorrectNumberOfArguments");
+        let arity = error.kind_as::<IncorrectNumberOfArguments>().unwrap();
+        assert_eq!(arity.expected, 2);
+        assert_eq!(arity.found, 2);
+    }
+
+    #[cfg(all(feature = "f64", feature = "bool"))]
+    #[test]
+    fn port_type_failures_report_the_exact_argument_role() {
+        let (_, output) = scalar(10.0);
+        let (_, input) = scalar(1.0);
+        let invocation = FunctionInvocation::from(FunctionArgs::Unary(output, input));
+        let (output, input) = invocation.expect_unary().unwrap();
+
+        let input_error = input.try_ref::<bool>().unwrap_err();
+        assert_eq!(
+            input_error
+                .kind_as::<FunctionArgumentTypeMismatch>()
+                .unwrap()
+                .role,
+            FunctionArgumentRole::Input(0),
+        );
+        let output_error = output.try_ref::<bool>().unwrap_err();
+        assert_eq!(
+            output_error
+                .kind_as::<FunctionArgumentTypeMismatch>()
+                .unwrap()
+                .role,
+            FunctionArgumentRole::Output,
+        );
+    }
+
+    #[cfg(feature = "f64")]
+    #[test]
+    fn invocation_ports_do_not_unwrap_typed_or_mutable_values() {
+        let (_, output) = scalar(10.0);
+        let (_, scalar) = scalar(1.0);
+        let typed = LegacyValue::Typed(Box::new(scalar.clone()), crate::ValueKind::F64);
+        let mutable = LegacyValue::MutableReference(Ref::new(scalar));
+
+        for wrapped in [typed, mutable] {
+            let invocation = FunctionInvocation::from(FunctionArgs::Unary(output.clone(), wrapped));
+            let (_, input) = invocation.expect_unary().unwrap();
+            assert!(input.try_ref::<f64>().is_err());
+        }
+    }
+
+    #[cfg(all(feature = "f64", feature = "matrix", feature = "matrix2"))]
+    #[test]
+    fn matrix_ports_preserve_the_exact_backing_handle() {
+        use crate::matrix::Matrix;
+        use nalgebra::Matrix2;
+
+        let matrix = Ref::new(Matrix2::<f64>::identity());
+        let value = LegacyValue::MatrixF64(Matrix::Matrix2(matrix.clone()));
+        let invocation = FunctionInvocation::from(FunctionArgs::Unary(LegacyValue::Empty, value));
+        let (_, input) = invocation.expect_unary().unwrap();
+        assert!(
+            input
+                .try_ref::<Matrix2<f64>>()
+                .unwrap()
+                .same_handle(&matrix)
+        );
+    }
+
+    #[cfg(feature = "f64")]
+    #[test]
+    fn invocation_debug_output_is_opaque() {
+        let (_, output) = scalar(9_876_543.25);
+        let (_, input) = scalar(1_234_567.5);
+        let invocation = FunctionInvocation::from(FunctionArgs::Unary(output, input));
+
+        for debug in [
+            format!("{invocation:?}"),
+            format!("{:?}", invocation.output()),
+            format!("{:?}", invocation.input(0).unwrap()),
+            format!("{:?}", invocation.inputs()),
+        ] {
+            assert!(!debug.contains("9876543"));
+            assert!(!debug.contains("1234567"));
+            assert!(!debug.contains("0x"));
+        }
+        assert_eq!(
+            format!("{invocation:?}"),
+            "FunctionInvocation { layout: \"Unary\", input_count: 1 }"
+        );
+    }
 
     #[cfg(feature = "f64")]
     #[test]

--- a/src/core/src/function/argument.rs
+++ b/src/core/src/function/argument.rs
@@ -1,14 +1,9 @@
 #[cfg(feature = "no_std")]
-use alloc::{
-    string::{String, ToString},
-    vec,
-    vec::Vec,
-};
+use alloc::string::{String, ToString};
+#[cfg(all(feature = "no_std", test))]
+use alloc::vec;
 #[cfg(not(feature = "no_std"))]
-use std::{
-    string::{String, ToString},
-    vec::Vec,
-};
+use std::string::{String, ToString};
 
 use core::{any::type_name, fmt};
 
@@ -16,7 +11,7 @@ use core::{any::type_name, fmt};
 use crate::structures::Matrix;
 use crate::{
     FunctionArgs, FunctionRuntimeType, IncorrectNumberOfArguments, LegacyValue, MResult, MechError,
-    MechErrorKind, ReactiveCellId, Ref, RuntimeFunctionInputs, RuntimeFunctionSignature,
+    MechErrorKind, ReactiveCellId, Ref, RuntimeFunctionSignature,
 };
 
 mod function_port_backing {
@@ -250,24 +245,9 @@ impl FunctionInvocation {
     }
 
     pub(crate) fn normalize_for_signature(self, signature: RuntimeFunctionSignature) -> Self {
-        if !matches!(signature.inputs, RuntimeFunctionInputs::Variadic { .. }) {
-            return self;
+        Self {
+            args: self.args.normalize_for_signature(signature),
         }
-        let args = match self.args {
-            FunctionArgs::Nullary(output) => FunctionArgs::Variadic(output, Vec::new()),
-            FunctionArgs::Unary(output, first) => FunctionArgs::Variadic(output, vec![first]),
-            FunctionArgs::Binary(output, first, second) => {
-                FunctionArgs::Variadic(output, vec![first, second])
-            }
-            FunctionArgs::Ternary(output, first, second, third) => {
-                FunctionArgs::Variadic(output, vec![first, second, third])
-            }
-            FunctionArgs::Quaternary(output, first, second, third, fourth) => {
-                FunctionArgs::Variadic(output, vec![first, second, third, fourth])
-            }
-            args @ FunctionArgs::Variadic(_, _) => args,
-        };
-        Self { args }
     }
 
     pub(crate) fn legacy_args(&self) -> &FunctionArgs {

--- a/src/core/src/function/catalog.rs
+++ b/src/core/src/function/catalog.rs
@@ -4,10 +4,10 @@ use alloc::{boxed::Box, collections::BTreeMap, string::String, sync::Arc, vec::V
 use std::{boxed::Box, collections::BTreeMap, string::String, sync::Arc, vec::Vec};
 
 use crate::{
-    FunctionArgs, GuardFunctionSafety, LegacyValue, MResult, MechError, MechErrorKind,
-    MechFunction, MechFunctionFactory, OperationContractDeclaration, ResidentKernelFactory,
-    ResidentKernelFactoryEntry, ResidentOperationKey, RuntimeFunctionContract,
-    RuntimeFunctionSignature, RuntimeOutputAliasPolicy, hash_str,
+    FunctionArgs, FunctionInvocation, GuardFunctionSafety, LegacyValue, MResult, MechError,
+    MechErrorKind, MechFunction, MechFunctionFactory, OperationContractDeclaration,
+    ResidentKernelFactory, ResidentKernelFactoryEntry, ResidentOperationKey,
+    RuntimeFunctionContract, RuntimeFunctionSignature, RuntimeOutputAliasPolicy, hash_str,
 };
 
 #[cfg(test)]
@@ -52,6 +52,7 @@ impl RuntimeFunctionId {
 }
 
 type RuntimeFunctionFactory = fn(FunctionArgs) -> MResult<Box<dyn MechFunction>>;
+type RuntimeFunctionInvocationFactory = fn(FunctionInvocation) -> MResult<Box<dyn MechFunction>>;
 
 #[cfg(feature = "native-plan")]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -106,17 +107,33 @@ pub trait FunctionSpecializer: Send + Sync {
     }
 }
 
-#[derive(Clone)]
 pub struct RuntimeFunctionEntry {
     pub id: RuntimeFunctionId,
     pub name: String,
     factory: RuntimeFunctionFactory,
+    invocation_factory: RuntimeFunctionInvocationFactory,
     signature: RuntimeFunctionSignature,
     contract: RuntimeFunctionContract,
     semantic_contract: Option<&'static OperationContractDeclaration>,
 
     #[cfg(feature = "native-plan")]
     pub native_linkage: Option<NativeFunctionLinkage>,
+}
+
+impl Clone for RuntimeFunctionEntry {
+    fn clone(&self) -> Self {
+        Self {
+            id: self.id,
+            name: self.name.clone(),
+            factory: self.factory,
+            invocation_factory: self.invocation_factory,
+            signature: self.signature,
+            contract: self.contract,
+            semantic_contract: self.semantic_contract,
+            #[cfg(feature = "native-plan")]
+            native_linkage: self.native_linkage.clone(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -172,23 +189,43 @@ impl RuntimeFunctionEntry {
     }
 
     pub fn validate_args(&self, args: &FunctionArgs) -> MResult<()> {
-        let args = args.clone().normalize_for_signature(self.signature);
-        args.validate_signature(self.signature)
+        self.validate_invocation(&FunctionInvocation::from(args.clone()))
+    }
+
+    pub fn validate_invocation(&self, invocation: &FunctionInvocation) -> MResult<()> {
+        let invocation = invocation.clone().normalize_for_signature(self.signature);
+        invocation
+            .legacy_args()
+            .validate_signature(self.signature)
             .map_err(|error| self.wrap_contract_error(error))?;
-        args.validate_contract(self.contract)
+        invocation
+            .legacy_args()
+            .validate_contract(self.contract)
             .map_err(|error| self.wrap_contract_error(error))?;
-        let function = (self.factory)(args).map_err(|error| self.wrap_contract_error(error))?;
+        let function = (self.invocation_factory)(invocation)
+            .map_err(|error| self.wrap_contract_error(error))?;
         drop(function);
         Ok(())
     }
 
     pub fn instantiate(&self, args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        let args = args.normalize_for_signature(self.signature);
-        args.validate_signature(self.signature)
+        self.instantiate_invocation(args.into())
+    }
+
+    pub fn instantiate_invocation(
+        &self,
+        invocation: FunctionInvocation,
+    ) -> MResult<Box<dyn MechFunction>> {
+        let invocation = invocation.normalize_for_signature(self.signature);
+        invocation
+            .legacy_args()
+            .validate_signature(self.signature)
             .map_err(|error| self.wrap_contract_error(error))?;
-        args.validate_contract(self.contract)
+        invocation
+            .legacy_args()
+            .validate_contract(self.contract)
             .map_err(|error| self.wrap_contract_error(error))?;
-        (self.factory)(args).map_err(|error| self.wrap_contract_error(error))
+        (self.invocation_factory)(invocation).map_err(|error| self.wrap_contract_error(error))
     }
 }
 
@@ -654,6 +691,7 @@ impl FunctionCatalogBuilder {
             id,
             name,
             factory: F::new,
+            invocation_factory: F::new_invocation,
             signature: F::SIGNATURE,
             contract,
             semantic_contract: None,
@@ -716,6 +754,7 @@ impl FunctionCatalogBuilder {
             id,
             name,
             factory: F::new,
+            invocation_factory: F::new_invocation,
             signature: F::SIGNATURE,
             contract,
             semantic_contract: Some(semantic_contract),
@@ -740,6 +779,7 @@ impl FunctionCatalogBuilder {
             id,
             name,
             factory: F::new,
+            invocation_factory: F::new_invocation,
             signature: F::SIGNATURE,
             contract,
             semantic_contract: None,
@@ -764,6 +804,7 @@ impl FunctionCatalogBuilder {
             id,
             name,
             factory: F::new,
+            invocation_factory: F::new_invocation,
             signature: F::SIGNATURE,
             contract,
             semantic_contract: Some(semantic_contract),
@@ -1397,6 +1438,7 @@ fn validate_export(export: &FunctionExport) -> MResult<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::sync::atomic::{AtomicUsize, Ordering};
 
     fn test_runtime_contract() -> RuntimeFunctionContract {
         RuntimeFunctionContract::no_matrix(RuntimeOutputAliasPolicy::DisallowInputAlias)
@@ -1441,6 +1483,114 @@ mod tests {
             unreachable!("catalog tests do not instantiate runtime functions")
         }
     }
+
+    struct CatalogTestFunction;
+
+    impl crate::MechFunctionImpl for CatalogTestFunction {
+        fn solve_result(&self) -> MResult<()> {
+            Ok(())
+        }
+
+        fn out(&self) -> LegacyValue {
+            LegacyValue::Empty
+        }
+
+        fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
+            Ok(Vec::new())
+        }
+
+        fn to_string(&self) -> String {
+            String::from("CatalogTestFunction")
+        }
+    }
+
+    #[cfg(feature = "semantic-compiler")]
+    impl crate::MechFunctionCompiler for CatalogTestFunction {
+        fn compile(
+            &self,
+            _ctx: &mut dyn crate::BytecodeCompilerContext,
+        ) -> MResult<crate::Register> {
+            Ok(0)
+        }
+    }
+
+    static PREFERRED_LEGACY_CALLS: AtomicUsize = AtomicUsize::new(0);
+    static LEGACY_ONLY_CALLS: AtomicUsize = AtomicUsize::new(0);
+    static INVOCATION_FACTORY_CALLS: AtomicUsize = AtomicUsize::new(0);
+    #[cfg(feature = "f64")]
+    static CONTRACT_FACTORY_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+    struct InvocationPreferredFactory;
+
+    impl crate::MechFunctionFactory for InvocationPreferredFactory {
+        const SIGNATURE: RuntimeFunctionSignature =
+            RuntimeFunctionSignature::nullary(FunctionValueRepresentation::Empty);
+
+        fn new(_: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
+            PREFERRED_LEGACY_CALLS.fetch_add(1, Ordering::SeqCst);
+            Err(MechError::new(
+                crate::IncorrectNumberOfArguments {
+                    expected: 7,
+                    found: 0,
+                },
+                None,
+            )
+            .with_compiler_loc())
+        }
+
+        fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+            INVOCATION_FACTORY_CALLS.fetch_add(1, Ordering::SeqCst);
+            invocation.expect_nullary()?;
+            Ok(Box::new(CatalogTestFunction))
+        }
+    }
+
+    struct LegacyOnlyFactory;
+
+    impl crate::MechFunctionFactory for LegacyOnlyFactory {
+        const SIGNATURE: RuntimeFunctionSignature =
+            RuntimeFunctionSignature::nullary(FunctionValueRepresentation::Empty);
+
+        fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
+            LEGACY_ONLY_CALLS.fetch_add(1, Ordering::SeqCst);
+            if matches!(args, FunctionArgs::Nullary(_)) {
+                Ok(Box::new(CatalogTestFunction))
+            } else {
+                Err(MechError::new(
+                    crate::IncorrectNumberOfArguments {
+                        expected: 0,
+                        found: args.input_count(),
+                    },
+                    None,
+                )
+                .with_compiler_loc())
+            }
+        }
+    }
+
+    #[cfg(feature = "f64")]
+    struct ContractObservedFactory;
+
+    #[cfg(feature = "f64")]
+    impl crate::MechFunctionFactory for ContractObservedFactory {
+        const SIGNATURE: RuntimeFunctionSignature = RuntimeFunctionSignature::binary(
+            FunctionValueRepresentation::F64,
+            FunctionValueRepresentation::F64,
+            FunctionValueRepresentation::F64,
+        );
+
+        fn new(_: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
+            CONTRACT_FACTORY_CALLS.fetch_add(1, Ordering::SeqCst);
+            Ok(Box::new(CatalogTestFunction))
+        }
+    }
+
+    static TEST_SEMANTIC_CONTRACT: std::sync::LazyLock<OperationContractDeclaration> =
+        std::sync::LazyLock::new(|| OperationContractDeclaration {
+            inputs: crate::InputPortLayout::Fixed(Vec::new().into_boxed_slice()),
+            outputs: Vec::new().into_boxed_slice(),
+            interaction: crate::ExternalInteraction::Pure,
+        });
 
     crate::declare_native_runtime_factory! {
         cfg: test,
@@ -1553,6 +1703,7 @@ mod tests {
                 id,
                 name: String::from("first"),
                 factory: TestFactory::new,
+                invocation_factory: TestFactory::new_invocation,
                 signature: TestFactory::SIGNATURE,
                 contract: test_runtime_contract(),
                 semantic_contract: None,
@@ -1566,6 +1717,7 @@ mod tests {
                 id,
                 name: String::from("second"),
                 factory: TestFactory::new,
+                invocation_factory: TestFactory::new_invocation,
                 signature: TestFactory::SIGNATURE,
                 contract: test_runtime_contract(),
                 semantic_contract: None,
@@ -1614,6 +1766,198 @@ mod tests {
             .insert_runtime_factory::<TestFactory>("AddSS<f64>", test_runtime_contract())
             .unwrap_err();
         assert_eq!(error.kind_name(), "FunctionCatalogDuplicateRuntimeFactory");
+    }
+
+    fn assert_test_factory_pointers(entry: &RuntimeFunctionEntry) {
+        assert_eq!(
+            entry.factory as usize,
+            TestFactory::new as RuntimeFunctionFactory as usize,
+        );
+        assert_eq!(
+            entry.invocation_factory as usize,
+            TestFactory::new_invocation as RuntimeFunctionInvocationFactory as usize,
+        );
+    }
+
+    #[test]
+    fn every_runtime_builder_preserves_both_factory_pointers() {
+        let mut plain = FunctionCatalogBuilder::new();
+        plain
+            .insert_runtime_factory::<TestFactory>("PlainPointers", test_runtime_contract())
+            .unwrap();
+        let plain = plain.build().unwrap();
+        assert_test_factory_pointers(
+            plain
+                .runtime_entry(RuntimeFunctionId::from_name("PlainPointers"))
+                .unwrap(),
+        );
+
+        let mut semantic = FunctionCatalogBuilder::new();
+        semantic
+            .insert_runtime_factory_with_semantic_contract::<TestFactory>(
+                "SemanticPointers",
+                test_runtime_contract(),
+                &TEST_SEMANTIC_CONTRACT,
+            )
+            .unwrap();
+        let semantic = semantic.build().unwrap();
+        let semantic_entry = semantic
+            .runtime_entry(RuntimeFunctionId::from_name("SemanticPointers"))
+            .unwrap();
+        assert_test_factory_pointers(semantic_entry);
+        assert!(std::ptr::eq(
+            semantic_entry.semantic_contract().unwrap(),
+            &*TEST_SEMANTIC_CONTRACT,
+        ));
+
+        #[cfg(feature = "native-plan")]
+        {
+            let linkage = NativeFunctionLinkage {
+                package: "mech-core",
+                crate_name: "mech_core",
+                installer_path: "mech_core::__mech_native::install_test_factory",
+                cargo_features: vec!["runtime"],
+            };
+            let mut linked = FunctionCatalogBuilder::new();
+            linked
+                .insert_runtime_factory_with_linkage::<TestFactory>(
+                    "LinkedPointers",
+                    test_runtime_contract(),
+                    linkage.clone(),
+                )
+                .unwrap();
+            let linked = linked.build().unwrap();
+            let linked_entry = linked
+                .runtime_entry(RuntimeFunctionId::from_name("LinkedPointers"))
+                .unwrap();
+            assert_test_factory_pointers(linked_entry);
+            assert_eq!(linked_entry.native_linkage.as_ref(), Some(&linkage));
+
+            let mut linked_semantic = FunctionCatalogBuilder::new();
+            linked_semantic
+                .insert_runtime_factory_with_linkage_and_semantic_contract::<TestFactory>(
+                    "LinkedSemanticPointers",
+                    test_runtime_contract(),
+                    linkage.clone(),
+                    &TEST_SEMANTIC_CONTRACT,
+                )
+                .unwrap();
+            let linked_semantic = linked_semantic.build().unwrap();
+            let linked_semantic_entry = linked_semantic
+                .runtime_entry(RuntimeFunctionId::from_name("LinkedSemanticPointers"))
+                .unwrap();
+            assert_test_factory_pointers(linked_semantic_entry);
+            assert_eq!(
+                linked_semantic_entry.native_linkage.as_ref(),
+                Some(&linkage)
+            );
+            assert!(std::ptr::eq(
+                linked_semantic_entry.semantic_contract().unwrap(),
+                &*TEST_SEMANTIC_CONTRACT,
+            ));
+        }
+    }
+
+    #[test]
+    fn catalog_dispatch_prefers_invocations_and_validates_before_factories() {
+        PREFERRED_LEGACY_CALLS.store(0, Ordering::SeqCst);
+        INVOCATION_FACTORY_CALLS.store(0, Ordering::SeqCst);
+
+        let mut builder = FunctionCatalogBuilder::new();
+        builder
+            .insert_runtime_factory::<InvocationPreferredFactory>(
+                "InvocationPreferredFactory",
+                test_runtime_contract(),
+            )
+            .unwrap();
+        let catalog = builder.build().unwrap();
+        let entry = catalog
+            .runtime_entry(RuntimeFunctionId::from_name("InvocationPreferredFactory"))
+            .unwrap();
+
+        let legacy_function = entry
+            .instantiate(FunctionArgs::Nullary(LegacyValue::Empty))
+            .unwrap();
+        let invocation_function = entry
+            .instantiate_invocation(FunctionArgs::Nullary(LegacyValue::Empty).into())
+            .unwrap();
+        assert!(matches!(legacy_function.out(), LegacyValue::Empty));
+        assert!(matches!(invocation_function.out(), LegacyValue::Empty));
+        entry
+            .validate_args(&FunctionArgs::Nullary(LegacyValue::Empty))
+            .unwrap();
+        entry
+            .validate_invocation(&FunctionArgs::Nullary(LegacyValue::Empty).into())
+            .unwrap();
+
+        assert_eq!(PREFERRED_LEGACY_CALLS.load(Ordering::SeqCst), 0);
+        assert_eq!(INVOCATION_FACTORY_CALLS.load(Ordering::SeqCst), 4);
+
+        let error = entry
+            .instantiate_invocation(
+                FunctionArgs::Unary(LegacyValue::Empty, LegacyValue::Empty).into(),
+            )
+            .err()
+            .expect("signature validation must reject unary arguments");
+        assert_eq!(error.kind_name(), "RuntimeFunctionContractViolation");
+        assert_eq!(INVOCATION_FACTORY_CALLS.load(Ordering::SeqCst), 4);
+
+        #[cfg(feature = "f64")]
+        {
+            use crate::ToValue;
+
+            CONTRACT_FACTORY_CALLS.store(0, Ordering::SeqCst);
+            let mut builder = FunctionCatalogBuilder::new();
+            builder
+                .insert_runtime_factory::<ContractObservedFactory>(
+                    "ContractObservedFactory",
+                    test_runtime_contract(),
+                )
+                .unwrap();
+            let catalog = builder.build().unwrap();
+            let entry = catalog
+                .runtime_entry(RuntimeFunctionId::from_name("ContractObservedFactory"))
+                .unwrap();
+            let aliased = crate::Ref::new(1.0_f64);
+            let rhs = crate::Ref::new(2.0_f64);
+            let error = entry
+                .instantiate(FunctionArgs::Binary(
+                    aliased.to_value(),
+                    aliased.to_value(),
+                    rhs.to_value(),
+                ))
+                .err()
+                .expect("contract validation must reject output aliasing");
+            assert_eq!(error.kind_name(), "RuntimeFunctionContractViolation");
+            assert_eq!(CONTRACT_FACTORY_CALLS.load(Ordering::SeqCst), 0);
+        }
+    }
+
+    #[test]
+    fn legacy_only_factory_uses_the_default_invocation_bridge() {
+        LEGACY_ONLY_CALLS.store(0, Ordering::SeqCst);
+        let mut builder = FunctionCatalogBuilder::new();
+        builder
+            .insert_runtime_factory::<LegacyOnlyFactory>(
+                "LegacyOnlyFactory",
+                test_runtime_contract(),
+            )
+            .unwrap();
+        let catalog = builder.build().unwrap();
+        let entry = catalog
+            .runtime_entry(RuntimeFunctionId::from_name("LegacyOnlyFactory"))
+            .unwrap();
+
+        let legacy = entry
+            .instantiate(FunctionArgs::Nullary(LegacyValue::Empty))
+            .unwrap();
+        let invocation = entry
+            .instantiate_invocation(FunctionArgs::Nullary(LegacyValue::Empty).into())
+            .unwrap();
+
+        assert!(matches!(legacy.out(), LegacyValue::Empty));
+        assert!(matches!(invocation.out(), LegacyValue::Empty));
+        assert_eq!(LEGACY_ONLY_CALLS.load(Ordering::SeqCst), 2);
     }
 
     #[test]

--- a/src/core/src/function/mod.rs
+++ b/src/core/src/function/mod.rs
@@ -182,19 +182,9 @@ pub enum FunctionArgs {
 
 impl FunctionArgs {
     pub(crate) fn normalize_for_signature(self, signature: RuntimeFunctionSignature) -> Self {
-        if !matches!(signature.inputs, RuntimeFunctionInputs::Variadic { .. }) {
-            return self;
-        }
-        match self {
-            FunctionArgs::Nullary(output) => FunctionArgs::Variadic(output, Vec::new()),
-            FunctionArgs::Unary(output, a) => FunctionArgs::Variadic(output, vec![a]),
-            FunctionArgs::Binary(output, a, b) => FunctionArgs::Variadic(output, vec![a, b]),
-            FunctionArgs::Ternary(output, a, b, c) => FunctionArgs::Variadic(output, vec![a, b, c]),
-            FunctionArgs::Quaternary(output, a, b, c, d) => {
-                FunctionArgs::Variadic(output, vec![a, b, c, d])
-            }
-            args @ FunctionArgs::Variadic(_, _) => args,
-        }
+        FunctionInvocation::from(self)
+            .normalize_for_signature(signature)
+            .into_legacy_args()
     }
 
     pub fn output_value(&self) -> &LegacyValue {
@@ -359,6 +349,10 @@ pub trait MechFunctionFactory {
     /// reject arbitrary incompatible [`FunctionArgs`], validate every exact
     /// backing extraction, and must not execute or solve the function.
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>>;
+
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        Self::new(invocation.into_legacy_args())
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/core/src/function/mod.rs
+++ b/src/core/src/function/mod.rs
@@ -182,9 +182,19 @@ pub enum FunctionArgs {
 
 impl FunctionArgs {
     pub(crate) fn normalize_for_signature(self, signature: RuntimeFunctionSignature) -> Self {
-        FunctionInvocation::from(self)
-            .normalize_for_signature(signature)
-            .into_legacy_args()
+        if !matches!(signature.inputs, RuntimeFunctionInputs::Variadic { .. }) {
+            return self;
+        }
+        match self {
+            FunctionArgs::Nullary(output) => FunctionArgs::Variadic(output, Vec::new()),
+            FunctionArgs::Unary(output, a) => FunctionArgs::Variadic(output, vec![a]),
+            FunctionArgs::Binary(output, a, b) => FunctionArgs::Variadic(output, vec![a, b]),
+            FunctionArgs::Ternary(output, a, b, c) => FunctionArgs::Variadic(output, vec![a, b, c]),
+            FunctionArgs::Quaternary(output, a, b, c, d) => {
+                FunctionArgs::Variadic(output, vec![a, b, c, d])
+            }
+            args @ FunctionArgs::Variadic(_, _) => args,
+        }
     }
 
     pub fn output_value(&self) -> &LegacyValue {

--- a/src/core/src/stdlib.rs
+++ b/src/core/src/stdlib.rs
@@ -238,9 +238,9 @@ macro_rules! impl_binop {
                 + Zero
                 + One,
             Ref<$out_type>: ToValue,
-            $arg1_type: FunctionRuntimeType,
-            $arg2_type: FunctionRuntimeType,
-            $out_type: FunctionRuntimeType,
+            $arg1_type: FunctionRuntimeType + FunctionPortBacking,
+            $arg2_type: FunctionRuntimeType + FunctionPortBacking,
+            $out_type: FunctionRuntimeType + FunctionPortBacking,
         {
             const SIGNATURE: RuntimeFunctionSignature = RuntimeFunctionSignature::binary(
                 <$out_type as FunctionRuntimeType>::REPRESENTATION,
@@ -248,26 +248,16 @@ macro_rules! impl_binop {
                 <$arg2_type as FunctionRuntimeType>::REPRESENTATION,
             );
 
+            fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+                let (out, lhs, rhs) = invocation.expect_binary()?;
+                let lhs: Ref<$arg1_type> = lhs.try_ref()?;
+                let rhs: Ref<$arg2_type> = rhs.try_ref()?;
+                let out: Ref<$out_type> = out.try_ref()?;
+                Ok(Box::new(Self { lhs, rhs, out }))
+            }
+
             fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-                match args {
-                    FunctionArgs::Binary(out, arg1, arg2) => {
-                        let lhs: Ref<$arg1_type> =
-                            arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                        let rhs: Ref<$arg2_type> =
-                            arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                        let out: Ref<$out_type> =
-                            out.try_function_ref(FunctionArgumentRole::Output)?;
-                        Ok(Box::new(Self { lhs, rhs, out }))
-                    }
-                    _ => Err(MechError::new(
-                        IncorrectNumberOfArguments {
-                            expected: 2,
-                            found: args.len(),
-                        },
-                        None,
-                    )
-                    .with_compiler_loc()),
-                }
+                Self::new_invocation(args.into())
             }
         }
         impl<T> MechFunctionImpl for $struct_name<T>
@@ -332,30 +322,27 @@ macro_rules! impl_unop {
             arg: Ref<$arg_type>,
             out: Ref<$out_type>,
         }
-        impl MechFunctionFactory for $struct_name {
+        impl MechFunctionFactory for $struct_name
+        where
+            $arg_type: FunctionPortBacking,
+            $out_type: FunctionPortBacking,
+        {
             const SIGNATURE: RuntimeFunctionSignature = RuntimeFunctionSignature::unary(
                 <$out_type as FunctionRuntimeType>::REPRESENTATION,
                 <$arg_type as FunctionRuntimeType>::REPRESENTATION,
             );
 
+            fn new_invocation(
+                invocation: FunctionInvocation,
+            ) -> MResult<Box<dyn MechFunction>> {
+                let (out, arg) = invocation.expect_unary()?;
+                let arg: Ref<$arg_type> = arg.try_ref()?;
+                let out: Ref<$out_type> = out.try_ref()?;
+                Ok(Box::new(Self { arg, out }))
+            }
+
             fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-                match args {
-                    FunctionArgs::Unary(out, arg) => {
-                        let arg: Ref<$arg_type> =
-                            arg.try_function_ref(FunctionArgumentRole::Input(0))?;
-                        let out: Ref<$out_type> =
-                            out.try_function_ref(FunctionArgumentRole::Output)?;
-                        Ok(Box::new(Self { arg, out }))
-                    }
-                    _ => Err(MechError::new(
-                        IncorrectNumberOfArguments {
-                            expected: 1,
-                            found: args.len(),
-                        },
-                        None,
-                    )
-                    .with_compiler_loc()),
-                }
+                Self::new_invocation(args.into())
             }
         }
         impl MechFunctionImpl for $struct_name {


### PR DESCRIPTION
## Summary

- adds an opaque `FunctionInvocation` around the legacy `FunctionArgs` backing
- exposes typed input and output ports without exposing `LegacyValue`
- routes runtime catalog validation and instantiation through invocation factories
- preserves the exact legacy `F::new` factory pointer for compatibility
- migrates exact-representation comparison, logic, and math factory constructors to typed ports
- preserves source specializers, machine algorithms, signatures, IDs, contracts, output/checkpoint APIs, and native linkage

## Behavior

| Case | Result |
|---|---|
| Unmigrated factory implements only `new` | Default invocation bridge calls `new` |
| Migrated factory | Catalog calls `new_invocation` |
| Legacy caller uses `instantiate(FunctionArgs)` | Wrapped into `FunctionInvocation` |
| New caller uses `instantiate_invocation` | Direct invocation path |
| Wrong arity | Existing error behavior |
| Wrong exact representation | Existing type-mismatch behavior |
| `Typed` input | Not implicitly unwrapped |
| `MutableReference` input | Not implicitly followed |
| Legacy factory identity | Exact `F::new` pointer retained |
| Source specializer | Existing `LegacyValue` path retained |

## Deliberate compatibility boundaries

- `StrictEqValue` and `StrictNotEqValue` remain on the default legacy bridge because their signatures intentionally accept `AnyValue` and their runtime fields retain arbitrary `LegacyValue` payloads. Migrating them through the mandated exact-only `try_ref<T>` port API would require exposing the legacy payload, which this PR explicitly forbids.
- `machines/math/src/op_assign/mod.rs` is unchanged per the explicit op-assignment non-goal.
- The exact-representation compare, logic, and math factories migrated by this PR contain no production `FunctionArgs` matching or direct `try_function_ref` calls; the remaining production audit hits are only the two boundaries above.

## Non-goals

- no function output/checkpoint migration
- no `FunctionArgs` deletion
- no source-specializer migration
- no matrix or aggregate package sweep
- no op-assignment migration
- no runtime ID, signature, contract, or native-linkage changes
- no architecture JSON regeneration

## Evidence

Revised PR4 base: `f41b6a6adbc59741bdc64b957c11dd0694bd4df5`

PR5 head: `cc39a8a0f1363ec58e140b896b6817f06b5a2d30`

Passing local validation:

- formatting and diff checks
- `mech-core --lib --all-features`: 383 passed
- compare `full_compiler`: passed
- logic `full_compiler`: passed
- math `full_compiler`: 31 passed
- engine `full_compiler`: 293 passed
- runtime `full_compiler`: 465 passed (one file-watcher timing test passed on immediate isolated and full-suite reruns)
- value-system retirement: passed; `LegacyValue` reviewed 4,928, live 4,906, removed 22; zero unreviewed audited occurrences
- value execution boundary: passed
- compiler-planning quarantine: passed
- bytecode v1: 20 deterministic fixtures passed
- production resident routing: passed
- function-system source slice: passed
- function-system consumer slice: passed
- frozen value-system and function-system JSON: unchanged
- Cargo manifests, lockfile, and workflows: unchanged
- catalog tests prove both stored pointers remain exact (`F::new` and `F::new_invocation`) across every registration builder

Known base-gate issue:

- the complete `check-function-system-contracts.sh` command passes the frozen 9,031-factory surface, then fails the standard-machine profile check because math's existing `compiler` feature enables `mech-core/semantic-compiler`, while the checker requires the separate `mech-core/compiler` feature. The same feature graph is present on the untouched PR4 base. Resolving it requires a Cargo or checker change, both prohibited in PR5; the separately required source and consumer compatibility suites pass.

## Commits

1. `feat(core): add opaque function invocation ports`
2. `refactor(core): dispatch runtime factories through invocations`
3. `refactor(machines): migrate compare and logic factories to ports`
4. `refactor(math): migrate runtime factories to ports`

The shared `impl_binop` and `impl_unop` macro changes automatically route generated factories outside math through the new factory implementation without editing those packages or changing their semantics.


## Blocking review revision

- adds sealed `FunctionPortBacking` approval for exact scalar, matrix, and container backings
- deliberately provides no backing implementation for `LegacyValue`, `ValueCell`, `Ref<LegacyValue>`, or reference wrappers around universal cells
- keeps `require_function_ref::<LegacyValue>` unchanged for legacy callers
- adds input and output compile-fail regressions using `LegacyValue::MutableReference` backing values
- local revision validation passed: 2 compile-fail doc tests, 383 core tests, 4 compare tests, 4 logic tests, 31 math tests, retirement audit, four architecture audits, and source/consumer compatibility suites

Revised head: `cc39a8a0f1363ec58e140b896b6817f06b5a2d30`

## Initial CI

Impact-selected CI passed on head `d52e78c609300f2f6063e3de61dd7c360d3f33f1`: Impact, Standard Linux, Standard Windows, Static contracts, Browser canary, and all 14 owner shards.

Run: https://github.com/mech-lang/mech/actions/runs/33086806172



## Revised CI

Impact-selected CI passed on revised head `cc39a8a0f1363ec58e140b896b6817f06b5a2d30`: Impact, Standard Linux, Standard Windows, Static Contracts, Browser Canary, and all 14 owner shards.

Run: https://github.com/mech-lang/mech/actions/runs/33094761773
