### PR TITLE
[PR8] refactor(sets): migrate set and string function boundaries

### DIFF
--- a/machines/set/src/lib.rs
+++ b/machines/set/src/lib.rs
@@ -86,6 +86,9 @@ pub use self::relations::*;
 #[cfg(all(feature = "setdata", feature = "size", feature = "u64"))]
 pub use self::setdata::*;
 
+#[cfg(test)]
+mod port_tests;
+
 // ----------------------------------------------------------------------------
 // Set Library
 // ----------------------------------------------------------------------------

--- a/machines/set/src/membership/element_of.rs
+++ b/machines/set/src/membership/element_of.rs
@@ -42,6 +42,12 @@ impl MechFunctionFactory for SetElementOfFxn {
 }
 
 impl MechFunctionImpl for SetElementOfFxn {
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
+    }
     fn solve_result(&self) -> MResult<()> {
         unsafe {
             let out_ptr: &mut bool = &mut *(self.out.as_mut_ptr());

--- a/machines/set/src/membership/not_element_of.rs
+++ b/machines/set/src/membership/not_element_of.rs
@@ -42,6 +42,12 @@ impl MechFunctionFactory for SetNotElementOfFxn {
 }
 
 impl MechFunctionImpl for SetNotElementOfFxn {
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
+    }
     fn solve_result(&self) -> MResult<()> {
         unsafe {
             let out_ptr: &mut bool = &mut *(self.out.as_mut_ptr());

--- a/machines/set/src/modify/insert.rs
+++ b/machines/set/src/modify/insert.rs
@@ -79,6 +79,12 @@ fn match_types(type1: ValueKind, type2: ValueKind) -> (bool, bool) {
 }
 
 impl MechFunctionImpl for SetInsertFxn {
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
+    }
     fn solve_result(&self) -> MResult<()> {
         unsafe {
             // Get mutable reference to the output set

--- a/machines/set/src/modify/remove.rs
+++ b/machines/set/src/modify/remove.rs
@@ -66,6 +66,12 @@ impl MechFunctionFactory for SetRemoveFxn {
     }
 }
 impl MechFunctionImpl for SetRemoveFxn {
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
+    }
     fn solve_result(&self) -> MResult<()> {
         unsafe {
             // Get mutable reference to the output set

--- a/machines/set/src/operations/cartesian_product.rs
+++ b/machines/set/src/operations/cartesian_product.rs
@@ -80,6 +80,12 @@ impl MechFunctionFactory for SetCartesianProductFxn {
     }
 }
 impl MechFunctionImpl for SetCartesianProductFxn {
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
+    }
     fn solve_result(&self) -> MResult<()> {
         unsafe {
             let lhs_ptr: &MechSet = &*(self.lhs.as_ptr());

--- a/machines/set/src/operations/cartesian_product.rs
+++ b/machines/set/src/operations/cartesian_product.rs
@@ -67,23 +67,16 @@ impl MechFunctionFactory for SetCartesianProductFxn {
         FunctionValueRepresentation::Set,
     );
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, lhs, rhs) = invocation.expect_binary()?;
+        let lhs: Ref<MechSet> = lhs.try_ref()?;
+        let rhs: Ref<MechSet> = rhs.try_ref()?;
+        let out: Ref<MechSet> = out.try_ref()?;
+        Ok(Box::new(Self { lhs, rhs, out }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Binary(out, arg1, arg2) => {
-                let lhs: Ref<MechSet> = arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let rhs: Ref<MechSet> = arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                let out: Ref<MechSet> = out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(SetCartesianProductFxn { lhs, rhs, out }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 2,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 impl MechFunctionImpl for SetCartesianProductFxn {

--- a/machines/set/src/operations/difference.rs
+++ b/machines/set/src/operations/difference.rs
@@ -17,23 +17,16 @@ impl MechFunctionFactory for SetDifferenceFxn {
         FunctionValueRepresentation::Set,
     );
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, lhs, rhs) = invocation.expect_binary()?;
+        let lhs: Ref<MechSet> = lhs.try_ref()?;
+        let rhs: Ref<MechSet> = rhs.try_ref()?;
+        let out: Ref<MechSet> = out.try_ref()?;
+        Ok(Box::new(Self { lhs, rhs, out }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Binary(out, arg1, arg2) => {
-                let lhs: Ref<MechSet> = arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let rhs: Ref<MechSet> = arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                let out: Ref<MechSet> = out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(SetDifferenceFxn { lhs, rhs, out }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 2,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 impl MechFunctionImpl for SetDifferenceFxn {

--- a/machines/set/src/operations/difference.rs
+++ b/machines/set/src/operations/difference.rs
@@ -30,6 +30,12 @@ impl MechFunctionFactory for SetDifferenceFxn {
     }
 }
 impl MechFunctionImpl for SetDifferenceFxn {
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
+    }
     fn solve_result(&self) -> MResult<()> {
         unsafe {
             // Get mutable reference to the output set

--- a/machines/set/src/operations/intersection.rs
+++ b/machines/set/src/operations/intersection.rs
@@ -17,23 +17,16 @@ impl MechFunctionFactory for SetIntersectionFxn {
         FunctionValueRepresentation::Set,
     );
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, lhs, rhs) = invocation.expect_binary()?;
+        let lhs: Ref<MechSet> = lhs.try_ref()?;
+        let rhs: Ref<MechSet> = rhs.try_ref()?;
+        let out: Ref<MechSet> = out.try_ref()?;
+        Ok(Box::new(Self { lhs, rhs, out }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Binary(out, arg1, arg2) => {
-                let lhs: Ref<MechSet> = arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let rhs: Ref<MechSet> = arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                let out: Ref<MechSet> = out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(SetIntersectionFxn { lhs, rhs, out }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 2,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 impl MechFunctionImpl for SetIntersectionFxn {

--- a/machines/set/src/operations/intersection.rs
+++ b/machines/set/src/operations/intersection.rs
@@ -30,6 +30,12 @@ impl MechFunctionFactory for SetIntersectionFxn {
     }
 }
 impl MechFunctionImpl for SetIntersectionFxn {
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
+    }
     fn solve_result(&self) -> MResult<()> {
         unsafe {
             // Get mutable reference to the output set

--- a/machines/set/src/operations/powerset.rs
+++ b/machines/set/src/operations/powerset.rs
@@ -63,22 +63,15 @@ impl MechFunctionFactory for SetPowersetFxn {
         FunctionValueRepresentation::Set,
     );
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, input) = invocation.expect_unary()?;
+        let input: Ref<MechSet> = input.try_ref()?;
+        let out: Ref<MechSet> = out.try_ref()?;
+        Ok(Box::new(Self { input, out }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Unary(out, input) => {
-                let input: Ref<MechSet> = input.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let out: Ref<MechSet> = out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(SetPowersetFxn { input, out }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 1,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 

--- a/machines/set/src/operations/powerset.rs
+++ b/machines/set/src/operations/powerset.rs
@@ -118,6 +118,12 @@ where
 }
 
 impl MechFunctionImpl for SetPowersetFxn {
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
+    }
     fn solve_result(&self) -> MResult<()> {
         unsafe {
             // Get mutable reference to the output set

--- a/machines/set/src/operations/symmetric_difference.rs
+++ b/machines/set/src/operations/symmetric_difference.rs
@@ -32,6 +32,12 @@ impl MechFunctionFactory for SetSymDifferenceFxn {
 }
 
 impl MechFunctionImpl for SetSymDifferenceFxn {
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
+    }
     fn solve_result(&self) -> MResult<()> {
         unsafe {
             // Get mutable reference to the output set

--- a/machines/set/src/operations/symmetric_difference.rs
+++ b/machines/set/src/operations/symmetric_difference.rs
@@ -18,23 +18,16 @@ impl MechFunctionFactory for SetSymDifferenceFxn {
         FunctionValueRepresentation::Set,
     );
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, lhs, rhs) = invocation.expect_binary()?;
+        let lhs: Ref<MechSet> = lhs.try_ref()?;
+        let rhs: Ref<MechSet> = rhs.try_ref()?;
+        let out: Ref<MechSet> = out.try_ref()?;
+        Ok(Box::new(Self { lhs, rhs, out }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Binary(out, arg1, arg2) => {
-                let lhs: Ref<MechSet> = arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let rhs: Ref<MechSet> = arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                let out: Ref<MechSet> = out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(SetSymDifferenceFxn { lhs, rhs, out }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 2,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 

--- a/machines/set/src/operations/union.rs
+++ b/machines/set/src/operations/union.rs
@@ -17,23 +17,16 @@ impl MechFunctionFactory for SetUnionFxn {
         FunctionValueRepresentation::Set,
     );
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, lhs, rhs) = invocation.expect_binary()?;
+        let lhs: Ref<MechSet> = lhs.try_ref()?;
+        let rhs: Ref<MechSet> = rhs.try_ref()?;
+        let out: Ref<MechSet> = out.try_ref()?;
+        Ok(Box::new(Self { lhs, rhs, out }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Binary(out, arg1, arg2) => {
-                let lhs: Ref<MechSet> = arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let rhs: Ref<MechSet> = arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                let out: Ref<MechSet> = out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(SetUnionFxn { lhs, rhs, out }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 2,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 impl MechFunctionImpl for SetUnionFxn {

--- a/machines/set/src/operations/union.rs
+++ b/machines/set/src/operations/union.rs
@@ -30,6 +30,12 @@ impl MechFunctionFactory for SetUnionFxn {
     }
 }
 impl MechFunctionImpl for SetUnionFxn {
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
+    }
     fn solve_result(&self) -> MResult<()> {
         unsafe {
             // Get mutable reference to the output set

--- a/machines/set/src/port_tests.rs
+++ b/machines/set/src/port_tests.rs
@@ -20,8 +20,9 @@ mod typed_factories {
         setdata::size::SetSizeFxn,
     };
     use mech_core::{
-        FunctionArgs, FunctionInvocation, IncorrectNumberOfArguments, LegacyValue, MechError,
-        MechFunctionFactory, MechSet, Ref, ToValue, ValueKind,
+        EncodedConstant, FunctionArgs, FunctionInvocation, IncorrectNumberOfArguments,
+        LegacyValue, MechError, MechFunctionFactory, MechSet, Ref, RuntimeType, ToValue,
+        decode_encoded_constants,
     };
 
     fn set(values: &[usize]) -> Ref<MechSet> {
@@ -29,13 +30,42 @@ mod typed_factories {
             values
                 .iter()
                 .copied()
-                .map(|value| LegacyValue::Index(Ref::new(value)))
+                .map(|value| Ref::new(value).to_value())
                 .collect(),
         ))
     }
 
     fn set_output() -> Ref<MechSet> {
-        Ref::new(MechSet::new(ValueKind::Empty, 0))
+        Ref::new(MechSet::from_vec(Vec::new()))
+    }
+
+    fn framed(payload: &[u8]) -> Vec<u8> {
+        let mut framed = (payload.len() as u32).to_le_bytes().to_vec();
+        framed.extend_from_slice(payload);
+        framed
+    }
+
+    fn decoded_set_wrapper(reference: bool) -> LegacyValue {
+        let set_type = RuntimeType::Set {
+            element: Box::new(RuntimeType::Index),
+            max_len: Some(1),
+        };
+        let set_payload = 0_u32.to_le_bytes();
+        let (runtime_type, bytes) = if reference {
+            (RuntimeType::Reference(Box::new(set_type)), framed(&set_payload))
+        } else {
+            let mut bytes = vec![1];
+            bytes.extend(framed(&set_payload));
+            (RuntimeType::Option(Box::new(set_type)), bytes)
+        };
+        decode_encoded_constants(&[EncodedConstant {
+            runtime_type,
+            alignment: 4,
+            bytes,
+        }])
+        .unwrap()
+        .pop()
+        .unwrap()
     }
 
     fn factory_error(
@@ -177,7 +207,7 @@ mod typed_factories {
         .unwrap();
         lhs.borrow_mut()
             .set
-            .insert(LegacyValue::Index(Ref::new(3)));
+            .insert(Ref::new(3_usize).to_value());
         powerset.solve_result().unwrap();
         assert_eq!(powerset_out.borrow().set.len(), 8);
     }
@@ -189,7 +219,7 @@ mod typed_factories {
         let wrong_type = factory_error(SetUnionFxn::new_invocation(
             FunctionArgs::Binary(
                 out.to_value(),
-                LegacyValue::Bool(Ref::new(true)),
+                Ref::new(true).to_value(),
                 rhs.to_value(),
             )
             .into(),
@@ -219,18 +249,14 @@ mod typed_factories {
     #[test]
     fn typed_factories_do_not_traverse_legacy_wrappers() {
         let out = set_output();
-        let lhs = set(&[1]);
         let rhs = set(&[2]);
-        let typed = LegacyValue::Typed(
-            Box::new(lhs.to_value()),
-            ValueKind::Set(Box::new(ValueKind::Index), Some(1)),
-        );
+        let typed = decoded_set_wrapper(false);
         let typed_error = factory_error(SetUnionFxn::new_invocation(
             FunctionArgs::Binary(out.to_value(), typed, rhs.to_value()).into(),
         ));
         assert_eq!(typed_error.kind_name(), "FunctionArgumentTypeMismatch");
 
-        let mutable = LegacyValue::MutableReference(Ref::new(lhs.to_value()));
+        let mutable = decoded_set_wrapper(true);
         let mutable_error = factory_error(SetUnionFxn::new_invocation(
             FunctionArgs::Binary(out.to_value(), mutable, rhs.to_value()).into(),
         ));
@@ -248,5 +274,461 @@ mod typed_factories {
 
         assert!(first.try_ref::<MechSet>().unwrap().same_handle(&lhs));
         assert!(second.try_ref::<MechSet>().unwrap().same_handle(&rhs));
+    }
+}
+
+#[cfg(all(
+    feature = "union",
+    feature = "insert",
+    feature = "powerset",
+    feature = "cartesian_product",
+    feature = "tuple"
+))]
+mod graph_state {
+    use crate::{
+        modify::insert::SetInsertFxn,
+        operations::{
+            cartesian_product::SetCartesianProductFxn, powerset::SetPowersetFxn,
+            union::SetUnionFxn,
+        },
+    };
+    use mech_core::{
+        FunctionArgs, LegacyValue, MechFunctionFactory, MechSet, MechTuple, Ref, ToValue,
+        with_reactive_journal_participant,
+    };
+
+    fn index(value: usize) -> Ref<usize> {
+        Ref::new(value)
+    }
+
+    fn index_value(reference: &Ref<usize>) -> LegacyValue {
+        reference.to_value()
+    }
+
+    fn set(values: &[usize]) -> Ref<MechSet> {
+        Ref::new(MechSet::from_vec(
+            values
+                .iter()
+                .copied()
+                .map(|value| index_value(&index(value)))
+                .collect(),
+        ))
+    }
+
+    fn output_set() -> Ref<MechSet> {
+        Ref::new(MechSet::from_vec(Vec::new()))
+    }
+
+    #[test]
+    fn union_graph_state_restores_root_metadata_and_deduplicates() {
+        let lhs = set(&[1, 2]);
+        let rhs = set(&[2, 3]);
+        let out = output_set();
+        let out_alias = out.clone();
+        let function = SetUnionFxn::new_invocation(
+            FunctionArgs::Binary(out.to_value(), lhs.to_value(), rhs.to_value()).into(),
+        )
+        .unwrap();
+        function.solve_result().unwrap();
+        let expected = out.borrow().clone();
+        let expected_ids = function.out().reactive_root_cell_ids();
+        assert_eq!(function.reactive_output_cell_ids(), expected_ids);
+        assert_eq!(function.transaction_state_ports().unwrap().unwrap().len(), 1);
+
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*function)?;
+            let captured_cells = participant.cell_count();
+            participant.capture_function_state(&*function)?;
+            assert_eq!(participant.cell_count(), captured_cells);
+
+            let mut payload = out.borrow_mut();
+            payload.set.clear();
+            payload.kind = lhs.to_value().kind();
+            payload.max_elements = Some(99);
+            payload.num_elements = 99;
+            drop(payload);
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+
+        assert!(out.same_handle(&out_alias));
+        assert_eq!(*out.borrow(), expected);
+    }
+
+    #[test]
+    fn cartesian_product_graph_state_restores_tuples_and_shared_cells() {
+        let shared = index(1);
+        let nested_tuple = Ref::new(MechTuple::from_vec(vec![index_value(&shared)]));
+        let nested_tuple_alias = nested_tuple.clone();
+        let lhs = Ref::new(MechSet::from_vec(vec![nested_tuple.to_value()]));
+        let rhs = set(&[10, 20]);
+        let out = output_set();
+        let function = SetCartesianProductFxn::new_invocation(
+            FunctionArgs::Binary(out.to_value(), lhs.to_value(), rhs.to_value()).into(),
+        )
+        .unwrap();
+        function.solve_result().unwrap();
+        let expected = out.borrow().clone();
+        assert_eq!(nested_tuple.borrow().elements[0].reactive_root_cell_ids(), shared.to_value().reactive_root_cell_ids());
+
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*function)?;
+            *shared.borrow_mut() = 99;
+            nested_tuple.borrow_mut().elements.clear();
+            out.borrow_mut().num_elements = 77;
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(*shared.borrow(), 1);
+        assert!(nested_tuple.same_handle(&nested_tuple_alias));
+        assert_eq!(nested_tuple.borrow().elements.len(), 1);
+        assert_eq!(nested_tuple.borrow().elements[0].reactive_root_cell_ids(), shared.to_value().reactive_root_cell_ids());
+        assert_eq!(*out.borrow(), expected);
+    }
+
+    #[test]
+    fn powerset_graph_state_restores_nested_sets_recursively() {
+        let shared = index(1);
+        let nested = Ref::new(MechSet::from_vec(vec![index_value(&shared)]));
+        let nested_alias = nested.clone();
+        let input = Ref::new(MechSet::from_vec(vec![nested.to_value()]));
+        let out = output_set();
+        let function = SetPowersetFxn::new_invocation(
+            FunctionArgs::Unary(out.to_value(), input.to_value()).into(),
+        )
+        .unwrap();
+        function.solve_result().unwrap();
+        let expected = out.borrow().clone();
+        let changed_kind = nested.to_value().kind();
+
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*function)?;
+            nested.borrow_mut().set.clear();
+            nested.borrow_mut().kind = changed_kind.clone();
+            out.borrow_mut().set.clear();
+            *shared.borrow_mut() = 9;
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+
+        assert!(nested.same_handle(&nested_alias));
+        assert_eq!(nested.borrow().set.len(), 1);
+        assert_eq!(nested.borrow().kind, index_value(&shared).kind());
+        assert!(nested.borrow().set.contains(&index_value(&shared)));
+        assert_eq!(*shared.borrow(), 1);
+        assert_eq!(*out.borrow(), expected);
+    }
+
+    #[test]
+    fn distinct_equal_graph_outputs_keep_distinct_reactive_identity() {
+        let lhs = set(&[1]);
+        let rhs = set(&[2]);
+        let first_out = output_set();
+        let second_out = output_set();
+        let first = SetUnionFxn::new_invocation(
+            FunctionArgs::Binary(first_out.to_value(), lhs.to_value(), rhs.to_value()).into(),
+        )
+        .unwrap();
+        let second = SetUnionFxn::new_invocation(
+            FunctionArgs::Binary(second_out.to_value(), lhs.to_value(), rhs.to_value()).into(),
+        )
+        .unwrap();
+        first.solve_result().unwrap();
+        second.solve_result().unwrap();
+
+        assert_eq!(*first_out.borrow(), *second_out.borrow());
+        assert!(!first_out.same_handle(&second_out));
+        assert_ne!(
+            first.reactive_output_cell_ids(),
+            second.reactive_output_cell_ids()
+        );
+    }
+
+    #[test]
+    fn limit_error_is_atomic_and_the_prior_output_can_be_restored() {
+        let lhs = set(&[1, 2]);
+        let rhs = set(&[3, 4]);
+        let out = output_set();
+        let function = SetCartesianProductFxn::new_invocation(
+            FunctionArgs::Binary(out.to_value(), lhs.to_value(), rhs.to_value()).into(),
+        )
+        .unwrap();
+        function.solve_result().unwrap();
+        let successful = out.borrow().clone();
+
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*function)?;
+            *lhs.borrow_mut() = MechSet::from_vec(
+                (0..257)
+                    .map(|value| Ref::new(value).to_value())
+                    .collect(),
+            );
+            *rhs.borrow_mut() = MechSet::from_vec(
+                (0..257)
+                    .map(|value| Ref::new(value).to_value())
+                    .collect(),
+            );
+            let error = function.solve_result().unwrap_err();
+            assert_eq!(error.kind_name(), "SetCartesianProductLimitExceeded");
+            assert_eq!(*out.borrow(), successful);
+
+            out.borrow_mut().set.clear();
+            out.borrow_mut().kind = lhs.to_value().kind();
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(*out.borrow(), successful);
+    }
+
+    #[test]
+    fn insert_output_uses_the_same_graph_state_path() {
+        let member = index(1);
+        let input = Ref::new(MechSet::from_vec(vec![index_value(&member)]));
+        let inserted = index(2);
+        let out = Ref::new(MechSet::new(index_value(&inserted).kind(), 2));
+        let out_alias = out.clone();
+        let function = SetInsertFxn::new_invocation(
+            FunctionArgs::Binary(out.to_value(), input.to_value(), index_value(&inserted)).into(),
+        )
+        .unwrap();
+        function.solve_result().unwrap();
+        let expected = out.borrow().clone();
+
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*function)?;
+            out.borrow_mut().set.clear();
+            out.borrow_mut().max_elements = Some(99);
+            *inserted.borrow_mut() = 20;
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+
+        assert!(out.same_handle(&out_alias));
+        assert_eq!(*out.borrow(), expected);
+        assert_eq!(*inserted.borrow(), 2);
+    }
+}
+
+#[cfg(all(
+    feature = "element_of",
+    feature = "not_element_of",
+    feature = "insert",
+    feature = "remove",
+    feature = "bool",
+    feature = "f64"
+))]
+mod any_value_compatibility {
+    use crate::{
+        membership::{element_of::SetElementOfFxn, not_element_of::SetNotElementOfFxn},
+        modify::{insert::SetInsertFxn, remove::SetRemoveFxn},
+    };
+    use mech_core::{
+        EncodedConstant, FunctionArgs, LegacyValue, MechFunctionFactory, MechSet, Ref,
+        RuntimeType, ToValue, decode_encoded_constants, with_reactive_journal_participant,
+    };
+
+    fn scalar(value: f64) -> Ref<f64> {
+        Ref::new(value)
+    }
+
+    fn scalar_value(reference: &Ref<f64>) -> LegacyValue {
+        reference.to_value()
+    }
+
+    fn referenced_scalar(value: f64) -> LegacyValue {
+        let payload = value.to_le_bytes();
+        let mut bytes = (payload.len() as u32).to_le_bytes().to_vec();
+        bytes.extend_from_slice(&payload);
+        decode_encoded_constants(&[EncodedConstant {
+            runtime_type: RuntimeType::Reference(Box::new(RuntimeType::F64)),
+            alignment: 8,
+            bytes,
+        }])
+        .unwrap()
+        .pop()
+        .unwrap()
+    }
+
+    fn scalar_set(values: &[f64]) -> Ref<MechSet> {
+        Ref::new(MechSet::from_vec(
+            values
+                .iter()
+                .copied()
+                .map(|value| scalar_value(&scalar(value)))
+                .collect(),
+        ))
+    }
+
+    #[test]
+    fn any_value_membership_uses_the_default_invocation_bridge() {
+        let set = scalar_set(&[1.0, 2.0]);
+        let member = scalar(2.0);
+        let element_of_out = Ref::new(false);
+        let not_element_of_out = Ref::new(false);
+        let element_of = SetElementOfFxn::new_invocation(
+            FunctionArgs::Binary(
+                element_of_out.to_value(),
+                scalar_value(&member),
+                set.to_value(),
+            )
+            .into(),
+        )
+        .unwrap();
+        let not_element_of = SetNotElementOfFxn::new_invocation(
+            FunctionArgs::Binary(
+                not_element_of_out.to_value(),
+                scalar_value(&member),
+                set.to_value(),
+            )
+            .into(),
+        )
+        .unwrap();
+        element_of.solve_result().unwrap();
+        not_element_of.solve_result().unwrap();
+        assert!(*element_of_out.borrow());
+        assert!(!*not_element_of_out.borrow());
+
+        let wrapped = referenced_scalar(2.0);
+        let wrapped_out = Ref::new(false);
+        SetElementOfFxn::new_invocation(
+            FunctionArgs::Binary(wrapped_out.to_value(), wrapped, set.to_value()).into(),
+        )
+        .unwrap()
+        .solve_result()
+        .unwrap();
+        assert!(*wrapped_out.borrow());
+    }
+
+    #[test]
+    fn any_value_insert_and_remove_preserve_kind_and_cardinality() {
+        let input = scalar_set(&[1.0]);
+        let inserted = scalar(2.0);
+        let scalar_kind = scalar_value(&inserted).kind();
+        let insert_out = Ref::new(MechSet::new(scalar_kind.clone(), 2));
+        let insert = SetInsertFxn::new_invocation(
+            FunctionArgs::Binary(
+                insert_out.to_value(),
+                input.to_value(),
+                scalar_value(&inserted),
+            )
+            .into(),
+        )
+        .unwrap();
+        insert.solve_result().unwrap();
+        assert_eq!(insert_out.borrow().kind, scalar_kind);
+        assert_eq!(insert_out.borrow().num_elements, 2);
+        assert_eq!(insert_out.borrow().max_elements, Some(2));
+
+        let remove_out = Ref::new(MechSet::new(scalar_value(&inserted).kind(), 2));
+        let remove = SetRemoveFxn::new_invocation(
+            FunctionArgs::Binary(
+                remove_out.to_value(),
+                insert_out.to_value(),
+                scalar_value(&inserted),
+            )
+            .into(),
+        )
+        .unwrap();
+        remove.solve_result().unwrap();
+        assert_eq!(remove_out.borrow().kind, scalar_value(&inserted).kind());
+        assert_eq!(remove_out.borrow().num_elements, 1);
+        assert_eq!(remove_out.borrow().max_elements, Some(1));
+    }
+
+    #[test]
+    fn membership_scalar_state_is_authoritative() {
+        let set = scalar_set(&[1.0]);
+        let out = Ref::new(false);
+        let function = SetElementOfFxn::new_invocation(
+            FunctionArgs::Binary(
+                out.to_value(),
+                Ref::new(1.0_f64).to_value(),
+                set.to_value(),
+            )
+            .into(),
+        )
+        .unwrap();
+        function.solve_result().unwrap();
+        assert!(function.transaction_state_ports().unwrap().is_some());
+
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*function)?;
+            *out.borrow_mut() = false;
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+        assert!(*out.borrow());
+    }
+}
+
+#[cfg(all(
+    feature = "equals",
+    feature = "size",
+    feature = "bool",
+    feature = "u64"
+))]
+mod scalar_state {
+    use crate::{relations::equals::SetEqualsFxn, setdata::size::SetSizeFxn};
+    use mech_core::{
+        FunctionArgs, MechFunctionFactory, MechSet, Ref, ToValue,
+        with_reactive_journal_participant,
+    };
+
+    fn set(values: &[usize]) -> Ref<MechSet> {
+        Ref::new(MechSet::from_vec(
+            values
+                .iter()
+                .copied()
+                .map(|value| Ref::new(value).to_value())
+                .collect(),
+        ))
+    }
+
+    #[test]
+    fn relation_and_size_outputs_restore_through_exact_state_ports() {
+        let lhs = set(&[1, 2]);
+        let rhs = set(&[1, 2]);
+        let relation_out = Ref::new(false);
+        let size_out = Ref::new(0_u64);
+        let relation = SetEqualsFxn::new_invocation(
+            FunctionArgs::Binary(relation_out.to_value(), lhs.to_value(), rhs.to_value()).into(),
+        )
+        .unwrap();
+        let size = SetSizeFxn::new_invocation(
+            FunctionArgs::Unary(size_out.to_value(), lhs.to_value()).into(),
+        )
+        .unwrap();
+        relation.solve_result().unwrap();
+        size.solve_result().unwrap();
+        assert!(*relation_out.borrow());
+        assert_eq!(*size_out.borrow(), 2);
+
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*relation)?;
+            participant.capture_function_state(&*size)?;
+            *relation_out.borrow_mut() = false;
+            *size_out.borrow_mut() = 99;
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+
+        assert!(*relation_out.borrow());
+        assert_eq!(*size_out.borrow(), 2);
     }
 }

--- a/machines/set/src/port_tests.rs
+++ b/machines/set/src/port_tests.rs
@@ -1,0 +1,252 @@
+#[cfg(all(
+    feature = "union",
+    feature = "difference",
+    feature = "intersection",
+    feature = "powerset",
+    feature = "cartesian_product",
+    feature = "subset",
+    feature = "equals",
+    feature = "size",
+    feature = "bool",
+    feature = "u64"
+))]
+mod typed_factories {
+    use crate::{
+        operations::{
+            cartesian_product::SetCartesianProductFxn, difference::SetDifferenceFxn,
+            intersection::SetIntersectionFxn, powerset::SetPowersetFxn, union::SetUnionFxn,
+        },
+        relations::{equals::SetEqualsFxn, subset::SetSubsetFxn},
+        setdata::size::SetSizeFxn,
+    };
+    use mech_core::{
+        FunctionArgs, FunctionInvocation, IncorrectNumberOfArguments, LegacyValue, MechError,
+        MechFunctionFactory, MechSet, Ref, ToValue, ValueKind,
+    };
+
+    fn set(values: &[usize]) -> Ref<MechSet> {
+        Ref::new(MechSet::from_vec(
+            values
+                .iter()
+                .copied()
+                .map(|value| LegacyValue::Index(Ref::new(value)))
+                .collect(),
+        ))
+    }
+
+    fn set_output() -> Ref<MechSet> {
+        Ref::new(MechSet::new(ValueKind::Empty, 0))
+    }
+
+    fn factory_error(
+        result: Result<Box<dyn mech_core::MechFunction>, MechError>,
+    ) -> MechError {
+        match result {
+            Ok(_) => panic!("factory unexpectedly accepted invalid arguments"),
+            Err(error) => error,
+        }
+    }
+
+    fn assert_binary_set_factories_are_equivalent<F>()
+    where
+        F: MechFunctionFactory,
+    {
+        let lhs = set(&[1, 2]);
+        let rhs = set(&[2, 3]);
+        let legacy_out = set_output();
+        let invocation_out = set_output();
+
+        let legacy = F::new(FunctionArgs::Binary(
+            legacy_out.to_value(),
+            lhs.to_value(),
+            rhs.to_value(),
+        ))
+        .unwrap();
+        let invocation = F::new_invocation(
+            FunctionArgs::Binary(
+                invocation_out.to_value(),
+                lhs.to_value(),
+                rhs.to_value(),
+            )
+            .into(),
+        )
+        .unwrap();
+        legacy.solve_result().unwrap();
+        invocation.solve_result().unwrap();
+
+        assert_eq!(*legacy_out.borrow(), *invocation_out.borrow());
+    }
+
+    fn assert_binary_bool_factories_are_equivalent<F>()
+    where
+        F: MechFunctionFactory,
+    {
+        let lhs = set(&[1, 2]);
+        let rhs = set(&[1, 2, 3]);
+        let legacy_out = Ref::new(false);
+        let invocation_out = Ref::new(false);
+
+        let legacy = F::new(FunctionArgs::Binary(
+            legacy_out.to_value(),
+            lhs.to_value(),
+            rhs.to_value(),
+        ))
+        .unwrap();
+        let invocation = F::new_invocation(
+            FunctionArgs::Binary(
+                invocation_out.to_value(),
+                lhs.to_value(),
+                rhs.to_value(),
+            )
+            .into(),
+        )
+        .unwrap();
+        legacy.solve_result().unwrap();
+        invocation.solve_result().unwrap();
+
+        assert_eq!(*legacy_out.borrow(), *invocation_out.borrow());
+    }
+
+    #[test]
+    fn selected_binary_set_factories_match_the_legacy_adapter() {
+        assert_binary_set_factories_are_equivalent::<SetUnionFxn>();
+        assert_binary_set_factories_are_equivalent::<SetDifferenceFxn>();
+        assert_binary_set_factories_are_equivalent::<SetIntersectionFxn>();
+        assert_binary_set_factories_are_equivalent::<SetCartesianProductFxn>();
+    }
+
+    #[test]
+    fn selected_relation_factories_match_the_legacy_adapter() {
+        assert_binary_bool_factories_are_equivalent::<SetSubsetFxn>();
+        assert_binary_bool_factories_are_equivalent::<SetEqualsFxn>();
+    }
+
+    #[test]
+    fn powerset_and_size_factories_match_the_legacy_adapter() {
+        let input = set(&[1, 2]);
+        let legacy_powerset_out = set_output();
+        let invocation_powerset_out = set_output();
+        let legacy_powerset = SetPowersetFxn::new(FunctionArgs::Unary(
+            legacy_powerset_out.to_value(),
+            input.to_value(),
+        ))
+        .unwrap();
+        let invocation_powerset = SetPowersetFxn::new_invocation(
+            FunctionArgs::Unary(invocation_powerset_out.to_value(), input.to_value()).into(),
+        )
+        .unwrap();
+        legacy_powerset.solve_result().unwrap();
+        invocation_powerset.solve_result().unwrap();
+        assert_eq!(
+            *legacy_powerset_out.borrow(),
+            *invocation_powerset_out.borrow()
+        );
+
+        let legacy_size_out = Ref::new(0_u64);
+        let invocation_size_out = Ref::new(0_u64);
+        let legacy_size = SetSizeFxn::new(FunctionArgs::Unary(
+            legacy_size_out.to_value(),
+            input.to_value(),
+        ))
+        .unwrap();
+        let invocation_size = SetSizeFxn::new_invocation(
+            FunctionArgs::Unary(invocation_size_out.to_value(), input.to_value()).into(),
+        )
+        .unwrap();
+        legacy_size.solve_result().unwrap();
+        invocation_size.solve_result().unwrap();
+        assert_eq!(*legacy_size_out.borrow(), *invocation_size_out.borrow());
+    }
+
+    #[test]
+    fn binary_and_unary_factories_preserve_input_positions() {
+        let lhs = set(&[1, 2]);
+        let rhs = set(&[2, 3]);
+        let difference_out = set_output();
+        let difference = SetDifferenceFxn::new_invocation(
+            FunctionArgs::Binary(difference_out.to_value(), lhs.to_value(), rhs.to_value()).into(),
+        )
+        .unwrap();
+        difference.solve_result().unwrap();
+        assert_eq!(*difference_out.borrow(), *set(&[1]).borrow());
+
+        let powerset_out = set_output();
+        let powerset = SetPowersetFxn::new_invocation(
+            FunctionArgs::Unary(powerset_out.to_value(), lhs.to_value()).into(),
+        )
+        .unwrap();
+        lhs.borrow_mut()
+            .set
+            .insert(LegacyValue::Index(Ref::new(3)));
+        powerset.solve_result().unwrap();
+        assert_eq!(powerset_out.borrow().set.len(), 8);
+    }
+
+    #[test]
+    fn typed_factories_reject_wrong_types_and_layouts() {
+        let out = set_output();
+        let rhs = set(&[1]);
+        let wrong_type = factory_error(SetUnionFxn::new_invocation(
+            FunctionArgs::Binary(
+                out.to_value(),
+                LegacyValue::Bool(Ref::new(true)),
+                rhs.to_value(),
+            )
+            .into(),
+        ));
+        assert_eq!(wrong_type.kind_name(), "FunctionArgumentTypeMismatch");
+
+        let wrong_binary_layout = factory_error(SetUnionFxn::new_invocation(
+            FunctionArgs::Unary(out.to_value(), rhs.to_value()).into(),
+        ));
+        assert_eq!(wrong_binary_layout.kind_name(), "IncorrectNumberOfArguments");
+        let wrong_binary_layout = wrong_binary_layout
+            .kind_as::<IncorrectNumberOfArguments>()
+            .unwrap();
+        assert_eq!((wrong_binary_layout.expected, wrong_binary_layout.found), (2, 1));
+
+        let size_out = Ref::new(0_u64);
+        let wrong_unary_layout = factory_error(SetSizeFxn::new_invocation(
+            FunctionArgs::Binary(size_out.to_value(), rhs.to_value(), rhs.to_value()).into(),
+        ));
+        assert_eq!(wrong_unary_layout.kind_name(), "IncorrectNumberOfArguments");
+        let wrong_unary_layout = wrong_unary_layout
+            .kind_as::<IncorrectNumberOfArguments>()
+            .unwrap();
+        assert_eq!((wrong_unary_layout.expected, wrong_unary_layout.found), (1, 2));
+    }
+
+    #[test]
+    fn typed_factories_do_not_traverse_legacy_wrappers() {
+        let out = set_output();
+        let lhs = set(&[1]);
+        let rhs = set(&[2]);
+        let typed = LegacyValue::Typed(
+            Box::new(lhs.to_value()),
+            ValueKind::Set(Box::new(ValueKind::Index), Some(1)),
+        );
+        let typed_error = factory_error(SetUnionFxn::new_invocation(
+            FunctionArgs::Binary(out.to_value(), typed, rhs.to_value()).into(),
+        ));
+        assert_eq!(typed_error.kind_name(), "FunctionArgumentTypeMismatch");
+
+        let mutable = LegacyValue::MutableReference(Ref::new(lhs.to_value()));
+        let mutable_error = factory_error(SetUnionFxn::new_invocation(
+            FunctionArgs::Binary(out.to_value(), mutable, rhs.to_value()).into(),
+        ));
+        assert_eq!(mutable_error.kind_name(), "FunctionArgumentTypeMismatch");
+    }
+
+    #[test]
+    fn function_invocation_keeps_the_exact_argument_layout() {
+        let out = set_output();
+        let lhs = set(&[1]);
+        let rhs = set(&[2]);
+        let invocation: FunctionInvocation =
+            FunctionArgs::Binary(out.to_value(), lhs.to_value(), rhs.to_value()).into();
+        let (_, first, second) = invocation.expect_binary().unwrap();
+
+        assert!(first.try_ref::<MechSet>().unwrap().same_handle(&lhs));
+        assert!(second.try_ref::<MechSet>().unwrap().same_handle(&rhs));
+    }
+}

--- a/machines/set/src/relations/disjoint.rs
+++ b/machines/set/src/relations/disjoint.rs
@@ -17,23 +17,16 @@ impl MechFunctionFactory for SetDisjointFxn {
         FunctionValueRepresentation::Set,
     );
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, lhs, rhs) = invocation.expect_binary()?;
+        let lhs: Ref<MechSet> = lhs.try_ref()?;
+        let rhs: Ref<MechSet> = rhs.try_ref()?;
+        let out: Ref<bool> = out.try_ref()?;
+        Ok(Box::new(Self { lhs, rhs, out }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Binary(out, arg1, arg2) => {
-                let lhs: Ref<MechSet> = arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let rhs: Ref<MechSet> = arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                let out: Ref<bool> = out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(SetDisjointFxn { lhs, rhs, out }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 2,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 impl MechFunctionImpl for SetDisjointFxn {

--- a/machines/set/src/relations/disjoint.rs
+++ b/machines/set/src/relations/disjoint.rs
@@ -30,6 +30,12 @@ impl MechFunctionFactory for SetDisjointFxn {
     }
 }
 impl MechFunctionImpl for SetDisjointFxn {
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
+    }
     fn solve_result(&self) -> MResult<()> {
         unsafe {
             // Get mutable reference to the output set

--- a/machines/set/src/relations/equals.rs
+++ b/machines/set/src/relations/equals.rs
@@ -21,23 +21,16 @@ impl MechFunctionFactory for SetEqualsFxn {
         FunctionValueRepresentation::Set,
     );
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, lhs, rhs) = invocation.expect_binary()?;
+        let lhs: Ref<MechSet> = lhs.try_ref()?;
+        let rhs: Ref<MechSet> = rhs.try_ref()?;
+        let out: Ref<bool> = out.try_ref()?;
+        Ok(Box::new(Self { lhs, rhs, out }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Binary(out, arg1, arg2) => {
-                let lhs: Ref<MechSet> = arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let rhs: Ref<MechSet> = arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                let out: Ref<bool> = out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(SetEqualsFxn { lhs, rhs, out }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 2,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 

--- a/machines/set/src/relations/equals.rs
+++ b/machines/set/src/relations/equals.rs
@@ -35,6 +35,12 @@ impl MechFunctionFactory for SetEqualsFxn {
 }
 
 impl MechFunctionImpl for SetEqualsFxn {
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
+    }
     fn solve_result(&self) -> MResult<()> {
         unsafe {
             let out_ptr: &mut bool = &mut *(self.out.as_mut_ptr());

--- a/machines/set/src/relations/not_equals.rs
+++ b/machines/set/src/relations/not_equals.rs
@@ -21,23 +21,16 @@ impl MechFunctionFactory for SetNotEqualsFxn {
         FunctionValueRepresentation::Set,
     );
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, lhs, rhs) = invocation.expect_binary()?;
+        let lhs: Ref<MechSet> = lhs.try_ref()?;
+        let rhs: Ref<MechSet> = rhs.try_ref()?;
+        let out: Ref<bool> = out.try_ref()?;
+        Ok(Box::new(Self { lhs, rhs, out }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Binary(out, arg1, arg2) => {
-                let lhs: Ref<MechSet> = arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let rhs: Ref<MechSet> = arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                let out: Ref<bool> = out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(SetNotEqualsFxn { lhs, rhs, out }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 2,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 

--- a/machines/set/src/relations/not_equals.rs
+++ b/machines/set/src/relations/not_equals.rs
@@ -35,6 +35,12 @@ impl MechFunctionFactory for SetNotEqualsFxn {
 }
 
 impl MechFunctionImpl for SetNotEqualsFxn {
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
+    }
     fn solve_result(&self) -> MResult<()> {
         unsafe {
             let out_ptr: &mut bool = &mut *(self.out.as_mut_ptr());

--- a/machines/set/src/relations/proper_subset.rs
+++ b/machines/set/src/relations/proper_subset.rs
@@ -21,23 +21,16 @@ impl MechFunctionFactory for SetProperSubsetFxn {
         FunctionValueRepresentation::Set,
     );
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, lhs, rhs) = invocation.expect_binary()?;
+        let lhs: Ref<MechSet> = lhs.try_ref()?;
+        let rhs: Ref<MechSet> = rhs.try_ref()?;
+        let out: Ref<bool> = out.try_ref()?;
+        Ok(Box::new(Self { lhs, rhs, out }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Binary(out, arg1, arg2) => {
-                let lhs: Ref<MechSet> = arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let rhs: Ref<MechSet> = arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                let out: Ref<bool> = out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(SetProperSubsetFxn { lhs, rhs, out }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 2,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 

--- a/machines/set/src/relations/proper_subset.rs
+++ b/machines/set/src/relations/proper_subset.rs
@@ -35,6 +35,12 @@ impl MechFunctionFactory for SetProperSubsetFxn {
 }
 
 impl MechFunctionImpl for SetProperSubsetFxn {
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
+    }
     fn solve_result(&self) -> MResult<()> {
         unsafe {
             let out_ptr: &mut bool = &mut *(self.out.as_mut_ptr());

--- a/machines/set/src/relations/proper_superset.rs
+++ b/machines/set/src/relations/proper_superset.rs
@@ -35,6 +35,12 @@ impl MechFunctionFactory for SetProperSupersetFxn {
 }
 
 impl MechFunctionImpl for SetProperSupersetFxn {
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
+    }
     fn solve_result(&self) -> MResult<()> {
         unsafe {
             let out_ptr: &mut bool = &mut *(self.out.as_mut_ptr());

--- a/machines/set/src/relations/proper_superset.rs
+++ b/machines/set/src/relations/proper_superset.rs
@@ -21,23 +21,16 @@ impl MechFunctionFactory for SetProperSupersetFxn {
         FunctionValueRepresentation::Set,
     );
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, lhs, rhs) = invocation.expect_binary()?;
+        let lhs: Ref<MechSet> = lhs.try_ref()?;
+        let rhs: Ref<MechSet> = rhs.try_ref()?;
+        let out: Ref<bool> = out.try_ref()?;
+        Ok(Box::new(Self { lhs, rhs, out }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Binary(out, arg1, arg2) => {
-                let lhs: Ref<MechSet> = arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let rhs: Ref<MechSet> = arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                let out: Ref<bool> = out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(SetProperSupersetFxn { lhs, rhs, out }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 2,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 

--- a/machines/set/src/relations/subset.rs
+++ b/machines/set/src/relations/subset.rs
@@ -30,6 +30,12 @@ impl MechFunctionFactory for SetSubsetFxn {
     }
 }
 impl MechFunctionImpl for SetSubsetFxn {
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
+    }
     fn solve_result(&self) -> MResult<()> {
         unsafe {
             // Get mutable reference to the output set

--- a/machines/set/src/relations/subset.rs
+++ b/machines/set/src/relations/subset.rs
@@ -17,23 +17,16 @@ impl MechFunctionFactory for SetSubsetFxn {
         FunctionValueRepresentation::Set,
     );
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, lhs, rhs) = invocation.expect_binary()?;
+        let lhs: Ref<MechSet> = lhs.try_ref()?;
+        let rhs: Ref<MechSet> = rhs.try_ref()?;
+        let out: Ref<bool> = out.try_ref()?;
+        Ok(Box::new(Self { lhs, rhs, out }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Binary(out, arg1, arg2) => {
-                let lhs: Ref<MechSet> = arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let rhs: Ref<MechSet> = arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                let out: Ref<bool> = out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(SetSubsetFxn { lhs, rhs, out }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 2,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 impl MechFunctionImpl for SetSubsetFxn {

--- a/machines/set/src/relations/superset.rs
+++ b/machines/set/src/relations/superset.rs
@@ -17,23 +17,16 @@ impl MechFunctionFactory for SetSupersetFxn {
         FunctionValueRepresentation::Set,
     );
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, lhs, rhs) = invocation.expect_binary()?;
+        let lhs: Ref<MechSet> = lhs.try_ref()?;
+        let rhs: Ref<MechSet> = rhs.try_ref()?;
+        let out: Ref<bool> = out.try_ref()?;
+        Ok(Box::new(Self { lhs, rhs, out }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Binary(out, arg1, arg2) => {
-                let lhs: Ref<MechSet> = arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let rhs: Ref<MechSet> = arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                let out: Ref<bool> = out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(SetSupersetFxn { lhs, rhs, out }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 2,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 impl MechFunctionImpl for SetSupersetFxn {

--- a/machines/set/src/relations/superset.rs
+++ b/machines/set/src/relations/superset.rs
@@ -30,6 +30,12 @@ impl MechFunctionFactory for SetSupersetFxn {
     }
 }
 impl MechFunctionImpl for SetSupersetFxn {
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
+    }
     fn solve_result(&self) -> MResult<()> {
         unsafe {
             // Get mutable reference to the output set

--- a/machines/set/src/setdata/size.rs
+++ b/machines/set/src/setdata/size.rs
@@ -19,22 +19,15 @@ impl MechFunctionFactory for SetSizeFxn {
         FunctionValueRepresentation::Set,
     );
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, input) = invocation.expect_unary()?;
+        let input: Ref<MechSet> = input.try_ref()?;
+        let out: Ref<u64> = out.try_ref()?;
+        Ok(Box::new(Self { input, out }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Unary(out, arg1) => {
-                let input: Ref<MechSet> = arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let out: Ref<u64> = out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(SetSizeFxn { input, out }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 1,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 

--- a/machines/set/src/setdata/size.rs
+++ b/machines/set/src/setdata/size.rs
@@ -32,6 +32,12 @@ impl MechFunctionFactory for SetSizeFxn {
 }
 
 impl MechFunctionImpl for SetSizeFxn {
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
+    }
     fn solve_result(&self) -> MResult<()> {
         unsafe {
             let out_ptr: &mut u64 = &mut *(self.out.as_mut_ptr());

--- a/machines/string/src/concat.rs
+++ b/machines/string/src/concat.rs
@@ -122,3 +122,313 @@ fn impl_concat_fxn(lhs_value: LegacyValue, rhs_value: LegacyValue) -> MResult<Bo
 
 #[cfg(feature = "source")]
 impl_mech_binop_fxn!(StringConcat, impl_concat_fxn, "string/concat");
+
+#[cfg(all(test, feature = "string"))]
+mod scalar_port_tests {
+    use super::*;
+
+    fn binary_args<L, R, O>(out: &Ref<O>, lhs: &Ref<L>, rhs: &Ref<R>) -> FunctionArgs
+    where
+        Ref<L>: ToValue,
+        Ref<R>: ToValue,
+        Ref<O>: ToValue,
+    {
+        FunctionArgs::Binary(out.to_value(), lhs.to_value(), rhs.to_value())
+    }
+
+    #[test]
+    fn scalar_legacy_and_invocation_factories_are_equivalent() {
+        let lhs = Ref::new("left".to_string());
+        let rhs = Ref::new("-right".to_string());
+        let legacy_out = Ref::new(String::new());
+        let invocation_out = Ref::new(String::new());
+        let legacy = ConcatSS::<String>::new(binary_args(&legacy_out, &lhs, &rhs)).unwrap();
+        let invocation = ConcatSS::<String>::new_invocation(
+            binary_args(&invocation_out, &lhs, &rhs).into(),
+        )
+        .unwrap();
+
+        legacy.solve_result().unwrap();
+        invocation.solve_result().unwrap();
+        assert_eq!(&*legacy_out.borrow(), "left-right");
+        assert_eq!(*legacy_out.borrow(), *invocation_out.borrow());
+    }
+
+    #[test]
+    fn scalar_state_restores_the_same_output_cell_and_identity() {
+        let lhs = Ref::new("a".to_string());
+        let rhs = Ref::new("b".to_string());
+        let out = Ref::new(String::new());
+        let out_alias = out.clone();
+        let function =
+            ConcatSS::<String>::new_invocation(binary_args(&out, &lhs, &rhs).into()).unwrap();
+        function.solve_result().unwrap();
+        assert_eq!(
+            function.reactive_output_cell_ids(),
+            function.out().reactive_root_cell_ids()
+        );
+
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*function)?;
+            *out.borrow_mut() = "mutated".to_string();
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+
+        assert!(out.same_handle(&out_alias));
+        assert_eq!(&*out.borrow(), "ab");
+    }
+
+    #[test]
+    fn distinct_equal_scalar_outputs_keep_distinct_identity() {
+        let lhs = Ref::new("a".to_string());
+        let rhs = Ref::new("b".to_string());
+        let first_out = Ref::new(String::new());
+        let second_out = Ref::new(String::new());
+        let first = ConcatSS::<String>::new_invocation(
+            binary_args(&first_out, &lhs, &rhs).into(),
+        )
+        .unwrap();
+        let second = ConcatSS::<String>::new_invocation(
+            binary_args(&second_out, &lhs, &rhs).into(),
+        )
+        .unwrap();
+        first.solve_result().unwrap();
+        second.solve_result().unwrap();
+
+        assert_eq!(*first_out.borrow(), *second_out.borrow());
+        assert!(!first_out.same_handle(&second_out));
+        assert_ne!(
+            first.reactive_output_cell_ids(),
+            second.reactive_output_cell_ids()
+        );
+    }
+
+    #[test]
+    fn scalar_factory_rejects_the_wrong_argument_layout() {
+        let lhs = Ref::new("a".to_string());
+        let out = Ref::new(String::new());
+        let error = ConcatSS::<String>::new_invocation(
+            FunctionArgs::Unary(out.to_value(), lhs.to_value()).into(),
+        )
+        .err()
+        .expect("unary layout must be rejected");
+
+        assert_eq!(error.kind_name(), "IncorrectNumberOfArguments");
+        let error = error.kind_as::<IncorrectNumberOfArguments>().unwrap();
+        assert_eq!((error.expected, error.found), (2, 1));
+    }
+
+    #[cfg(feature = "source")]
+    #[test]
+    fn source_specialization_keeps_existing_concat_behavior() {
+        let lhs = Ref::new("source".to_string());
+        let rhs = Ref::new("-path".to_string());
+        let function = StringConcat {}
+            .specialize(&[lhs.to_value(), rhs.to_value()])
+            .unwrap();
+        function.solve_result().unwrap();
+        let LegacyValue::String(out) = function.out() else {
+            panic!("expected string output")
+        };
+        assert_eq!(&*out.borrow(), "source-path");
+    }
+}
+
+#[cfg(all(test, feature = "string", feature = "matrix2", feature = "matrixd"))]
+mod fixed_matrix_port_tests {
+    use super::*;
+
+    fn binary_args<L, R, O>(out: &Ref<O>, lhs: &Ref<L>, rhs: &Ref<R>) -> FunctionArgs
+    where
+        Ref<L>: ToValue,
+        Ref<R>: ToValue,
+        Ref<O>: ToValue,
+    {
+        FunctionArgs::Binary(out.to_value(), lhs.to_value(), rhs.to_value())
+    }
+
+    #[test]
+    fn fixed_matrix_factories_match_and_restore_exact_contents() {
+        let lhs = Ref::new(Matrix2::new(
+            "a".to_string(),
+            "b".to_string(),
+            "c".to_string(),
+            "d".to_string(),
+        ));
+        let rhs = Ref::new(Matrix2::new(
+            "1".to_string(),
+            "2".to_string(),
+            "3".to_string(),
+            "4".to_string(),
+        ));
+        let empty = || Matrix2::from_element(String::new());
+        let legacy_out = Ref::new(empty());
+        let invocation_out = Ref::new(empty());
+        let legacy =
+            ConcatM2M2::<String>::new(binary_args(&legacy_out, &lhs, &rhs)).unwrap();
+        let invocation = ConcatM2M2::<String>::new_invocation(
+            binary_args(&invocation_out, &lhs, &rhs).into(),
+        )
+        .unwrap();
+        legacy.solve_result().unwrap();
+        invocation.solve_result().unwrap();
+        assert_eq!(*legacy_out.borrow(), *invocation_out.borrow());
+        let expected = invocation_out.borrow().clone();
+
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*invocation)?;
+            *invocation_out.borrow_mut() = Matrix2::from_element("changed".to_string());
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(*invocation_out.borrow(), expected);
+    }
+
+    #[test]
+    fn fixed_factory_rejects_dynamic_matrix_storage() {
+        let wrong = Ref::new(DMatrix::from_element(2, 2, "x".to_string()));
+        let rhs = Ref::new(Matrix2::from_element("y".to_string()));
+        let out = Ref::new(Matrix2::from_element(String::new()));
+        let error = ConcatM2M2::<String>::new_invocation(
+            binary_args(&out, &wrong, &rhs).into(),
+        )
+        .err()
+        .expect("dynamic storage must not satisfy a Matrix2 port");
+        assert_eq!(error.kind_name(), "FunctionArgumentTypeMismatch");
+    }
+}
+
+#[cfg(all(
+    test,
+    feature = "string",
+    feature = "matrixd",
+    feature = "vectord",
+    feature = "row_vectord"
+))]
+mod dynamic_matrix_port_tests {
+    use super::*;
+
+    fn binary_args<L, R, O>(out: &Ref<O>, lhs: &Ref<L>, rhs: &Ref<R>) -> FunctionArgs
+    where
+        Ref<L>: ToValue,
+        Ref<R>: ToValue,
+        Ref<O>: ToValue,
+    {
+        FunctionArgs::Binary(out.to_value(), lhs.to_value(), rhs.to_value())
+    }
+
+    fn matrix(values: &[&str]) -> DMatrix<String> {
+        DMatrix::from_row_slice(
+            2,
+            2,
+            &values.iter().map(|value| (*value).to_string()).collect::<Vec<_>>(),
+        )
+    }
+
+    #[test]
+    fn scalar_and_dynamic_matrix_combinations_are_exact() {
+        let scalar = Ref::new("s".to_string());
+        let matrix_ref = Ref::new(matrix(&["a", "b", "c", "d"]));
+
+        let scalar_lhs_out = Ref::new(DMatrix::from_element(2, 2, String::new()));
+        ConcatSMD::<String>::new_invocation(
+            binary_args(&scalar_lhs_out, &scalar, &matrix_ref).into(),
+        )
+        .unwrap()
+        .solve_result()
+        .unwrap();
+        assert_eq!(*scalar_lhs_out.borrow(), matrix(&["sa", "sb", "sc", "sd"]));
+
+        let scalar_rhs_out = Ref::new(DMatrix::from_element(2, 2, String::new()));
+        ConcatMDS::<String>::new_invocation(
+            binary_args(&scalar_rhs_out, &matrix_ref, &scalar).into(),
+        )
+        .unwrap()
+        .solve_result()
+        .unwrap();
+        assert_eq!(*scalar_rhs_out.borrow(), matrix(&["as", "bs", "cs", "ds"]));
+    }
+
+    #[test]
+    fn dynamic_matrix_factories_match_and_restore_shape() {
+        let lhs = Ref::new(matrix(&["a", "b", "c", "d"]));
+        let rhs = Ref::new(matrix(&["1", "2", "3", "4"]));
+        let legacy_out = Ref::new(DMatrix::from_element(2, 2, String::new()));
+        let invocation_out = Ref::new(DMatrix::from_element(2, 2, String::new()));
+        let legacy = ConcatMDMD::<String>::new(binary_args(&legacy_out, &lhs, &rhs)).unwrap();
+        let invocation = ConcatMDMD::<String>::new_invocation(
+            binary_args(&invocation_out, &lhs, &rhs).into(),
+        )
+        .unwrap();
+        legacy.solve_result().unwrap();
+        invocation.solve_result().unwrap();
+        assert_eq!(*legacy_out.borrow(), *invocation_out.borrow());
+        let expected = invocation_out.borrow().clone();
+        assert_eq!(
+            invocation.reactive_output_cell_ids(),
+            invocation.out().reactive_root_cell_ids()
+        );
+
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*invocation)?;
+            *invocation_out.borrow_mut() = DMatrix::from_element(1, 3, "changed".to_string());
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(invocation_out.borrow().shape(), (2, 2));
+        assert_eq!(*invocation_out.borrow(), expected);
+    }
+
+    #[test]
+    fn dynamic_vector_and_row_broadcasts_preserve_orientation() {
+        let matrix_ref = Ref::new(matrix(&["a", "b", "c", "d"]));
+        let vector = Ref::new(DVector::from_vec(vec!["v1".to_string(), "v2".to_string()]));
+        let row = Ref::new(RowDVector::from_vec(vec!["r1".to_string(), "r2".to_string()]));
+        let out = || Ref::new(DMatrix::from_element(2, 2, String::new()));
+
+        let matrix_vector = out();
+        ConcatMDVD::<String>::new_invocation(
+            binary_args(&matrix_vector, &matrix_ref, &vector).into(),
+        )
+        .unwrap()
+        .solve_result()
+        .unwrap();
+        assert_eq!(
+            *matrix_vector.borrow(),
+            matrix(&["av1", "bv1", "cv2", "dv2"])
+        );
+
+        let vector_matrix = out();
+        ConcatVDMD::<String>::new_invocation(
+            binary_args(&vector_matrix, &vector, &matrix_ref).into(),
+        )
+        .unwrap()
+        .solve_result()
+        .unwrap();
+        assert_eq!(
+            *vector_matrix.borrow(),
+            matrix(&["v1a", "v1b", "v2c", "v2d"])
+        );
+
+        let matrix_row = out();
+        ConcatMDRD::<String>::new_invocation(binary_args(&matrix_row, &matrix_ref, &row).into())
+            .unwrap()
+            .solve_result()
+            .unwrap();
+        assert_eq!(*matrix_row.borrow(), matrix(&["ar1", "br2", "cr1", "dr2"]));
+
+        let row_matrix = out();
+        ConcatRDMD::<String>::new_invocation(binary_args(&row_matrix, &row, &matrix_ref).into())
+            .unwrap()
+            .solve_result()
+            .unwrap();
+        assert_eq!(*row_matrix.borrow(), matrix(&["r1a", "r2b", "r1c", "r2d"]));
+    }
+}

--- a/machines/string/src/lib.rs
+++ b/machines/string/src/lib.rs
@@ -134,9 +134,9 @@ macro_rules! impl_string_binop {
             #[cfg(feature = "semantic-compiler")]
             T: ConstElem + CompileConst,
             Ref<$out_type>: ToValue,
-            $arg1_type: FunctionRuntimeType,
-            $arg2_type: FunctionRuntimeType,
-            $out_type: FunctionRuntimeType,
+            $arg1_type: FunctionPortBacking,
+            $arg2_type: FunctionPortBacking,
+            $out_type: FunctionStateBacking,
         {
             const SIGNATURE: RuntimeFunctionSignature = RuntimeFunctionSignature::binary(
                 <$out_type as FunctionRuntimeType>::REPRESENTATION,
@@ -144,34 +144,30 @@ macro_rules! impl_string_binop {
                 <$arg2_type as FunctionRuntimeType>::REPRESENTATION,
             );
 
+            fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+                let (out, lhs, rhs) = invocation.expect_binary()?;
+                let lhs: Ref<$arg1_type> = lhs.try_ref()?;
+                let rhs: Ref<$arg2_type> = rhs.try_ref()?;
+                let out: Ref<$out_type> = out.try_ref()?;
+                Ok(Box::new(Self { lhs, rhs, out }))
+            }
+
             fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-                match args {
-                    FunctionArgs::Binary(out, arg1, arg2) => {
-                        let lhs: Ref<$arg1_type> =
-                            arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                        let rhs: Ref<$arg2_type> =
-                            arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                        let out: Ref<$out_type> =
-                            out.try_function_ref(FunctionArgumentRole::Output)?;
-                        Ok(Box::new(Self { lhs, rhs, out }))
-                    }
-                    _ => Err(MechError::new(
-                        IncorrectNumberOfArguments {
-                            expected: 2,
-                            found: args.len(),
-                        },
-                        None,
-                    )
-                    .with_compiler_loc()),
-                }
+                Self::new_invocation(args.into())
             }
         }
         impl<T> MechFunctionImpl for $struct_name<T>
         where
             T: std::fmt::Debug + Clone + Sync + Send + 'static + Concat,
             Ref<$out_type>: ToValue,
-            $out_type: FunctionRuntimeType,
+            $out_type: FunctionStateBacking,
         {
+            fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+                Some(FunctionStatePort::from_ref(&self.out))
+            }
+            fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+                Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
+            }
             fn solve_result(&self) -> MResult<()> {
                 let lhs_ptr = self.lhs.as_ptr();
                 let rhs_ptr = self.rhs.as_ptr();

--- a/src/core/src/function/state.rs
+++ b/src/core/src/function/state.rs
@@ -14,15 +14,50 @@ use core::fmt;
 
 use crate::{
     FunctionPortBacking, FunctionReactiveCell, FunctionRuntimeType, FunctionValueRepresentation,
-    MResult, Ref, ToValue, ValueStateJournal,
+    MResult, Ref, ToValue,
 };
 
 mod function_state_sealed {
+    pub(super) use crate::ValueStateJournal as Journal;
+
     pub struct FlatElement;
 
-    pub trait Sealed {
+    pub trait PortSealed {
         type ElementShape;
+
+        fn capture(reference: &crate::Ref<Self>, journal: &mut Journal) -> crate::MResult<()>
+        where
+            Self: Sized;
     }
+
+    pub trait ExactSealed: PortSealed {}
+}
+
+/// A runtime backing that can be exposed through an opaque state port.
+///
+/// Implementations choose a private capture strategy. Exact scalar and matrix
+/// backings clone their payload, while supported graph aggregates delegate to
+/// the value-state journal's recursive traversal.
+///
+/// ```compile_fail
+/// use mech_core::{FunctionStatePortBacking, LegacyValue};
+/// fn require_state_port_backing<T: FunctionStatePortBacking>() {}
+/// require_state_port_backing::<LegacyValue>();
+/// ```
+///
+/// ```compile_fail
+/// use mech_core::{FunctionStatePortBacking, ValueCell};
+/// fn require_state_port_backing<T: FunctionStatePortBacking>() {}
+/// require_state_port_backing::<ValueCell>();
+/// ```
+pub trait FunctionStatePortBacking:
+    function_state_sealed::PortSealed + FunctionPortBacking + FunctionRuntimeType + 'static
+{
+}
+
+impl<T> FunctionStatePortBacking for T where
+    T: function_state_sealed::PortSealed + FunctionPortBacking + FunctionRuntimeType + 'static
+{
 }
 
 /// An exact runtime backing whose clone is a complete independent checkpoint.
@@ -43,26 +78,42 @@ mod function_state_sealed {
 /// ```
 ///
 /// ```compile_fail
+/// use mech_core::{FunctionStateBacking, MechSet};
+/// fn require_state_backing<T: FunctionStateBacking>() {}
+/// require_state_backing::<MechSet>();
+/// ```
+///
+/// ```compile_fail
 /// use mech_core::{FunctionStateBacking, Matrix2};
 /// fn require_state_backing<T: FunctionStateBacking>() {}
 /// require_state_backing::<Matrix2<Matrix2<f64>>>();
 /// ```
 pub trait FunctionStateBacking:
-    function_state_sealed::Sealed + FunctionPortBacking + FunctionRuntimeType + Clone + 'static
+    FunctionStatePortBacking + function_state_sealed::ExactSealed + Clone + 'static
 {
 }
 
 impl<T> FunctionStateBacking for T where
-    T: function_state_sealed::Sealed + FunctionPortBacking + FunctionRuntimeType + Clone + 'static
+    T: FunctionStatePortBacking + function_state_sealed::ExactSealed + Clone + 'static
 {
 }
 
 macro_rules! scalar_function_state_backing {
     ($type:ty, $feature:literal) => {
         #[cfg(feature = $feature)]
-        impl function_state_sealed::Sealed for $type {
+        impl function_state_sealed::PortSealed for $type {
             type ElementShape = function_state_sealed::FlatElement;
+
+            fn capture(
+                reference: &Ref<Self>,
+                journal: &mut function_state_sealed::Journal,
+            ) -> MResult<()> {
+                journal.capture_exact_ref(reference)
+            }
         }
+
+        #[cfg(feature = $feature)]
+        impl function_state_sealed::ExactSealed for $type {}
     };
 }
 
@@ -81,32 +132,66 @@ scalar_function_state_backing!(f64, "f64");
 scalar_function_state_backing!(bool, "bool");
 scalar_function_state_backing!(String, "string");
 
-impl function_state_sealed::Sealed for usize {
+impl function_state_sealed::PortSealed for usize {
     type ElementShape = function_state_sealed::FlatElement;
+
+    fn capture(reference: &Ref<Self>, journal: &mut function_state_sealed::Journal) -> MResult<()> {
+        journal.capture_exact_ref(reference)
+    }
 }
+impl function_state_sealed::ExactSealed for usize {}
 
 #[cfg(feature = "complex")]
-impl function_state_sealed::Sealed for crate::C64 {
+impl function_state_sealed::PortSealed for crate::C64 {
     type ElementShape = function_state_sealed::FlatElement;
+
+    fn capture(reference: &Ref<Self>, journal: &mut function_state_sealed::Journal) -> MResult<()> {
+        journal.capture_exact_ref(reference)
+    }
 }
+#[cfg(feature = "complex")]
+impl function_state_sealed::ExactSealed for crate::C64 {}
 
 #[cfg(feature = "rational")]
-impl function_state_sealed::Sealed for crate::R64 {
+impl function_state_sealed::PortSealed for crate::R64 {
     type ElementShape = function_state_sealed::FlatElement;
+
+    fn capture(reference: &Ref<Self>, journal: &mut function_state_sealed::Journal) -> MResult<()> {
+        journal.capture_exact_ref(reference)
+    }
 }
+#[cfg(feature = "rational")]
+impl function_state_sealed::ExactSealed for crate::R64 {}
 
 macro_rules! exact_matrix_function_state_backing {
     ($type:ident, $feature:literal) => {
         #[cfg(feature = $feature)]
-        impl<T> function_state_sealed::Sealed for crate::$type<T>
+        impl<T> function_state_sealed::PortSealed for crate::$type<T>
         where
-            T: function_state_sealed::Sealed<ElementShape = function_state_sealed::FlatElement>
+            T: function_state_sealed::PortSealed<ElementShape = function_state_sealed::FlatElement>
                 + FunctionPortBacking
                 + FunctionRuntimeType
                 + Clone
                 + 'static,
         {
             type ElementShape = ();
+
+            fn capture(
+                reference: &Ref<Self>,
+                journal: &mut function_state_sealed::Journal,
+            ) -> MResult<()> {
+                journal.capture_exact_ref(reference)
+            }
+        }
+
+        #[cfg(feature = $feature)]
+        impl<T> function_state_sealed::ExactSealed for crate::$type<T> where
+            T: function_state_sealed::PortSealed<ElementShape = function_state_sealed::FlatElement>
+                + FunctionPortBacking
+                + FunctionRuntimeType
+                + Clone
+                + 'static
+        {
         }
     };
 }
@@ -127,15 +212,25 @@ exact_matrix_function_state_backing!(Vector4, "vector4");
 exact_matrix_function_state_backing!(DVector, "vectord");
 exact_matrix_function_state_backing!(DMatrix, "matrixd");
 
+#[cfg(feature = "set")]
+impl function_state_sealed::PortSealed for crate::MechSet {
+    type ElementShape = ();
+
+    fn capture(reference: &Ref<Self>, journal: &mut function_state_sealed::Journal) -> MResult<()> {
+        let root = reference.to_value();
+        journal.capture_value(&root)
+    }
+}
+
 trait ErasedFunctionState {
     fn representation(&self) -> FunctionValueRepresentation;
     fn reactive_cell_ids(&self) -> Vec<FunctionReactiveCell>;
-    fn capture(&self, journal: &mut ValueStateJournal) -> MResult<()>;
+    fn capture(&self, journal: &mut function_state_sealed::Journal) -> MResult<()>;
 }
 
 impl<T> ErasedFunctionState for Ref<T>
 where
-    T: FunctionStateBacking,
+    T: FunctionStatePortBacking,
     Ref<T>: ToValue,
 {
     fn representation(&self) -> FunctionValueRepresentation {
@@ -146,12 +241,12 @@ where
         self.to_value().reactive_root_cell_ids()
     }
 
-    fn capture(&self, journal: &mut ValueStateJournal) -> MResult<()> {
-        journal.capture_exact_ref(self)
+    fn capture(&self, journal: &mut function_state_sealed::Journal) -> MResult<()> {
+        <T as function_state_sealed::PortSealed>::capture(self, journal)
     }
 }
 
-/// A borrowed, opaque capability over one exact typed function-owned cell.
+/// A borrowed, opaque capability over one typed function-owned state root.
 ///
 /// State ports reveal only the cell's declared representation. They do not
 /// expose its payload, typed reference, physical identity, or a legacy value.
@@ -161,10 +256,10 @@ pub struct FunctionStatePort<'a> {
 }
 
 impl<'a> FunctionStatePort<'a> {
-    /// Borrows an exact typed cell without cloning either its handle or payload.
+    /// Borrows a typed state root without cloning either its handle or payload.
     pub fn from_ref<T>(reference: &'a Ref<T>) -> Self
     where
-        T: FunctionStateBacking,
+        T: FunctionStatePortBacking,
         Ref<T>: ToValue,
     {
         Self { inner: reference }
@@ -178,7 +273,7 @@ impl<'a> FunctionStatePort<'a> {
         self.inner.reactive_cell_ids()
     }
 
-    pub(crate) fn capture_into(self, journal: &mut ValueStateJournal) -> MResult<()> {
+    pub(crate) fn capture_into(self, journal: &mut crate::ValueStateJournal) -> MResult<()> {
         self.inner.capture(journal)
     }
 }
@@ -196,6 +291,14 @@ impl fmt::Debug for FunctionStatePort<'_> {
 mod tests {
     use super::*;
     use crate::{DMatrix, FunctionMatrixRepresentation, FunctionMatrixStoragePattern, Matrix2};
+
+    fn require_exact_state<T: FunctionStateBacking>() {}
+
+    #[test]
+    fn scalar_and_matrix_backings_remain_exact() {
+        require_exact_state::<f64>();
+        require_exact_state::<Matrix2<f64>>();
+    }
 
     #[test]
     fn scalar_state_port_borrows_the_existing_cell_and_reports_exact_representation() {
@@ -231,6 +334,30 @@ mod tests {
     }
 
     #[test]
+    fn exact_ports_restore_the_original_scalar_and_matrix_cells() {
+        let scalar = Ref::new(1.25_f64);
+        let scalar_alias = scalar.clone();
+        let matrix = Ref::new(Matrix2::new(1.0_f64, 2.0, 3.0, 4.0));
+        let matrix_alias = matrix.clone();
+        let mut journal = Default::default();
+
+        FunctionStatePort::from_ref(&scalar)
+            .capture_into(&mut journal)
+            .unwrap();
+        FunctionStatePort::from_ref(&matrix)
+            .capture_into(&mut journal)
+            .unwrap();
+        *scalar.borrow_mut() = 9.0;
+        *matrix.borrow_mut() = Matrix2::new(9.0, 8.0, 7.0, 6.0);
+        journal.restore_before().unwrap();
+
+        assert!(scalar.same_handle(&scalar_alias));
+        assert!(matrix.same_handle(&matrix_alias));
+        assert_eq!(*scalar.borrow(), 1.25);
+        assert_eq!(*matrix.borrow(), Matrix2::new(1.0, 2.0, 3.0, 4.0));
+    }
+
+    #[test]
     fn state_port_debug_exposes_only_the_representation() {
         let reference = Ref::new(1234.56789_f64);
         let debug = format!("{:?}", FunctionStatePort::from_ref(&reference));
@@ -241,5 +368,175 @@ mod tests {
         assert!(!debug.contains("ReactiveCellId"));
         assert!(!debug.contains("0x"));
         assert!(!debug.contains('@'));
+    }
+}
+
+#[cfg(all(test, feature = "set", feature = "tuple", feature = "f64"))]
+mod set_graph_tests {
+    use super::*;
+    use crate::{LegacyValue, MechSet, MechTuple};
+
+    fn scalar(value: f64) -> Ref<f64> {
+        Ref::new(value)
+    }
+
+    fn scalar_value(reference: &Ref<f64>) -> LegacyValue {
+        reference.to_value()
+    }
+
+    fn scalar_member(value: &LegacyValue) -> Ref<f64> {
+        value.expect_f64().unwrap()
+    }
+
+    fn require_state_port<T: FunctionStatePortBacking>() {}
+
+    #[test]
+    fn mech_set_is_a_graph_state_port_backing_with_legacy_identity() {
+        require_state_port::<MechSet>();
+
+        let set = Ref::new(MechSet::from_vec(vec![scalar_value(&scalar(1.0))]));
+        let legacy = set.to_value();
+        let port = FunctionStatePort::from_ref(&set);
+
+        assert_eq!(port.representation(), FunctionValueRepresentation::Set);
+        assert_eq!(port.reactive_cell_ids(), legacy.reactive_root_cell_ids());
+
+        let debug = format!("{port:?}");
+        assert_eq!(debug, "FunctionStatePort { representation: Set }");
+        assert!(!debug.contains("1.0"));
+        assert!(!debug.contains("ReactiveCellId"));
+        assert!(!debug.contains("0x"));
+        assert!(!debug.contains('@'));
+    }
+
+    #[test]
+    fn graph_port_restores_set_root_metadata_order_and_nested_cells() {
+        let removed = scalar(1.0);
+        let retained = scalar(2.0);
+        let added = scalar(3.0);
+        let set = Ref::new(MechSet {
+            kind: scalar_value(&removed).kind(),
+            max_elements: Some(2),
+            num_elements: 2,
+            set: [scalar_value(&removed), scalar_value(&retained)]
+                .into_iter()
+                .collect(),
+        });
+        let set_alias = set.clone();
+        let mut journal = Default::default();
+        FunctionStatePort::from_ref(&set)
+            .capture_into(&mut journal)
+            .unwrap();
+
+        let changed_kind = set.to_value().kind();
+        {
+            let mut payload = set.borrow_mut();
+            payload.set.shift_remove(&scalar_value(&removed));
+            payload.set.insert(scalar_value(&added));
+            payload.kind = changed_kind;
+            payload.max_elements = Some(9);
+            payload.num_elements = 9;
+        }
+        *retained.borrow_mut() = 20.0;
+        journal.restore_before().unwrap();
+
+        assert!(set.same_handle(&set_alias));
+        let payload = set.borrow();
+        assert_eq!(payload.kind, scalar_value(&removed).kind());
+        assert_eq!(payload.max_elements, Some(2));
+        assert_eq!(payload.num_elements, 2);
+        let members = payload.set.iter().map(scalar_member).collect::<Vec<_>>();
+        assert!(members[0].same_handle(&removed));
+        assert!(members[1].same_handle(&retained));
+        assert_eq!((*members[0].borrow(), *members[1].borrow()), (1.0, 2.0));
+    }
+
+    #[test]
+    fn graph_port_preserves_nested_sets_and_shared_cells() {
+        let shared = scalar(4.0);
+        let left = Ref::new(MechTuple::from_vec(vec![
+            scalar(1.0).to_value(),
+            scalar_value(&shared),
+        ]));
+        let right = Ref::new(MechTuple::from_vec(vec![
+            scalar(2.0).to_value(),
+            scalar_value(&shared),
+        ]));
+        let inner = Ref::new(MechSet::from_vec(vec![left.to_value(), right.to_value()]));
+        let outer = Ref::new(MechSet::from_vec(vec![inner.to_value()]));
+        let mut journal = Default::default();
+        FunctionStatePort::from_ref(&outer)
+            .capture_into(&mut journal)
+            .unwrap();
+
+        let changed_kind = inner.to_value().kind();
+        *shared.borrow_mut() = 40.0;
+        inner.borrow_mut().kind = changed_kind.clone();
+        outer.borrow_mut().num_elements = 99;
+        journal.restore_before().unwrap();
+
+        assert!(outer.borrow().set.contains(&inner.to_value()));
+        assert!(inner.borrow().set.contains(&left.to_value()));
+        assert!(inner.borrow().set.contains(&right.to_value()));
+        let tuples = [left, right];
+        let tuple_scalar = |tuple: &Ref<MechTuple>| {
+            let tuple = tuple.borrow();
+            scalar_member(&tuple.elements[1])
+        };
+        let left_shared = tuple_scalar(&tuples[0]);
+        let right_shared = tuple_scalar(&tuples[1]);
+        assert!(left_shared.same_handle(&shared));
+        assert!(right_shared.same_handle(&shared));
+        assert!(left_shared.same_handle(&right_shared));
+        assert_eq!(*shared.borrow(), 4.0);
+        assert_eq!(outer.borrow().num_elements, 1);
+        assert_ne!(inner.borrow().kind, changed_kind);
+    }
+
+    #[test]
+    fn graph_ports_deduplicate_and_keep_equal_roots_distinct() {
+        let first = Ref::new(MechSet::from_vec(vec![scalar_value(&scalar(1.0))]));
+        let second = Ref::new(MechSet::from_vec(vec![scalar_value(&scalar(1.0))]));
+        let mut journal = Default::default();
+
+        FunctionStatePort::from_ref(&first)
+            .capture_into(&mut journal)
+            .unwrap();
+        assert_eq!(journal.cell_count(), 2);
+        FunctionStatePort::from_ref(&first)
+            .capture_into(&mut journal)
+            .unwrap();
+        assert_eq!(journal.cell_count(), 2);
+        FunctionStatePort::from_ref(&second)
+            .capture_into(&mut journal)
+            .unwrap();
+        assert_eq!(journal.cell_count(), 4);
+        assert!(!first.same_handle(&second));
+    }
+
+    #[test]
+    fn graph_port_delta_rewinds_and_replays() {
+        let member = scalar(1.0);
+        let set = Ref::new(MechSet::from_vec(vec![scalar_value(&member)]));
+        let set_alias = set.clone();
+        let mut journal = Default::default();
+        FunctionStatePort::from_ref(&set)
+            .capture_into(&mut journal)
+            .unwrap();
+
+        *member.borrow_mut() = 2.0;
+        set.borrow_mut().max_elements = Some(7);
+        journal.record_after().unwrap();
+        let delta = journal.into_delta().unwrap();
+
+        delta.rewind().unwrap();
+        assert!(set.same_handle(&set_alias));
+        assert_eq!(*member.borrow(), 1.0);
+        assert_eq!(set.borrow().max_elements, Some(1));
+
+        delta.replay().unwrap();
+        assert!(set.same_handle(&set_alias));
+        assert_eq!(*member.borrow(), 2.0);
+        assert_eq!(set.borrow().max_elements, Some(7));
     }
 }


### PR DESCRIPTION
## Summary

This PR is stacked directly on the current PR7 head `e014ce8f326842d2ef6ad5366642751e5bfe3c1f`.

Rebased PR8 head: `e4ff3d10959bcc26cb45739fb696e5ac74aecd5c`.

- Adds a sealed `FunctionStatePortBacking` boundary for both exact state and graph-backed state capture.
- Keeps `FunctionStateBacking` as the exact-clone subset.
- Captures `MechSet` state by traversing its complete reachable value graph through the journal.
- Migrates all 14 typed set factories to `FunctionInvocation` and typed ports.
- Adds output and transaction state ports to all 18 set functions.
- Migrates all string concat factories and output state to invocation and port boundaries.
- Preserves source specializers, canonical IDs, catalogs, algorithms, and legacy compatibility entry points.

## Boundary behavior

| Area | Result |
| --- | --- |
| Exact scalar and matrix state | Continues to use exact typed capture through `FunctionStateBacking` |
| Set state | Uses graph-backed `MechSet` capture through `FunctionStatePortBacking` |
| Typed set factories | Validate and extract through `FunctionInvocation` ports |
| Set outputs | Expose primary output and transaction checkpoint state ports |
| String concat | Uses exact invocation extraction and output state ports across scalar, matrix, and broadcast layouts |
| Legacy callers | Existing `new(FunctionArgs)` compatibility adapters remain available |

## Explicit compatibility exceptions

The four arbitrary-value set operations remain on the legacy bridge:

- element-of
- not-element-of
- insert
- remove

Those operations accept arbitrary `LegacyValue` payloads. `MechSet` also stores `LegacyValue`, so migrating those inputs requires a canonical arbitrary-value representation that is outside this PR. `MechSet` is intentionally supported by `FunctionStatePortBacking`, but not by the exact-only `FunctionStateBacking` marker.

## Non-goals

- No changes to source specialization or lowering.
- No catalog, identifier, signature, semantic-contract, or algorithm changes.
- No removal of the legacy factory ABI.
- No migration of the four arbitrary-value set inputs.

## Commit structure

1. `feat(core): support graph-backed function state ports`
2. `refactor(set): route typed set factories through invocations`
3. `refactor(set): checkpoint all set outputs through state ports`
4. `refactor(string): migrate concat factories and output state`

## Local validation

Completed successfully:

- Core all-feature tests: 404 passed.
- Core compile-fail documentation tests: 8 passed.
- Bytecode all-feature tests.
- Engine full compiler tests: 293 passed.
- Runtime full compiler tests: 465 passed.
- Set full profile: 22 passed.
- Set standard profile: 4 passed.
- Typed set profile with tuple support: 11 passed.
- Arbitrary-value set compatibility tests: 4 passed.
- String full profile: 11 passed.
- String standard profile: 9 passed.
- String scalar profile: 4 passed.
- String dynamic profile: 7 passed.

Additional evidence:

- The rebased branch contains exactly 4 commits across 23 changed files; each commit compiles independently.
- All five architecture checks pass. Retirement mode reports 22 reviewed `LegacyValue` occurrences removed and zero unaudited growth.
- Function-system source and consumer compatibility slices pass. The complete script stops at the documented frozen math compiler-profile assertion on both current PR7 and PR8.
- The prescribed typed-set profile without `tuple` fails identically on current PR7 and PR8 because cartesian product requires tuple support; the corrected profile passes all 11 tests.
- Catalogs, configuration, frozen contracts, and unrelated machinery are unchanged from current PR7.
- Hosted selected CI is green, including Static Contracts, Linux, Windows, browser canary, all owner shards, and the PR gate. The browser canary passed on retry after a transient null-DOM startup race.

The PR remains draft for re-review.

