### PR TITLE
fix(web): use blog scrollbar across pages

### DIFF
--- a/include/blog.css
+++ b/include/blog.css
@@ -20,7 +20,7 @@ html[data-mech-shim="blog"] body::-webkit-scrollbar {
 }
 
 html[data-mech-shim="blog"] .content-shell {
-  scrollbar-color: var(--mech-surface-accent) transparent;
+  scrollbar-color: var(--mech-scrollbar) transparent;
 }
 
 html[data-mech-shim="blog"] .content-shell::-webkit-scrollbar {
@@ -28,13 +28,13 @@ html[data-mech-shim="blog"] .content-shell::-webkit-scrollbar {
 }
 
 html[data-mech-shim="blog"] .content-shell::-webkit-scrollbar-thumb {
-  background: var(--mech-brand);
+  background: var(--mech-scrollbar);
   background-clip: content-box;
   border: 2px solid transparent;
 }
 
 html[data-mech-shim="blog"] .content-shell::-webkit-scrollbar-thumb:hover {
-  background: var(--mech-nav-hover);
+  background: var(--mech-scrollbar-hover);
   background-clip: content-box;
 }
 

--- a/include/style.css
+++ b/include/style.css
@@ -58,7 +58,7 @@ html, body {
   color: var(--text-primary);
   background: var(--bg-primary);
   scroll-behavior: smooth;
-  scrollbar-color: var(--mech-scrollbar) transparent;
+  scrollbar-color: var(--mech-brand) transparent;
   scrollbar-width: thin;
   overflow-x: hidden;
   max-width: 100%;
@@ -70,8 +70,8 @@ body {
 
 html::-webkit-scrollbar,
 body::-webkit-scrollbar {
-  height: 6px;
-  width: 6px;
+  height: 8px;
+  width: 8px;
 }
 
 html::-webkit-scrollbar-track,
@@ -81,13 +81,16 @@ body::-webkit-scrollbar-track {
 
 html::-webkit-scrollbar-thumb,
 body::-webkit-scrollbar-thumb {
-  background: var(--mech-scrollbar);
+  background: var(--mech-brand);
+  background-clip: content-box;
+  border: 2px solid transparent;
   border-radius: 999px;
 }
 
 html::-webkit-scrollbar-thumb:hover,
 body::-webkit-scrollbar-thumb:hover {
-  background: var(--mech-scrollbar-hover);
+  background: var(--mech-nav-hover);
+  background-clip: content-box;
 }
 
 body { min-height: 100vh; }
@@ -231,11 +234,11 @@ a { color: inherit; text-decoration: none; }
   top: var(--header-height);
   align-self: start;
   scrollbar-width: thin;
-  scrollbar-color: var(--bg-accent) transparent;
+  scrollbar-color: var(--mech-brand) transparent;
 }
 
 .content-shell::-webkit-scrollbar {
-  width: 6px;
+  width: 8px;
 }
 
 .content-shell::-webkit-scrollbar-track {
@@ -243,12 +246,15 @@ a { color: inherit; text-decoration: none; }
 }
 
 .content-shell::-webkit-scrollbar-thumb {
-  background: var(--mech-scrollbar);
+  background: var(--mech-brand);
+  background-clip: content-box;
+  border: 2px solid transparent;
   border-radius: 999px;
 }
 
 .content-shell::-webkit-scrollbar-thumb:hover {
-  background: var(--mech-scrollbar-hover);
+  background: var(--mech-nav-hover);
+  background-clip: content-box;
 }
 
 .content-shell {

--- a/include/style.css
+++ b/include/style.css
@@ -58,7 +58,7 @@ html, body {
   color: var(--text-primary);
   background: var(--bg-primary);
   scroll-behavior: smooth;
-  scrollbar-color: var(--mech-brand) transparent;
+  scrollbar-color: var(--mech-scrollbar) transparent;
   scrollbar-width: thin;
   overflow-x: hidden;
   max-width: 100%;
@@ -81,7 +81,7 @@ body::-webkit-scrollbar-track {
 
 html::-webkit-scrollbar-thumb,
 body::-webkit-scrollbar-thumb {
-  background: var(--mech-brand);
+  background: var(--mech-scrollbar);
   background-clip: content-box;
   border: 2px solid transparent;
   border-radius: 999px;
@@ -89,7 +89,7 @@ body::-webkit-scrollbar-thumb {
 
 html::-webkit-scrollbar-thumb:hover,
 body::-webkit-scrollbar-thumb:hover {
-  background: var(--mech-nav-hover);
+  background: var(--mech-scrollbar-hover);
   background-clip: content-box;
 }
 
@@ -234,7 +234,7 @@ a { color: inherit; text-decoration: none; }
   top: var(--header-height);
   align-self: start;
   scrollbar-width: thin;
-  scrollbar-color: var(--mech-brand) transparent;
+  scrollbar-color: var(--mech-scrollbar) transparent;
 }
 
 .content-shell::-webkit-scrollbar {
@@ -246,14 +246,14 @@ a { color: inherit; text-decoration: none; }
 }
 
 .content-shell::-webkit-scrollbar-thumb {
-  background: var(--mech-brand);
+  background: var(--mech-scrollbar);
   background-clip: content-box;
   border: 2px solid transparent;
   border-radius: 999px;
 }
 
 .content-shell::-webkit-scrollbar-thumb:hover {
-  background: var(--mech-nav-hover);
+  background: var(--mech-scrollbar-hover);
   background-clip: content-box;
 }
 

--- a/tests/style_layer_contract.rs
+++ b/tests/style_layer_contract.rs
@@ -283,7 +283,9 @@ fn document_controller_keeps_toc_and_error_activity_state_continuous() {
     assert!(page.contains(".toc li.expanded > .toc-sub"));
     assert!(page.contains("border-left: 1px dotted var(--toc-accent-soft)"));
     assert!(page.contains(".article-layout.is-toc-open > .main-content"));
-    assert!(page.contains("scrollbar-color: var(--mech-scrollbar) transparent"));
+    assert!(page.contains("scrollbar-color: var(--mech-brand) transparent"));
+    assert!(page.contains("background: var(--mech-nav-hover)"));
+    assert!(page.contains("background-clip: content-box"));
 
     let repl = include("mech-repl.css");
     assert!(repl.contains(".mech-console-error-count"));

--- a/tests/style_layer_contract.rs
+++ b/tests/style_layer_contract.rs
@@ -283,8 +283,8 @@ fn document_controller_keeps_toc_and_error_activity_state_continuous() {
     assert!(page.contains(".toc li.expanded > .toc-sub"));
     assert!(page.contains("border-left: 1px dotted var(--toc-accent-soft)"));
     assert!(page.contains(".article-layout.is-toc-open > .main-content"));
-    assert!(page.contains("scrollbar-color: var(--mech-brand) transparent"));
-    assert!(page.contains("background: var(--mech-nav-hover)"));
+    assert!(page.contains("scrollbar-color: var(--mech-scrollbar) transparent"));
+    assert!(page.contains("background: var(--mech-scrollbar-hover)"));
     assert!(page.contains("background-clip: content-box"));
 
     let repl = include("mech-repl.css");
@@ -494,8 +494,8 @@ fn established_blog_color_and_component_details_are_preserved() {
         "color: var(--mech-text-body)",
         "font-size: 1.06rem",
         "line-height: 1.85",
-        "scrollbar-color: var(--mech-surface-accent) transparent",
-        "background: var(--mech-brand)",
+        "scrollbar-color: var(--mech-scrollbar) transparent",
+        "background: var(--mech-scrollbar-hover)",
         ".mech-image,",
         "max-width: 110%",
         "width: min(48%, 520px)",


### PR DESCRIPTION
## Summary
- apply the established blog scrollbar treatment to shared document scrolling surfaces
- preserve the narrow transparent track, muted gray thumb, and lighter gray hover state
- extend the style-layer contract so future generated pages preserve it

## Validation
- cargo +nightly-2026-03-03 test --test style_layer_contract (19 passed)