### PR TITLE
[PR7] refactor(matrix): migrate matrix and statistics functions to typed ports

### DIFF
--- a/machines/matrix/src/dot.rs
+++ b/machines/matrix/src/dot.rs
@@ -206,3 +206,81 @@ mod checked_dot_tests {
         assert_eq!(*out.borrow(), 200);
     }
 }
+
+#[cfg(all(
+    test,
+    feature = "runtime",
+    feature = "f64",
+    feature = "vector2",
+    feature = "matrixd"
+))]
+mod invocation_port_tests {
+    use super::*;
+
+    fn binary_args<L, R, O>(out: &Ref<O>, lhs: &Ref<L>, rhs: &Ref<R>) -> FunctionArgs
+    where
+        Ref<L>: ToValue,
+        Ref<R>: ToValue,
+        Ref<O>: ToValue,
+    {
+        FunctionArgs::Binary(out.to_value(), lhs.to_value(), rhs.to_value())
+    }
+
+    #[test]
+    fn scalar_and_matrix_factories_preserve_legacy_behavior() {
+        let scalar_lhs = Ref::new(2.5_f64);
+        let scalar_rhs = Ref::new(4.0_f64);
+        let legacy_out = Ref::new(0.0_f64);
+        let invocation_out = Ref::new(0.0_f64);
+
+        let legacy =
+            DotScalar::<f64>::new(binary_args(&legacy_out, &scalar_lhs, &scalar_rhs)).unwrap();
+        let invocation = DotScalar::<f64>::new_invocation(
+            binary_args(&invocation_out, &scalar_lhs, &scalar_rhs).into(),
+        )
+        .unwrap();
+        legacy.solve_result().unwrap();
+        invocation.solve_result().unwrap();
+        assert_eq!(*legacy_out.borrow(), 10.0);
+        assert_eq!(*legacy_out.borrow(), *invocation_out.borrow());
+
+        let fixed_lhs = Ref::new(Vector2::new(1.0_f64, 2.0));
+        let fixed_rhs = Ref::new(Vector2::new(3.0_f64, 4.0));
+        let fixed_out = Ref::new(0.0_f64);
+        DotV2V2::<f64>::new_invocation(binary_args(&fixed_out, &fixed_lhs, &fixed_rhs).into())
+            .unwrap()
+            .solve_result()
+            .unwrap();
+        assert_eq!(*fixed_out.borrow(), 11.0);
+
+        let dynamic_lhs = Ref::new(DMatrix::from_row_slice(2, 2, &[1.0_f64, 2.0, 3.0, 4.0]));
+        let dynamic_rhs = Ref::new(DMatrix::from_row_slice(2, 2, &[2.0_f64, 0.0, 1.0, 2.0]));
+        let dynamic_out = Ref::new(0.0_f64);
+        DotMDMD::<f64>::new_invocation(
+            binary_args(&dynamic_out, &dynamic_lhs, &dynamic_rhs).into(),
+        )
+        .unwrap()
+        .solve_result()
+        .unwrap();
+        assert_eq!(*dynamic_out.borrow(), 13.0);
+    }
+
+    #[test]
+    fn dot_invocation_rejects_wrong_exact_type_and_layout() {
+        let out = Ref::new(0.0_f64);
+        let rhs = Ref::new(Vector2::new(1.0_f64, 2.0));
+        let wrong_lhs = Ref::new(1.0_f64);
+
+        let type_error = DotV2V2::<f64>::new_invocation(binary_args(&out, &wrong_lhs, &rhs).into())
+            .err()
+            .expect("wrong exact input type must be rejected");
+        assert_eq!(type_error.kind_name(), "FunctionArgumentTypeMismatch");
+
+        let arity_error = DotV2V2::<f64>::new_invocation(
+            FunctionArgs::Unary(out.to_value(), rhs.to_value()).into(),
+        )
+        .err()
+        .expect("wrong invocation layout must be rejected");
+        assert_eq!(arity_error.kind_name(), "IncorrectNumberOfArguments");
+    }
+}

--- a/machines/matrix/src/dot.rs
+++ b/machines/matrix/src/dot.rs
@@ -199,10 +199,19 @@ mod checked_dot_tests {
 
         function.solve_result().unwrap();
         assert_eq!(*out.borrow(), 200);
-        *rhs.borrow_mut() = Vector2::new(2, 2);
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&function)?;
+            *rhs.borrow_mut() = Vector2::new(2, 2);
 
-        let error = function.solve_result().unwrap_err();
-        assert_eq!(error.kind_name(), "MatrixArithmeticOverflow");
+            let error = function.solve_result().unwrap_err();
+            assert_eq!(error.kind_name(), "MatrixArithmeticOverflow");
+            assert_eq!(*out.borrow(), 200);
+            *out.borrow_mut() = 19;
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
         assert_eq!(*out.borrow(), 200);
     }
 }
@@ -243,6 +252,21 @@ mod invocation_port_tests {
         invocation.solve_result().unwrap();
         assert_eq!(*legacy_out.borrow(), 10.0);
         assert_eq!(*legacy_out.borrow(), *invocation_out.borrow());
+        assert_eq!(
+            invocation.reactive_output_cell_ids(),
+            invocation.out().reactive_root_cell_ids(),
+        );
+        let invocation_out_alias = invocation_out.clone();
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*invocation)?;
+            *invocation_out.borrow_mut() = -1.0;
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+        assert!(invocation_out.same_handle(&invocation_out_alias));
+        assert_eq!(*invocation_out.borrow(), 10.0);
 
         let fixed_lhs = Ref::new(Vector2::new(1.0_f64, 2.0));
         let fixed_rhs = Ref::new(Vector2::new(3.0_f64, 4.0));

--- a/machines/matrix/src/lib.rs
+++ b/machines/matrix/src/lib.rs
@@ -370,7 +370,7 @@ macro_rules! impl_checked_matrix_binop {
         where
             T: RuntimeMatrixArithmetic,
             Ref<$out_type>: ToValue,
-            $out_type: FunctionRuntimeType,
+            $out_type: FunctionStateBacking,
         {
             fn solve_result(&self) -> MResult<()> {
                 let lhs_ptr = self.lhs.as_ptr();
@@ -378,6 +378,14 @@ macro_rules! impl_checked_matrix_binop {
                 let out_ptr = self.out.as_mut_ptr();
                 $op!(lhs_ptr, rhs_ptr, out_ptr);
                 Ok(())
+            }
+
+            fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+                Some(FunctionStatePort::from_ref(&self.out))
+            }
+
+            fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+                Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
             }
 
             fn out(&self) -> LegacyValue {

--- a/machines/matrix/src/lib.rs
+++ b/machines/matrix/src/lib.rs
@@ -341,9 +341,9 @@ macro_rules! impl_checked_matrix_binop {
             #[cfg(feature = "semantic-compiler")]
             T: ConstElem + CompileConst,
             Ref<$out_type>: ToValue,
-            $arg1_type: FunctionRuntimeType,
-            $arg2_type: FunctionRuntimeType,
-            $out_type: FunctionRuntimeType,
+            $arg1_type: FunctionPortBacking,
+            $arg2_type: FunctionPortBacking,
+            $out_type: FunctionStateBacking,
         {
             const SIGNATURE: RuntimeFunctionSignature = RuntimeFunctionSignature::binary(
                 <$out_type as FunctionRuntimeType>::REPRESENTATION,
@@ -351,23 +351,18 @@ macro_rules! impl_checked_matrix_binop {
                 <$arg2_type as FunctionRuntimeType>::REPRESENTATION,
             );
 
+            fn new_invocation(
+                invocation: FunctionInvocation,
+            ) -> MResult<Box<dyn MechFunction>> {
+                let (out, lhs, rhs) = invocation.expect_binary()?;
+                let lhs: Ref<$arg1_type> = lhs.try_ref()?;
+                let rhs: Ref<$arg2_type> = rhs.try_ref()?;
+                let out: Ref<$out_type> = out.try_ref()?;
+                Ok(Box::new(Self { lhs, rhs, out }))
+            }
+
             fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-                match args {
-                    FunctionArgs::Binary(out, arg1, arg2) => {
-                        let lhs = arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                        let rhs = arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                        let out = out.try_function_ref(FunctionArgumentRole::Output)?;
-                        Ok(Box::new(Self { lhs, rhs, out }))
-                    }
-                    _ => Err(MechError::new(
-                        IncorrectNumberOfArguments {
-                            expected: 2,
-                            found: args.len(),
-                        },
-                        None,
-                    )
-                    .with_compiler_loc()),
-                }
+                Self::new_invocation(args.into())
             }
         }
 

--- a/machines/matrix/src/matmul.rs
+++ b/machines/matrix/src/matmul.rs
@@ -424,3 +424,136 @@ mod checked_matmul_tests {
         assert_eq!(out.borrow()[(0, 0)], 200);
     }
 }
+
+#[cfg(all(
+    test,
+    feature = "runtime",
+    feature = "f64",
+    feature = "matrix2",
+    feature = "vector2",
+    feature = "matrixd",
+    feature = "vectord"
+))]
+mod invocation_port_tests {
+    use super::*;
+
+    fn binary_args<L, R, O>(out: &Ref<O>, lhs: &Ref<L>, rhs: &Ref<R>) -> FunctionArgs
+    where
+        Ref<L>: ToValue,
+        Ref<R>: ToValue,
+        Ref<O>: ToValue,
+    {
+        FunctionArgs::Binary(out.to_value(), lhs.to_value(), rhs.to_value())
+    }
+
+    #[test]
+    fn scalar_fixed_and_dynamic_products_use_exact_invocation_ports() {
+        let scalar_lhs = Ref::new(2.5_f64);
+        let scalar_rhs = Ref::new(4.0_f64);
+        let legacy_out = Ref::new(0.0_f64);
+        let invocation_out = Ref::new(0.0_f64);
+        let legacy =
+            MatMulScalar::<f64>::new(binary_args(&legacy_out, &scalar_lhs, &scalar_rhs)).unwrap();
+        let invocation = MatMulScalar::<f64>::new_invocation(
+            binary_args(&invocation_out, &scalar_lhs, &scalar_rhs).into(),
+        )
+        .unwrap();
+        legacy.solve_result().unwrap();
+        invocation.solve_result().unwrap();
+        assert_eq!(*legacy_out.borrow(), 10.0);
+        assert_eq!(*legacy_out.borrow(), *invocation_out.borrow());
+
+        let fixed_lhs = Ref::new(Matrix2::new(1.0_f64, 2.0, 3.0, 4.0));
+        let fixed_rhs = Ref::new(Matrix2::new(5.0_f64, 6.0, 7.0, 8.0));
+        let fixed_out = Ref::new(Matrix2::zeros());
+        MatMulM2M2::<f64>::new_invocation(binary_args(&fixed_out, &fixed_lhs, &fixed_rhs).into())
+            .unwrap()
+            .solve_result()
+            .unwrap();
+        assert_eq!(*fixed_out.borrow(), Matrix2::new(19.0, 22.0, 43.0, 50.0));
+
+        let vector = Ref::new(Vector2::new(2.0_f64, 3.0));
+        let vector_out = Ref::new(Vector2::zeros());
+        MatMulM2V2::<f64>::new_invocation(binary_args(&vector_out, &fixed_lhs, &vector).into())
+            .unwrap()
+            .solve_result()
+            .unwrap();
+        assert_eq!(*vector_out.borrow(), Vector2::new(8.0, 18.0));
+
+        let dynamic_lhs = Ref::new(DMatrix::from_row_slice(
+            2,
+            3,
+            &[1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+        ));
+        let dynamic_rhs = Ref::new(DMatrix::from_row_slice(
+            3,
+            2,
+            &[7.0_f64, 8.0, 9.0, 10.0, 11.0, 12.0],
+        ));
+        let dynamic_out = Ref::new(DMatrix::zeros(2, 2));
+        MatMulMDMD::<f64>::new_invocation(
+            binary_args(&dynamic_out, &dynamic_lhs, &dynamic_rhs).into(),
+        )
+        .unwrap()
+        .solve_result()
+        .unwrap();
+        assert_eq!(
+            *dynamic_out.borrow(),
+            DMatrix::from_row_slice(2, 2, &[58.0, 64.0, 139.0, 154.0])
+        );
+
+        let dynamic_vector = Ref::new(DVector::from_vec(vec![1.0_f64, 2.0, 3.0]));
+        let dynamic_vector_out = Ref::new(DVector::zeros(2));
+        MatMulMDVD::<f64>::new_invocation(
+            binary_args(&dynamic_vector_out, &dynamic_lhs, &dynamic_vector).into(),
+        )
+        .unwrap()
+        .solve_result()
+        .unwrap();
+        assert_eq!(
+            *dynamic_vector_out.borrow(),
+            DVector::from_vec(vec![14.0, 32.0])
+        );
+    }
+
+    #[test]
+    fn dimension_failure_does_not_publish_a_partial_product() {
+        let lhs = Ref::new(DMatrix::from_element(2, 3, 2.0_f64));
+        let rhs = Ref::new(DMatrix::from_element(2, 2, 3.0_f64));
+        let original = DMatrix::from_element(2, 2, 17.0_f64);
+        let out = Ref::new(original.clone());
+        let function =
+            MatMulMDMD::<f64>::new_invocation(binary_args(&out, &lhs, &rhs).into()).unwrap();
+
+        let error = function.solve_result().unwrap_err();
+        assert_eq!(error.kind_name(), "DimensionMismatch");
+        assert_eq!(*out.borrow(), original);
+    }
+}
+
+#[cfg(all(
+    test,
+    feature = "runtime",
+    feature = "f64",
+    feature = "row_vectord",
+    feature = "vectord",
+    feature = "matrixd",
+    not(feature = "matrix1")
+))]
+mod dynamic_fallback_invocation_tests {
+    use super::*;
+
+    #[test]
+    fn row_vector_product_uses_dynamic_matrix_fallback_without_matrix1() {
+        let lhs = Ref::new(RowDVector::from_vec(vec![1.0_f64, 2.0]));
+        let rhs = Ref::new(DVector::from_vec(vec![3.0_f64, 4.0]));
+        let out = Ref::new(DMatrix::zeros(1, 1));
+        let function = MatMulRDVDMD::<f64>::new_invocation(
+            FunctionArgs::Binary(out.to_value(), lhs.to_value(), rhs.to_value()).into(),
+        )
+        .unwrap();
+
+        function.solve_result().unwrap();
+        assert_eq!(*out.borrow(), DMatrix::from_element(1, 1, 11.0));
+    }
+}

--- a/machines/matrix/src/matmul.rs
+++ b/machines/matrix/src/matmul.rs
@@ -417,10 +417,20 @@ mod checked_matmul_tests {
 
         function.solve_result().unwrap();
         assert_eq!(out.borrow()[(0, 0)], 200);
-        *rhs.borrow_mut() = DMatrix::from_column_slice(2, 1, &[2, 2]);
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&function)?;
+            *rhs.borrow_mut() = DMatrix::from_column_slice(2, 1, &[2, 2]);
 
-        let error = function.solve_result().unwrap_err();
-        assert_eq!(error.kind_name(), "MatrixArithmeticOverflow");
+            let error = function.solve_result().unwrap_err();
+            assert_eq!(error.kind_name(), "MatrixArithmeticOverflow");
+            assert_eq!(out.borrow()[(0, 0)], 200);
+            *out.borrow_mut() = DMatrix::from_element(2, 2, 19);
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(out.borrow().shape(), (1, 1));
         assert_eq!(out.borrow()[(0, 0)], 200);
     }
 }
@@ -466,10 +476,20 @@ mod invocation_port_tests {
         let fixed_lhs = Ref::new(Matrix2::new(1.0_f64, 2.0, 3.0, 4.0));
         let fixed_rhs = Ref::new(Matrix2::new(5.0_f64, 6.0, 7.0, 8.0));
         let fixed_out = Ref::new(Matrix2::zeros());
-        MatMulM2M2::<f64>::new_invocation(binary_args(&fixed_out, &fixed_lhs, &fixed_rhs).into())
-            .unwrap()
-            .solve_result()
-            .unwrap();
+        let fixed = MatMulM2M2::<f64>::new_invocation(
+            binary_args(&fixed_out, &fixed_lhs, &fixed_rhs).into(),
+        )
+        .unwrap();
+        fixed.solve_result().unwrap();
+        assert_eq!(*fixed_out.borrow(), Matrix2::new(19.0, 22.0, 43.0, 50.0));
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*fixed)?;
+            *fixed_out.borrow_mut() = Matrix2::from_element(-1.0);
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
         assert_eq!(*fixed_out.borrow(), Matrix2::new(19.0, 22.0, 43.0, 50.0));
 
         let vector = Ref::new(Vector2::new(2.0_f64, 3.0));
@@ -491,16 +511,31 @@ mod invocation_port_tests {
             &[7.0_f64, 8.0, 9.0, 10.0, 11.0, 12.0],
         ));
         let dynamic_out = Ref::new(DMatrix::zeros(2, 2));
-        MatMulMDMD::<f64>::new_invocation(
+        let dynamic = MatMulMDMD::<f64>::new_invocation(
             binary_args(&dynamic_out, &dynamic_lhs, &dynamic_rhs).into(),
         )
-        .unwrap()
-        .solve_result()
         .unwrap();
+        dynamic.solve_result().unwrap();
         assert_eq!(
             *dynamic_out.borrow(),
             DMatrix::from_row_slice(2, 2, &[58.0, 64.0, 139.0, 154.0])
         );
+        assert_eq!(
+            dynamic.reactive_output_cell_ids(),
+            dynamic.out().reactive_root_cell_ids(),
+        );
+        let expected_dynamic = dynamic_out.borrow().clone();
+        let dynamic_out_alias = dynamic_out.clone();
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*dynamic)?;
+            *dynamic_out.borrow_mut() = DMatrix::from_element(1, 3, -1.0);
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+        assert!(dynamic_out.same_handle(&dynamic_out_alias));
+        assert_eq!(*dynamic_out.borrow(), expected_dynamic);
 
         let dynamic_vector = Ref::new(DVector::from_vec(vec![1.0_f64, 2.0, 3.0]));
         let dynamic_vector_out = Ref::new(DVector::zeros(2));
@@ -528,6 +563,28 @@ mod invocation_port_tests {
         let error = function.solve_result().unwrap_err();
         assert_eq!(error.kind_name(), "DimensionMismatch");
         assert_eq!(*out.borrow(), original);
+    }
+
+    #[test]
+    fn equal_matrix_outputs_keep_distinct_reactive_identity() {
+        let lhs = Ref::new(DMatrix::<f64>::identity(2, 2));
+        let rhs = Ref::new(DMatrix::<f64>::identity(2, 2));
+        let first_out = Ref::new(DMatrix::<f64>::zeros(2, 2));
+        let second_out = Ref::new(DMatrix::<f64>::zeros(2, 2));
+        let first = MatMulMDMD::<f64>::new_invocation(
+            binary_args(&first_out, &lhs, &rhs).into(),
+        )
+        .unwrap();
+        let second = MatMulMDMD::<f64>::new_invocation(
+            binary_args(&second_out, &lhs, &rhs).into(),
+        )
+        .unwrap();
+
+        assert_eq!(*first_out.borrow(), *second_out.borrow());
+        assert_ne!(
+            first.reactive_output_cell_ids(),
+            second.reactive_output_cell_ids(),
+        );
     }
 }
 

--- a/machines/matrix/src/solve.rs
+++ b/machines/matrix/src/solve.rs
@@ -78,9 +78,9 @@ macro_rules! impl_binop_solve {
                 + Zero
                 + One,
             Ref<$out_type>: ToValue,
-            $arg1_type: FunctionRuntimeType,
-            $arg2_type: FunctionRuntimeType,
-            $out_type: FunctionRuntimeType,
+            $arg1_type: FunctionPortBacking,
+            $arg2_type: FunctionPortBacking,
+            $out_type: FunctionStateBacking,
         {
             const SIGNATURE: RuntimeFunctionSignature = RuntimeFunctionSignature::binary(
                 <$out_type as FunctionRuntimeType>::REPRESENTATION,
@@ -88,26 +88,18 @@ macro_rules! impl_binop_solve {
                 <$arg2_type as FunctionRuntimeType>::REPRESENTATION,
             );
 
+            fn new_invocation(
+                invocation: FunctionInvocation,
+            ) -> MResult<Box<dyn MechFunction>> {
+                let (out, lhs, rhs) = invocation.expect_binary()?;
+                let lhs: Ref<$arg1_type> = lhs.try_ref()?;
+                let rhs: Ref<$arg2_type> = rhs.try_ref()?;
+                let out: Ref<$out_type> = out.try_ref()?;
+                Ok(Box::new(Self { lhs, rhs, out }))
+            }
+
             fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-                match args {
-                    FunctionArgs::Binary(out, arg1, arg2) => {
-                        let lhs: Ref<$arg1_type> =
-                            arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                        let rhs: Ref<$arg2_type> =
-                            arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                        let out: Ref<$out_type> =
-                            out.try_function_ref(FunctionArgumentRole::Output)?;
-                        Ok(Box::new(Self { lhs, rhs, out }))
-                    }
-                    _ => Err(MechError::new(
-                        IncorrectNumberOfArguments {
-                            expected: 2,
-                            found: args.len(),
-                        },
-                        None,
-                    )
-                    .with_compiler_loc()),
-                }
+                Self::new_invocation(args.into())
             }
         }
         impl<T> MechFunctionImpl for $struct_name<T>
@@ -199,6 +191,67 @@ impl_solve!(MatrixSolveM2M2x3, Matrix2<T>, Matrix2x3<T>, Matrix2x3<T>);
 mod tests {
     use super::*;
 
+    fn binary_args<L, R, O>(out: &Ref<O>, lhs: &Ref<L>, rhs: &Ref<R>) -> FunctionArgs
+    where
+        Ref<L>: ToValue,
+        Ref<R>: ToValue,
+        Ref<O>: ToValue,
+    {
+        FunctionArgs::Binary(out.to_value(), lhs.to_value(), rhs.to_value())
+    }
+
+    #[test]
+    fn vector_and_matrix_rhs_factories_use_invocation_ports() {
+        let lhs = Ref::new(DMatrix::from_row_slice(2, 2, &[4.0, 1.0, 2.0, 3.0]));
+        let vector_rhs = Ref::new(DVector::from_vec(vec![9.0, 8.0]));
+        let legacy_out = Ref::new(DVector::<f64>::zeros(2));
+        let invocation_out = Ref::new(DVector::<f64>::zeros(2));
+        let legacy = MatrixSolveMDVD::<f64>::new(binary_args(
+            &legacy_out,
+            &lhs,
+            &vector_rhs,
+        ))
+        .unwrap();
+        let invocation = MatrixSolveMDVD::<f64>::new_invocation(
+            binary_args(&invocation_out, &lhs, &vector_rhs).into(),
+        )
+        .unwrap();
+        legacy.solve_result().unwrap();
+        invocation.solve_result().unwrap();
+        assert_eq!(*legacy_out.borrow(), *invocation_out.borrow());
+
+        let matrix_rhs = Ref::new(DMatrix::<f64>::identity(2, 2));
+        let matrix_out = Ref::new(DMatrix::<f64>::zeros(2, 2));
+        MatrixSolveMDMD::<f64>::new_invocation(
+            binary_args(&matrix_out, &lhs, &matrix_rhs).into(),
+        )
+        .unwrap()
+        .solve_result()
+        .unwrap();
+        let residual = lhs.borrow().clone() * matrix_out.borrow().clone();
+        assert!((residual - matrix_rhs.borrow().clone()).norm() < 1.0e-12);
+    }
+
+    #[test]
+    fn solve_invocation_rejects_wrong_rhs_representation_and_layout() {
+        let lhs = Ref::new(DMatrix::<f64>::identity(2, 2));
+        let wrong_rhs = Ref::new(DMatrix::<f64>::identity(2, 2));
+        let out = Ref::new(DVector::<f64>::zeros(2));
+        let type_error = MatrixSolveMDVD::<f64>::new_invocation(
+            binary_args(&out, &lhs, &wrong_rhs).into(),
+        )
+        .err()
+        .expect("wrong exact right-hand-side type must be rejected");
+        assert_eq!(type_error.kind_name(), "FunctionArgumentTypeMismatch");
+
+        let arity_error = MatrixSolveMDVD::<f64>::new_invocation(
+            FunctionArgs::Unary(out.to_value(), lhs.to_value()).into(),
+        )
+        .err()
+        .expect("wrong solve invocation layout must be rejected");
+        assert_eq!(arity_error.kind_name(), "IncorrectNumberOfArguments");
+    }
+
     #[test]
     fn singular_matrix_is_a_structured_error_on_reactive_resolve() {
         let lhs = Ref::new(DMatrix::identity(2, 2));
@@ -238,6 +291,25 @@ mod tests {
 
         let residual = lhs.borrow().clone() * out.borrow().clone() - rhs.borrow().clone();
         assert!(residual.norm() < 1.0e-12);
+    }
+}
+
+#[cfg(all(test, feature = "f64", feature = "matrix2", feature = "matrix2x3"))]
+mod fixed_invocation_port_tests {
+    use super::*;
+
+    #[test]
+    fn fixed_matrix_rhs_uses_exact_invocation_ports() {
+        let lhs = Ref::new(Matrix2::<f64>::identity());
+        let rhs = Ref::new(Matrix2x3::new(1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0));
+        let out = Ref::new(Matrix2x3::<f64>::zeros());
+        let function = MatrixSolveM2M2x3::<f64>::new_invocation(
+            FunctionArgs::Binary(out.to_value(), lhs.to_value(), rhs.to_value()).into(),
+        )
+        .unwrap();
+
+        function.solve_result().unwrap();
+        assert_eq!(*out.borrow(), *rhs.borrow());
     }
 }
 

--- a/machines/matrix/src/solve.rs
+++ b/machines/matrix/src/solve.rs
@@ -125,6 +125,7 @@ macro_rules! impl_binop_solve {
                 + Zero
                 + One,
             Ref<$out_type>: ToValue,
+            $out_type: FunctionStateBacking,
         {
             fn solve_result(&self) -> MResult<()> {
                 let lhs_ptr = self.lhs.as_ptr();
@@ -132,6 +133,12 @@ macro_rules! impl_binop_solve {
                 let out_ptr = self.out.as_mut_ptr();
                 $op!(lhs_ptr, rhs_ptr, out_ptr);
                 Ok(())
+            }
+            fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+                Some(FunctionStatePort::from_ref(&self.out))
+            }
+            fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+                Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
             }
             fn out(&self) -> LegacyValue {
                 self.out.to_value()
@@ -265,10 +272,19 @@ mod tests {
 
         function.solve_result().unwrap();
         let previous = out.borrow().clone();
-        *lhs.borrow_mut() = DMatrix::from_row_slice(2, 2, &[1.0, 2.0, 2.0, 4.0]);
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&function)?;
+            *lhs.borrow_mut() = DMatrix::from_row_slice(2, 2, &[1.0, 2.0, 2.0, 4.0]);
 
-        let error = function.solve_result().unwrap_err();
-        assert_eq!(error.kind_name(), "MatrixSolveSingular");
+            let error = function.solve_result().unwrap_err();
+            assert_eq!(error.kind_name(), "MatrixSolveSingular");
+            assert_eq!(*out.borrow(), previous);
+            *out.borrow_mut() = DVector::from_vec(vec![99.0]);
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
         assert_eq!(*out.borrow(), previous);
     }
 

--- a/machines/matrix/src/transpose.rs
+++ b/machines/matrix/src/transpose.rs
@@ -50,32 +50,25 @@ macro_rules! impl_transpose {
             #[cfg(feature = "semantic-compiler")]
             T: CompileConst + ConstElem,
             Ref<$out_type>: ToValue,
-            $arg_type: FunctionRuntimeType,
-            $out_type: FunctionRuntimeType,
+            $arg_type: FunctionPortBacking,
+            $out_type: FunctionStateBacking,
         {
             const SIGNATURE: RuntimeFunctionSignature = RuntimeFunctionSignature::unary(
                 <$out_type as FunctionRuntimeType>::REPRESENTATION,
                 <$arg_type as FunctionRuntimeType>::REPRESENTATION,
             );
 
+            fn new_invocation(
+                invocation: FunctionInvocation,
+            ) -> MResult<Box<dyn MechFunction>> {
+                let (out, arg) = invocation.expect_unary()?;
+                let arg: Ref<$arg_type> = arg.try_ref()?;
+                let out: Ref<$out_type> = out.try_ref()?;
+                Ok(Box::new($struct_name { arg, out }))
+            }
+
             fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-                match args {
-                    FunctionArgs::Unary(out, arg) => {
-                        let arg: Ref<$arg_type> =
-                            arg.try_function_ref(FunctionArgumentRole::Input(0))?;
-                        let out: Ref<$out_type> =
-                            out.try_function_ref(FunctionArgumentRole::Output)?;
-                        Ok(Box::new($struct_name { arg, out }))
-                    }
-                    _ => Err(MechError::new(
-                        IncorrectNumberOfArguments {
-                            expected: 1,
-                            found: args.len(),
-                        },
-                        None,
-                    )
-                    .with_compiler_loc()),
-                }
+                Self::new_invocation(args.into())
             }
         }
         impl<T> MechFunctionImpl for $struct_name<T>
@@ -146,6 +139,135 @@ impl_transpose!(TransposeR3, RowVector3<T>, Vector3<T>, transpose_op);
 impl_transpose!(TransposeR4, RowVector4<T>, Vector4<T>, transpose_op);
 #[cfg(all(feature = "row_vectord", feature = "vectord"))]
 impl_transpose!(TransposeRD, RowDVector<T>, DVector<T>, transpose_op);
+
+#[cfg(all(
+    test,
+    feature = "runtime",
+    feature = "f64",
+    feature = "bool",
+    feature = "string",
+    feature = "matrix2",
+    feature = "matrix2x3",
+    feature = "matrix3x2",
+    feature = "vector3",
+    feature = "row_vector3",
+    feature = "matrixd"
+))]
+mod invocation_port_tests {
+    use super::*;
+
+    fn unary_args<I, O>(out: &Ref<O>, arg: &Ref<I>) -> FunctionArgs
+    where
+        Ref<I>: ToValue,
+        Ref<O>: ToValue,
+    {
+        FunctionArgs::Unary(out.to_value(), arg.to_value())
+    }
+
+    #[test]
+    fn numeric_fixed_vector_and_dynamic_transposes_use_exact_ports() {
+        let matrix = Ref::new(Matrix2::new(1.0_f64, 2.0, 3.0, 4.0));
+        let legacy_out = Ref::new(Matrix2::zeros());
+        let invocation_out = Ref::new(Matrix2::zeros());
+        let legacy = TransposeM2::<f64>::new(unary_args(&legacy_out, &matrix)).unwrap();
+        let invocation = TransposeM2::<f64>::new_invocation(
+            unary_args(&invocation_out, &matrix).into(),
+        )
+        .unwrap();
+        legacy.solve_result().unwrap();
+        invocation.solve_result().unwrap();
+        assert_eq!(*legacy_out.borrow(), Matrix2::new(1.0, 3.0, 2.0, 4.0));
+        assert_eq!(*legacy_out.borrow(), *invocation_out.borrow());
+
+        let rectangular = Ref::new(Matrix2x3::new(1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0));
+        let rectangular_out = Ref::new(Matrix3x2::zeros());
+        TransposeM2x3::<f64>::new_invocation(
+            unary_args(&rectangular_out, &rectangular).into(),
+        )
+        .unwrap()
+        .solve_result()
+        .unwrap();
+        assert_eq!(
+            *rectangular_out.borrow(),
+            Matrix3x2::new(1.0, 4.0, 2.0, 5.0, 3.0, 6.0)
+        );
+
+        let vector = Ref::new(Vector3::new(1.0_f64, 2.0, 3.0));
+        let vector_out = Ref::new(RowVector3::zeros());
+        TransposeV3::<f64>::new_invocation(unary_args(&vector_out, &vector).into())
+            .unwrap()
+            .solve_result()
+            .unwrap();
+        assert_eq!(*vector_out.borrow(), RowVector3::new(1.0, 2.0, 3.0));
+
+        let dynamic = Ref::new(DMatrix::from_row_slice(
+            2,
+            3,
+            &[1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+        ));
+        let dynamic_out = Ref::new(DMatrix::zeros(3, 2));
+        TransposeMD::<f64>::new_invocation(unary_args(&dynamic_out, &dynamic).into())
+            .unwrap()
+            .solve_result()
+            .unwrap();
+        assert_eq!(
+            *dynamic_out.borrow(),
+            DMatrix::from_row_slice(3, 2, &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0])
+        );
+    }
+
+    #[test]
+    fn bool_and_string_transposes_preserve_element_backings() {
+        let bool_arg = Ref::new(Matrix2::new(true, false, false, true));
+        let bool_out = Ref::new(Matrix2::from_element(false));
+        TransposeM2::<bool>::new_invocation(unary_args(&bool_out, &bool_arg).into())
+            .unwrap()
+            .solve_result()
+            .unwrap();
+        assert_eq!(*bool_out.borrow(), *bool_arg.borrow());
+
+        let string_arg = Ref::new(Matrix2::new(
+            "a".to_string(),
+            "b".to_string(),
+            "c".to_string(),
+            "d".to_string(),
+        ));
+        let string_out = Ref::new(Matrix2::from_element(String::new()));
+        TransposeM2::<String>::new_invocation(unary_args(&string_out, &string_arg).into())
+            .unwrap()
+            .solve_result()
+            .unwrap();
+        assert_eq!(
+            *string_out.borrow(),
+            Matrix2::new(
+                "a".to_string(),
+                "c".to_string(),
+                "b".to_string(),
+                "d".to_string(),
+            )
+        );
+    }
+
+    #[test]
+    fn transpose_invocation_rejects_wrong_storage_and_layout() {
+        let out = Ref::new(Matrix2::<f64>::zeros());
+        let wrong_storage = Ref::new(DMatrix::<f64>::zeros(2, 2));
+        let type_error = TransposeM2::<f64>::new_invocation(
+            unary_args(&out, &wrong_storage).into(),
+        )
+        .err()
+        .expect("wrong exact matrix storage must be rejected");
+        assert_eq!(type_error.kind_name(), "FunctionArgumentTypeMismatch");
+
+        let arg = Ref::new(Matrix2::<f64>::identity());
+        let arity_error = TransposeM2::<f64>::new_invocation(
+            FunctionArgs::Binary(out.to_value(), arg.to_value(), arg.to_value()).into(),
+        )
+        .err()
+        .expect("wrong transpose invocation layout must be rejected");
+        assert_eq!(arity_error.kind_name(), "IncorrectNumberOfArguments");
+    }
+}
 
 #[cfg(feature = "source")]
 macro_rules! impl_transpose_match_arms {

--- a/machines/matrix/src/transpose.rs
+++ b/machines/matrix/src/transpose.rs
@@ -75,12 +75,19 @@ macro_rules! impl_transpose {
         where
             T: Debug + Clone + Sync + Send + 'static + PartialEq + PartialOrd,
             Ref<$out_type>: ToValue,
+            $out_type: FunctionStateBacking,
         {
             fn solve_result(&self) -> MResult<()> {
                 let arg_ptr = self.arg.as_ptr();
                 let out_ptr = self.out.as_mut_ptr();
                 $op!(arg_ptr, out_ptr);
                 Ok(())
+            }
+            fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+                Some(FunctionStatePort::from_ref(&self.out))
+            }
+            fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+                Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
             }
             fn out(&self) -> LegacyValue {
                 self.out.to_value()
@@ -206,10 +213,26 @@ mod invocation_port_tests {
             &[1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
         ));
         let dynamic_out = Ref::new(DMatrix::zeros(3, 2));
-        TransposeMD::<f64>::new_invocation(unary_args(&dynamic_out, &dynamic).into())
-            .unwrap()
-            .solve_result()
-            .unwrap();
+        let dynamic_function =
+            TransposeMD::<f64>::new_invocation(unary_args(&dynamic_out, &dynamic).into()).unwrap();
+        dynamic_function.solve_result().unwrap();
+        assert_eq!(
+            *dynamic_out.borrow(),
+            DMatrix::from_row_slice(3, 2, &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0])
+        );
+        assert_eq!(
+            dynamic_function.reactive_output_cell_ids(),
+            dynamic_function.out().reactive_root_cell_ids(),
+        );
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*dynamic_function)?;
+            *dynamic_out.borrow_mut() = DMatrix::from_element(1, 4, -1.0);
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(dynamic_out.borrow().shape(), (3, 2));
         assert_eq!(
             *dynamic_out.borrow(),
             DMatrix::from_row_slice(3, 2, &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0])

--- a/machines/stats/src/lib.rs
+++ b/machines/stats/src/lib.rs
@@ -182,30 +182,25 @@ macro_rules! impl_stats_unop {
             #[cfg(feature = "semantic-compiler")]
             T: CompileConst + ConstElem,
             Ref<$out_type>: ToValue,
-            $arg_type: FunctionRuntimeType,
-            $out_type: FunctionRuntimeType,
+            $arg_type: FunctionPortBacking,
+            $out_type: FunctionStateBacking,
         {
             const SIGNATURE: RuntimeFunctionSignature = RuntimeFunctionSignature::unary(
                 <$out_type as FunctionRuntimeType>::REPRESENTATION,
                 <$arg_type as FunctionRuntimeType>::REPRESENTATION,
             );
 
+            fn new_invocation(
+                invocation: FunctionInvocation,
+            ) -> MResult<Box<dyn MechFunction>> {
+                let (out, arg) = invocation.expect_unary()?;
+                let arg: Ref<$arg_type> = arg.try_ref()?;
+                let out: Ref<$out_type> = out.try_ref()?;
+                Ok(Box::new($struct_name { arg, out }))
+            }
+
             fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-                match args {
-                    FunctionArgs::Unary(out, arg) => {
-                        let arg = arg.try_function_ref(FunctionArgumentRole::Input(0))?;
-                        let out = out.try_function_ref(FunctionArgumentRole::Output)?;
-                        Ok(Box::new($struct_name { arg, out }))
-                    }
-                    _ => Err(MechError::new(
-                        IncorrectNumberOfArguments {
-                            expected: 2,
-                            found: args.len(),
-                        },
-                        None,
-                    )
-                    .with_compiler_loc()),
-                }
+                Self::new_invocation(args.into())
             }
         }
         impl<T> MechFunctionImpl for $struct_name<T>
@@ -224,6 +219,7 @@ macro_rules! impl_stats_unop {
                 + PartialOrd,
             T: StatsCheckedAdd,
             Ref<$out_type>: ToValue,
+            $out_type: FunctionStateBacking,
         {
             fn solve_result(&self) -> MResult<()> {
                 let mut next = self.out.borrow().clone();
@@ -233,6 +229,12 @@ macro_rules! impl_stats_unop {
                 }
                 *self.out.borrow_mut() = next;
                 Ok(())
+            }
+            fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+                Some(FunctionStatePort::from_ref(&self.out))
+            }
+            fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+                Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
             }
             fn out(&self) -> LegacyValue {
                 self.out.to_value()

--- a/machines/stats/src/sum_column.rs
+++ b/machines/stats/src/sum_column.rs
@@ -102,30 +102,23 @@ where
     #[cfg(feature = "semantic-compiler")]
     T: CompileConst + ConstElem,
     Ref<DMatrix<T>>: ToValue,
-    RowDVector<T>: FunctionRuntimeType,
-    DMatrix<T>: FunctionRuntimeType,
+    RowDVector<T>: FunctionPortBacking,
+    DMatrix<T>: FunctionStateBacking,
 {
     const SIGNATURE: RuntimeFunctionSignature = RuntimeFunctionSignature::unary(
         <DMatrix<T> as FunctionRuntimeType>::REPRESENTATION,
         <RowDVector<T> as FunctionRuntimeType>::REPRESENTATION,
     );
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, arg) = invocation.expect_unary()?;
+        let arg: Ref<RowDVector<T>> = arg.try_ref()?;
+        let out: Ref<DMatrix<T>> = out.try_ref()?;
+        Ok(Box::new(StatsSumColumnRD2 { arg, out }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Unary(out, arg) => {
-                let arg = arg.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let out = out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(StatsSumColumnRD2 { arg, out }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 2,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 #[cfg(all(feature = "row_vectord", feature = "matrixd", not(feature = "matrix1")))]
@@ -145,6 +138,7 @@ where
         + PartialOrd,
     T: StatsCheckedAdd,
     Ref<DMatrix<T>>: ToValue,
+    DMatrix<T>: FunctionStateBacking,
 {
     fn solve_result(&self) -> MResult<()> {
         let mut next = self.out.borrow().clone();
@@ -154,6 +148,12 @@ where
         }
         *self.out.borrow_mut() = next;
         Ok(())
+    }
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
     }
     fn out(&self) -> LegacyValue {
         self.out.to_value()
@@ -256,10 +256,11 @@ impl_mech_urnop_fxn!(
     "stats/sum/column"
 );
 
-#[cfg(test)]
+#[cfg(all(test, any(feature = "u8", feature = "rational")))]
 mod checked_sum_tests {
     use super::*;
 
+    #[cfg(feature = "u8")]
     #[test]
     fn integer_column_sum_rejects_reactive_overflow_and_retains_output() {
         let arg = Ref::new(DMatrix::from_row_slice(1, 2, &[1u8, 2]));
@@ -270,10 +271,18 @@ mod checked_sum_tests {
         };
         function.solve_result().unwrap();
         assert_eq!(out.borrow().as_slice(), &[3]);
-
-        *arg.borrow_mut() = DMatrix::from_row_slice(1, 2, &[u8::MAX, 1]);
-        let error = function.solve_result().unwrap_err();
-        assert_eq!(error.kind_name(), "StatsArithmeticOverflow");
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&function)?;
+            *arg.borrow_mut() = DMatrix::from_row_slice(1, 2, &[u8::MAX, 1]);
+            let error = function.solve_result().unwrap_err();
+            assert_eq!(error.kind_name(), "StatsArithmeticOverflow");
+            assert_eq!(out.borrow().as_slice(), &[3]);
+            *out.borrow_mut() = DVector::from_vec(vec![17, 18]);
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
         assert_eq!(out.borrow().as_slice(), &[3]);
     }
 
@@ -293,5 +302,128 @@ mod checked_sum_tests {
         let error = function.solve_result().unwrap_err();
         assert_eq!(error.kind_name(), "StatsArithmeticOverflow");
         assert_eq!(out.borrow().as_slice(), &[R64::new(7, 1)]);
+    }
+}
+
+#[cfg(all(
+    test,
+    feature = "runtime",
+    feature = "f64",
+    feature = "matrix2",
+    feature = "vector2",
+    feature = "matrixd",
+    feature = "vectord"
+))]
+mod invocation_port_tests {
+    use super::*;
+
+    fn unary_args<I, O>(out: &Ref<O>, arg: &Ref<I>) -> FunctionArgs
+    where
+        Ref<I>: ToValue,
+        Ref<O>: ToValue,
+    {
+        FunctionArgs::Unary(out.to_value(), arg.to_value())
+    }
+
+    #[test]
+    fn fixed_and_dynamic_column_sums_preserve_factory_behavior_and_state() {
+        let fixed_arg = Ref::new(Matrix2::new(1.0_f64, 2.0, 3.0, 4.0));
+        let legacy_out = Ref::new(Vector2::zeros());
+        let invocation_out = Ref::new(Vector2::zeros());
+        let legacy =
+            StatsSumColumnM2::<f64>::new(unary_args(&legacy_out, &fixed_arg)).unwrap();
+        let invocation = StatsSumColumnM2::<f64>::new_invocation(
+            unary_args(&invocation_out, &fixed_arg).into(),
+        )
+        .unwrap();
+        legacy.solve_result().unwrap();
+        invocation.solve_result().unwrap();
+        assert_eq!(*legacy_out.borrow(), Vector2::new(3.0, 7.0));
+        assert_eq!(*legacy_out.borrow(), *invocation_out.borrow());
+
+        let dynamic_arg = Ref::new(DMatrix::from_row_slice(
+            2,
+            3,
+            &[1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+        ));
+        let dynamic_out = Ref::new(DVector::zeros(2));
+        let dynamic = StatsSumColumnMD::<f64>::new_invocation(
+            unary_args(&dynamic_out, &dynamic_arg).into(),
+        )
+        .unwrap();
+        dynamic.solve_result().unwrap();
+        assert_eq!(*dynamic_out.borrow(), DVector::from_vec(vec![6.0, 15.0]));
+        assert_eq!(
+            dynamic.reactive_output_cell_ids(),
+            dynamic.out().reactive_root_cell_ids(),
+        );
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*dynamic)?;
+            *dynamic_out.borrow_mut() = DVector::from_vec(vec![-1.0, -2.0, -3.0]);
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(*dynamic_out.borrow(), DVector::from_vec(vec![6.0, 15.0]));
+    }
+
+    #[test]
+    fn column_sum_rejects_wrong_exact_storage_and_reports_unary_arity() {
+        let out = Ref::new(Vector2::<f64>::zeros());
+        let wrong_arg = Ref::new(DMatrix::<f64>::zeros(2, 2));
+        let type_error = StatsSumColumnM2::<f64>::new_invocation(
+            unary_args(&out, &wrong_arg).into(),
+        )
+        .err()
+        .expect("wrong exact statistics input must be rejected");
+        assert_eq!(type_error.kind_name(), "FunctionArgumentTypeMismatch");
+
+        let fixed_arg = Ref::new(Matrix2::<f64>::zeros());
+        let arity_error = StatsSumColumnM2::<f64>::new_invocation(
+            FunctionArgs::Binary(out.to_value(), fixed_arg.to_value(), fixed_arg.to_value()).into(),
+        )
+        .err()
+        .expect("binary layout must be rejected for unary statistics functions");
+        let arity = arity_error.kind_as::<IncorrectNumberOfArguments>().unwrap();
+        assert_eq!(arity.expected, 1);
+        assert_eq!(arity.found, 2);
+    }
+}
+
+#[cfg(all(
+    test,
+    feature = "runtime",
+    feature = "f64",
+    feature = "row_vectord",
+    feature = "matrixd",
+    not(feature = "matrix1")
+))]
+mod direct_dynamic_invocation_tests {
+    use super::*;
+
+    #[test]
+    fn row_vector_column_sum_uses_direct_dynamic_factory_and_state_port() {
+        let arg = Ref::new(RowDVector::from_vec(vec![1.0_f64, 2.0, 3.0]));
+        let out = Ref::new(DMatrix::zeros(1, 1));
+        let function = StatsSumColumnRD2::<f64>::new_invocation(
+            FunctionArgs::Unary(out.to_value(), arg.to_value()).into(),
+        )
+        .unwrap();
+        function.solve_result().unwrap();
+        assert_eq!(*out.borrow(), DMatrix::from_element(1, 1, 6.0));
+        assert_eq!(
+            function.reactive_output_cell_ids(),
+            function.out().reactive_root_cell_ids(),
+        );
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*function)?;
+            *out.borrow_mut() = DMatrix::from_element(2, 2, -1.0);
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(*out.borrow(), DMatrix::from_element(1, 1, 6.0));
     }
 }

--- a/machines/stats/src/sum_row.rs
+++ b/machines/stats/src/sum_row.rs
@@ -142,10 +142,11 @@ fn impl_stats_sum_row_fxn(lhs_value: LegacyValue) -> MResult<Box<dyn MechFunctio
 #[cfg(feature = "source")]
 impl_mech_urnop_fxn!(StatsSumRow, impl_stats_sum_row_fxn, "stats/sum/row");
 
-#[cfg(test)]
+#[cfg(all(test, feature = "u8"))]
 mod checked_sum_tests {
     use super::*;
 
+    #[cfg(feature = "u8")]
     #[test]
     fn integer_row_sum_rejects_reactive_overflow_and_retains_output() {
         let arg = Ref::new(DMatrix::from_row_slice(2, 1, &[1u8, 2]));
@@ -156,10 +157,112 @@ mod checked_sum_tests {
         };
         function.solve_result().unwrap();
         assert_eq!(out.borrow().as_slice(), &[3]);
-
-        *arg.borrow_mut() = DMatrix::from_row_slice(2, 1, &[u8::MAX, 1]);
-        let error = function.solve_result().unwrap_err();
-        assert_eq!(error.kind_name(), "StatsArithmeticOverflow");
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&function)?;
+            *arg.borrow_mut() = DMatrix::from_row_slice(2, 1, &[u8::MAX, 1]);
+            let error = function.solve_result().unwrap_err();
+            assert_eq!(error.kind_name(), "StatsArithmeticOverflow");
+            assert_eq!(out.borrow().as_slice(), &[3]);
+            *out.borrow_mut() = RowDVector::from_vec(vec![17, 18]);
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
         assert_eq!(out.borrow().as_slice(), &[3]);
+    }
+}
+
+#[cfg(all(
+    test,
+    feature = "runtime",
+    feature = "f64",
+    feature = "matrix2",
+    feature = "row_vector2",
+    feature = "matrixd",
+    feature = "row_vectord"
+))]
+mod invocation_port_tests {
+    use super::*;
+
+    fn unary_args<I, O>(out: &Ref<O>, arg: &Ref<I>) -> FunctionArgs
+    where
+        Ref<I>: ToValue,
+        Ref<O>: ToValue,
+    {
+        FunctionArgs::Unary(out.to_value(), arg.to_value())
+    }
+
+    #[test]
+    fn fixed_and_dynamic_row_sums_preserve_factory_behavior_and_state() {
+        let fixed_arg = Ref::new(Matrix2::new(1.0_f64, 2.0, 3.0, 4.0));
+        let legacy_out = Ref::new(RowVector2::zeros());
+        let invocation_out = Ref::new(RowVector2::zeros());
+        let legacy = StatsSumRowM2::<f64>::new(unary_args(&legacy_out, &fixed_arg)).unwrap();
+        let invocation = StatsSumRowM2::<f64>::new_invocation(
+            unary_args(&invocation_out, &fixed_arg).into(),
+        )
+        .unwrap();
+        legacy.solve_result().unwrap();
+        invocation.solve_result().unwrap();
+        assert_eq!(*legacy_out.borrow(), RowVector2::new(4.0, 6.0));
+        assert_eq!(*legacy_out.borrow(), *invocation_out.borrow());
+
+        let dynamic_arg = Ref::new(DMatrix::from_row_slice(
+            2,
+            3,
+            &[1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+        ));
+        let dynamic_out = Ref::new(RowDVector::zeros(3));
+        let dynamic = StatsSumRowMD::<f64>::new_invocation(
+            unary_args(&dynamic_out, &dynamic_arg).into(),
+        )
+        .unwrap();
+        dynamic.solve_result().unwrap();
+        assert_eq!(
+            *dynamic_out.borrow(),
+            RowDVector::from_vec(vec![5.0, 7.0, 9.0])
+        );
+        assert_eq!(
+            dynamic.reactive_output_cell_ids(),
+            dynamic.out().reactive_root_cell_ids(),
+        );
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*dynamic)?;
+            *dynamic_out.borrow_mut() = RowDVector::from_vec(vec![-1.0]);
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(
+            *dynamic_out.borrow(),
+            RowDVector::from_vec(vec![5.0, 7.0, 9.0])
+        );
+    }
+}
+
+#[cfg(all(
+    test,
+    feature = "runtime",
+    feature = "f64",
+    feature = "vectord",
+    feature = "matrixd",
+    not(feature = "matrix1")
+))]
+mod dynamic_fallback_invocation_tests {
+    use super::*;
+
+    #[test]
+    fn dynamic_vector_row_sum_uses_matrix_fallback_without_matrix1() {
+        let arg = Ref::new(DVector::from_vec(vec![1.0_f64, 2.0, 3.0]));
+        let out = Ref::new(DMatrix::zeros(1, 1));
+        let function = StatsSumRowVDMD::<f64>::new_invocation(
+            FunctionArgs::Unary(out.to_value(), arg.to_value()).into(),
+        )
+        .unwrap();
+
+        function.solve_result().unwrap();
+        assert_eq!(*out.borrow(), DMatrix::from_element(1, 1, 6.0));
     }
 }


### PR DESCRIPTION
## Summary

- routes matrix dot, product, solve, and transpose factories through `FunctionInvocation`
- routes statistics reduction factories through `FunctionInvocation`
- exposes matrix and statistics outputs through `FunctionStatePort`
- makes reactive identity and rollback use exact typed output cells
- preserves legacy factory, `out`, and checkpoint methods as compatibility adapters
- preserves source-specializer `LegacyValue` handling for the later source-boundary cutover
- corrects the statistics unary wrong-arity diagnostic from expected 2 to expected 1

Stacked on the final reviewed PR6 head: `573e772f32ecc2084980b3ad6814b3cc942dbcd5`.

## Behavior

| Function family | Factory path | Normal state path |
|---|---|---|
| Matrix dot | Typed invocation ports | Exact typed output port |
| Matrix multiplication | Typed invocation ports | Exact typed output port |
| Matrix solve | Typed invocation ports | Exact typed output port |
| Matrix transpose | Typed invocation ports | Exact typed output port |
| Statistics row sum | Typed invocation ports | Exact typed output port |
| Statistics column sum | Typed invocation ports | Exact typed output port |
| Source specialization | Existing `LegacyValue` match | Unchanged |
| Legacy factory caller | `new(FunctionArgs)` adapter | Unchanged |
| Legacy output caller | `out()` | Unchanged |
| Unmigrated package | Existing fallback | Unchanged |

## Non-goals

- no source-specializer migration
- no removal of `FunctionArgs`
- no removal of `LegacyValue` output methods
- no matrix algorithm or storage changes
- no catalog, ID, signature, or linkage changes
- no core API or feature changes
- no contract regeneration

## Evidence

- PR7 head: `2f91b88d910642c5fb745f0a5195de5791b07280`
- formatting and diff checks pass
- matrix library profiles pass: full compiler (19 tests), standard compiler (7 tests), scalar-only compile, and dynamic-only without `matrix1` (6 tests)
- statistics profiles pass: full compiler (7 tests), standard compiler (3 tests), and dynamic-only without `matrix1` (2 tests), plus doc tests
- core (397), engine (293), and runtime (465) test suites pass
- retirement check: `LegacyValue` 4,928 -> 4,906, `ValueKind` 1,181, `Kind` 162, zero unreviewed growth
- value-execution boundary, compiler-planning quarantine, bytecode-v1 format, and production-resident routing checks pass
- function-system source and consumer slices pass
- the complete function-system check reaches the known frozen math compiler-profile assertion; the exact PR6 base and PR7 head both fail at `math compiler omitted required layer: mech-core feature compiler`
- exact standalone matrix command-wide failures are also reproduced on PR6 and come from untouched math warnings or an example whose source feature is disabled; the affected production library profiles pass
- source audit: no production `FunctionArgs` matching and no `try_function_ref`
- catalogs, Cargo files, workflows, core/runtime code, and frozen JSON inventories are unchanged

This PR remains draft and must not merge before PR6.