### PR TITLE
[PR6] refactor(functions): expose typed output and checkpoint ports

### DIFF
--- a/machines/compare/src/eq.rs
+++ b/machines/compare/src/eq.rs
@@ -142,6 +142,9 @@ impl MechFunctionImpl for AtomEq {
         };
         Ok(())
     }
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
     fn out(&self) -> LegacyValue {
         self.out.to_value()
     }
@@ -151,6 +154,10 @@ impl MechFunctionImpl for AtomEq {
 
     fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
         Ok(self.reactive_output_values())
+    }
+
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
     }
 }
 #[cfg(feature = "atom")]
@@ -200,6 +207,9 @@ impl MechFunctionImpl for TableEq {
         };
         Ok(())
     }
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
     fn out(&self) -> LegacyValue {
         self.out.to_value()
     }
@@ -209,6 +219,10 @@ impl MechFunctionImpl for TableEq {
 
     fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
         Ok(self.reactive_output_values())
+    }
+
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
     }
 }
 #[cfg(feature = "table")]
@@ -272,12 +286,13 @@ impl_mech_binop_fxn!(CompareEqual, impl_eq_fxn, "compare/eq");
     feature = "f64",
     feature = "bool",
     feature = "matrix2",
+    feature = "matrixd",
     feature = "atom",
     feature = "table"
 ))]
 mod invocation_port_tests {
     use super::*;
-    use nalgebra::Matrix2;
+    use nalgebra::{DMatrix, Matrix2};
 
     fn binary_args<T, O>(out: &Ref<O>, lhs: &Ref<T>, rhs: &Ref<T>) -> FunctionArgs
     where
@@ -304,6 +319,20 @@ mod invocation_port_tests {
 
         assert!(*legacy_out.borrow());
         assert_eq!(*legacy_out.borrow(), *invocation_out.borrow());
+        assert_eq!(
+            invocation.reactive_output_cell_ids(),
+            invocation.out().reactive_root_cell_ids(),
+        );
+
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*invocation)?;
+            *invocation_out.borrow_mut() = false;
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+        assert!(*invocation_out.borrow());
     }
 
     #[test]
@@ -314,6 +343,36 @@ mod invocation_port_tests {
         let function = EQM2M2::<f64>::new_invocation(binary_args(&out, &lhs, &rhs).into()).unwrap();
         function.solve_result().unwrap();
         assert_eq!(*out.borrow(), Matrix2::new(true, false, true, false));
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*function)?;
+            *out.borrow_mut() = Matrix2::from_element(false);
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(*out.borrow(), Matrix2::new(true, false, true, false));
+
+        let dynamic_lhs = Ref::new(DMatrix::from_row_slice(1, 2, &[1.0_f64, 2.0]));
+        let dynamic_rhs = Ref::new(DMatrix::from_row_slice(1, 2, &[1.0_f64, 0.0]));
+        let dynamic_out = Ref::new(DMatrix::from_element(1, 2, false));
+        let dynamic = EQMDMD::<f64>::new_invocation(
+            binary_args(&dynamic_out, &dynamic_lhs, &dynamic_rhs).into(),
+        )
+        .unwrap();
+        dynamic.solve_result().unwrap();
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*dynamic)?;
+            *dynamic_out.borrow_mut() = DMatrix::from_element(2, 1, false);
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(
+            *dynamic_out.borrow(),
+            DMatrix::from_row_slice(1, 2, &[true, false]),
+        );
 
         let atom_lhs = Ref::new(MechAtom::from_name("same"));
         let atom_rhs = Ref::new(MechAtom::from_name("same"));
@@ -322,6 +381,10 @@ mod invocation_port_tests {
             .unwrap();
         atom.solve_result().unwrap();
         assert!(*atom_out.borrow());
+        assert_eq!(
+            atom.reactive_output_cell_ids(),
+            atom.out().reactive_root_cell_ids(),
+        );
 
         let table_lhs = Ref::new(MechTable::from_parts(0, 0, Vec::new(), Vec::new()));
         let table_rhs = Ref::new(MechTable::from_parts(0, 0, Vec::new(), Vec::new()));
@@ -331,6 +394,10 @@ mod invocation_port_tests {
                 .unwrap();
         table.solve_result().unwrap();
         assert!(*table_out.borrow());
+        assert_eq!(
+            table.reactive_output_cell_ids(),
+            table.out().reactive_root_cell_ids(),
+        );
     }
 
     #[test]

--- a/machines/compare/src/lib.rs
+++ b/machines/compare/src/lib.rs
@@ -179,7 +179,7 @@ macro_rules! impl_compare_binop {
             Ref<$out_type>: ToValue,
             $arg1_type: FunctionRuntimeType + FunctionPortBacking,
             $arg2_type: FunctionRuntimeType + FunctionPortBacking,
-            $out_type: FunctionRuntimeType + FunctionPortBacking,
+            $out_type: FunctionStateBacking,
         {
             const SIGNATURE: RuntimeFunctionSignature = RuntimeFunctionSignature::binary(
                 <$out_type as FunctionRuntimeType>::REPRESENTATION,
@@ -205,7 +205,7 @@ macro_rules! impl_compare_binop {
         where
             T: std::fmt::Debug + Clone + 'static + PartialEq + PartialOrd,
             Ref<$out_type>: ToValue,
-            $out_type: FunctionRuntimeType,
+            $out_type: FunctionStateBacking,
         {
             fn solve_result(&self) -> MResult<()> {
                 let lhs_ptr = self.lhs.as_ptr();
@@ -213,6 +213,9 @@ macro_rules! impl_compare_binop {
                 let out_ptr = self.out.as_mut_ptr();
                 $op!(lhs_ptr, rhs_ptr, out_ptr);
                 Ok(())
+            }
+            fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+                Some(FunctionStatePort::from_ref(&self.out))
             }
             fn out(&self) -> LegacyValue {
                 self.out.to_value()
@@ -228,6 +231,10 @@ macro_rules! impl_compare_binop {
 
             fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
                 Ok(self.reactive_output_values())
+            }
+
+            fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+                Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
             }
         }
         #[cfg(feature = "semantic-compiler")]

--- a/machines/compare/src/neq.rs
+++ b/machines/compare/src/neq.rs
@@ -142,6 +142,9 @@ impl MechFunctionImpl for AtomNeq {
         };
         Ok(())
     }
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
     fn out(&self) -> LegacyValue {
         self.out.to_value()
     }
@@ -151,6 +154,10 @@ impl MechFunctionImpl for AtomNeq {
 
     fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
         Ok(self.reactive_output_values())
+    }
+
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
     }
 }
 #[cfg(feature = "atom")]
@@ -200,6 +207,9 @@ impl MechFunctionImpl for TableNeq {
         };
         Ok(())
     }
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
     fn out(&self) -> LegacyValue {
         self.out.to_value()
     }
@@ -209,6 +219,10 @@ impl MechFunctionImpl for TableNeq {
 
     fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
         Ok(self.reactive_output_values())
+    }
+
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
     }
 }
 #[cfg(feature = "table")]

--- a/machines/compare/src/seq.rs
+++ b/machines/compare/src/seq.rs
@@ -20,6 +20,9 @@ impl MechFunctionImpl for StrictEqValue {
         *self.out.borrow_mut() = lhs == rhs;
         Ok(())
     }
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
     fn out(&self) -> LegacyValue {
         self.out.to_value()
     }
@@ -34,6 +37,10 @@ impl MechFunctionImpl for StrictEqValue {
 
     fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
         Ok(self.reactive_output_values())
+    }
+
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
     }
 }
 
@@ -86,3 +93,46 @@ fn impl_seq_fxn(lhs_value: LegacyValue, rhs_value: LegacyValue) -> MResult<Box<d
 
 #[cfg(feature = "source")]
 impl_mech_binop_fxn!(CompareStrictEqual, impl_seq_fxn, "compare/seq");
+
+#[cfg(all(test, feature = "runtime", feature = "bool", feature = "sneq"))]
+mod state_port_tests {
+    use super::*;
+    use crate::StrictNotEqValue;
+
+    #[test]
+    fn strict_comparison_outputs_use_typed_identity_and_checkpoint_state() {
+        let equal_out = Ref::new(false);
+        let equal = StrictEqValue {
+            lhs: LegacyValue::Index(Ref::new(1)),
+            rhs: LegacyValue::Index(Ref::new(1)),
+            out: equal_out.clone(),
+        };
+        equal.solve_result().unwrap();
+        assert_eq!(
+            equal.reactive_output_cell_ids(),
+            equal.out().reactive_root_cell_ids(),
+        );
+
+        let not_equal_out = Ref::new(false);
+        let not_equal = StrictNotEqValue {
+            lhs: LegacyValue::Index(Ref::new(1)),
+            rhs: LegacyValue::Index(Ref::new(2)),
+            out: not_equal_out.clone(),
+        };
+        not_equal.solve_result().unwrap();
+
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&equal)?;
+            participant.capture_function_state(&not_equal)?;
+            *equal_out.borrow_mut() = false;
+            *not_equal_out.borrow_mut() = false;
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+
+        assert!(*equal_out.borrow());
+        assert!(*not_equal_out.borrow());
+    }
+}

--- a/machines/compare/src/sneq.rs
+++ b/machines/compare/src/sneq.rs
@@ -20,6 +20,9 @@ impl MechFunctionImpl for StrictNotEqValue {
         *self.out.borrow_mut() = lhs != rhs;
         Ok(())
     }
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
     fn out(&self) -> LegacyValue {
         self.out.to_value()
     }
@@ -34,6 +37,10 @@ impl MechFunctionImpl for StrictNotEqValue {
 
     fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
         Ok(self.reactive_output_values())
+    }
+
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
     }
 }
 

--- a/machines/logic/src/lib.rs
+++ b/machines/logic/src/lib.rs
@@ -224,6 +224,9 @@ macro_rules! impl_logic_binop {
                 $op!(lhs_ptr, rhs_ptr, out_ptr);
                 Ok(())
             }
+            fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+                Some(FunctionStatePort::from_ref(&self.out))
+            }
             fn out(&self) -> LegacyValue {
                 self.out.to_value()
             }
@@ -238,6 +241,10 @@ macro_rules! impl_logic_binop {
 
             fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
                 Ok(self.reactive_output_values())
+            }
+
+            fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+                Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
             }
         }
         #[cfg(feature = "semantic-compiler")]
@@ -288,6 +295,10 @@ mod invocation_port_tests {
         .unwrap();
         binary.solve_result().unwrap();
         assert!(!*binary_out.borrow());
+        assert_eq!(
+            binary.reactive_output_cell_ids(),
+            binary.out().reactive_root_cell_ids(),
+        );
 
         let unary_out = Ref::new(false);
         let unary = crate::not::NotS::<bool>::new_invocation(
@@ -295,6 +306,19 @@ mod invocation_port_tests {
         )
         .unwrap();
         unary.solve_result().unwrap();
+        assert!(!*unary_out.borrow());
+
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*binary)?;
+            participant.capture_function_state(&*unary)?;
+            *binary_out.borrow_mut() = true;
+            *unary_out.borrow_mut() = true;
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+        assert!(!*binary_out.borrow());
         assert!(!*unary_out.borrow());
     }
 
@@ -311,6 +335,18 @@ mod invocation_port_tests {
         assert_eq!(
             *fixed_out.borrow(),
             Matrix2::new(true, false, false, false)
+        );
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*fixed)?;
+            *fixed_out.borrow_mut() = Matrix2::from_element(true);
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(
+            *fixed_out.borrow(),
+            Matrix2::new(true, false, false, false),
         );
 
         let dynamic_lhs = Ref::new(DMatrix::from_row_slice(
@@ -332,6 +368,18 @@ mod invocation_port_tests {
         assert_eq!(
             *dynamic_out.borrow(),
             DMatrix::from_row_slice(2, 2, &[true, false, false, false])
+        );
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*dynamic)?;
+            *dynamic_out.borrow_mut() = DMatrix::from_element(1, 1, true);
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(
+            *dynamic_out.borrow(),
+            DMatrix::from_row_slice(2, 2, &[true, false, false, false]),
         );
     }
 

--- a/machines/logic/src/not.rs
+++ b/machines/logic/src/not.rs
@@ -21,7 +21,7 @@ where
     #[cfg(feature = "semantic-compiler")]
     T: CompileConst + ConstElem,
     Ref<T>: ToValue,
-    T: FunctionRuntimeType + FunctionPortBacking,
+    T: FunctionStateBacking,
 {
     const SIGNATURE: RuntimeFunctionSignature =
         RuntimeFunctionSignature::unary(T::REPRESENTATION, T::REPRESENTATION);
@@ -51,7 +51,7 @@ where
         + PartialEq
         + 'static
         + Not<Output = T>
-        + FunctionRuntimeType,
+        + FunctionStateBacking,
     Ref<T>: ToValue,
 {
     fn solve_result(&self) -> MResult<()> {
@@ -61,6 +61,9 @@ where
             *out_ptr = !*arg_ptr;
         };
         Ok(())
+    }
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
     }
     fn out(&self) -> LegacyValue {
         self.out.to_value()
@@ -74,6 +77,10 @@ where
 
     fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
         Ok(self.reactive_output_values())
+    }
+
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
     }
 }
 #[cfg(feature = "semantic-compiler")]
@@ -105,7 +112,7 @@ where
     #[cfg(feature = "semantic-compiler")]
     MatA: CompileConst + ConstElem,
     Ref<MatA>: ToValue,
-    MatA: FunctionRuntimeType + FunctionPortBacking,
+    MatA: FunctionStateBacking,
 {
     const SIGNATURE: RuntimeFunctionSignature =
         RuntimeFunctionSignature::unary(MatA::REPRESENTATION, MatA::REPRESENTATION);
@@ -131,7 +138,7 @@ where
     T: Debug + Clone + Sync + Send + 'static + AsValueKind + Not<Output = T>,
     for<'a> &'a MatA: IntoIterator<Item = &'a T>,
     for<'a> &'a mut MatA: IntoIterator<Item = &'a mut T>,
-    MatA: Debug + FunctionRuntimeType,
+    MatA: Debug + FunctionStateBacking,
 {
     fn solve_result(&self) -> MResult<()> {
         unsafe {
@@ -145,6 +152,9 @@ where
         };
         Ok(())
     }
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
     fn out(&self) -> LegacyValue {
         self.out.to_value()
     }
@@ -157,6 +167,10 @@ where
 
     fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
         Ok(self.reactive_output_values())
+    }
+
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
     }
 }
 #[cfg(feature = "semantic-compiler")]

--- a/machines/math/src/arithmetic/copysign.rs
+++ b/machines/math/src/arithmetic/copysign.rs
@@ -64,6 +64,9 @@ macro_rules! impl_two_arg_fxn {
                 $op!(arg1_ptr, arg2_ptr, out_ptr);
                 Ok(())
             }
+            fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+                Some(FunctionStatePort::from_ref(&self.out))
+            }
             fn out(&self) -> LegacyValue {
                 self.out.to_value()
             }
@@ -73,6 +76,10 @@ macro_rules! impl_two_arg_fxn {
 
             fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
                 Ok(self.reactive_output_values())
+            }
+
+            fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+                Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
             }
         }
         #[cfg(feature = "semantic-compiler")]

--- a/machines/math/src/arithmetic/fdim.rs
+++ b/machines/math/src/arithmetic/fdim.rs
@@ -64,6 +64,9 @@ macro_rules! impl_two_arg_fxn {
                 $op!(arg1_ptr, arg2_ptr, out_ptr);
                 Ok(())
             }
+            fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+                Some(FunctionStatePort::from_ref(&self.out))
+            }
             fn out(&self) -> LegacyValue {
                 self.out.to_value()
             }
@@ -73,6 +76,10 @@ macro_rules! impl_two_arg_fxn {
 
             fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
                 Ok(self.reactive_output_values())
+            }
+
+            fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+                Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
             }
         }
         #[cfg(feature = "semantic-compiler")]

--- a/machines/math/src/arithmetic/fmod.rs
+++ b/machines/math/src/arithmetic/fmod.rs
@@ -64,6 +64,9 @@ macro_rules! impl_two_arg_fxn {
                 $op!(arg1_ptr, arg2_ptr, out_ptr);
                 Ok(())
             }
+            fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+                Some(FunctionStatePort::from_ref(&self.out))
+            }
             fn out(&self) -> LegacyValue {
                 self.out.to_value()
             }
@@ -73,6 +76,10 @@ macro_rules! impl_two_arg_fxn {
 
             fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
                 Ok(self.reactive_output_values())
+            }
+
+            fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+                Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
             }
         }
         #[cfg(feature = "semantic-compiler")]

--- a/machines/math/src/arithmetic/nextafter.rs
+++ b/machines/math/src/arithmetic/nextafter.rs
@@ -64,6 +64,9 @@ macro_rules! impl_two_arg_fxn {
                 $op!(arg1_ptr, arg2_ptr, out_ptr);
                 Ok(())
             }
+            fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+                Some(FunctionStatePort::from_ref(&self.out))
+            }
             fn out(&self) -> LegacyValue {
                 self.out.to_value()
             }
@@ -73,6 +76,10 @@ macro_rules! impl_two_arg_fxn {
 
             fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
                 Ok(self.reactive_output_values())
+            }
+
+            fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+                Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
             }
         }
         #[cfg(feature = "semantic-compiler")]

--- a/machines/math/src/arithmetic/remainder.rs
+++ b/machines/math/src/arithmetic/remainder.rs
@@ -64,6 +64,9 @@ macro_rules! impl_two_arg_fxn {
                 $op!(arg1_ptr, arg2_ptr, out_ptr);
                 Ok(())
             }
+            fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+                Some(FunctionStatePort::from_ref(&self.out))
+            }
             fn out(&self) -> LegacyValue {
                 self.out.to_value()
             }
@@ -73,6 +76,10 @@ macro_rules! impl_two_arg_fxn {
 
             fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
                 Ok(self.reactive_output_values())
+            }
+
+            fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+                Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
             }
         }
         #[cfg(feature = "semantic-compiler")]

--- a/machines/math/src/bessel/jn.rs
+++ b/machines/math/src/bessel/jn.rs
@@ -64,6 +64,9 @@ macro_rules! impl_two_arg_fxn {
                 $op!(arg1_ptr, arg2_ptr, out_ptr);
                 Ok(())
             }
+            fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+                Some(FunctionStatePort::from_ref(&self.out))
+            }
             fn out(&self) -> LegacyValue {
                 self.out.to_value()
             }
@@ -73,6 +76,10 @@ macro_rules! impl_two_arg_fxn {
 
             fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
                 Ok(self.reactive_output_values())
+            }
+
+            fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+                Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
             }
         }
         #[cfg(feature = "semantic-compiler")]

--- a/machines/math/src/bessel/yn.rs
+++ b/machines/math/src/bessel/yn.rs
@@ -64,6 +64,9 @@ macro_rules! impl_two_arg_fxn {
                 $op!(arg1_ptr, arg2_ptr, out_ptr);
                 Ok(())
             }
+            fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+                Some(FunctionStatePort::from_ref(&self.out))
+            }
             fn out(&self) -> LegacyValue {
                 self.out.to_value()
             }
@@ -73,6 +76,10 @@ macro_rules! impl_two_arg_fxn {
 
             fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
                 Ok(self.reactive_output_values())
+            }
+
+            fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+                Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
             }
         }
         #[cfg(feature = "semantic-compiler")]

--- a/machines/math/src/ops/add.rs
+++ b/machines/math/src/ops/add.rs
@@ -286,10 +286,62 @@ mod checked_arithmetic_tests {
 
         function.solve_result().unwrap();
         assert_eq!(*out.borrow(), 41);
-        *rhs.borrow_mut() = u8::MAX;
-        let error = function.solve_result().unwrap_err();
-        assert_eq!(error.kind_name(), "MathArithmeticOverflow");
+        assert_eq!(
+            function.reactive_output_cell_ids(),
+            function.out().reactive_root_cell_ids(),
+        );
+
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&function)?;
+            *rhs.borrow_mut() = u8::MAX;
+            let error = function.solve_result().unwrap_err();
+            assert_eq!(error.kind_name(), "MathArithmeticOverflow");
+            assert_eq!(*out.borrow(), 41);
+            *out.borrow_mut() = 99;
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
         assert_eq!(*out.borrow(), 41);
+    }
+}
+
+#[cfg(all(test, feature = "f64", feature = "matrix2", feature = "matrixd"))]
+mod state_port_tests {
+    use super::*;
+
+    #[test]
+    fn fixed_and_dynamic_add_outputs_restore_through_typed_state_ports() {
+        let fixed_out = Ref::new(Matrix2::from_element(0.0_f64));
+        let fixed = AddM2M2 {
+            lhs: Ref::new(Matrix2::from_element(1.0)),
+            rhs: Ref::new(Matrix2::from_element(2.0)),
+            out: fixed_out.clone(),
+        };
+        fixed.solve_result().unwrap();
+
+        let dynamic_out = Ref::new(DMatrix::from_element(1, 2, 0.0_f64));
+        let dynamic = AddMDMD {
+            lhs: Ref::new(DMatrix::from_element(1, 2, 3.0)),
+            rhs: Ref::new(DMatrix::from_element(1, 2, 4.0)),
+            out: dynamic_out.clone(),
+        };
+        dynamic.solve_result().unwrap();
+
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&fixed)?;
+            participant.capture_function_state(&dynamic)?;
+            *fixed_out.borrow_mut() = Matrix2::from_element(9.0);
+            *dynamic_out.borrow_mut() = DMatrix::from_element(2, 1, 9.0);
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(*fixed_out.borrow(), Matrix2::from_element(3.0));
+        assert_eq!(*dynamic_out.borrow(), DMatrix::from_element(1, 2, 7.0));
     }
 }
 

--- a/machines/math/src/ops/div.rs
+++ b/machines/math/src/ops/div.rs
@@ -138,7 +138,7 @@ macro_rules! impl_checked_div_binop {
             Ref<$out_type>: ToValue,
             $arg1_type: FunctionRuntimeType + FunctionPortBacking,
             $arg2_type: FunctionRuntimeType + FunctionPortBacking,
-            $out_type: FunctionRuntimeType + FunctionPortBacking,
+            $out_type: FunctionStateBacking,
         {
             const SIGNATURE: RuntimeFunctionSignature = RuntimeFunctionSignature::binary(
                 <$out_type as FunctionRuntimeType>::REPRESENTATION,
@@ -183,7 +183,7 @@ macro_rules! impl_checked_div_binop {
                 + One
                 + RuntimeCheckedDiv,
             Ref<$out_type>: ToValue,
-            $out_type: FunctionRuntimeType,
+            $out_type: FunctionStateBacking,
         {
             fn solve_result(&self) -> MResult<()> {
                 let lhs_ptr = self.lhs.as_ptr();
@@ -191,6 +191,9 @@ macro_rules! impl_checked_div_binop {
                 let out_ptr = self.out.as_mut_ptr();
                 $op!(lhs_ptr, rhs_ptr, out_ptr);
                 Ok(())
+            }
+            fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+                Some(FunctionStatePort::from_ref(&self.out))
             }
             fn out(&self) -> LegacyValue {
                 self.out.to_value()
@@ -206,6 +209,10 @@ macro_rules! impl_checked_div_binop {
 
             fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
                 Ok(self.reactive_output_values())
+            }
+
+            fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+                Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
             }
         }
         #[cfg(feature = "semantic-compiler")]

--- a/machines/math/src/ops/mod.rs
+++ b/machines/math/src/ops/mod.rs
@@ -357,7 +357,7 @@ macro_rules! impl_checked_arithmetic_binop {
             Ref<$out_type>: ToValue,
             $arg1_type: FunctionRuntimeType + FunctionPortBacking,
             $arg2_type: FunctionRuntimeType + FunctionPortBacking,
-            $out_type: FunctionRuntimeType + FunctionPortBacking,
+            $out_type: FunctionStateBacking,
         {
             const SIGNATURE: RuntimeFunctionSignature = RuntimeFunctionSignature::binary(
                 <$out_type as FunctionRuntimeType>::REPRESENTATION,
@@ -403,7 +403,7 @@ macro_rules! impl_checked_arithmetic_binop {
                 + One
                 + RuntimeCheckedArithmetic,
             Ref<$out_type>: ToValue,
-            $out_type: FunctionRuntimeType,
+            $out_type: FunctionStateBacking,
         {
             fn solve_result(&self) -> MResult<()> {
                 let lhs_ptr = self.lhs.as_ptr();
@@ -411,6 +411,10 @@ macro_rules! impl_checked_arithmetic_binop {
                 let out_ptr = self.out.as_mut_ptr();
                 $op!(lhs_ptr, rhs_ptr, out_ptr);
                 Ok(())
+            }
+
+            fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+                Some(FunctionStatePort::from_ref(&self.out))
             }
 
             fn out(&self) -> LegacyValue {
@@ -427,6 +431,10 @@ macro_rules! impl_checked_arithmetic_binop {
 
             fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
                 Ok(self.reactive_output_values())
+            }
+
+            fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+                Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
             }
         }
 

--- a/machines/math/src/ops/modulus.rs
+++ b/machines/math/src/ops/modulus.rs
@@ -103,7 +103,7 @@ macro_rules! impl_binop2 {
             Ref<$out_type>: ToValue,
             $arg1_type: FunctionRuntimeType + FunctionPortBacking,
             $arg2_type: FunctionRuntimeType + FunctionPortBacking,
-            $out_type: FunctionRuntimeType + FunctionPortBacking,
+            $out_type: FunctionStateBacking,
         {
             const SIGNATURE: RuntimeFunctionSignature = RuntimeFunctionSignature::binary(
                 <$out_type as FunctionRuntimeType>::REPRESENTATION,
@@ -149,7 +149,7 @@ macro_rules! impl_binop2 {
                 + One
                 + RuntimeCheckedRem,
             Ref<$out_type>: ToValue,
-            $out_type: FunctionRuntimeType,
+            $out_type: FunctionStateBacking,
         {
             fn solve_result(&self) -> MResult<()> {
                 let lhs_ptr = self.lhs.as_ptr();
@@ -157,6 +157,9 @@ macro_rules! impl_binop2 {
                 let out_ptr = self.out.as_mut_ptr();
                 $op!(lhs_ptr, rhs_ptr, out_ptr);
                 Ok(())
+            }
+            fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+                Some(FunctionStatePort::from_ref(&self.out))
             }
             fn out(&self) -> LegacyValue {
                 self.out.to_value()
@@ -172,6 +175,10 @@ macro_rules! impl_binop2 {
 
             fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
                 Ok(self.reactive_output_values())
+            }
+
+            fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+                Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
             }
         }
         #[cfg(feature = "semantic-compiler")]

--- a/machines/math/src/ops/negate.rs
+++ b/machines/math/src/ops/negate.rs
@@ -26,7 +26,7 @@ where
     #[cfg(feature = "semantic-compiler")]
     O: CompileConst + ConstElem,
     Ref<O>: ToValue,
-    O: FunctionRuntimeType + FunctionPortBacking,
+    O: FunctionStateBacking,
 {
     const SIGNATURE: RuntimeFunctionSignature =
         RuntimeFunctionSignature::unary(O::REPRESENTATION, O::REPRESENTATION);
@@ -58,7 +58,7 @@ where
         + PartialEq
         + 'static,
     Ref<O>: ToValue,
-    O: FunctionRuntimeType,
+    O: FunctionStateBacking,
 {
     fn solve_result(&self) -> MResult<()> {
         let arg_ptr = self.arg.as_ptr();
@@ -70,6 +70,9 @@ where
             *out_ptr = next;
         };
         Ok(())
+    }
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
     }
     fn out(&self) -> LegacyValue {
         self.out.to_value()
@@ -83,6 +86,10 @@ where
 
     fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
         Ok(self.reactive_output_values())
+    }
+
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
     }
 }
 #[cfg(feature = "semantic-compiler")]
@@ -118,7 +125,7 @@ where
     #[cfg(feature = "semantic-compiler")]
     O: CompileConst + ConstElem,
     Ref<O>: ToValue,
-    O: FunctionRuntimeType + FunctionPortBacking,
+    O: FunctionStateBacking,
 {
     const SIGNATURE: RuntimeFunctionSignature =
         RuntimeFunctionSignature::unary(O::REPRESENTATION, O::REPRESENTATION);
@@ -151,7 +158,7 @@ where
         + PartialEq
         + 'static,
     Ref<O>: ToValue,
-    O: FunctionRuntimeType,
+    O: FunctionStateBacking,
 {
     fn solve_result(&self) -> MResult<()> {
         let arg_ptr = self.arg.as_ptr();
@@ -163,6 +170,9 @@ where
             *out_ptr = next;
         };
         Ok(())
+    }
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
     }
     fn out(&self) -> LegacyValue {
         self.out.to_value()
@@ -176,6 +186,10 @@ where
 
     fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
         Ok(self.reactive_output_values())
+    }
+
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
     }
 }
 #[cfg(feature = "semantic-compiler")]
@@ -203,6 +217,16 @@ mod checked_arithmetic_tests {
         .unwrap();
 
         function.solve_result().unwrap();
+        assert_eq!(*output.borrow(), -7);
+
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*function)?;
+            *output.borrow_mut() = 99;
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
         assert_eq!(*output.borrow(), -7);
     }
 

--- a/machines/math/src/ops/pow.rs
+++ b/machines/math/src/ops/pow.rs
@@ -156,7 +156,7 @@ macro_rules! impl_powop {
             Ref<$out_type>: ToValue,
             $arg1_type: FunctionRuntimeType + FunctionPortBacking,
             $arg2_type: FunctionRuntimeType + FunctionPortBacking,
-            $out_type: FunctionRuntimeType + FunctionPortBacking,
+            $out_type: FunctionStateBacking,
         {
             const SIGNATURE: RuntimeFunctionSignature = RuntimeFunctionSignature::binary(
                 <$out_type as FunctionRuntimeType>::REPRESENTATION,
@@ -201,7 +201,7 @@ macro_rules! impl_powop {
                 + Zero
                 + One,
             Ref<$out_type>: ToValue,
-            $out_type: FunctionRuntimeType,
+            $out_type: FunctionStateBacking,
         {
             fn solve_result(&self) -> MResult<()> {
                 let lhs_ptr = self.lhs.as_ptr();
@@ -209,6 +209,9 @@ macro_rules! impl_powop {
                 let out_ptr = self.out.as_mut_ptr();
                 $op!(lhs_ptr, rhs_ptr, out_ptr);
                 Ok(())
+            }
+            fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+                Some(FunctionStatePort::from_ref(&self.out))
             }
             fn out(&self) -> LegacyValue {
                 self.out.to_value()
@@ -224,6 +227,10 @@ macro_rules! impl_powop {
 
             fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
                 Ok(self.reactive_output_values())
+            }
+
+            fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+                Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
             }
         }
         #[cfg(feature = "semantic-compiler")]
@@ -264,6 +271,15 @@ mod checked_arithmetic_tests {
         .unwrap();
 
         function.solve_result().unwrap();
+        assert_eq!(*out.borrow(), R64::new(9, 4));
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*function)?;
+            *out.borrow_mut() = R64::default();
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
         assert_eq!(*out.borrow(), R64::new(9, 4));
     }
 
@@ -324,6 +340,9 @@ impl MechFunctionImpl for PowRational {
         };
         Ok(())
     }
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
     fn out(&self) -> LegacyValue {
         self.out.to_value()
     }
@@ -333,6 +352,10 @@ impl MechFunctionImpl for PowRational {
 
     fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
         Ok(self.reactive_output_values())
+    }
+
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
     }
 }
 #[cfg(all(feature = "rational", feature = "i32", feature = "semantic-compiler"))]

--- a/machines/math/src/trig/atan2.rs
+++ b/machines/math/src/trig/atan2.rs
@@ -66,7 +66,7 @@ macro_rules! impl_two_arg_fxn {
         where
             $kind1: FunctionPortBacking,
             $kind2: FunctionPortBacking,
-            $out_kind: FunctionPortBacking,
+            $out_kind: FunctionStateBacking,
         {
             const SIGNATURE: RuntimeFunctionSignature = RuntimeFunctionSignature::binary(
                 <$out_kind as FunctionRuntimeType>::REPRESENTATION,
@@ -96,6 +96,9 @@ macro_rules! impl_two_arg_fxn {
                 $op!(arg1_ptr, arg2_ptr, out_ptr);
                 Ok(())
             }
+            fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+                Some(FunctionStatePort::from_ref(&self.out))
+            }
             fn out(&self) -> LegacyValue {
                 self.out.to_value()
             }
@@ -110,6 +113,10 @@ macro_rules! impl_two_arg_fxn {
 
             fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
                 Ok(self.reactive_output_values())
+            }
+
+            fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+                Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
             }
         }
         #[cfg(feature = "semantic-compiler")]
@@ -204,6 +211,15 @@ mod invocation_port_tests {
         .unwrap();
 
         function.solve_result().unwrap();
+        assert!((*out.borrow() - core::f64::consts::FRAC_PI_4).abs() < f64::EPSILON);
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*function)?;
+            *out.borrow_mut() = 99.0;
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
         assert!((*out.borrow() - core::f64::consts::FRAC_PI_4).abs() < f64::EPSILON);
     }
 }

--- a/machines/math/src/trig/hypot.rs
+++ b/machines/math/src/trig/hypot.rs
@@ -53,11 +53,18 @@ macro_rules! impl_two_arg_fxn {
       ;
           Ok(())
       }
+      fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+      }
       fn out(&self) -> LegacyValue { self.out.to_value() }
       fn to_string(&self) -> String { format!("{:#?}", self) }
 
       fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
         Ok(self.reactive_output_values())
+      }
+
+      fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
       }
     }
     #[cfg(feature = "semantic-compiler")]

--- a/scripts/check-value-system-contract.py
+++ b/scripts/check-value-system-contract.py
@@ -762,7 +762,11 @@ def frozen_occurrence_target_failures(
 
 
 def occurrence_classification_failures(
-    live: dict[str, Any], migration: dict[str, Any], migration_path: Path
+    live: dict[str, Any],
+    migration: dict[str, Any],
+    migration_path: Path,
+    *,
+    exact_locations: bool = True,
 ) -> list[Failure]:
     failures: list[Failure] = []
     expected = {
@@ -808,36 +812,37 @@ def occurrence_classification_failures(
         for site in classification["sites"]:
             key = (enum_name, variant, path, site["line"], site["column"])
             actual.setdefault(key, []).append(classification)
-    for enum_name, variant, path, line, column in sorted(expected - set(actual)):
-        failures.append(
-            failure(
-                "C0-OCCURRENCE-CLASSIFICATION",
-                "qualified variant use",
-                path,
-                "exactly one reviewed occurrence classification",
-                "unclassified production occurrence",
-                f"{migration_path}:use_classifications",
-                line,
-                column,
-                enum_name,
-                variant,
+    if exact_locations:
+        for enum_name, variant, path, line, column in sorted(expected - set(actual)):
+            failures.append(
+                failure(
+                    "C0-OCCURRENCE-CLASSIFICATION",
+                    "qualified variant use",
+                    path,
+                    "exactly one reviewed occurrence classification",
+                    "unclassified production occurrence",
+                    f"{migration_path}:use_classifications",
+                    line,
+                    column,
+                    enum_name,
+                    variant,
+                )
             )
-        )
-    for enum_name, variant, path, line, column in sorted(set(actual) - expected):
-        failures.append(
-            failure(
-                "C0-OCCURRENCE-CLASSIFICATION",
-                "qualified variant use",
-                path,
-                "live production occurrence",
-                "stale or nonexistent classification",
-                f"{migration_path}:use_classifications",
-                line,
-                column,
-                enum_name,
-                variant,
+        for enum_name, variant, path, line, column in sorted(set(actual) - expected):
+            failures.append(
+                failure(
+                    "C0-OCCURRENCE-CLASSIFICATION",
+                    "qualified variant use",
+                    path,
+                    "live production occurrence",
+                    "stale or nonexistent classification",
+                    f"{migration_path}:use_classifications",
+                    line,
+                    column,
+                    enum_name,
+                    variant,
+                )
             )
-        )
     for (enum_name, variant, path, line, column), classifications in sorted(actual.items()):
         if len(classifications) > 1:
             failures.append(
@@ -969,18 +974,43 @@ def frozen_semantics_failures(migration: dict[str, Any], migration_path: Path) -
 def matrix_value_classification_failures(
     migration: dict[str, Any], migration_path: Path, root: Path = ROOT
 ) -> list[Failure]:
+    reviewed_sites: dict[str, list[tuple[int, int]]] = {}
+    for row in migration["use_classifications"]:
+        if row["enum"] != "LegacyValue" or row["variant"] != "MatrixValue":
+            continue
+        reviewed_sites.setdefault(row["path"], []).extend(
+            (int(site["line"]), int(site["column"])) for site in row["sites"]
+        )
+    for sites in reviewed_sites.values():
+        sites.sort()
+
     def is_explicit_rejection(path: str, site: dict[str, Any]) -> bool:
         source_path = root / path
         try:
             lines = source_path.read_text(encoding="utf-8").splitlines()
         except (OSError, UnicodeError):
             return False
-        start = int(site["line"]) - 1
+        reviewed = reviewed_sites.get(path, [])
+        reviewed_site = (int(site["line"]), int(site["column"]))
+        try:
+            occurrence_index = reviewed.index(reviewed_site)
+        except ValueError:
+            return False
+        live_sites = [
+            (line_number, match.start() + 1)
+            for line_number, line in enumerate(lines, start=1)
+            for match in re.finditer(
+                r"\b(?:LegacyValue|Value)::MatrixValue\b", line
+            )
+        ]
+        if occurrence_index >= len(live_sites):
+            return False
+        start = live_sites[occurrence_index][0] - 1
         if start < 0 or start >= len(lines):
             return False
         end = len(lines)
         for index in range(start + 1, len(lines)):
-            if re.match(r"\s*LegacyValue::", lines[index]):
+            if re.match(r"\s*(?:LegacyValue|Value)::", lines[index]):
                 end = index
                 break
         arm = "\n".join(lines[start:end])
@@ -3984,7 +4014,10 @@ def audit(
     failures.extend(target_applicability_failures(migration, migration_path))
     failures.extend(
         occurrence_classification_failures(
-            reviewed_surface, migration, migration_path
+            reviewed_surface,
+            migration,
+            migration_path,
+            exact_locations=mode == "exact",
         )
     )
     failures.extend(frozen_semantics_failures(migration, migration_path))

--- a/scripts/tests/test_check_value_system_contract.py
+++ b/scripts/tests/test_check_value_system_contract.py
@@ -1068,6 +1068,22 @@ class ValueSystemContractFixtureTests(unittest.TestCase):
         self.assertIn("C0-INVENTORY-DRIFT", self.ids(self.audit()))
         self.assertEqual(self.audit(mode="retirement"), [])
 
+    def test_retirement_mode_allows_reviewed_occurrence_locations_to_move(self):
+        source = (self.root / "src/core/src/live.rs").read_text(encoding="utf-8")
+        self.write("src/core/src/live.rs", "\n" + source)
+        for row in self.migration["use_classifications"]:
+            if row["path"] == "src/core/src/live.rs":
+                for site in row["sites"]:
+                    site["line"] += 1
+        self.save_path(self.migration_path, self.migration)
+        self.frozen_targets["occurrence_targets"] = (
+            CHECKER.occurrence_target_projection(self.migration)
+        )
+        self.save_path(self.frozen_targets_path, self.frozen_targets)
+
+        self.assertIn("C0-INVENTORY-DRIFT", self.ids(self.audit()))
+        self.assertEqual(self.audit(mode="retirement"), [])
+
     def test_retirement_mode_uses_relaxed_type_contract_generation(self):
         path = self.root / "src/core/src/function/signature.rs"
         source = path.read_text(encoding="utf-8").replace(

--- a/src/core/src/function/mod.rs
+++ b/src/core/src/function/mod.rs
@@ -3,11 +3,13 @@ pub mod catalog;
 pub mod contract;
 pub mod resident;
 pub mod signature;
+pub mod state;
 pub use argument::*;
 pub use catalog::*;
 pub use contract::*;
 pub use resident::*;
 pub use signature::*;
+pub use state::*;
 
 use crate::legacy_value::*;
 use crate::nodes::*;
@@ -406,6 +408,19 @@ pub trait MechFunctionImpl {
         )
         .with_compiler_loc())
     }
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        None
+    }
+    fn reactive_output_state_ports(&self) -> Option<Vec<FunctionStatePort<'_>>> {
+        self.primary_output_state_port().map(|output| vec![output])
+    }
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(None)
+    }
+    /// Returns the function output through the legacy universal-value bridge.
+    ///
+    /// This compatibility API remains required until every function family has
+    /// migrated to typed state ports.
     fn out(&self) -> LegacyValue;
     fn reactive_dependency_kinds(
         &self,
@@ -419,11 +434,14 @@ pub trait MechFunctionImpl {
     ) -> Option<Vec<ReactiveDependencyScope>> {
         None
     }
+    /// Returns reactive outputs through the legacy universal-value bridge.
+    ///
+    /// This compatibility API remains available for unmigrated functions.
     fn reactive_output_values(&self) -> Vec<LegacyValue> {
         vec![self.out()]
     }
-    /// Returns every `Value`-backed cell that contains retained mutable state
-    /// owned by this function.
+    /// Returns every legacy `Value`-backed cell that contains retained mutable
+    /// state owned by this function.
     ///
     /// Reactive outputs cover the common case. Functions with hidden retained
     /// cells must return those cells, while functions whose retained state
@@ -640,6 +658,18 @@ impl MechFunctionImpl for SemanticMechFunction {
 
     fn stage_register(&self) -> MResult<Box<dyn ReactiveRegisterCommit>> {
         self.function.stage_register()
+    }
+
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        self.function.primary_output_state_port()
+    }
+
+    fn reactive_output_state_ports(&self) -> Option<Vec<FunctionStatePort<'_>>> {
+        self.function.reactive_output_state_ports()
+    }
+
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        self.function.transaction_state_ports()
     }
 
     fn out(&self) -> LegacyValue {

--- a/src/core/src/function/mod.rs
+++ b/src/core/src/function/mod.rs
@@ -27,6 +27,8 @@ use tabled::{
     settings::{Alignment, Panel, Style},
 };
 
+pub(crate) type FunctionReactiveCell = ReactiveCellId;
+
 // Functions ------------------------------------------------------------------
 
 /// Program-local user-function definitions keyed by their stable name hash.
@@ -408,12 +410,26 @@ pub trait MechFunctionImpl {
         )
         .with_compiler_loc())
     }
+    /// Returns the primary output as an exact typed state port.
+    ///
+    /// `None` means this function has not migrated and the legacy output API is
+    /// authoritative. `Some(port)` makes the typed port authoritative.
     fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
         None
     }
+    /// Returns the authoritative typed list of reactive output cells.
+    ///
+    /// `None` means unmigrated and directs callers to the legacy fallback.
+    /// `Some(ports)` is authoritative, including `Some(Vec::new())`, which
+    /// declares that the function has no reactive output state.
     fn reactive_output_state_ports(&self) -> Option<Vec<FunctionStatePort<'_>>> {
         self.primary_output_state_port().map(|output| vec![output])
     }
+    /// Returns the authoritative typed list of transaction checkpoint cells.
+    ///
+    /// `None` means unmigrated and directs callers to the legacy fallback.
+    /// `Some(ports)` is authoritative, including `Some(Vec::new())`, which
+    /// declares that the function has no retained transaction state.
     fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
         Ok(None)
     }
@@ -457,10 +473,20 @@ pub trait MechFunctionImpl {
     fn reactive_output_cell_ids(&self) -> Vec<ReactiveCellId> {
         let mut cells = Vec::new();
 
-        for output in self.reactive_output_values() {
-            for cell in output.reactive_root_cell_ids() {
-                if !cells.contains(&cell) {
-                    cells.push(cell);
+        if let Some(outputs) = self.reactive_output_state_ports() {
+            for output in outputs {
+                for cell in output.reactive_cell_ids() {
+                    if !cells.contains(&cell) {
+                        cells.push(cell);
+                    }
+                }
+            }
+        } else {
+            for output in self.reactive_output_values() {
+                for cell in output.reactive_root_cell_ids() {
+                    if !cells.contains(&cell) {
+                        cells.push(cell);
+                    }
                 }
             }
         }

--- a/src/core/src/function/state.rs
+++ b/src/core/src/function/state.rs
@@ -1,17 +1,28 @@
 //! Opaque capabilities over exact typed cells owned by runtime functions.
 
-#[cfg(feature = "no_std")]
+#[cfg(all(feature = "no_std", feature = "string"))]
 use alloc::string::String;
+#[cfg(feature = "no_std")]
+use alloc::vec::Vec;
+#[cfg(all(not(feature = "no_std"), feature = "string"))]
+use std::string::String;
 #[cfg(not(feature = "no_std"))]
-use std::{fmt, string::String};
+use std::{fmt, vec::Vec};
 
 #[cfg(feature = "no_std")]
 use core::fmt;
 
-use crate::{FunctionPortBacking, FunctionRuntimeType, FunctionValueRepresentation, Ref, ToValue};
+use crate::{
+    FunctionPortBacking, FunctionReactiveCell, FunctionRuntimeType, FunctionValueRepresentation,
+    MResult, Ref, ToValue, ValueStateJournal,
+};
 
 mod function_state_sealed {
-    pub trait Sealed {}
+    pub struct FlatElement;
+
+    pub trait Sealed {
+        type ElementShape;
+    }
 }
 
 /// An exact runtime backing whose clone is a complete independent checkpoint.
@@ -30,6 +41,12 @@ mod function_state_sealed {
 /// fn require_state_backing<T: FunctionStateBacking>() {}
 /// require_state_backing::<ValueCell>();
 /// ```
+///
+/// ```compile_fail
+/// use mech_core::{FunctionStateBacking, Matrix2};
+/// fn require_state_backing<T: FunctionStateBacking>() {}
+/// require_state_backing::<Matrix2<Matrix2<f64>>>();
+/// ```
 pub trait FunctionStateBacking:
     function_state_sealed::Sealed + FunctionPortBacking + FunctionRuntimeType + Clone + 'static
 {
@@ -43,7 +60,9 @@ impl<T> FunctionStateBacking for T where
 macro_rules! scalar_function_state_backing {
     ($type:ty, $feature:literal) => {
         #[cfg(feature = $feature)]
-        impl function_state_sealed::Sealed for $type {}
+        impl function_state_sealed::Sealed for $type {
+            type ElementShape = function_state_sealed::FlatElement;
+        }
     };
 }
 
@@ -62,18 +81,33 @@ scalar_function_state_backing!(f64, "f64");
 scalar_function_state_backing!(bool, "bool");
 scalar_function_state_backing!(String, "string");
 
-impl function_state_sealed::Sealed for usize {}
+impl function_state_sealed::Sealed for usize {
+    type ElementShape = function_state_sealed::FlatElement;
+}
 
 #[cfg(feature = "complex")]
-impl function_state_sealed::Sealed for crate::C64 {}
+impl function_state_sealed::Sealed for crate::C64 {
+    type ElementShape = function_state_sealed::FlatElement;
+}
 
 #[cfg(feature = "rational")]
-impl function_state_sealed::Sealed for crate::R64 {}
+impl function_state_sealed::Sealed for crate::R64 {
+    type ElementShape = function_state_sealed::FlatElement;
+}
 
 macro_rules! exact_matrix_function_state_backing {
     ($type:ident, $feature:literal) => {
         #[cfg(feature = $feature)]
-        impl<T: FunctionStateBacking> function_state_sealed::Sealed for crate::$type<T> {}
+        impl<T> function_state_sealed::Sealed for crate::$type<T>
+        where
+            T: function_state_sealed::Sealed<ElementShape = function_state_sealed::FlatElement>
+                + FunctionPortBacking
+                + FunctionRuntimeType
+                + Clone
+                + 'static,
+        {
+            type ElementShape = ();
+        }
     };
 }
 
@@ -95,6 +129,8 @@ exact_matrix_function_state_backing!(DMatrix, "matrixd");
 
 trait ErasedFunctionState {
     fn representation(&self) -> FunctionValueRepresentation;
+    fn reactive_cell_ids(&self) -> Vec<FunctionReactiveCell>;
+    fn capture(&self, journal: &mut ValueStateJournal) -> MResult<()>;
 }
 
 impl<T> ErasedFunctionState for Ref<T>
@@ -104,6 +140,14 @@ where
 {
     fn representation(&self) -> FunctionValueRepresentation {
         T::REPRESENTATION
+    }
+
+    fn reactive_cell_ids(&self) -> Vec<FunctionReactiveCell> {
+        self.to_value().reactive_root_cell_ids()
+    }
+
+    fn capture(&self, journal: &mut ValueStateJournal) -> MResult<()> {
+        journal.capture_exact_ref(self)
     }
 }
 
@@ -128,6 +172,14 @@ impl<'a> FunctionStatePort<'a> {
 
     pub fn representation(self) -> FunctionValueRepresentation {
         self.inner.representation()
+    }
+
+    pub(crate) fn reactive_cell_ids(self) -> Vec<FunctionReactiveCell> {
+        self.inner.reactive_cell_ids()
+    }
+
+    pub(crate) fn capture_into(self, journal: &mut ValueStateJournal) -> MResult<()> {
+        self.inner.capture(journal)
     }
 }
 

--- a/src/core/src/function/state.rs
+++ b/src/core/src/function/state.rs
@@ -1,0 +1,193 @@
+//! Opaque capabilities over exact typed cells owned by runtime functions.
+
+#[cfg(feature = "no_std")]
+use alloc::string::String;
+#[cfg(not(feature = "no_std"))]
+use std::{fmt, string::String};
+
+#[cfg(feature = "no_std")]
+use core::fmt;
+
+use crate::{FunctionPortBacking, FunctionRuntimeType, FunctionValueRepresentation, Ref, ToValue};
+
+mod function_state_sealed {
+    pub trait Sealed {}
+}
+
+/// An exact runtime backing whose clone is a complete independent checkpoint.
+///
+/// The sealed implementation list deliberately excludes universal values,
+/// mutable value cells, and aggregates that can contain nested cell identity.
+///
+/// ```compile_fail
+/// use mech_core::{FunctionStateBacking, LegacyValue};
+/// fn require_state_backing<T: FunctionStateBacking>() {}
+/// require_state_backing::<LegacyValue>();
+/// ```
+///
+/// ```compile_fail
+/// use mech_core::{FunctionStateBacking, ValueCell};
+/// fn require_state_backing<T: FunctionStateBacking>() {}
+/// require_state_backing::<ValueCell>();
+/// ```
+pub trait FunctionStateBacking:
+    function_state_sealed::Sealed + FunctionPortBacking + FunctionRuntimeType + Clone + 'static
+{
+}
+
+impl<T> FunctionStateBacking for T where
+    T: function_state_sealed::Sealed + FunctionPortBacking + FunctionRuntimeType + Clone + 'static
+{
+}
+
+macro_rules! scalar_function_state_backing {
+    ($type:ty, $feature:literal) => {
+        #[cfg(feature = $feature)]
+        impl function_state_sealed::Sealed for $type {}
+    };
+}
+
+scalar_function_state_backing!(u8, "u8");
+scalar_function_state_backing!(u16, "u16");
+scalar_function_state_backing!(u32, "u32");
+scalar_function_state_backing!(u64, "u64");
+scalar_function_state_backing!(u128, "u128");
+scalar_function_state_backing!(i8, "i8");
+scalar_function_state_backing!(i16, "i16");
+scalar_function_state_backing!(i32, "i32");
+scalar_function_state_backing!(i64, "i64");
+scalar_function_state_backing!(i128, "i128");
+scalar_function_state_backing!(f32, "f32");
+scalar_function_state_backing!(f64, "f64");
+scalar_function_state_backing!(bool, "bool");
+scalar_function_state_backing!(String, "string");
+
+impl function_state_sealed::Sealed for usize {}
+
+#[cfg(feature = "complex")]
+impl function_state_sealed::Sealed for crate::C64 {}
+
+#[cfg(feature = "rational")]
+impl function_state_sealed::Sealed for crate::R64 {}
+
+macro_rules! exact_matrix_function_state_backing {
+    ($type:ident, $feature:literal) => {
+        #[cfg(feature = $feature)]
+        impl<T: FunctionStateBacking> function_state_sealed::Sealed for crate::$type<T> {}
+    };
+}
+
+exact_matrix_function_state_backing!(Matrix1, "matrix1");
+exact_matrix_function_state_backing!(Matrix2, "matrix2");
+exact_matrix_function_state_backing!(Matrix3, "matrix3");
+exact_matrix_function_state_backing!(Matrix4, "matrix4");
+exact_matrix_function_state_backing!(Matrix2x3, "matrix2x3");
+exact_matrix_function_state_backing!(Matrix3x2, "matrix3x2");
+exact_matrix_function_state_backing!(RowVector2, "row_vector2");
+exact_matrix_function_state_backing!(RowVector3, "row_vector3");
+exact_matrix_function_state_backing!(RowVector4, "row_vector4");
+exact_matrix_function_state_backing!(RowDVector, "row_vectord");
+exact_matrix_function_state_backing!(Vector2, "vector2");
+exact_matrix_function_state_backing!(Vector3, "vector3");
+exact_matrix_function_state_backing!(Vector4, "vector4");
+exact_matrix_function_state_backing!(DVector, "vectord");
+exact_matrix_function_state_backing!(DMatrix, "matrixd");
+
+trait ErasedFunctionState {
+    fn representation(&self) -> FunctionValueRepresentation;
+}
+
+impl<T> ErasedFunctionState for Ref<T>
+where
+    T: FunctionStateBacking,
+    Ref<T>: ToValue,
+{
+    fn representation(&self) -> FunctionValueRepresentation {
+        T::REPRESENTATION
+    }
+}
+
+/// A borrowed, opaque capability over one exact typed function-owned cell.
+///
+/// State ports reveal only the cell's declared representation. They do not
+/// expose its payload, typed reference, physical identity, or a legacy value.
+#[derive(Clone, Copy)]
+pub struct FunctionStatePort<'a> {
+    inner: &'a dyn ErasedFunctionState,
+}
+
+impl<'a> FunctionStatePort<'a> {
+    /// Borrows an exact typed cell without cloning either its handle or payload.
+    pub fn from_ref<T>(reference: &'a Ref<T>) -> Self
+    where
+        T: FunctionStateBacking,
+        Ref<T>: ToValue,
+    {
+        Self { inner: reference }
+    }
+
+    pub fn representation(self) -> FunctionValueRepresentation {
+        self.inner.representation()
+    }
+}
+
+impl fmt::Debug for FunctionStatePort<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("FunctionStatePort")
+            .field("representation", &self.representation())
+            .finish()
+    }
+}
+
+#[cfg(all(test, feature = "f64", feature = "matrix2", feature = "matrixd"))]
+mod tests {
+    use super::*;
+    use crate::{DMatrix, FunctionMatrixRepresentation, FunctionMatrixStoragePattern, Matrix2};
+
+    #[test]
+    fn scalar_state_port_borrows_the_existing_cell_and_reports_exact_representation() {
+        let reference = Ref::new(1.25_f64);
+        let existing_alias = reference.clone();
+
+        let port = FunctionStatePort::from_ref(&reference);
+
+        assert!(reference.same_handle(&existing_alias));
+        assert_eq!(*reference.borrow(), 1.25);
+        assert_eq!(port.representation(), FunctionValueRepresentation::F64);
+    }
+
+    #[test]
+    fn matrix_state_ports_report_exact_storage() {
+        let fixed = Ref::new(Matrix2::new(1.0_f64, 2.0, 3.0, 4.0));
+        let dynamic = Ref::new(DMatrix::from_vec(2, 2, vec![1.0_f64, 2.0, 3.0, 4.0]));
+
+        assert_eq!(
+            FunctionStatePort::from_ref(&fixed).representation(),
+            FunctionValueRepresentation::Matrix {
+                element: crate::FunctionMatrixElement::F64,
+                storage: FunctionMatrixStoragePattern::Exact(FunctionMatrixRepresentation::Matrix2,),
+            },
+        );
+        assert_eq!(
+            FunctionStatePort::from_ref(&dynamic).representation(),
+            FunctionValueRepresentation::Matrix {
+                element: crate::FunctionMatrixElement::F64,
+                storage: FunctionMatrixStoragePattern::Exact(FunctionMatrixRepresentation::MatrixD,),
+            },
+        );
+    }
+
+    #[test]
+    fn state_port_debug_exposes_only_the_representation() {
+        let reference = Ref::new(1234.56789_f64);
+        let debug = format!("{:?}", FunctionStatePort::from_ref(&reference));
+
+        assert_eq!(debug, "FunctionStatePort { representation: F64 }",);
+        assert!(!debug.contains("1234.56789"));
+        assert!(!debug.contains("LegacyValue"));
+        assert!(!debug.contains("ReactiveCellId"));
+        assert!(!debug.contains("0x"));
+        assert!(!debug.contains('@'));
+    }
+}

--- a/src/core/src/function/tests/transaction_state.rs
+++ b/src/core/src/function/tests/transaction_state.rs
@@ -1,9 +1,55 @@
 #[cfg(feature = "semantic-compiler")]
 use super::super::MechFunctionCompiler;
-use super::super::{MechFunctionImpl, Plan, TransactionStateUnsupportedError};
+use super::super::{FunctionStatePort, MechFunctionImpl, Plan, TransactionStateUnsupportedError};
 #[cfg(feature = "semantic-compiler")]
 use crate::{BytecodeCompilerContext, Register};
 use crate::{LegacyValue, MResult, MechError, Ref, ValueCell};
+use std::{cell::Cell, rc::Rc};
+
+struct TypedOutputFunction {
+    output: Ref<usize>,
+    legacy_reactive_calls: Rc<Cell<usize>>,
+}
+
+impl MechFunctionImpl for TypedOutputFunction {
+    fn solve_result(&self) -> MResult<()> {
+        Ok(())
+    }
+
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.output))
+    }
+
+    fn reactive_output_state_ports(&self) -> Option<Vec<FunctionStatePort<'_>>> {
+        let output = FunctionStatePort::from_ref(&self.output);
+        Some(vec![output, output])
+    }
+
+    fn out(&self) -> LegacyValue {
+        LegacyValue::Index(self.output.clone())
+    }
+
+    fn reactive_output_values(&self) -> Vec<LegacyValue> {
+        self.legacy_reactive_calls
+            .set(self.legacy_reactive_calls.get() + 1);
+        vec![self.out()]
+    }
+
+    fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
+        Ok(vec![self.out()])
+    }
+
+    fn to_string(&self) -> String {
+        "typed-output".to_string()
+    }
+}
+
+#[cfg(feature = "semantic-compiler")]
+impl MechFunctionCompiler for TypedOutputFunction {
+    fn compile(&self, _ctx: &mut dyn BytecodeCompilerContext) -> MResult<Register> {
+        Ok(0)
+    }
+}
 
 struct UnsupportedStateFunction;
 impl MechFunctionImpl for UnsupportedStateFunction {
@@ -91,6 +137,20 @@ fn transaction_state_unsupported_error_is_structured() {
     let function = UnsupportedStateFunction;
     let error = function.transaction_state_values().unwrap_err();
     assert_eq!(error.kind_name(), "TransactionStateUnsupported");
+}
+
+#[test]
+fn reactive_output_identity_prefers_typed_ports_and_deduplicates_them() {
+    let output = Ref::new(42usize);
+    let legacy_reactive_calls = Rc::new(Cell::new(0));
+    let function = TypedOutputFunction {
+        output: output.clone(),
+        legacy_reactive_calls: legacy_reactive_calls.clone(),
+    };
+
+    let expected = LegacyValue::Index(output).reactive_root_cell_ids();
+    assert_eq!(function.reactive_output_cell_ids(), expected);
+    assert_eq!(legacy_reactive_calls.get(), 0);
 }
 
 #[test]

--- a/src/core/src/reactive_transaction.rs
+++ b/src/core/src/reactive_transaction.rs
@@ -27,6 +27,13 @@ impl ReactiveTurnJournal {
     }
 
     pub(crate) fn capture_function_state(&mut self, function: &dyn MechFunction) -> MResult<()> {
+        if let Some(ports) = function.transaction_state_ports()? {
+            for port in ports {
+                port.capture_into(&mut self.values)?;
+            }
+            return Ok(());
+        }
+
         let mut values = function.transaction_state_values()?;
         if values.is_empty() {
             values.push(function.out());
@@ -201,7 +208,10 @@ pub fn with_reactive_journal_participant<T>(
 mod tests {
     use super::*;
     use crate::*;
-    use std::{cell::RefCell, rc::Rc};
+    use std::{
+        cell::{Cell, RefCell},
+        rc::Rc,
+    };
 
     fn deliberate_journal_error(message: &'static str) -> MechError {
         MechError::new(
@@ -418,6 +428,110 @@ mod tests {
             solve_error: false,
             sampled: false,
         }
+    }
+
+    #[derive(Clone, Copy)]
+    enum TypedStateMode {
+        State,
+        Empty,
+        Error,
+    }
+
+    struct TypedJournalFunction {
+        output: Ref<usize>,
+        retained: Ref<usize>,
+        mode: TypedStateMode,
+        out_calls: Rc<Cell<usize>>,
+        legacy_state_calls: Rc<Cell<usize>>,
+        solve_calls: Rc<Cell<usize>>,
+    }
+
+    impl MechFunctionImpl for TypedJournalFunction {
+        fn solve_result(&self) -> MResult<()> {
+            Ok(())
+        }
+
+        fn solve_reactive(&self) -> MResult<ReactiveSolveStatus> {
+            self.solve_calls.set(self.solve_calls.get() + 1);
+            *self.output.borrow_mut() += 1;
+            *self.retained.borrow_mut() += 10;
+            Ok(ReactiveSolveStatus::Changed)
+        }
+
+        fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+            Some(FunctionStatePort::from_ref(&self.output))
+        }
+
+        fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+            match self.mode {
+                TypedStateMode::State => {
+                    let output = FunctionStatePort::from_ref(&self.output);
+                    let retained = FunctionStatePort::from_ref(&self.retained);
+                    Ok(Some(vec![output, retained, retained]))
+                }
+                TypedStateMode::Empty => Ok(Some(Vec::new())),
+                TypedStateMode::Error => Err(MechError::new(
+                    TransactionStateUnsupportedError {
+                        function: "typed-journal".into(),
+                        reason: "deliberate typed state error".into(),
+                    },
+                    None,
+                )),
+            }
+        }
+
+        fn out(&self) -> LegacyValue {
+            self.out_calls.set(self.out_calls.get() + 1);
+            LegacyValue::Index(self.output.clone())
+        }
+
+        fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
+            self.legacy_state_calls
+                .set(self.legacy_state_calls.get() + 1);
+            Err(MechError::new(
+                GenericError {
+                    msg: "legacy typed-state fallback was invoked".into(),
+                },
+                None,
+            ))
+        }
+
+        fn to_string(&self) -> String {
+            "typed-journal".into()
+        }
+    }
+
+    #[cfg(feature = "semantic-compiler")]
+    impl MechFunctionCompiler for TypedJournalFunction {
+        fn compile(&self, _ctx: &mut dyn BytecodeCompilerContext) -> MResult<Register> {
+            Ok(0)
+        }
+    }
+
+    fn typed_journal_function(
+        mode: TypedStateMode,
+    ) -> (
+        TypedJournalFunction,
+        Rc<Cell<usize>>,
+        Rc<Cell<usize>>,
+        Rc<Cell<usize>>,
+    ) {
+        let out_calls = Rc::new(Cell::new(0));
+        let legacy_state_calls = Rc::new(Cell::new(0));
+        let solve_calls = Rc::new(Cell::new(0));
+        (
+            TypedJournalFunction {
+                output: Ref::new(1),
+                retained: Ref::new(2),
+                mode,
+                out_calls: out_calls.clone(),
+                legacy_state_calls: legacy_state_calls.clone(),
+                solve_calls: solve_calls.clone(),
+            },
+            out_calls,
+            legacy_state_calls,
+            solve_calls,
+        )
     }
 
     struct JournalRegisterCommit {
@@ -666,6 +780,84 @@ mod tests {
         journal.restore_before().unwrap();
 
         assert_eq!(*retained.borrow(), 2);
+    }
+
+    #[test]
+    fn reactive_transaction_prefers_typed_ports_restores_hidden_state_and_deduplicates() {
+        let (function, out_calls, legacy_state_calls, _) =
+            typed_journal_function(TypedStateMode::State);
+        let output = function.output.clone();
+        let retained = function.retained.clone();
+        let mut journal = ReactiveTurnJournal::new();
+
+        journal.capture_function_state(&function).unwrap();
+        assert_eq!(journal.cell_count(), 2);
+        *output.borrow_mut() = 11;
+        *retained.borrow_mut() = 22;
+        journal.restore_before().unwrap();
+
+        assert_eq!((*output.borrow(), *retained.borrow()), (1, 2));
+        assert_eq!(out_calls.get(), 0);
+        assert_eq!(legacy_state_calls.get(), 0);
+    }
+
+    #[test]
+    fn empty_typed_state_is_authoritative_without_out_fallback() {
+        let (function, out_calls, legacy_state_calls, _) =
+            typed_journal_function(TypedStateMode::Empty);
+        let mut journal = ReactiveTurnJournal::new();
+
+        journal.capture_function_state(&function).unwrap();
+
+        assert!(journal.is_empty());
+        assert_eq!(out_calls.get(), 0);
+        assert_eq!(legacy_state_calls.get(), 0);
+    }
+
+    #[test]
+    fn typed_state_error_prevents_solve_without_compatibility_fallback() {
+        let input = Ref::new(1usize);
+        let (function, _out_calls, legacy_state_calls, solve_calls) =
+            typed_journal_function(TypedStateMode::Error);
+        let mut plan = ReactivePlan::new();
+        plan.register(Box::new(function), &[LegacyValue::Index(input.clone())])
+            .unwrap();
+
+        let error = plan
+            .solve_dirty_cells_with_journal(
+                &LegacyValue::Index(input).reactive_root_cell_ids(),
+                &mut ReactiveTurnJournal::new(),
+            )
+            .unwrap_err();
+
+        assert_eq!(error.kind_name(), "TransactionStateUnsupported");
+        assert_eq!(legacy_state_calls.get(), 0);
+        assert_eq!(solve_calls.get(), 0);
+    }
+
+    #[test]
+    fn typed_and_legacy_function_state_coexist_in_one_journal() {
+        let (typed, _, _, _) = typed_journal_function(TypedStateMode::State);
+        let typed_output = typed.output.clone();
+        let legacy_output = Ref::new(3usize);
+        let legacy_retained = Ref::new(4usize);
+        let legacy = journal_function(
+            "legacy",
+            legacy_output.clone(),
+            legacy_retained.clone(),
+            Rc::new(RefCell::new(Vec::new())),
+        );
+        let mut journal = ReactiveTurnJournal::new();
+
+        journal.capture_function_state(&typed).unwrap();
+        journal.capture_function_state(&legacy).unwrap();
+        *typed_output.borrow_mut() = 10;
+        *legacy_output.borrow_mut() = 30;
+        *legacy_retained.borrow_mut() = 40;
+        journal.restore_before().unwrap();
+
+        assert_eq!(*typed_output.borrow(), 1);
+        assert_eq!((*legacy_output.borrow(), *legacy_retained.borrow()), (3, 4));
     }
 
     #[test]

--- a/src/core/src/state_journal/mod.rs
+++ b/src/core/src/state_journal/mod.rs
@@ -3,7 +3,7 @@
 //!
 //! This module deliberately has no integration with execution or reactive
 //! scheduling. Callers pay for graph traversal only when they explicitly
-//! construct and populate a [`ValueStateJournal`].
+//! construct and populate a value-state journal.
 
 #[cfg(feature = "matrix")]
 use crate::structures::matrix::Matrix;
@@ -441,10 +441,77 @@ impl CaptureSide {
     }
 }
 
-#[derive(Clone)]
 enum ValueStateRoot {
     Value(LegacyValue),
     Cell(ValueCell),
+    #[cfg(any(feature = "functions", test))]
+    ExactRef(Box<dyn ErasedValueStateRoot>),
+}
+
+impl Clone for ValueStateRoot {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Value(value) => Self::Value(value.clone()),
+            Self::Cell(cell) => Self::Cell(cell.clone()),
+            #[cfg(any(feature = "functions", test))]
+            Self::ExactRef(root) => Self::ExactRef(root.clone_box()),
+        }
+    }
+}
+
+#[cfg(any(feature = "functions", test))]
+trait ErasedValueStateRoot {
+    fn clone_box(&self) -> Box<dyn ErasedValueStateRoot>;
+    fn preflight(
+        &self,
+        journal: &ValueStateJournal,
+        side: CaptureSide,
+        seen: &mut HashSet<ValueStateKey>,
+    ) -> MResult<()>;
+    fn visit(
+        &self,
+        journal: &mut ValueStateJournal,
+        side: CaptureSide,
+        seen: &mut HashSet<ValueStateKey>,
+    ) -> MResult<()>;
+}
+
+#[cfg(any(feature = "functions", test))]
+struct RefValueStateRoot<T>
+where
+    T: Clone + 'static,
+{
+    target: Ref<T>,
+}
+
+#[cfg(any(feature = "functions", test))]
+impl<T> ErasedValueStateRoot for RefValueStateRoot<T>
+where
+    T: Clone + 'static,
+{
+    fn clone_box(&self) -> Box<dyn ErasedValueStateRoot> {
+        Box::new(Self {
+            target: self.target.clone(),
+        })
+    }
+
+    fn preflight(
+        &self,
+        journal: &ValueStateJournal,
+        side: CaptureSide,
+        seen: &mut HashSet<ValueStateKey>,
+    ) -> MResult<()> {
+        journal.preflight_ref(&self.target, side, seen, |_, _, _| Ok(()))
+    }
+
+    fn visit(
+        &self,
+        journal: &mut ValueStateJournal,
+        side: CaptureSide,
+        seen: &mut HashSet<ValueStateKey>,
+    ) -> MResult<()> {
+        journal.visit_ref(&self.target, side, seen, |_, _, _| Ok(()))
+    }
 }
 
 trait ErasedValueStateEntry {
@@ -595,6 +662,34 @@ impl ValueStateJournal {
         Ok(())
     }
 
+    /// Captures one exact typed cell without projecting it through a universal
+    /// value. The saved root owns only a cloned handle for after-state capture.
+    #[cfg(any(feature = "functions", test))]
+    pub(crate) fn capture_exact_ref<T>(&mut self, target: &Ref<T>) -> MResult<()>
+    where
+        T: Clone + 'static,
+    {
+        self.ensure_open()?;
+
+        let mut preflight_seen = HashSet::default();
+        self.preflight_ref(
+            target,
+            CaptureSide::Before,
+            &mut preflight_seen,
+            |_, _, _| Ok(()),
+        )?;
+
+        let mut capture_seen = HashSet::default();
+        self.visit_ref(target, CaptureSide::Before, &mut capture_seen, |_, _, _| {
+            Ok(())
+        })?;
+        self.roots
+            .push(ValueStateRoot::ExactRef(Box::new(RefValueStateRoot {
+                target: target.clone(),
+            })));
+        Ok(())
+    }
+
     /// Restores all captured before-state into the original cells.
     ///
     /// Every target is preflighted before the first payload is changed.
@@ -695,6 +790,8 @@ impl ValueStateJournal {
                     journal.preflight_value(value, side, seen)
                 })
             }
+            #[cfg(any(feature = "functions", test))]
+            ValueStateRoot::ExactRef(root) => root.preflight(self, side, seen),
         }
     }
 
@@ -712,6 +809,8 @@ impl ValueStateJournal {
                     journal.visit_value(value, side, seen)
                 })
             }
+            #[cfg(any(feature = "functions", test))]
+            ValueStateRoot::ExactRef(root) => root.visit(self, side, seen),
         }
     }
 
@@ -1554,6 +1653,10 @@ impl MechErrorKind for ValueStateAfterNotRecorded {
         "The value-state journal has no recorded after-state.".to_string()
     }
 }
+
+#[cfg(test)]
+#[path = "tests/exact_minimal.rs"]
+mod exact_ref_feature_smoke_tests;
 
 #[cfg(test)]
 mod tests;

--- a/src/core/src/state_journal/tests/exact.rs
+++ b/src/core/src/state_journal/tests/exact.rs
@@ -1,0 +1,112 @@
+use crate::{DMatrix, LegacyValue, Matrix2, Ref, ValueCell, ValueStateJournal};
+
+#[test]
+fn exact_scalar_roots_restore_deduplicate_and_preserve_handles() {
+    let first = Ref::new(1.0_f64);
+    let first_alias = first.clone();
+    let equal_but_distinct = Ref::new(1.0_f64);
+    let mut journal = ValueStateJournal::new();
+
+    journal.capture_exact_ref(&first).unwrap();
+    journal.capture_exact_ref(&first).unwrap();
+    journal.capture_exact_ref(&equal_but_distinct).unwrap();
+    assert_eq!(journal.cell_count(), 2);
+
+    *first.borrow_mut() = 10.0;
+    *equal_but_distinct.borrow_mut() = 20.0;
+    journal.restore_before().unwrap();
+
+    assert!(first.same_handle(&first_alias));
+    assert_eq!((*first.borrow(), *equal_but_distinct.borrow()), (1.0, 1.0));
+}
+
+#[test]
+fn exact_scalar_roots_record_after_rewind_and_replay() {
+    let target = Ref::new(2.0_f64);
+    let mut journal = ValueStateJournal::new();
+    journal.capture_exact_ref(&target).unwrap();
+    *target.borrow_mut() = 7.0;
+    journal.record_after().unwrap();
+    let delta = journal.into_delta().unwrap();
+
+    delta.rewind().unwrap();
+    assert_eq!(*target.borrow(), 2.0);
+    delta.replay().unwrap();
+    assert_eq!(*target.borrow(), 7.0);
+}
+
+#[test]
+fn exact_root_borrow_conflicts_are_structured_and_atomic() {
+    let target = Ref::new(3.0_f64);
+    let held_write = target.borrow_mut();
+    let mut journal = ValueStateJournal::new();
+    let error = journal.capture_exact_ref(&target).unwrap_err();
+    assert_eq!(error.kind_name(), "ValueStateBorrowConflict");
+    assert_eq!(
+        error.kind_message(),
+        "Cannot borrow f64 cell during capture-before."
+    );
+    assert!(journal.is_empty());
+    drop(held_write);
+
+    journal.capture_exact_ref(&target).unwrap();
+    *target.borrow_mut() = 9.0;
+    let held_read = target.borrow();
+    let error = journal.restore_before().unwrap_err();
+    assert_eq!(error.kind_name(), "ValueStateBorrowConflict");
+    assert_eq!(*held_read, 9.0);
+    drop(held_read);
+    journal.restore_before().unwrap();
+    assert_eq!(*target.borrow(), 3.0);
+}
+
+#[test]
+fn exact_fixed_and_dynamic_matrix_roots_restore_shape_and_storage() {
+    let fixed = Ref::new(Matrix2::new(1.0_f64, 2.0, 3.0, 4.0));
+    let dynamic = Ref::new(DMatrix::from_vec(
+        2,
+        3,
+        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+    ));
+    let mut journal = ValueStateJournal::new();
+    journal.capture_exact_ref(&fixed).unwrap();
+    journal.capture_exact_ref(&dynamic).unwrap();
+
+    *fixed.borrow_mut() = Matrix2::new(9.0, 8.0, 7.0, 6.0);
+    *dynamic.borrow_mut() = DMatrix::from_vec(1, 2, vec![9.0, 8.0]);
+    journal.restore_before().unwrap();
+
+    assert_eq!(*fixed.borrow(), Matrix2::new(1.0, 2.0, 3.0, 4.0));
+    assert_eq!(dynamic.borrow().shape(), (2, 3));
+    assert_eq!(dynamic.borrow().as_slice(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+}
+
+#[test]
+fn exact_legacy_and_value_cell_roots_coexist_and_share_deduplication() {
+    let exact = Ref::new(4.0_f64);
+    let legacy_index = Ref::new(5usize);
+    let cell = ValueCell::new(LegacyValue::Index(legacy_index.clone()));
+    let mut journal = ValueStateJournal::new();
+
+    journal.capture_exact_ref(&exact).unwrap();
+    journal
+        .capture_value(&LegacyValue::F64(exact.clone()))
+        .unwrap();
+    journal.capture_value_cell(&cell).unwrap();
+    journal
+        .capture_value(&LegacyValue::Index(legacy_index.clone()))
+        .unwrap();
+
+    assert_eq!(journal.cell_count(), 3);
+    *exact.borrow_mut() = 40.0;
+    *legacy_index.borrow_mut() = 50;
+    *cell.borrow_mut() = LegacyValue::Empty;
+    journal.restore_before().unwrap();
+
+    assert_eq!(*exact.borrow(), 4.0);
+    assert_eq!(*legacy_index.borrow(), 5);
+    let LegacyValue::Index(restored) = &*cell.borrow() else {
+        panic!("expected restored legacy index")
+    };
+    assert!(restored.same_handle(&legacy_index));
+}

--- a/src/core/src/state_journal/tests/exact_minimal.rs
+++ b/src/core/src/state_journal/tests/exact_minimal.rs
@@ -1,0 +1,13 @@
+use crate::{Ref, ValueStateJournal};
+
+#[test]
+fn exact_ref_capture_is_live_in_the_minimal_test_profile() {
+    let target = Ref::new(7_u8);
+    let mut journal = ValueStateJournal::new();
+
+    journal.capture_exact_ref(&target).unwrap();
+    *target.borrow_mut() = 9;
+    journal.restore_before().unwrap();
+
+    assert_eq!(*target.borrow(), 7);
+}

--- a/src/core/src/state_journal/tests/mod.rs
+++ b/src/core/src/state_journal/tests/mod.rs
@@ -14,6 +14,8 @@ mod borrow_conflicts;
 mod collections;
 mod collisions;
 mod delta;
+#[cfg(feature = "matrix2")]
+mod exact;
 mod hashed_cycles;
 mod nested;
 mod scalar;

--- a/src/core/src/stdlib.rs
+++ b/src/core/src/stdlib.rs
@@ -240,7 +240,7 @@ macro_rules! impl_binop {
             Ref<$out_type>: ToValue,
             $arg1_type: FunctionRuntimeType + FunctionPortBacking,
             $arg2_type: FunctionRuntimeType + FunctionPortBacking,
-            $out_type: FunctionRuntimeType + FunctionPortBacking,
+            $out_type: FunctionStateBacking,
         {
             const SIGNATURE: RuntimeFunctionSignature = RuntimeFunctionSignature::binary(
                 <$out_type as FunctionRuntimeType>::REPRESENTATION,
@@ -282,6 +282,7 @@ macro_rules! impl_binop {
                 + Zero
                 + One,
             Ref<$out_type>: ToValue,
+            $out_type: FunctionStateBacking,
         {
             fn solve_result(&self) -> MResult<()> {
                 let lhs_ptr = self.lhs.as_ptr();
@@ -289,6 +290,9 @@ macro_rules! impl_binop {
                 let out_ptr = self.out.as_mut_ptr();
                 $op!(lhs_ptr, rhs_ptr, out_ptr);
                 Ok(())
+            }
+            fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+                Some(FunctionStatePort::from_ref(&self.out))
             }
             fn out(&self) -> LegacyValue {
                 self.out.to_value()
@@ -299,6 +303,10 @@ macro_rules! impl_binop {
 
             fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
                 Ok(self.reactive_output_values())
+            }
+
+            fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+                Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
             }
         }
         #[cfg(feature = "semantic-compiler")]
@@ -325,7 +333,7 @@ macro_rules! impl_unop {
         impl MechFunctionFactory for $struct_name
         where
             $arg_type: FunctionPortBacking,
-            $out_type: FunctionPortBacking,
+            $out_type: FunctionStateBacking,
         {
             const SIGNATURE: RuntimeFunctionSignature = RuntimeFunctionSignature::unary(
                 <$out_type as FunctionRuntimeType>::REPRESENTATION,
@@ -345,12 +353,19 @@ macro_rules! impl_unop {
                 Self::new_invocation(args.into())
             }
         }
-        impl MechFunctionImpl for $struct_name {
+        impl MechFunctionImpl for $struct_name
+        where
+            $out_type: FunctionStateBacking,
+            Ref<$out_type>: ToValue,
+        {
             fn solve_result(&self) -> MResult<()> {
                 let arg_ptr = self.arg.as_ptr();
                 let out_ptr = self.out.as_mut_ptr();
                 $op!(arg_ptr, out_ptr);
                 Ok(())
+            }
+            fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+                Some(FunctionStatePort::from_ref(&self.out))
             }
             fn out(&self) -> LegacyValue {
                 self.out.to_value()
@@ -368,6 +383,10 @@ macro_rules! impl_unop {
 
             fn transaction_state_values(&self) -> MResult<Vec<LegacyValue>> {
                 Ok(self.reactive_output_values())
+            }
+
+            fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+                Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
             }
         }
         #[cfg(feature = "semantic-compiler")]

--- a/src/engine/src/intrinsics/access/mod.rs
+++ b/src/engine/src/intrinsics/access/mod.rs
@@ -51,7 +51,12 @@ use crate::{
     FunctionCatalogBuilder, FunctionSpecializer, IncorrectNumberOfArguments, LegacyValue, MResult,
     MechError, MechFunction, UnhandledFunctionArgumentKind2,
 };
-#[cfg(feature = "semantic-compiler")]
+#[cfg(all(
+    feature = "semantic-compiler",
+    feature = "subscript",
+    feature = "access",
+    feature = "subscript_slice"
+))]
 use crate::{InterpreterExecution, MatrixSelector, OperationId};
 #[cfg(any(feature = "record", feature = "table"))]
 use crate::{MechTuple, Ref, UndefinedRecordFieldError};
@@ -183,7 +188,15 @@ fn matrix_access_index_is_scalar(index: &LegacyValue) -> bool {
     index.shape().as_slice() == [1, 1]
 }
 
-#[cfg(any(feature = "matrix", feature = "semantic-compiler"))]
+#[cfg(any(
+    feature = "matrix",
+    all(
+        feature = "semantic-compiler",
+        feature = "subscript",
+        feature = "access",
+        feature = "subscript_slice"
+    )
+))]
 fn legacy_all_selector() -> LegacyValue {
     LegacyValue::IndexAll
 }
@@ -255,7 +268,12 @@ fn compile_matrix_access(arguments: &[LegacyValue]) -> MResult<Box<dyn MechFunct
 }
 
 /// Lowers source-level selectors at the legacy access specialization boundary.
-#[cfg(feature = "semantic-compiler")]
+#[cfg(all(
+    feature = "semantic-compiler",
+    feature = "subscript",
+    feature = "access",
+    feature = "subscript_slice"
+))]
 pub(crate) fn specialize_matrix_access(
     execution: &InterpreterExecution<'_>,
     canonical_name: &str,

--- a/src/engine/src/intrinsics/assign/mod.rs
+++ b/src/engine/src/intrinsics/assign/mod.rs
@@ -1,5 +1,19 @@
 use crate::intrinsics::*;
-#[cfg(feature = "semantic-compiler")]
+#[cfg(all(
+    feature = "semantic-compiler",
+    any(
+        all(feature = "subscript", feature = "assign"),
+        all(
+            any(
+                feature = "math_add_assign",
+                feature = "math_sub_assign",
+                feature = "math_div_assign",
+                feature = "math_mul_assign"
+            ),
+            any(feature = "subscript_formula", feature = "subscript_range")
+        )
+    )
+))]
 use crate::{InterpreterExecution, MatrixSelector, OperationId};
 
 pub mod catalog;
@@ -873,7 +887,24 @@ enum AssignmentIndexKind {
     All,
 }
 
-#[cfg(any(feature = "matrix", feature = "semantic-compiler"))]
+#[cfg(any(
+    feature = "matrix",
+    all(
+        feature = "semantic-compiler",
+        any(
+            all(feature = "subscript", feature = "assign"),
+            all(
+                any(
+                    feature = "math_add_assign",
+                    feature = "math_sub_assign",
+                    feature = "math_div_assign",
+                    feature = "math_mul_assign"
+                ),
+                any(feature = "subscript_formula", feature = "subscript_range")
+            )
+        )
+    )
+))]
 fn legacy_all_selector() -> LegacyValue {
     LegacyValue::IndexAll
 }
@@ -892,7 +923,21 @@ fn assignment_index_kind(value: &LegacyValue) -> AssignmentIndexKind {
 }
 
 /// Lowers source-level selectors at the legacy assignment specialization boundary.
-#[cfg(feature = "semantic-compiler")]
+#[cfg(all(
+    feature = "semantic-compiler",
+    any(
+        all(feature = "subscript", feature = "assign"),
+        all(
+            any(
+                feature = "math_add_assign",
+                feature = "math_sub_assign",
+                feature = "math_div_assign",
+                feature = "math_mul_assign"
+            ),
+            any(feature = "subscript_formula", feature = "subscript_range")
+        )
+    )
+))]
 pub(crate) fn specialize_matrix_assignment(
     execution: &InterpreterExecution<'_>,
     canonical_name: &str,

--- a/src/engine/src/intrinsics/define.rs
+++ b/src/engine/src/intrinsics/define.rs
@@ -712,6 +712,7 @@ impl MechFunctionImpl for VariableDefineEmpty {
 #[cfg(feature = "semantic-compiler")]
 impl MechFunctionCompiler for VariableDefineEmpty {
     fn reserve_bytecode_registers(&self, ctx: &mut dyn BytecodeCompilerContext) -> MResult<()> {
+        #[cfg(feature = "matrix")]
         if self
             .initial
             .exact_matrix_any()
@@ -719,7 +720,9 @@ impl MechFunctionCompiler for VariableDefineEmpty {
             .is_some()
         {
             compile_value_register_for_ptr(&self.initial, self.var.addr(), ctx)?;
-        } else if *self.mutable.borrow() {
+            return Ok(());
+        }
+        if *self.mutable.borrow() {
             compile_register_initial!(self.var, self.initial, ctx);
         }
         Ok(())

--- a/src/engine/src/lib.rs
+++ b/src/engine/src/lib.rs
@@ -53,11 +53,41 @@ pub(crate) use interpreter::{Interpreter, InterpreterExecution, RuntimeContextBi
 pub mod intrinsics;
 #[cfg(feature = "semantic-compiler")]
 pub mod literals;
-#[cfg(feature = "semantic-compiler")]
+#[cfg(all(
+    feature = "semantic-compiler",
+    any(
+        all(feature = "subscript", feature = "assign"),
+        all(feature = "subscript", feature = "access", feature = "subscript_slice"),
+        all(
+            any(
+                feature = "math_add_assign",
+                feature = "math_sub_assign",
+                feature = "math_div_assign",
+                feature = "math_mul_assign"
+            ),
+            any(feature = "subscript_formula", feature = "subscript_range")
+        )
+    )
+))]
 mod matrix_selector;
 #[cfg(feature = "semantic-compiler")]
 pub mod mechdown;
-#[cfg(feature = "semantic-compiler")]
+#[cfg(all(
+    feature = "semantic-compiler",
+    any(
+        all(feature = "subscript", feature = "assign"),
+        all(feature = "subscript", feature = "access", feature = "subscript_slice"),
+        all(
+            any(
+                feature = "math_add_assign",
+                feature = "math_sub_assign",
+                feature = "math_div_assign",
+                feature = "math_mul_assign"
+            ),
+            any(feature = "subscript_formula", feature = "subscript_range")
+        )
+    )
+))]
 pub(crate) use matrix_selector::MatrixSelector;
 #[cfg(feature = "semantic-compiler")]
 pub mod patterns;

--- a/tests/architecture/value-execution/legacy-boundary.json
+++ b/tests/architecture/value-execution/legacy-boundary.json
@@ -96,8 +96,9 @@
       "description": "Legacy mutable Value rollback journal declaration and production use sites",
       "pattern": "ValueStateJournal",
       "allowed": [
+        { "path": "src/core/src/function/state.rs", "scope_contains": "<file>", "max_occurrences": 4 },
         { "path": "src/core/src/reactive_transaction.rs", "scope_contains": "<file>", "max_occurrences": 3 },
-        { "path": "src/core/src/state_journal/mod.rs", "scope_contains": "<file>", "max_occurrences": 9 },
+        { "path": "src/core/src/state_journal/mod.rs", "scope_contains": "<file>", "max_occurrences": 12 },
         { "path": "src/engine/src/interpreter/bytecode/registers.rs", "scope_contains": "<file>", "max_occurrences": 2 },
         { "path": "src/engine/src/interpreter/mod.rs", "scope_contains": "<file>", "max_occurrences": 6 }
       ]

--- a/tests/architecture/value-system/migration.json
+++ b/tests/architecture/value-system/migration.json
@@ -322,6 +322,54 @@
     },
     {
       "count": 1,
+      "fingerprint": "2faec2f1b0188be6b3cdbd8df1de19293bcee0e5cdf60579d319bb4fff7c7c27",
+      "gate": "E4",
+      "identifier": "value-state-journal",
+      "path": "src/core/src/function/state.rs",
+      "reason": "typed function-state capture uses the existing journal as its concrete internal sink; no new universal value owner"
+    },
+    {
+      "count": 1,
+      "fingerprint": "1f844d21c6cb367975e2cc9cacd546f6ab5bd7a0eb312d775b63ed82ed0383d7",
+      "gate": "E4",
+      "identifier": "value-state-journal",
+      "path": "src/core/src/function/state.rs",
+      "reason": "typed function-state capture uses the existing journal as its concrete internal sink; no new universal value owner"
+    },
+    {
+      "count": 1,
+      "fingerprint": "196b45e3d32dc661a6f1af4150156eea1630274abd2cde3849aff6f4a9c741a8",
+      "gate": "E4",
+      "identifier": "value-state-journal",
+      "path": "src/core/src/function/state.rs",
+      "reason": "typed function-state capture uses the existing journal as its concrete internal sink; no new universal value owner"
+    },
+    {
+      "count": 1,
+      "fingerprint": "6ce2bc66cd704e34586186087824fdb02459f88bf52c336864befdd6d628a72c",
+      "gate": "E4",
+      "identifier": "value-state-journal",
+      "path": "src/core/src/function/state.rs",
+      "reason": "typed function-state capture uses the existing journal as its concrete internal sink; no new universal value owner"
+    },
+    {
+      "count": 2,
+      "fingerprint": "3d0088b9cc04a7d6ebb9acc2a70b58bd26873dba83e18a6c8fb15c91f03ea67c",
+      "gate": "E4",
+      "identifier": "value-state-journal",
+      "path": "src/core/src/state_journal/mod.rs",
+      "reason": "private exact-root dispatch reuses the journal's generic preflight and capture machinery; no new universal value owner"
+    },
+    {
+      "count": 2,
+      "fingerprint": "4591727cbe8987c782fb7c2b2869d1bbca91facdd25ba42c14b001d39e65a29a",
+      "gate": "E4",
+      "identifier": "value-state-journal",
+      "path": "src/core/src/state_journal/mod.rs",
+      "reason": "private exact-root dispatch reuses the journal's generic preflight and capture machinery; no new universal value owner"
+    },
+    {
+      "count": 1,
       "fingerprint": "99b3c91345bc5fd6cb9eee6e4def9b5e66b05824837ac5536ddd791dc7eb5e89",
       "gate": "E4",
       "identifier": "value-typed-wrapper",


### PR DESCRIPTION
## Summary

- adds an opaque `FunctionStatePort` for exact typed function-owned cells
- seals checkpoint-safe state backings, excludes `LegacyValue` and nested aggregates, and limits matrix elements to flat scalar backings
- adds exact typed roots to `ValueStateJournal`
- hands state ports directly to the concrete journal while keeping erased root storage private to the journal
- reuses the journal's existing generic preflight and visit machinery
- makes reactive output identity and transaction rollback prefer typed state ports
- preserves `LegacyValue` output and checkpoint methods as unmigrated fallbacks
- migrates comparison, logic, and math output/checkpoint state
- preserves algorithms, factory identities, signatures, contracts, and native linkage
- keeps existing selector adapters out of reduced engine profiles that cannot call them

## Behavior

| Function capability | Result |
|---|---|
| Migrated typed output | Reactive IDs come from state port |
| Migrated typed checkpoint list | Journal captures exact `Ref<T>` cells |
| `Some([])` typed list | Authoritative no-state result |
| Typed checkpoint error | Returned without legacy fallback |
| Unmigrated function | Existing `LegacyValue` behavior |
| Legacy empty checkpoint list | Existing `out()` fallback |
| Hidden typed state | Included explicitly in typed list |
| Nested aggregate state | Remains on legacy fallback |
| Legacy `out()` caller | Existing behavior unchanged |

## Non-goals

- no removal of `LegacyValue` output methods
- no `FunctionArgs` or invocation changes
- no source-specializer migration
- no op-assignment migration
- no aggregate state migration
- no matrix/statistics package migration
- no bytecode or resident changes
- no frozen baseline or inventory regeneration

## Evidence

- approved PR5 base: `cc39a8a0f1363ec58e140b896b6817f06b5a2d30`
- current PR6 head: `573e772f32ecc2084980b3ad6814b3cc942dbcd5`
- four requested commits, each independently scoped
- formatting and `git diff --check`: pass
- core all-features tests: 396 passed; all 5 compile-fail docs passed
- compare full-compiler tests: 5 passed
- logic full-compiler tests: 4 passed
- bytecode owner all-features profile: pass
- bare core language-test profile: pass
- reduced compiler, full compiler, dynamic-module, and browser catalog profiles: pass
- string-only compiler/function profile without matrix support: pass
- bytecode compiler boundary and complete function-system migration checks: pass
- typed preference and exact journal before/after/delta regressions: pass
- value-system retirement: pass; 22 reviewed `LegacyValue` occurrences removed, zero unreviewed growth
- architecture qualification: 406 tests passed
- value-execution boundary audit: pass
- CI replacement run: [91/91 jobs passed](https://github.com/mech-lang/mech/actions/runs/33122028176), including selected CI, requested full validation, and the PR gate

## Reviewed journal boundary

`FunctionStatePort::capture_into` and its private erased backing accept `&mut ValueStateJournal` directly. The `Ref<T>` backing calls the production crate-private `capture_exact_ref`; only the journal retains a cloned exact root handle. `ErasedValueStateRoot`, `RefValueStateRoot`, and `CaptureSide` remain private to the journal, and exact capture uses the existing `preflight_ref` and `visit_ref` paths.

The two new audited source locations are bounded by exact high-risk fingerprints in `migration.json` and path/count ceilings in `legacy-boundary.json`. The immutable baseline and generated inventory are unchanged.
