### PR TITLE
[PR9] refactor(machinery): migrate range, combinatorics, and op-assignment ports

### DIFF
--- a/machines/combinatorics/src/n_choose_k.rs
+++ b/machines/combinatorics/src/n_choose_k.rs
@@ -105,10 +105,9 @@ pub(crate) fn bind_resident_n_choose_k_f64(
             })
         || output.alias != AliasPolicy::NoAlias
         || output.change_detection != ChangeDetectionPolicy::ExactScalar
-        || request
-            .inputs
-            .iter()
-            .any(|input| input.kind != ResidentValueKind::F64 || input.shape != ResidentShape::SCALAR)
+        || request.inputs.iter().any(|input| {
+            input.kind != ResidentValueKind::F64 || input.shape != ResidentShape::SCALAR
+        })
         || request.output.kind != ResidentValueKind::F64
         || request.output.shape != ResidentShape::SCALAR
     {
@@ -295,25 +294,21 @@ fn scalar_selection_count(value: &LegacyValue) -> Option<u128> {
         #[cfg(feature = "f32")]
         LegacyValue::F32(value) => {
             let value = *value.borrow();
-            (value.is_finite()
-                && value >= 0.0
-                && value.fract() == 0.0
-                && value <= u128::MAX as f32)
+            (value.is_finite() && value >= 0.0 && value.fract() == 0.0 && value <= u128::MAX as f32)
                 .then_some(value as u128)
         }
         #[cfg(feature = "f64")]
         LegacyValue::F64(value) => {
             let value = *value.borrow();
-            (value.is_finite()
-                && value >= 0.0
-                && value.fract() == 0.0
-                && value <= u128::MAX as f64)
+            (value.is_finite() && value >= 0.0 && value.fract() == 0.0 && value <= u128::MAX as f64)
                 .then_some(value as u128)
         }
         #[cfg(feature = "r64")]
         LegacyValue::R64(value) => {
             let value = value.borrow();
-            (*value.denom() == 1).then(|| u128::try_from(*value.numer()).ok()).flatten()
+            (*value.denom() == 1)
+                .then(|| u128::try_from(*value.numer()).ok())
+                .flatten()
         }
         #[cfg(feature = "c64")]
         LegacyValue::C64(value) => {
@@ -368,12 +363,12 @@ fn validate_n_choose_k_scalar_values(n: &LegacyValue, k: &LegacyValue) -> MResul
 
 pub(crate) fn validate_n_choose_k_scalar_contract(args: &FunctionArgs) -> MResult<()> {
     let contract = "n_choose_k_scalar";
-    let n = args.input_value(0).ok_or_else(|| {
-        function_shape_contract_violation(contract, "missing input 0")
-    })?;
-    let k = args.input_value(1).ok_or_else(|| {
-        function_shape_contract_violation(contract, "missing input 1")
-    })?;
+    let n = args
+        .input_value(0)
+        .ok_or_else(|| function_shape_contract_violation(contract, "missing input 0"))?;
+    let k = args
+        .input_value(1)
+        .ok_or_else(|| function_shape_contract_violation(contract, "missing input 1"))?;
     validate_n_choose_k_scalar_values(n, k)
 }
 
@@ -729,12 +724,7 @@ mod scalar_contract_tests {
         ))
         .unwrap();
         let invocation = NChooseK::<f64>::new_invocation(
-            FunctionArgs::Binary(
-                invocation_out.to_value(),
-                n.to_value(),
-                k.to_value(),
-            )
-            .into(),
+            FunctionArgs::Binary(invocation_out.to_value(), n.to_value(), k.to_value()).into(),
         )
         .unwrap();
         legacy.solve_result().unwrap();
@@ -772,12 +762,8 @@ mod scalar_contract_tests {
 
         assert!(
             NChooseK::<f64>::new_invocation(
-                FunctionArgs::Binary(
-                    out.to_value(),
-                    Ref::new(5_usize).to_value(),
-                    k.to_value(),
-                )
-                .into(),
+                FunctionArgs::Binary(out.to_value(), Ref::new(5_usize).to_value(), k.to_value(),)
+                    .into(),
             )
             .is_err()
         );
@@ -796,12 +782,7 @@ mod scalar_contract_tests {
         let n = Ref::new(10.0_f64);
         let out = Ref::new(0.0_f64);
         let function = NChooseK::<f64>::new_invocation(
-            FunctionArgs::Binary(
-                out.to_value(),
-                n.to_value(),
-                Ref::new(2.0_f64).to_value(),
-            )
-            .into(),
+            FunctionArgs::Binary(out.to_value(), n.to_value(), Ref::new(2.0_f64).to_value()).into(),
         )
         .unwrap();
         function.solve_result().unwrap();
@@ -1002,9 +983,9 @@ where
     T: CompileConst + ConstElem,
     Ref<T>: ToValue,
     Ref<DMatrix<T>>: ToValue,
-    T: FunctionRuntimeType,
+    T: FunctionPortBacking,
     Matrix<T>: FunctionRuntimeType,
-    DMatrix<T>: FunctionRuntimeType,
+    DMatrix<T>: FunctionRuntimeType + FunctionStateBacking,
 {
     const SIGNATURE: RuntimeFunctionSignature = RuntimeFunctionSignature::binary(
         <DMatrix<T> as FunctionRuntimeType>::REPRESENTATION,
@@ -1012,23 +993,16 @@ where
         T::REPRESENTATION,
     );
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, n, k) = invocation.expect_binary()?;
+        let n: Matrix<T> = n.try_matrix()?;
+        let k: Ref<T> = k.try_ref()?;
+        let out: Ref<DMatrix<T>> = out.try_ref()?;
+        Ok(Box::new(Self { n, k, out }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Binary(out, arg1, arg2) => {
-                let n: Matrix<T> = arg1.try_function_matrix(FunctionArgumentRole::Input(0))?;
-                let k: Ref<T> = arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                let out: Ref<DMatrix<T>> = out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(Self { n, k, out }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 2,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 #[cfg(all(feature = "matrix", feature = "matrixd"))]
@@ -1051,10 +1025,17 @@ where
         + PartialOrd,
     Ref<T>: ToValue,
     Ref<DMatrix<T>>: ToValue,
+    DMatrix<T>: FunctionStateBacking,
 {
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
+    }
     fn solve_result(&self) -> MResult<()> {
-        let requested = matrix_selection_size(&self.k.to_value())
-            .ok_or_else(invalid_matrix_selection_value)?;
+        let requested =
+            matrix_selection_size(&self.k.to_value()).ok_or_else(invalid_matrix_selection_value)?;
         let next = n_choose_k_matrix_result(&self.n, requested)?;
         *self.out.borrow_mut() = next;
         Ok(())
@@ -1090,6 +1071,72 @@ where
 mod transaction_state_tests {
     use super::*;
 
+    fn framed(payload: &[u8]) -> Vec<u8> {
+        let mut framed = (payload.len() as u32).to_le_bytes().to_vec();
+        framed.extend_from_slice(payload);
+        framed
+    }
+
+    fn decoded_matrix_wrapper(reference: bool) -> LegacyValue {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&2_u32.to_le_bytes());
+        payload.extend_from_slice(&1_u32.to_le_bytes());
+        payload.extend_from_slice(&1.0_f64.to_le_bytes());
+        payload.extend_from_slice(&2.0_f64.to_le_bytes());
+        let matrix_type = RuntimeType::Matrix {
+            element: Box::new(RuntimeType::F64),
+            storage: MatrixStorage::MatrixD,
+            rows: 2,
+            cols: 1,
+        };
+        let (runtime_type, bytes) = if reference {
+            (
+                RuntimeType::Reference(Box::new(matrix_type)),
+                framed(&payload),
+            )
+        } else {
+            let mut bytes = vec![1];
+            bytes.extend(framed(&payload));
+            (RuntimeType::Option(Box::new(matrix_type)), bytes)
+        };
+        decode_encoded_constants(&[EncodedConstant {
+            runtime_type,
+            alignment: 8,
+            bytes,
+        }])
+        .unwrap()
+        .pop()
+        .unwrap()
+    }
+
+    fn decoded_index_matrix() -> LegacyValue {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&2_u32.to_le_bytes());
+        bytes.extend_from_slice(&1_u32.to_le_bytes());
+        bytes.extend_from_slice(&1_u64.to_le_bytes());
+        bytes.extend_from_slice(&2_u64.to_le_bytes());
+        decode_encoded_constants(&[EncodedConstant {
+            runtime_type: RuntimeType::Matrix {
+                element: Box::new(RuntimeType::Index),
+                storage: MatrixStorage::MatrixD,
+                rows: 2,
+                cols: 1,
+            },
+            alignment: 8,
+            bytes,
+        }])
+        .unwrap()
+        .pop()
+        .unwrap()
+    }
+
+    fn factory_error(result: MResult<Box<dyn MechFunction>>) -> MechError {
+        match result {
+            Ok(_) => panic!("factory unexpectedly accepted invalid arguments"),
+            Err(error) => error,
+        }
+    }
+
     #[test]
     fn matrix_combinations_expose_value_backed_transaction_state() {
         let n = f64::to_matrix(vec![1.0, 2.0], 2, 1);
@@ -1105,6 +1152,83 @@ mod transaction_state_tests {
     }
 
     #[test]
+    fn matrix_factory_ports_preserve_dynamic_input_handles_and_match_legacy_factory() {
+        let n_ref = Ref::new(DMatrix::from_vec(3, 1, vec![1.0, 2.0, 3.0]));
+        let n_alias = n_ref.clone();
+        let n = Matrix::DMatrix(n_ref.clone());
+        let k = Ref::new(2.0_f64);
+        let legacy_out = Ref::new(DMatrix::zeros(1, 1));
+        let invocation_out = Ref::new(DMatrix::zeros(1, 1));
+        let invocation_alias = invocation_out.clone();
+        let legacy = NChooseKMatrix::<f64>::new(FunctionArgs::Binary(
+            legacy_out.to_value(),
+            n.to_value(),
+            k.to_value(),
+        ))
+        .unwrap();
+        let invocation = NChooseKMatrix::<f64>::new_invocation(
+            FunctionArgs::Binary(invocation_out.to_value(), n.to_value(), k.to_value()).into(),
+        )
+        .unwrap();
+
+        n_ref.borrow_mut()[(0, 0)] = 4.0;
+        legacy.solve_result().unwrap();
+        invocation.solve_result().unwrap();
+
+        assert!(n_ref.same_handle(&n_alias));
+        assert!(invocation_out.same_handle(&invocation_alias));
+        assert_eq!(*legacy_out.borrow(), *invocation_out.borrow());
+        assert_eq!(invocation_out.borrow().shape(), (2, 3));
+        assert_eq!(
+            invocation_out.borrow().as_slice(),
+            &[4.0, 2.0, 4.0, 3.0, 2.0, 3.0]
+        );
+        assert_eq!(
+            invocation.reactive_output_cell_ids(),
+            invocation.out().reactive_root_cell_ids(),
+        );
+
+        let successful = invocation_out.borrow().clone();
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*invocation)?;
+            *invocation_out.borrow_mut() = DMatrix::from_element(2, 2, 99.0);
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+        assert!(invocation_out.same_handle(&invocation_alias));
+        assert_eq!(*invocation_out.borrow(), successful);
+    }
+
+    #[test]
+    fn matrix_factory_ports_reject_layout_scalar_element_type_and_wrappers() {
+        let out: Ref<DMatrix<f64>> = Ref::new(DMatrix::zeros(1, 1));
+        let k = Ref::new(1.0_f64);
+        let n = f64::to_matrixd(vec![1.0, 2.0], 2, 1);
+
+        let layout = factory_error(NChooseKMatrix::<f64>::new_invocation(
+            FunctionArgs::Unary(out.to_value(), n.to_value()).into(),
+        ));
+        let arity = layout.kind_as::<IncorrectNumberOfArguments>().unwrap();
+        assert_eq!((arity.expected, arity.found), (2, 1));
+
+        for wrong_input in [
+            Ref::new(1.0_f64).to_value(),
+            decoded_index_matrix(),
+            decoded_matrix_wrapper(false),
+            decoded_matrix_wrapper(true),
+        ] {
+            assert!(
+                NChooseKMatrix::<f64>::new_invocation(
+                    FunctionArgs::Binary(out.to_value(), wrong_input, k.to_value()).into(),
+                )
+                .is_err()
+            );
+        }
+    }
+
+    #[test]
     fn matrix_combinations_reuse_one_output_root_across_shape_changes() {
         let n = f64::to_matrix(vec![1.0, 2.0, 3.0], 3, 1);
         let k = Ref::new(1.0);
@@ -1114,7 +1238,7 @@ mod transaction_state_tests {
             k: k.clone(),
             out: out.clone(),
         };
-        let output_cell = out.id();
+        let output_alias = out.clone();
 
         function.solve_result().unwrap();
         assert_eq!(out.borrow().shape(), (1, 3));
@@ -1122,13 +1246,13 @@ mod transaction_state_tests {
 
         *k.borrow_mut() = 2.0;
         function.solve_result().unwrap();
-        assert_eq!(out.id(), output_cell);
+        assert!(out.same_handle(&output_alias));
         assert_eq!(out.borrow().shape(), (2, 3));
         assert_eq!(out.borrow().as_slice(), &[1.0, 2.0, 1.0, 3.0, 2.0, 3.0]);
 
         *k.borrow_mut() = 3.0;
         function.solve_result().unwrap();
-        assert_eq!(out.id(), output_cell);
+        assert!(out.same_handle(&output_alias));
         assert_eq!(out.borrow().shape(), (3, 1));
         assert_eq!(out.borrow().as_slice(), &[1.0, 2.0, 3.0]);
     }
@@ -1145,13 +1269,55 @@ mod transaction_state_tests {
         };
         function.solve_result().unwrap();
         let expected = out.borrow().clone();
+        let out_alias = out.clone();
 
-        for invalid in [0.0, 4.0] {
-            *k.borrow_mut() = invalid;
-            let error = function.solve_result().unwrap_err();
-            assert_eq!(error.kind_name(), "NChooseKMatrixSelectionInvalid");
-            assert_eq!(*out.borrow(), expected);
-        }
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&function)?;
+            for invalid in [0.0, 4.0] {
+                *k.borrow_mut() = invalid;
+                let error = function.solve_result().unwrap_err();
+                assert_eq!(error.kind_name(), "NChooseKMatrixSelectionInvalid");
+                assert_eq!(*out.borrow(), expected);
+            }
+            *out.borrow_mut() = DMatrix::from_element(2, 2, -1.0);
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+        assert!(out.same_handle(&out_alias));
+        assert_eq!(*out.borrow(), expected);
+    }
+}
+
+#[cfg(all(
+    test,
+    feature = "matrix",
+    feature = "matrix2",
+    feature = "matrixd",
+    feature = "f64"
+))]
+mod fixed_matrix_port_tests {
+    use super::*;
+    use nalgebra::Matrix2;
+
+    #[test]
+    fn fixed_matrix_input_retains_exact_representation_and_inner_handle() {
+        let n_ref = Ref::new(Matrix2::from_vec(vec![1.0, 2.0, 3.0, 4.0]));
+        let n_alias = n_ref.clone();
+        let n = Matrix::Matrix2(n_ref.clone());
+        let out: Ref<DMatrix<f64>> = Ref::new(DMatrix::zeros(1, 1));
+        let function = NChooseKMatrix::<f64>::new_invocation(
+            FunctionArgs::Binary(out.to_value(), n.to_value(), Ref::new(1.0_f64).to_value()).into(),
+        )
+        .unwrap();
+
+        n_ref.borrow_mut()[(0, 0)] = 8.0;
+        function.solve_result().unwrap();
+
+        assert!(n_ref.same_handle(&n_alias));
+        assert_eq!(out.borrow().shape(), (1, 4));
+        assert_eq!(out.borrow().as_slice(), &[8.0, 2.0, 3.0, 4.0]);
     }
 }
 
@@ -1167,10 +1333,7 @@ mod signed_matrix_selection_tests {
         let args = FunctionArgs::Binary(out.to_value(), n.to_value(), k.to_value());
 
         let planning_error = validate_n_choose_k_matrix_contract(&args).unwrap_err();
-        assert_eq!(
-            planning_error.kind_name(),
-            "FunctionShapeContractViolation"
-        );
+        assert_eq!(planning_error.kind_name(), "FunctionShapeContractViolation");
 
         let function = NChooseKMatrix {
             n,
@@ -1211,6 +1374,7 @@ where
     T: ConstElem + CompileConst,
     Ref<T>: ToValue,
     Ref<DMatrix<T>>: ToValue,
+    DMatrix<T>: FunctionStateBacking,
 {
     Box::new(NChooseKMatrix {
         n,
@@ -1220,7 +1384,10 @@ where
 }
 
 #[cfg(feature = "source")]
-fn impl_combinatorics_n_choose_k_fxn(n: LegacyValue, k: LegacyValue) -> MResult<Box<dyn MechFunction>> {
+fn impl_combinatorics_n_choose_k_fxn(
+    n: LegacyValue,
+    k: LegacyValue,
+) -> MResult<Box<dyn MechFunction>> {
     match (n, k) {
         #[cfg(feature = "u8")]
         (LegacyValue::U8(n), LegacyValue::U8(k)) => Ok(Box::new(NChooseK {
@@ -1307,33 +1474,61 @@ fn impl_combinatorics_n_choose_k_fxn(n: LegacyValue, k: LegacyValue) -> MResult<
             out: Ref::new(C64::default()),
         })),
         #[cfg(all(feature = "matrix", feature = "matrixd", feature = "u8"))]
-        (LegacyValue::MatrixU8(n), LegacyValue::U8(k)) => Ok(n_choose_k_matrix_specialization(n, k)),
+        (LegacyValue::MatrixU8(n), LegacyValue::U8(k)) => {
+            Ok(n_choose_k_matrix_specialization(n, k))
+        }
         #[cfg(all(feature = "matrix", feature = "matrixd", feature = "u16"))]
-        (LegacyValue::MatrixU16(n), LegacyValue::U16(k)) => Ok(n_choose_k_matrix_specialization(n, k)),
+        (LegacyValue::MatrixU16(n), LegacyValue::U16(k)) => {
+            Ok(n_choose_k_matrix_specialization(n, k))
+        }
         #[cfg(all(feature = "matrix", feature = "matrixd", feature = "u32"))]
-        (LegacyValue::MatrixU32(n), LegacyValue::U32(k)) => Ok(n_choose_k_matrix_specialization(n, k)),
+        (LegacyValue::MatrixU32(n), LegacyValue::U32(k)) => {
+            Ok(n_choose_k_matrix_specialization(n, k))
+        }
         #[cfg(all(feature = "matrix", feature = "matrixd", feature = "u64"))]
-        (LegacyValue::MatrixU64(n), LegacyValue::U64(k)) => Ok(n_choose_k_matrix_specialization(n, k)),
+        (LegacyValue::MatrixU64(n), LegacyValue::U64(k)) => {
+            Ok(n_choose_k_matrix_specialization(n, k))
+        }
         #[cfg(all(feature = "matrix", feature = "matrixd", feature = "u128"))]
-        (LegacyValue::MatrixU128(n), LegacyValue::U128(k)) => Ok(n_choose_k_matrix_specialization(n, k)),
+        (LegacyValue::MatrixU128(n), LegacyValue::U128(k)) => {
+            Ok(n_choose_k_matrix_specialization(n, k))
+        }
         #[cfg(all(feature = "matrix", feature = "matrixd", feature = "i8"))]
-        (LegacyValue::MatrixI8(n), LegacyValue::I8(k)) => Ok(n_choose_k_matrix_specialization(n, k)),
+        (LegacyValue::MatrixI8(n), LegacyValue::I8(k)) => {
+            Ok(n_choose_k_matrix_specialization(n, k))
+        }
         #[cfg(all(feature = "matrix", feature = "matrixd", feature = "i16"))]
-        (LegacyValue::MatrixI16(n), LegacyValue::I16(k)) => Ok(n_choose_k_matrix_specialization(n, k)),
+        (LegacyValue::MatrixI16(n), LegacyValue::I16(k)) => {
+            Ok(n_choose_k_matrix_specialization(n, k))
+        }
         #[cfg(all(feature = "matrix", feature = "matrixd", feature = "i32"))]
-        (LegacyValue::MatrixI32(n), LegacyValue::I32(k)) => Ok(n_choose_k_matrix_specialization(n, k)),
+        (LegacyValue::MatrixI32(n), LegacyValue::I32(k)) => {
+            Ok(n_choose_k_matrix_specialization(n, k))
+        }
         #[cfg(all(feature = "matrix", feature = "matrixd", feature = "i64"))]
-        (LegacyValue::MatrixI64(n), LegacyValue::I64(k)) => Ok(n_choose_k_matrix_specialization(n, k)),
+        (LegacyValue::MatrixI64(n), LegacyValue::I64(k)) => {
+            Ok(n_choose_k_matrix_specialization(n, k))
+        }
         #[cfg(all(feature = "matrix", feature = "matrixd", feature = "i128"))]
-        (LegacyValue::MatrixI128(n), LegacyValue::I128(k)) => Ok(n_choose_k_matrix_specialization(n, k)),
+        (LegacyValue::MatrixI128(n), LegacyValue::I128(k)) => {
+            Ok(n_choose_k_matrix_specialization(n, k))
+        }
         #[cfg(all(feature = "matrix", feature = "matrixd", feature = "f32"))]
-        (LegacyValue::MatrixF32(n), LegacyValue::F32(k)) => Ok(n_choose_k_matrix_specialization(n, k)),
+        (LegacyValue::MatrixF32(n), LegacyValue::F32(k)) => {
+            Ok(n_choose_k_matrix_specialization(n, k))
+        }
         #[cfg(all(feature = "matrix", feature = "matrixd", feature = "f64"))]
-        (LegacyValue::MatrixF64(n), LegacyValue::F64(k)) => Ok(n_choose_k_matrix_specialization(n, k)),
+        (LegacyValue::MatrixF64(n), LegacyValue::F64(k)) => {
+            Ok(n_choose_k_matrix_specialization(n, k))
+        }
         #[cfg(all(feature = "matrix", feature = "matrixd", feature = "rational"))]
-        (LegacyValue::MatrixR64(n), LegacyValue::R64(k)) => Ok(n_choose_k_matrix_specialization(n, k)),
+        (LegacyValue::MatrixR64(n), LegacyValue::R64(k)) => {
+            Ok(n_choose_k_matrix_specialization(n, k))
+        }
         #[cfg(all(feature = "matrix", feature = "matrixd", feature = "complex"))]
-        (LegacyValue::MatrixC64(n), LegacyValue::C64(k)) => Ok(n_choose_k_matrix_specialization(n, k)),
+        (LegacyValue::MatrixC64(n), LegacyValue::C64(k)) => {
+            Ok(n_choose_k_matrix_specialization(n, k))
+        }
         (n, k) => Err(MechError::new(
             UnhandledFunctionArgumentKind2 {
                 arg: (n.kind(), k.kind()),

--- a/machines/combinatorics/src/n_choose_k.rs
+++ b/machines/combinatorics/src/n_choose_k.rs
@@ -560,28 +560,21 @@ where
     #[cfg(feature = "semantic-compiler")]
     T: CompileConst + ConstElem,
     Ref<T>: ToValue,
-    T: FunctionRuntimeType,
+    T: FunctionStateBacking,
 {
     const SIGNATURE: RuntimeFunctionSignature =
         RuntimeFunctionSignature::binary(T::REPRESENTATION, T::REPRESENTATION, T::REPRESENTATION);
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, n, k) = invocation.expect_binary()?;
+        let n: Ref<T> = n.try_ref()?;
+        let k: Ref<T> = k.try_ref()?;
+        let out: Ref<T> = out.try_ref()?;
+        Ok(Box::new(Self { n, k, out }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Binary(out, arg1, arg2) => {
-                let n: Ref<T> = arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let k: Ref<T> = arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                let out: Ref<T> = out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(Self { n, k, out }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 2,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 impl<T> MechFunctionImpl for NChooseK<T>
@@ -603,7 +596,14 @@ where
         + PartialEq
         + PartialOrd,
     Ref<T>: ToValue,
+    T: FunctionStateBacking,
 {
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
+    }
     fn solve_result(&self) -> MResult<()> {
         // Validate every reactive solve, not only bytecode installation: host
         // or live-resource producers may replace a previously safe operand.
@@ -640,6 +640,41 @@ where
 #[cfg(all(test, feature = "f64"))]
 mod scalar_contract_tests {
     use super::*;
+
+    fn framed(payload: &[u8]) -> Vec<u8> {
+        let mut framed = (payload.len() as u32).to_le_bytes().to_vec();
+        framed.extend_from_slice(payload);
+        framed
+    }
+
+    fn decoded_scalar_wrapper(reference: bool) -> LegacyValue {
+        let payload = 1.0_f64.to_le_bytes();
+        let (runtime_type, bytes) = if reference {
+            (
+                RuntimeType::Reference(Box::new(RuntimeType::F64)),
+                framed(&payload),
+            )
+        } else {
+            let mut bytes = vec![1];
+            bytes.extend(framed(&payload));
+            (RuntimeType::Option(Box::new(RuntimeType::F64)), bytes)
+        };
+        decode_encoded_constants(&[EncodedConstant {
+            runtime_type,
+            alignment: 8,
+            bytes,
+        }])
+        .unwrap()
+        .pop()
+        .unwrap()
+    }
+
+    fn factory_error(result: MResult<Box<dyn MechFunction>>) -> MechError {
+        match result {
+            Ok(_) => panic!("factory unexpectedly accepted invalid arguments"),
+            Err(error) => error,
+        }
+    }
 
     fn args(n: f64, k: f64) -> FunctionArgs {
         FunctionArgs::Binary(
@@ -679,6 +714,113 @@ mod scalar_contract_tests {
         let error = function.solve_result().unwrap_err();
         assert_eq!(error.kind_name(), "FunctionShapeContractViolation");
     }
+
+    #[test]
+    fn scalar_factory_ports_are_exact_and_restore_output_state() {
+        let n = Ref::new(5.0_f64);
+        let k = Ref::new(2.0_f64);
+        let legacy_out = Ref::new(0.0_f64);
+        let invocation_out = Ref::new(0.0_f64);
+        let invocation_alias = invocation_out.clone();
+        let legacy = NChooseK::<f64>::new(FunctionArgs::Binary(
+            legacy_out.to_value(),
+            n.to_value(),
+            k.to_value(),
+        ))
+        .unwrap();
+        let invocation = NChooseK::<f64>::new_invocation(
+            FunctionArgs::Binary(
+                invocation_out.to_value(),
+                n.to_value(),
+                k.to_value(),
+            )
+            .into(),
+        )
+        .unwrap();
+        legacy.solve_result().unwrap();
+        invocation.solve_result().unwrap();
+        assert_eq!(*legacy_out.borrow(), *invocation_out.borrow());
+        assert_eq!(*invocation_out.borrow(), 10.0);
+        assert_eq!(
+            invocation.reactive_output_cell_ids(),
+            invocation.out().reactive_root_cell_ids(),
+        );
+
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*invocation)?;
+            *invocation_out.borrow_mut() = 99.0;
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+        assert!(invocation_out.same_handle(&invocation_alias));
+        assert_eq!(*invocation_out.borrow(), 10.0);
+    }
+
+    #[test]
+    fn scalar_factory_ports_reject_wrong_layout_type_and_wrappers() {
+        let out = Ref::new(0.0_f64);
+        let n = Ref::new(5.0_f64);
+        let k = Ref::new(2.0_f64);
+
+        let layout = factory_error(NChooseK::<f64>::new_invocation(
+            FunctionArgs::Unary(out.to_value(), n.to_value()).into(),
+        ));
+        let arity = layout.kind_as::<IncorrectNumberOfArguments>().unwrap();
+        assert_eq!((arity.expected, arity.found), (2, 1));
+
+        assert!(
+            NChooseK::<f64>::new_invocation(
+                FunctionArgs::Binary(
+                    out.to_value(),
+                    Ref::new(5_usize).to_value(),
+                    k.to_value(),
+                )
+                .into(),
+            )
+            .is_err()
+        );
+        for wrapped in [decoded_scalar_wrapper(false), decoded_scalar_wrapper(true)] {
+            assert!(
+                NChooseK::<f64>::new_invocation(
+                    FunctionArgs::Binary(out.to_value(), wrapped, k.to_value()).into(),
+                )
+                .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn scalar_error_is_atomic_and_prior_state_remains_restorable() {
+        let n = Ref::new(10.0_f64);
+        let out = Ref::new(0.0_f64);
+        let function = NChooseK::<f64>::new_invocation(
+            FunctionArgs::Binary(
+                out.to_value(),
+                n.to_value(),
+                Ref::new(2.0_f64).to_value(),
+            )
+            .into(),
+        )
+        .unwrap();
+        function.solve_result().unwrap();
+        let successful = *out.borrow();
+
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*function)?;
+            *n.borrow_mut() = f64::NAN;
+            let error = function.solve_result().unwrap_err();
+            assert_eq!(error.kind_name(), "FunctionShapeContractViolation");
+            assert_eq!(*out.borrow(), successful);
+            *out.borrow_mut() = -1.0;
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(*out.borrow(), successful);
+    }
 }
 
 #[cfg(all(test, feature = "u8"))]
@@ -690,19 +832,105 @@ mod integer_scalar_tests {
         let n = Ref::new(20_u8);
         let k = Ref::new(2_u8);
         let out = Ref::new(17_u8);
-        let function = NChooseK {
-            n: n.clone(),
-            k,
-            out: out.clone(),
-        };
+        let legacy_out = Ref::new(0_u8);
+        let legacy = NChooseK::<u8>::new(FunctionArgs::Binary(
+            legacy_out.to_value(),
+            n.to_value(),
+            k.to_value(),
+        ))
+        .unwrap();
+        let function = NChooseK::<u8>::new_invocation(
+            FunctionArgs::Binary(out.to_value(), n.to_value(), k.to_value()).into(),
+        )
+        .unwrap();
 
+        legacy.solve_result().unwrap();
         function.solve_result().unwrap();
+        assert_eq!(*legacy_out.borrow(), *out.borrow());
         assert_eq!(*out.borrow(), 190);
 
-        *n.borrow_mut() = 30;
-        let error = function.solve_result().unwrap_err();
-        assert_eq!(error.kind_name(), "FunctionShapeContractViolation");
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*function)?;
+            *n.borrow_mut() = 30;
+            let error = function.solve_result().unwrap_err();
+            assert_eq!(error.kind_name(), "FunctionShapeContractViolation");
+            assert_eq!(*out.borrow(), 190);
+            *out.borrow_mut() = 0;
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
         assert_eq!(*out.borrow(), 190);
+    }
+}
+
+#[cfg(all(test, feature = "i8"))]
+mod signed_scalar_port_tests {
+    use super::*;
+
+    #[test]
+    fn signed_integer_factories_are_equivalent() {
+        let legacy_out = Ref::new(0_i8);
+        let invocation_out = Ref::new(0_i8);
+        let args = |out: &Ref<i8>| {
+            FunctionArgs::Binary(
+                out.to_value(),
+                Ref::new(5_i8).to_value(),
+                Ref::new(2_i8).to_value(),
+            )
+        };
+        let legacy = NChooseK::<i8>::new(args(&legacy_out)).unwrap();
+        let invocation = NChooseK::<i8>::new_invocation(args(&invocation_out).into()).unwrap();
+        legacy.solve_result().unwrap();
+        invocation.solve_result().unwrap();
+        assert_eq!(*legacy_out.borrow(), *invocation_out.borrow());
+    }
+}
+
+#[cfg(all(test, feature = "rational"))]
+mod rational_scalar_port_tests {
+    use super::*;
+
+    #[test]
+    fn rational_factories_are_equivalent() {
+        let legacy_out = Ref::new(R64::default());
+        let invocation_out = Ref::new(R64::default());
+        let args = |out: &Ref<R64>| {
+            FunctionArgs::Binary(
+                out.to_value(),
+                Ref::new(R64::new(5, 1)).to_value(),
+                Ref::new(R64::new(2, 1)).to_value(),
+            )
+        };
+        let legacy = NChooseK::<R64>::new(args(&legacy_out)).unwrap();
+        let invocation = NChooseK::<R64>::new_invocation(args(&invocation_out).into()).unwrap();
+        legacy.solve_result().unwrap();
+        invocation.solve_result().unwrap();
+        assert_eq!(*legacy_out.borrow(), *invocation_out.borrow());
+    }
+}
+
+#[cfg(all(test, feature = "complex"))]
+mod complex_scalar_port_tests {
+    use super::*;
+
+    #[test]
+    fn complex_factories_are_equivalent() {
+        let legacy_out = Ref::new(C64::default());
+        let invocation_out = Ref::new(C64::default());
+        let args = |out: &Ref<C64>| {
+            FunctionArgs::Binary(
+                out.to_value(),
+                Ref::new(C64::new(5.0, 0.0)).to_value(),
+                Ref::new(C64::new(2.0, 0.0)).to_value(),
+            )
+        };
+        let legacy = NChooseK::<C64>::new(args(&legacy_out)).unwrap();
+        let invocation = NChooseK::<C64>::new_invocation(args(&invocation_out).into()).unwrap();
+        legacy.solve_result().unwrap();
+        invocation.solve_result().unwrap();
+        assert_eq!(*legacy_out.borrow(), *invocation_out.borrow());
     }
 }
 

--- a/machines/math/src/op_assign/mod.rs
+++ b/machines/math/src/op_assign/mod.rs
@@ -1,5 +1,9 @@
 use crate::*;
 
+paste! {
+    const _: Option<&dyn Display> = None;
+}
+
 use std::sync::LazyLock;
 
 #[cfg(feature = "matrix")]
@@ -8,13 +12,25 @@ use nalgebra::{
     base::{Matrix as naMatrix, Storage, StorageMut},
 };
 
-#[cfg(feature = "add_assign")]
+#[cfg(all(
+    feature = "add_assign",
+    any(feature = "matrix", feature = "source")
+))]
 pub mod add_assign;
-#[cfg(feature = "div_assign")]
+#[cfg(all(
+    feature = "div_assign",
+    any(feature = "matrix", feature = "source")
+))]
 pub mod div_assign;
-#[cfg(feature = "mul_assign")]
+#[cfg(all(
+    feature = "mul_assign",
+    any(feature = "matrix", feature = "source")
+))]
 pub mod mul_assign;
-#[cfg(feature = "sub_assign")]
+#[cfg(all(
+    feature = "sub_assign",
+    any(feature = "matrix", feature = "source")
+))]
 pub mod sub_assign;
 
 #[cfg(feature = "add_assign")]
@@ -25,6 +41,9 @@ pub use self::div_assign::*;
 pub use self::mul_assign::*;
 #[cfg(feature = "sub_assign")]
 pub use self::sub_assign::*;
+
+#[cfg(test)]
+mod port_tests;
 
 pub trait RuntimeCheckedOpAssign: Copy {
     fn runtime_checked_add(self, rhs: Self) -> Option<Self>;
@@ -82,7 +101,9 @@ macro_rules! checked_op_assign {
     };
 }
 
+#[cfg(feature = "add_assign")]
 checked_op_assign!(checked_add_assign, runtime_checked_add, "addition assignment");
+#[cfg(feature = "sub_assign")]
 checked_op_assign!(checked_sub_assign, runtime_checked_sub, "subtraction assignment");
 #[cfg(feature = "mul_assign")]
 checked_op_assign!(checked_mul_assign, runtime_checked_mul, "multiplication assignment");
@@ -118,6 +139,7 @@ static PURE_WHOLE_VALUE_RMW_CONTRACT: LazyLock<OperationContractDeclaration> =
         interaction: ExternalInteraction::Pure,
     });
 
+#[cfg(feature = "matrix")]
 static PURE_INDEXED_AXIS_ZERO_RMW_CONTRACT: LazyLock<OperationContractDeclaration> =
     LazyLock::new(|| OperationContractDeclaration {
         inputs: InputPortLayout::Fixed(
@@ -151,6 +173,7 @@ static PURE_INDEXED_AXIS_ZERO_RMW_CONTRACT: LazyLock<OperationContractDeclaratio
         interaction: ExternalInteraction::Pure,
     });
 
+#[cfg(feature = "matrix")]
 fn checked_one_based_index(index: usize, len: usize) -> MResult<usize> {
     if index == 0 || index > len {
         return Err(function_shape_contract_violation(
@@ -161,6 +184,7 @@ fn checked_one_based_index(index: usize, len: usize) -> MResult<usize> {
     Ok(index - 1)
 }
 
+#[cfg(feature = "matrix")]
 fn validate_mask_len(mask_len: usize, sink_len: usize) -> MResult<()> {
     if mask_len > sink_len {
         return Err(function_shape_contract_violation(
@@ -171,6 +195,7 @@ fn validate_mask_len(mask_len: usize, sink_len: usize) -> MResult<()> {
     Ok(())
 }
 
+#[cfg(feature = "matrix")]
 fn validate_source_len(source_len: usize, selected_len: usize) -> MResult<()> {
     if source_len < selected_len {
         return Err(function_shape_contract_violation(
@@ -595,23 +620,23 @@ macro_rules! impl_assign_scalar_scalar {
         T: RuntimeCheckedOpAssign,
         #[cfg(feature = "semantic-compiler")]
         T: CompileConst + ConstElem,
-        Ref<T>: ToValue
-        , T: FunctionRuntimeType
+        Ref<T>: ToValue,
+        T: FunctionStateBacking,
       {
         const SIGNATURE: RuntimeFunctionSignature = RuntimeFunctionSignature::unary(
           T::REPRESENTATION,
           T::REPRESENTATION,
         );
 
+        fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+          let (sink, source) = invocation.expect_unary()?;
+          let source: Ref<T> = source.try_ref()?;
+          let sink: Ref<T> = sink.try_ref()?;
+          Ok(Box::new(Self { sink, source }))
+        }
+
         fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-          match args {
-            FunctionArgs::Unary(out, arg1) => {
-              let source: Ref<T> = arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-              let sink: Ref<T> = out.try_function_ref(FunctionArgumentRole::Output)?;
-              Ok(Box::new(Self { sink, source }))
-            },
-            _ => Err(MechError::new(IncorrectNumberOfArguments { expected: 2, found: args.len() }, None).with_compiler_loc())
-          }
+          Self::new_invocation(args.into())
         }
       }
       impl<T> MechFunctionImpl for [<$op_name AssignSS>]<T>
@@ -620,8 +645,15 @@ macro_rules! impl_assign_scalar_scalar {
            $op_name<Output = T> + [<$op_name Assign>] +
            PartialEq + PartialOrd,
         T: RuntimeCheckedOpAssign,
-        Ref<T>: ToValue
+        Ref<T>: ToValue,
+        T: FunctionStateBacking,
       {
+        fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+          Some(FunctionStatePort::from_ref(&self.sink))
+        }
+        fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+          Ok(Some(vec![FunctionStatePort::from_ref(&self.sink)]))
+        }
         fn solve_result(&self) -> MResult<()> {
           let next = $checked_op(*self.sink.borrow(), *self.source.borrow())?;
           *self.sink.borrow_mut() = next;
@@ -681,8 +713,8 @@ macro_rules! impl_assign_vector_vector {
         #[cfg(feature = "semantic-compiler")]
         MatA: CompileConst + ConstElem,
         MatB: Debug + AsValueKind + 'static,
-        MatA: FunctionRuntimeType,
-        MatB: FunctionRuntimeType,
+        MatA: FunctionStateBacking,
+        MatB: FunctionPortBacking,
         #[cfg(feature = "semantic-compiler")]
         MatB: CompileConst + ConstElem,
       {
@@ -691,15 +723,15 @@ macro_rules! impl_assign_vector_vector {
           MatB::REPRESENTATION,
         );
 
+        fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+          let (sink, source) = invocation.expect_unary()?;
+          let source: Ref<MatB> = source.try_ref()?;
+          let sink: Ref<MatA> = sink.try_ref()?;
+          Ok(Box::new(Self { sink, source, _marker: PhantomData::default() }))
+        }
+
         fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-          match args {
-            FunctionArgs::Unary(out, arg1) => {
-              let source: Ref<MatB> = arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-              let sink: Ref<MatA> = out.try_function_ref(FunctionArgumentRole::Output)?;
-              Ok(Box::new(Self { sink, source, _marker: PhantomData::default() }))
-            },
-            _ => Err(MechError::new(IncorrectNumberOfArguments { expected: 2, found: args.len() }, None).with_compiler_loc())
-          }
+          Self::new_invocation(args.into())
         }
       }
       impl<T, MatA, MatB> MechFunctionImpl for [<$op_name AssignVV>]<T, MatA, MatB>
@@ -710,9 +742,15 @@ macro_rules! impl_assign_vector_vector {
         for<'a> &'a MatA: IntoIterator<Item = &'a T>,
         for<'a> &'a mut MatA: IntoIterator<Item = &'a mut T>,
         for<'a> &'a MatB: IntoIterator<Item = &'a T>,
-        MatA: Debug + Clone + 'static,
+        MatA: Debug + Clone + FunctionStateBacking + 'static,
         MatB: Debug,
       {
+        fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+          Some(FunctionStatePort::from_ref(&self.sink))
+        }
+        fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+          Ok(Some(vec![FunctionStatePort::from_ref(&self.sink)]))
+        }
         fn solve_result(&self) -> MResult<()> {
           let mut next = self.sink.borrow().clone();
           {
@@ -782,8 +820,8 @@ macro_rules! impl_assign_vector_scalar {
         for<'a> &'a MatA: IntoIterator<Item = &'a T>,
         for<'a> &'a mut MatA: IntoIterator<Item = &'a mut T>,
         MatA: Debug + Clone + AsValueKind + 'static,
-        MatA: FunctionRuntimeType,
-        T: FunctionRuntimeType,
+        MatA: FunctionStateBacking,
+        T: FunctionPortBacking,
         #[cfg(feature = "semantic-compiler")]
         MatA: CompileConst + ConstElem,
       {
@@ -793,19 +831,15 @@ macro_rules! impl_assign_vector_scalar {
           T::REPRESENTATION,
         );
 
+        fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+          let (sink, _base, source) = invocation.expect_binary()?;
+          let source: Ref<T> = source.try_ref()?;
+          let sink: Ref<MatA> = sink.try_ref()?;
+          Ok(Box::new(Self { sink, source, _marker: PhantomData::default() }))
+        }
+
         fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-          match args {
-            FunctionArgs::Binary(out, _, arg2) => {
-              let source: Ref<T> = arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-              let sink: Ref<MatA> = out.try_function_ref(FunctionArgumentRole::Output)?;
-              Ok(Box::new(Self { sink, source, _marker: PhantomData::default() }))
-            },
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments { expected: 2, found: args.len() },
-                None
-              ).with_compiler_loc()
-            )
-          }
+          Self::new_invocation(args.into())
         }
       }
       impl<T, MatA> MechFunctionImpl for [<$op_name AssignVS>]<T, MatA>
@@ -815,8 +849,14 @@ macro_rules! impl_assign_vector_scalar {
         T: RuntimeCheckedOpAssign,
         for<'a> &'a MatA: IntoIterator<Item = &'a T>,
         for<'a> &'a mut MatA: IntoIterator<Item = &'a mut T>,
-        MatA: Debug + Clone + 'static,
+        MatA: Debug + Clone + FunctionStateBacking + 'static,
       {
+        fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+          Some(FunctionStatePort::from_ref(&self.sink))
+        }
+        fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+          Ok(Some(vec![FunctionStatePort::from_ref(&self.sink)]))
+        }
         fn solve_result(&self) -> MResult<()> {
           let mut next = self.sink.borrow().clone();
           let source = *self.source.borrow();
@@ -859,6 +899,40 @@ macro_rules! impl_assign_vector_scalar {
     }
   }
 }
+
+#[cfg(not(any(feature = "matrix", feature = "source")))]
+macro_rules! impl_scalar_op_assign_module {
+    ($module:ident, $op_name:tt, $checked_op:ident) => {
+        pub mod $module {
+            use super::*;
+
+            impl_assign_scalar_scalar!($op_name, $checked_op);
+            impl_assign_vector_vector!($op_name, $checked_op);
+            impl_assign_vector_scalar!($op_name, $checked_op);
+        }
+    };
+}
+
+#[cfg(all(
+    feature = "add_assign",
+    not(any(feature = "matrix", feature = "source"))
+))]
+impl_scalar_op_assign_module!(add_assign, Add, checked_add_assign);
+#[cfg(all(
+    feature = "div_assign",
+    not(any(feature = "matrix", feature = "source"))
+))]
+impl_scalar_op_assign_module!(div_assign, Div, checked_div_assign);
+#[cfg(all(
+    feature = "mul_assign",
+    not(any(feature = "matrix", feature = "source"))
+))]
+impl_scalar_op_assign_module!(mul_assign, Mul, checked_mul_assign);
+#[cfg(all(
+    feature = "sub_assign",
+    not(any(feature = "matrix", feature = "source"))
+))]
+impl_scalar_op_assign_module!(sub_assign, Sub, checked_sub_assign);
 
 #[cfg(feature = "source")]
 #[macro_export]
@@ -938,93 +1012,4 @@ macro_rules! impl_op_assign_value_match_arms {
       }
     }
   };
-}
-
-#[cfg(test)]
-mod checked_assignment_tests {
-    use super::*;
-
-    #[test]
-    fn integer_scalar_assignments_reject_overflow_and_invalid_division() {
-        let cases: Vec<(Box<dyn MechFunction>, Box<dyn Fn() -> i128>)> = vec![
-            {
-                let sink = Ref::new(u8::MAX);
-                let function = AddAssignSS::<u8>::new(FunctionArgs::Unary(
-                    LegacyValue::U8(sink.clone()),
-                    LegacyValue::U8(Ref::new(1)),
-                ))
-                .unwrap();
-                (function, Box::new(move || i128::from(*sink.borrow())))
-            },
-            {
-                let sink = Ref::new(i8::MIN);
-                let function = SubAssignSS::<i8>::new(FunctionArgs::Unary(
-                    LegacyValue::I8(sink.clone()),
-                    LegacyValue::I8(Ref::new(1)),
-                ))
-                .unwrap();
-                (function, Box::new(move || i128::from(*sink.borrow())))
-            },
-            {
-                let sink = Ref::new(u8::MAX);
-                let function = MulAssignSS::<u8>::new(FunctionArgs::Unary(
-                    LegacyValue::U8(sink.clone()),
-                    LegacyValue::U8(Ref::new(2)),
-                ))
-                .unwrap();
-                (function, Box::new(move || i128::from(*sink.borrow())))
-            },
-            {
-                let sink = Ref::new(7u8);
-                let function = DivAssignSS::<u8>::new(FunctionArgs::Unary(
-                    LegacyValue::U8(sink.clone()),
-                    LegacyValue::U8(Ref::new(0)),
-                ))
-                .unwrap();
-                (function, Box::new(move || i128::from(*sink.borrow())))
-            },
-        ];
-
-        for (function, value) in cases {
-            let before = value();
-            let error = function.solve_result().unwrap_err();
-            assert_eq!(error.kind_name(), "MathArithmeticOverflow");
-            assert_eq!(value(), before);
-            let error = match function.stage_register() {
-                Ok(_) => panic!("overflowing reactive assignment should fail while staging"),
-                Err(error) => error,
-            };
-            assert_eq!(error.kind_name(), "MathArithmeticOverflow");
-            assert_eq!(value(), before);
-        }
-    }
-
-    #[test]
-    fn range_assignment_revalidates_indices_and_is_transactional() {
-        let sink = Ref::new(DVector::from_vec(vec![1u8, u8::MAX]));
-        let source = Ref::new(DVector::from_vec(vec![1u8, 1]));
-        let indices = Ref::new(DVector::from_vec(vec![1usize, 2]));
-        let function = AddAssign1DRV::<u8, DVector<u8>, DVector<u8>, DVector<usize>>::new(
-            FunctionArgs::Binary(
-                LegacyValue::MatrixU8(mech_core::matrix::Matrix::DVector(sink.clone())),
-                LegacyValue::MatrixU8(mech_core::matrix::Matrix::DVector(source)),
-                LegacyValue::MatrixIndex(mech_core::matrix::Matrix::DVector(indices.clone())),
-            ),
-        )
-        .unwrap();
-
-        let error = function.solve_result().unwrap_err();
-        assert_eq!(error.kind_name(), "MathArithmeticOverflow");
-        assert_eq!(sink.borrow().as_slice(), &[1, u8::MAX]);
-
-        *indices.borrow_mut() = DVector::from_vec(vec![0, 1]);
-        let error = function.solve_result().unwrap_err();
-        assert_eq!(error.kind_name(), "FunctionShapeContractViolation");
-        assert_eq!(sink.borrow().as_slice(), &[1, u8::MAX]);
-
-        *indices.borrow_mut() = DVector::from_vec(vec![3, 1]);
-        let error = function.solve_result().unwrap_err();
-        assert_eq!(error.kind_name(), "FunctionShapeContractViolation");
-        assert_eq!(sink.borrow().as_slice(), &[1, u8::MAX]);
-    }
 }

--- a/machines/math/src/op_assign/mod.rs
+++ b/machines/math/src/op_assign/mod.rs
@@ -249,9 +249,9 @@ macro_rules! impl_op_assign_range_fxn_s {
             C1: Dim,
             S1: StorageMut<T, R1, C1> + Clone + Debug,
             naMatrix<T, R1, C1, S1>: Debug + AsNaKind,
-            naMatrix<T, R1, C1, S1>: FunctionRuntimeType,
-            IxVec: FunctionRuntimeType,
-            T: FunctionRuntimeType,
+            naMatrix<T, R1, C1, S1>: FunctionStateBacking,
+            IxVec: FunctionPortBacking,
+            T: FunctionPortBacking,
             #[cfg(feature = "semantic-compiler")]
             naMatrix<T, R1, C1, S1>: CompileConst + ConstElem,
         {
@@ -261,31 +261,21 @@ macro_rules! impl_op_assign_range_fxn_s {
                 IxVec::REPRESENTATION,
             );
 
+            fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+                let (sink, source, ixes) = invocation.expect_binary()?;
+                let source: Ref<T> = source.try_ref()?;
+                let ixes: Ref<IxVec> = ixes.try_ref()?;
+                let sink: Ref<naMatrix<T, R1, C1, S1>> = sink.try_ref()?;
+                Ok(Box::new(Self {
+                    sink,
+                    source,
+                    ixes,
+                    _marker: PhantomData::default(),
+                }))
+            }
+
             fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-                match args {
-                    FunctionArgs::Binary(out, arg1, arg2) => {
-                        let source: Ref<T> =
-                            arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                        let ixes: Ref<IxVec> =
-                            arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                        let sink: Ref<naMatrix<T, R1, C1, S1>> =
-                            out.try_function_ref(FunctionArgumentRole::Output)?;
-                        Ok(Box::new(Self {
-                            sink,
-                            source,
-                            ixes,
-                            _marker: PhantomData::default(),
-                        }))
-                    }
-                    _ => Err(MechError::new(
-                        IncorrectNumberOfArguments {
-                            expected: 3,
-                            found: args.len(),
-                        },
-                        None,
-                    )
-                    .with_compiler_loc()),
-                }
+                Self::new_invocation(args.into())
             }
         }
         impl<T, R1, C1, S1, IxVec> MechFunctionImpl
@@ -315,7 +305,14 @@ macro_rules! impl_op_assign_range_fxn_s {
             R1: Dim,
             C1: Dim,
             S1: StorageMut<T, R1, C1> + Clone + Debug,
+            naMatrix<T, R1, C1, S1>: FunctionStateBacking,
         {
+            fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+                Some(FunctionStatePort::from_ref(&self.sink))
+            }
+            fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+                Ok(Some(vec![FunctionStatePort::from_ref(&self.sink)]))
+            }
             fn solve_result(&self) -> MResult<()> {
                 unsafe {
                     let sink_ptr = &mut *self.sink.as_mut_ptr();
@@ -423,9 +420,9 @@ macro_rules! impl_op_assign_range_fxn_v {
             #[cfg(feature = "semantic-compiler")]
             naMatrix<T, R1, C1, S1>: CompileConst + ConstElem,
             naMatrix<T, R2, C2, S2>: Debug + AsNaKind,
-            naMatrix<T, R1, C1, S1>: FunctionRuntimeType,
-            naMatrix<T, R2, C2, S2>: FunctionRuntimeType,
-            IxVec: FunctionRuntimeType,
+            naMatrix<T, R1, C1, S1>: FunctionStateBacking,
+            naMatrix<T, R2, C2, S2>: FunctionPortBacking,
+            IxVec: FunctionPortBacking,
             #[cfg(feature = "semantic-compiler")]
             naMatrix<T, R2, C2, S2>: CompileConst + ConstElem,
         {
@@ -435,31 +432,21 @@ macro_rules! impl_op_assign_range_fxn_v {
                 IxVec::REPRESENTATION,
             );
 
+            fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+                let (sink, source, ixes) = invocation.expect_binary()?;
+                let source: Ref<naMatrix<T, R2, C2, S2>> = source.try_ref()?;
+                let ixes: Ref<IxVec> = ixes.try_ref()?;
+                let sink: Ref<naMatrix<T, R1, C1, S1>> = sink.try_ref()?;
+                Ok(Box::new(Self {
+                    sink,
+                    source,
+                    ixes,
+                    _marker: PhantomData::default(),
+                }))
+            }
+
             fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-                match args {
-                    FunctionArgs::Binary(out, arg1, arg2) => {
-                        let source: Ref<naMatrix<T, R2, C2, S2>> =
-                            arg1.try_function_ref(FunctionArgumentRole::Input(0))?;
-                        let ixes: Ref<IxVec> =
-                            arg2.try_function_ref(FunctionArgumentRole::Input(1))?;
-                        let sink: Ref<naMatrix<T, R1, C1, S1>> =
-                            out.try_function_ref(FunctionArgumentRole::Output)?;
-                        Ok(Box::new(Self {
-                            sink,
-                            source,
-                            ixes,
-                            _marker: PhantomData::default(),
-                        }))
-                    }
-                    _ => Err(MechError::new(
-                        IncorrectNumberOfArguments {
-                            expected: 3,
-                            found: args.len(),
-                        },
-                        None,
-                    )
-                    .with_compiler_loc()),
-                }
+                Self::new_invocation(args.into())
             }
         }
         impl<T, R1, C1, S1, R2, C2, S2, IxVec> MechFunctionImpl
@@ -492,7 +479,14 @@ macro_rules! impl_op_assign_range_fxn_v {
             R2: Dim,
             C2: Dim,
             S2: Storage<T, R2, C2> + Clone + Debug,
+            naMatrix<T, R1, C1, S1>: FunctionStateBacking,
         {
+            fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+                Some(FunctionStatePort::from_ref(&self.sink))
+            }
+            fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+                Ok(Some(vec![FunctionStatePort::from_ref(&self.sink)]))
+            }
             fn solve_result(&self) -> MResult<()> {
                 unsafe {
                     let sink_ptr = &mut *self.sink.as_mut_ptr();

--- a/machines/math/src/op_assign/port_tests.rs
+++ b/machines/math/src/op_assign/port_tests.rs
@@ -450,3 +450,320 @@ mod checked_integer {
         assert_eq!(*sink.borrow(), 7);
     }
 }
+
+#[cfg(all(
+    feature = "f64",
+    feature = "bool",
+    feature = "row_vectord",
+    feature = "vectord",
+    feature = "matrixd",
+    feature = "add_assign",
+    feature = "sub_assign",
+    feature = "mul_assign",
+    feature = "div_assign"
+))]
+mod indexed_f64 {
+    use super::super::{
+        AddAssign1DRB, AddAssign1DRS, AddAssign1DRV, AddAssign2DRAV, DivAssign1DRS, MulAssign1DRS,
+        MulAssign1DRVB, SubAssign1DRB, SubAssign1DRS,
+    };
+    use mech_core::{
+        FunctionArgs, FunctionInvocation, IncorrectNumberOfArguments, MechError, MechFunction,
+        MechFunctionFactory, Ref, ToValue, with_reactive_journal_participant,
+    };
+    use nalgebra::{DMatrix, DVector, RowDVector};
+
+    fn factory_error(result: Result<Box<dyn MechFunction>, MechError>) -> MechError {
+        match result {
+            Ok(_) => panic!("factory unexpectedly accepted invalid arguments"),
+            Err(error) => error,
+        }
+    }
+
+    macro_rules! assert_indexed_factories_match {
+        ($factory:ident, $expected:expr) => {{
+            let source = Ref::new(3.0_f64);
+            let ixes = Ref::new(DVector::from_vec(vec![1_usize, 3]));
+            let legacy_sink = Ref::new(DVector::from_vec(vec![12.0_f64, 18.0, 24.0]));
+            let invocation_sink = Ref::new(DVector::from_vec(vec![12.0_f64, 18.0, 24.0]));
+            let legacy = $factory::<f64, DVector<f64>, DVector<usize>>::new(FunctionArgs::Binary(
+                legacy_sink.to_value(),
+                source.to_value(),
+                ixes.to_value(),
+            ))
+            .unwrap();
+            let invocation = $factory::<f64, DVector<f64>, DVector<usize>>::new_invocation(
+                FunctionArgs::Binary(
+                    invocation_sink.to_value(),
+                    source.to_value(),
+                    ixes.to_value(),
+                )
+                .into(),
+            )
+            .unwrap();
+
+            legacy.solve_result().unwrap();
+            invocation.solve_result().unwrap();
+
+            assert_eq!(legacy_sink.borrow().as_slice(), $expected);
+            assert_eq!(invocation_sink.borrow().as_slice(), $expected);
+            assert_eq!(
+                invocation.reactive_output_cell_ids(),
+                invocation.out().reactive_root_cell_ids(),
+            );
+            assert_eq!(
+                invocation.transaction_state_ports().unwrap().unwrap().len(),
+                1,
+            );
+        }};
+    }
+
+    #[test]
+    fn all_indexed_scalar_operations_match_their_legacy_adapters() {
+        assert_indexed_factories_match!(AddAssign1DRS, &[15.0, 18.0, 27.0]);
+        assert_indexed_factories_match!(SubAssign1DRS, &[9.0, 18.0, 21.0]);
+        assert_indexed_factories_match!(MulAssign1DRS, &[36.0, 18.0, 72.0]);
+        assert_indexed_factories_match!(DivAssign1DRS, &[4.0, 18.0, 8.0]);
+    }
+
+    #[test]
+    fn indexed_layout_errors_report_two_inputs() {
+        let sink = Ref::new(DVector::from_vec(vec![1.0_f64, 2.0]));
+        let source = Ref::new(1.0_f64);
+        let vector_source = Ref::new(DVector::from_vec(vec![1.0_f64, 2.0]));
+
+        for error in [
+            factory_error(
+                AddAssign1DRS::<f64, DVector<f64>, DVector<usize>>::new_invocation(
+                    FunctionInvocation::from(FunctionArgs::Unary(
+                        sink.to_value(),
+                        source.to_value(),
+                    )),
+                ),
+            ),
+            factory_error(AddAssign1DRV::<
+                f64,
+                DVector<f64>,
+                DVector<f64>,
+                DVector<usize>,
+            >::new_invocation(FunctionInvocation::from(
+                FunctionArgs::Unary(sink.to_value(), vector_source.to_value()),
+            ))),
+        ] {
+            let arity = error.kind_as::<IncorrectNumberOfArguments>().unwrap();
+            assert_eq!((arity.expected, arity.found), (2, 1));
+        }
+    }
+
+    #[test]
+    fn indexed_matrix_state_is_exact_and_bad_index_rollback_restores_shape() {
+        let sink = Ref::new(DMatrix::from_vec(2, 2, vec![10.0_f64, 20.0, 30.0, 40.0]));
+        let sink_alias = sink.clone();
+        let source = Ref::new(DVector::from_vec(vec![1.0_f64, 2.0]));
+        let ixes = Ref::new(DVector::from_vec(vec![1_usize, 4]));
+        let function =
+            AddAssign1DRV::<f64, DMatrix<f64>, DVector<f64>, DVector<usize>>::new_invocation(
+                FunctionArgs::Binary(sink.to_value(), source.to_value(), ixes.to_value()).into(),
+            )
+            .unwrap();
+
+        function.solve_result().unwrap();
+        assert_eq!(sink.borrow().as_slice(), &[11.0, 20.0, 30.0, 42.0]);
+        assert_eq!(
+            function.reactive_output_cell_ids(),
+            function.out().reactive_root_cell_ids(),
+        );
+        assert_eq!(
+            function.transaction_state_ports().unwrap().unwrap().len(),
+            1,
+        );
+        let successful = sink.borrow().clone();
+
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*function)?;
+            *ixes.borrow_mut() = DVector::from_vec(vec![1_usize, 0]);
+            let error = function.solve_result().unwrap_err();
+            assert_eq!(error.kind_name(), "FunctionShapeContractViolation");
+            assert_eq!(*sink.borrow(), successful);
+            *sink.borrow_mut() = DMatrix::from_element(1, 3, 99.0);
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+
+        assert!(sink.same_handle(&sink_alias));
+        assert_eq!(*sink.borrow(), successful);
+    }
+
+    #[test]
+    fn indexed_matrix_source_aliasing_remains_supported() {
+        let sink = Ref::new(DVector::from_vec(vec![1.0_f64, 2.0, 3.0]));
+        let sink_alias = sink.clone();
+        let function =
+            AddAssign1DRV::<f64, DVector<f64>, DVector<f64>, DVector<usize>>::new_invocation(
+                FunctionArgs::Binary(
+                    sink.to_value(),
+                    sink.to_value(),
+                    Ref::new(DVector::from_vec(vec![1_usize, 2, 3])).to_value(),
+                )
+                .into(),
+            )
+            .unwrap();
+
+        function.solve_result().unwrap();
+
+        assert!(sink.same_handle(&sink_alias));
+        assert_eq!(sink.borrow().as_slice(), &[2.0, 4.0, 6.0]);
+    }
+
+    #[test]
+    fn short_indexed_matrix_source_is_atomic() {
+        let sink = Ref::new(DVector::from_vec(vec![10.0_f64, 20.0, 30.0]));
+        let before = sink.borrow().clone();
+        let function =
+            AddAssign1DRV::<f64, DVector<f64>, DVector<f64>, DVector<usize>>::new_invocation(
+                FunctionArgs::Binary(
+                    sink.to_value(),
+                    Ref::new(DVector::from_vec(vec![1.0_f64])).to_value(),
+                    Ref::new(DVector::from_vec(vec![1_usize, 2])).to_value(),
+                )
+                .into(),
+            )
+            .unwrap();
+
+        let error = function.solve_result().unwrap_err();
+        assert_eq!(error.kind_name(), "FunctionShapeContractViolation");
+        assert_eq!(*sink.borrow(), before);
+    }
+
+    #[test]
+    fn boolean_masks_support_scalar_and_matrix_sources() {
+        let scalar_sink = Ref::new(DVector::from_vec(vec![10.0_f64, 20.0, 30.0]));
+        let scalar = SubAssign1DRB::<f64, DVector<f64>, DVector<bool>>::new_invocation(
+            FunctionArgs::Binary(
+                scalar_sink.to_value(),
+                Ref::new(2.0_f64).to_value(),
+                Ref::new(DVector::from_vec(vec![true, false, true])).to_value(),
+            )
+            .into(),
+        )
+        .unwrap();
+        scalar.solve_result().unwrap();
+        assert_eq!(scalar_sink.borrow().as_slice(), &[8.0, 20.0, 28.0]);
+
+        let matrix_sink = Ref::new(DVector::from_vec(vec![2.0_f64, 3.0, 4.0]));
+        let matrix =
+            MulAssign1DRVB::<f64, DVector<f64>, DVector<f64>, DVector<bool>>::new_invocation(
+                FunctionArgs::Binary(
+                    matrix_sink.to_value(),
+                    Ref::new(DVector::from_vec(vec![10.0_f64, 20.0, 30.0])).to_value(),
+                    Ref::new(DVector::from_vec(vec![true, false, true])).to_value(),
+                )
+                .into(),
+            )
+            .unwrap();
+        matrix.solve_result().unwrap();
+        assert_eq!(matrix_sink.borrow().as_slice(), &[20.0, 3.0, 120.0]);
+    }
+
+    #[test]
+    fn two_dimensional_row_all_assignment_uses_exact_matrix_ports() {
+        let sink = Ref::new(DMatrix::from_row_slice(2, 2, &[1.0_f64, 2.0, 3.0, 4.0]));
+        let sink_alias = sink.clone();
+        let function =
+            AddAssign2DRAV::<f64, DMatrix<f64>, DMatrix<f64>, RowDVector<usize>>::new_invocation(
+                FunctionArgs::Binary(
+                    sink.to_value(),
+                    Ref::new(DMatrix::from_row_slice(1, 2, &[10.0_f64, 20.0])).to_value(),
+                    Ref::new(RowDVector::from_vec(vec![2_usize])).to_value(),
+                )
+                .into(),
+            )
+            .unwrap();
+
+        function.solve_result().unwrap();
+
+        assert!(sink.same_handle(&sink_alias));
+        assert_eq!(
+            *sink.borrow(),
+            DMatrix::from_row_slice(2, 2, &[1.0_f64, 2.0, 13.0, 24.0]),
+        );
+    }
+
+    #[test]
+    fn oversized_boolean_mask_leaves_the_sink_unchanged() {
+        let sink = Ref::new(DVector::from_vec(vec![10.0_f64, 20.0]));
+        let before = sink.borrow().clone();
+        let function = AddAssign1DRB::<f64, DVector<f64>, DVector<bool>>::new_invocation(
+            FunctionArgs::Binary(
+                sink.to_value(),
+                Ref::new(1.0_f64).to_value(),
+                Ref::new(DVector::from_vec(vec![true, false, true])).to_value(),
+            )
+            .into(),
+        )
+        .unwrap();
+
+        let error = function.solve_result().unwrap_err();
+        assert_eq!(error.kind_name(), "FunctionShapeContractViolation");
+        assert_eq!(*sink.borrow(), before);
+    }
+}
+
+#[cfg(all(
+    feature = "u8",
+    feature = "bool",
+    feature = "row_vectord",
+    feature = "vectord",
+    feature = "matrixd",
+    feature = "add_assign",
+    feature = "sub_assign",
+    feature = "mul_assign",
+    feature = "div_assign"
+))]
+mod indexed_checked_integer {
+    use super::super::{AddAssign1DRV, DivAssign1DRV};
+    use mech_core::{FunctionArgs, MechFunctionFactory, Ref, ToValue};
+    use nalgebra::DVector;
+
+    #[test]
+    fn indexed_integer_overflow_is_atomic_after_an_earlier_selection() {
+        let sink = Ref::new(DVector::from_vec(vec![1_u8, u8::MAX]));
+        let before = sink.borrow().clone();
+        let function =
+            AddAssign1DRV::<u8, DVector<u8>, DVector<u8>, DVector<usize>>::new_invocation(
+                FunctionArgs::Binary(
+                    sink.to_value(),
+                    Ref::new(DVector::from_vec(vec![1_u8, 1])).to_value(),
+                    Ref::new(DVector::from_vec(vec![1_usize, 2])).to_value(),
+                )
+                .into(),
+            )
+            .unwrap();
+
+        let error = function.solve_result().unwrap_err();
+        assert_eq!(error.kind_name(), "MathArithmeticOverflow");
+        assert_eq!(*sink.borrow(), before);
+    }
+
+    #[test]
+    fn indexed_integer_division_failure_is_atomic_after_an_earlier_selection() {
+        let sink = Ref::new(DVector::from_vec(vec![8_u8, 6]));
+        let before = sink.borrow().clone();
+        let function =
+            DivAssign1DRV::<u8, DVector<u8>, DVector<u8>, DVector<usize>>::new_invocation(
+                FunctionArgs::Binary(
+                    sink.to_value(),
+                    Ref::new(DVector::from_vec(vec![2_u8, 0])).to_value(),
+                    Ref::new(DVector::from_vec(vec![1_usize, 2])).to_value(),
+                )
+                .into(),
+            )
+            .unwrap();
+
+        let error = function.solve_result().unwrap_err();
+        assert_eq!(error.kind_name(), "MathArithmeticOverflow");
+        assert_eq!(*sink.borrow(), before);
+    }
+}

--- a/machines/math/src/op_assign/port_tests.rs
+++ b/machines/math/src/op_assign/port_tests.rs
@@ -1,0 +1,452 @@
+#[cfg(all(
+    feature = "f64",
+    feature = "add_assign",
+    feature = "sub_assign",
+    feature = "mul_assign",
+    feature = "div_assign"
+))]
+mod scalar_f64 {
+    use super::super::{AddAssignSS, DivAssignSS, MulAssignSS, SubAssignSS};
+    use mech_core::{
+        FunctionArgs, FunctionInvocation, IncorrectNumberOfArguments, MechError, MechFunction,
+        MechFunctionFactory, ReactiveNodeKind, Ref, ToValue, with_reactive_journal_participant,
+    };
+
+    fn factory_error(result: Result<Box<dyn MechFunction>, MechError>) -> MechError {
+        match result {
+            Ok(_) => panic!("factory unexpectedly accepted invalid arguments"),
+            Err(error) => error,
+        }
+    }
+
+    macro_rules! assert_scalar_factories_match {
+        ($factory:ident, $initial:expr, $source:expr, $expected:expr) => {{
+            let source = Ref::new($source);
+            let legacy_sink = Ref::new($initial);
+            let invocation_sink = Ref::new($initial);
+            let legacy = $factory::<f64>::new(FunctionArgs::Unary(
+                legacy_sink.to_value(),
+                source.to_value(),
+            ))
+            .unwrap();
+            let invocation = $factory::<f64>::new_invocation(
+                FunctionArgs::Unary(invocation_sink.to_value(), source.to_value()).into(),
+            )
+            .unwrap();
+
+            legacy.solve_result().unwrap();
+            invocation.solve_result().unwrap();
+
+            assert_eq!(*legacy_sink.borrow(), $expected);
+            assert_eq!(*invocation_sink.borrow(), $expected);
+            assert_eq!(
+                legacy.reactive_output_cell_ids(),
+                legacy.out().reactive_root_cell_ids(),
+            );
+            assert_eq!(
+                invocation.reactive_output_cell_ids(),
+                invocation.out().reactive_root_cell_ids(),
+            );
+        }};
+    }
+
+    #[test]
+    fn scalar_legacy_and_invocation_factories_are_equivalent() {
+        assert_scalar_factories_match!(AddAssignSS, 12.0, 3.0, 15.0);
+        assert_scalar_factories_match!(SubAssignSS, 12.0, 3.0, 9.0);
+        assert_scalar_factories_match!(MulAssignSS, 12.0, 3.0, 36.0);
+        assert_scalar_factories_match!(DivAssignSS, 12.0, 3.0, 4.0);
+    }
+
+    #[test]
+    fn scalar_ports_are_exact_and_unary_layout_reports_one_input() {
+        let sink = Ref::new(4.0_f64);
+        let source = Ref::new(2.0_f64);
+
+        assert!(
+            AddAssignSS::<f64>::new_invocation(
+                FunctionArgs::Unary(sink.to_value(), Ref::new(2_usize).to_value()).into(),
+            )
+            .is_err()
+        );
+        assert!(
+            AddAssignSS::<f64>::new_invocation(
+                FunctionArgs::Unary(Ref::new(0_usize).to_value(), source.to_value()).into(),
+            )
+            .is_err()
+        );
+
+        let error = factory_error(AddAssignSS::<f64>::new_invocation(
+            FunctionInvocation::from(FunctionArgs::Binary(
+                sink.to_value(),
+                source.to_value(),
+                source.to_value(),
+            )),
+        ));
+        let arity = error.kind_as::<IncorrectNumberOfArguments>().unwrap();
+        assert_eq!((arity.expected, arity.found), (1, 2));
+    }
+
+    #[test]
+    fn whole_value_alias_staging_and_typed_checkpoint_preserve_one_sink() {
+        let sink = Ref::new(2.0_f64);
+        let sink_alias = sink.clone();
+        let function = AddAssignSS::<f64>::new_invocation(
+            FunctionArgs::Unary(sink.to_value(), sink.to_value()).into(),
+        )
+        .unwrap();
+
+        assert_eq!(function.reactive_node_kind(), ReactiveNodeKind::Register);
+        assert_eq!(
+            function.transaction_state_ports().unwrap().unwrap().len(),
+            1
+        );
+        let output_cells = function.reactive_output_cell_ids();
+        assert_eq!(output_cells, function.out().reactive_root_cell_ids());
+
+        let staged = function.stage_register().unwrap();
+        assert_eq!(staged.output_cells(), output_cells.as_slice());
+        assert_eq!(*sink.borrow(), 2.0);
+        staged.commit();
+        assert_eq!(*sink.borrow(), 4.0);
+
+        function.solve_result().unwrap();
+        assert_eq!(*sink.borrow(), 8.0);
+        let successful = *sink.borrow();
+
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*function)?;
+            *sink.borrow_mut() = 99.0;
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+
+        assert!(sink.same_handle(&sink_alias));
+        assert_eq!(*sink.borrow(), successful);
+        assert_eq!(function.reactive_output_cell_ids(), output_cells);
+    }
+
+    #[test]
+    fn staged_assignment_matches_direct_solving_and_reports_the_same_output() {
+        let source = Ref::new(3.0_f64);
+        let sink = Ref::new(2.0_f64);
+        let direct = AddAssignSS::<f64>::new_invocation(
+            FunctionArgs::Unary(sink.to_value(), source.to_value()).into(),
+        )
+        .unwrap();
+        let staged = AddAssignSS::<f64>::new_invocation(
+            FunctionArgs::Unary(sink.to_value(), source.to_value()).into(),
+        )
+        .unwrap();
+
+        let staged_cells = staged.reactive_output_cell_ids();
+        assert_eq!(direct.reactive_output_cell_ids(), staged_cells);
+        assert_eq!(staged_cells, staged.out().reactive_root_cell_ids());
+        direct.solve_result().unwrap();
+        let direct_result = *sink.borrow();
+        *sink.borrow_mut() = 2.0;
+
+        let commit = staged.stage_register().unwrap();
+        assert_eq!(commit.output_cells(), staged_cells.as_slice());
+        assert_eq!(*sink.borrow(), 2.0);
+        commit.commit();
+        assert_eq!(*sink.borrow(), direct_result);
+        assert_eq!(staged.reactive_output_cell_ids(), staged_cells);
+    }
+
+    #[cfg(feature = "semantic-compiler")]
+    fn decoded_scalar_wrapper(reference: bool) -> mech_core::LegacyValue {
+        use mech_core::{EncodedConstant, RuntimeType, decode_encoded_constants};
+
+        fn framed(payload: &[u8]) -> Vec<u8> {
+            let mut framed = (payload.len() as u32).to_le_bytes().to_vec();
+            framed.extend_from_slice(payload);
+            framed
+        }
+
+        let payload = 1.0_f64.to_le_bytes();
+        let (runtime_type, bytes) = if reference {
+            (
+                RuntimeType::Reference(Box::new(RuntimeType::F64)),
+                framed(&payload),
+            )
+        } else {
+            let mut bytes = vec![1];
+            bytes.extend(framed(&payload));
+            (RuntimeType::Option(Box::new(RuntimeType::F64)), bytes)
+        };
+        decode_encoded_constants(&[EncodedConstant {
+            runtime_type,
+            alignment: 8,
+            bytes,
+        }])
+        .unwrap()
+        .pop()
+        .unwrap()
+    }
+
+    #[cfg(feature = "semantic-compiler")]
+    #[test]
+    fn scalar_ports_reject_typed_and_mutable_reference_inputs() {
+        let sink = Ref::new(4.0_f64);
+        for wrapped in [decoded_scalar_wrapper(false), decoded_scalar_wrapper(true)] {
+            assert!(
+                AddAssignSS::<f64>::new_invocation(
+                    FunctionArgs::Unary(sink.to_value(), wrapped).into(),
+                )
+                .is_err()
+            );
+        }
+    }
+}
+
+#[cfg(all(feature = "f64", feature = "matrix2", feature = "add_assign"))]
+mod fixed_matrix_f64 {
+    use super::super::AddAssignVV;
+    use mech_core::{FunctionArgs, MechFunctionFactory, Ref, ToValue};
+    use nalgebra::Matrix2;
+
+    #[test]
+    fn fixed_matrix_whole_value_assignment_uses_exact_ports() {
+        let source = Ref::new(Matrix2::new(1.0_f64, 2.0, 3.0, 4.0));
+        let sink = Ref::new(Matrix2::from_element(10.0_f64));
+        let sink_alias = sink.clone();
+        let function = AddAssignVV::<f64, Matrix2<f64>, Matrix2<f64>>::new_invocation(
+            FunctionArgs::Unary(sink.to_value(), source.to_value()).into(),
+        )
+        .unwrap();
+
+        function.solve_result().unwrap();
+
+        assert!(sink.same_handle(&sink_alias));
+        assert_eq!(*sink.borrow(), Matrix2::new(11.0_f64, 12.0, 13.0, 14.0),);
+        assert_eq!(
+            function.reactive_output_cell_ids(),
+            function.out().reactive_root_cell_ids(),
+        );
+    }
+}
+
+#[cfg(all(
+    feature = "f64",
+    feature = "matrixd",
+    feature = "vectord",
+    feature = "add_assign"
+))]
+mod dynamic_matrix_f64 {
+    use super::super::{AddAssignVS, AddAssignVV};
+    use mech_core::{
+        FunctionArgs, FunctionInvocation, IncorrectNumberOfArguments, MechError, MechFunction,
+        MechFunctionFactory, Ref, ToValue, with_reactive_journal_participant,
+    };
+    use nalgebra::{DMatrix, DVector};
+
+    fn factory_error(result: Result<Box<dyn MechFunction>, MechError>) -> MechError {
+        match result {
+            Ok(_) => panic!("factory unexpectedly accepted invalid arguments"),
+            Err(error) => error,
+        }
+    }
+
+    #[test]
+    fn dynamic_matrix_whole_value_factories_and_staging_preserve_exact_state() {
+        let source = Ref::new(DMatrix::from_row_slice(2, 2, &[1.0_f64, 2.0, 3.0, 4.0]));
+        let legacy_sink = Ref::new(DMatrix::from_element(2, 2, 10.0_f64));
+        let invocation_sink = Ref::new(DMatrix::from_element(2, 2, 10.0_f64));
+        let invocation_alias = invocation_sink.clone();
+        let legacy = AddAssignVV::<f64, DMatrix<f64>, DMatrix<f64>>::new(FunctionArgs::Unary(
+            legacy_sink.to_value(),
+            source.to_value(),
+        ))
+        .unwrap();
+        let invocation = AddAssignVV::<f64, DMatrix<f64>, DMatrix<f64>>::new_invocation(
+            FunctionArgs::Unary(invocation_sink.to_value(), source.to_value()).into(),
+        )
+        .unwrap();
+
+        legacy.solve_result().unwrap();
+        invocation.solve_result().unwrap();
+        assert_eq!(*legacy_sink.borrow(), *invocation_sink.borrow());
+        assert_eq!(
+            *invocation_sink.borrow(),
+            DMatrix::from_row_slice(2, 2, &[11.0_f64, 12.0, 13.0, 14.0]),
+        );
+        assert_eq!(
+            invocation.transaction_state_ports().unwrap().unwrap().len(),
+            1
+        );
+
+        let output_cells = invocation.reactive_output_cell_ids();
+        assert_eq!(output_cells, invocation.out().reactive_root_cell_ids());
+        let before_stage = invocation_sink.borrow().clone();
+        let staged = invocation.stage_register().unwrap();
+        assert_eq!(staged.output_cells(), output_cells.as_slice());
+        assert_eq!(*invocation_sink.borrow(), before_stage);
+        staged.commit();
+        assert_eq!(
+            *invocation_sink.borrow(),
+            DMatrix::from_row_slice(2, 2, &[12.0_f64, 14.0, 16.0, 18.0]),
+        );
+        let successful = invocation_sink.borrow().clone();
+
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*invocation)?;
+            *invocation_sink.borrow_mut() = DMatrix::from_element(1, 3, 99.0);
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+
+        assert!(invocation_sink.same_handle(&invocation_alias));
+        assert_eq!(*invocation_sink.borrow(), successful);
+    }
+
+    #[test]
+    fn matrix_scalar_assignment_keeps_binary_base_layout_and_stages_exact_sink() {
+        let sink = Ref::new(DMatrix::from_row_slice(1, 3, &[1.0_f64, 2.0, 3.0]));
+        let sink_alias = sink.clone();
+        let function = AddAssignVS::<f64, DMatrix<f64>>::new_invocation(
+            FunctionArgs::Binary(
+                sink.to_value(),
+                sink.to_value(),
+                Ref::new(2.0_f64).to_value(),
+            )
+            .into(),
+        )
+        .unwrap();
+
+        let output_cells = function.reactive_output_cell_ids();
+        let staged = function.stage_register().unwrap();
+        assert_eq!(staged.output_cells(), output_cells.as_slice());
+        assert_eq!(sink.borrow().as_slice(), &[1.0, 2.0, 3.0]);
+        staged.commit();
+
+        assert!(sink.same_handle(&sink_alias));
+        assert_eq!(sink.borrow().as_slice(), &[3.0, 4.0, 5.0]);
+        assert_eq!(
+            function.transaction_state_ports().unwrap().unwrap().len(),
+            1
+        );
+
+        let error = factory_error(AddAssignVS::<f64, DMatrix<f64>>::new_invocation(
+            FunctionInvocation::from(FunctionArgs::Unary(
+                sink.to_value(),
+                Ref::new(1.0_f64).to_value(),
+            )),
+        ));
+        let arity = error.kind_as::<IncorrectNumberOfArguments>().unwrap();
+        assert_eq!((arity.expected, arity.found), (2, 1));
+    }
+
+    #[test]
+    fn matrix_output_source_aliasing_remains_supported() {
+        let sink = Ref::new(DMatrix::from_row_slice(1, 3, &[1.0_f64, 2.0, 3.0]));
+        let sink_alias = sink.clone();
+        let function = AddAssignVV::<f64, DMatrix<f64>, DMatrix<f64>>::new_invocation(
+            FunctionArgs::Unary(sink.to_value(), sink.to_value()).into(),
+        )
+        .unwrap();
+
+        function.solve_result().unwrap();
+
+        assert!(sink.same_handle(&sink_alias));
+        assert_eq!(sink.borrow().as_slice(), &[2.0, 4.0, 6.0]);
+    }
+
+    #[test]
+    fn matrix_whole_value_ports_reject_storage_mismatches_and_report_unary_arity() {
+        let sink = Ref::new(DMatrix::from_element(1, 2, 1.0_f64));
+        let source = Ref::new(DMatrix::from_element(1, 2, 2.0_f64));
+        let vector = Ref::new(DVector::from_vec(vec![1.0_f64, 2.0]));
+
+        assert!(
+            AddAssignVV::<f64, DMatrix<f64>, DMatrix<f64>>::new_invocation(
+                FunctionArgs::Unary(sink.to_value(), vector.to_value()).into(),
+            )
+            .is_err()
+        );
+        assert!(
+            AddAssignVV::<f64, DMatrix<f64>, DMatrix<f64>>::new_invocation(
+                FunctionArgs::Unary(vector.to_value(), source.to_value()).into(),
+            )
+            .is_err()
+        );
+
+        let error = factory_error(
+            AddAssignVV::<f64, DMatrix<f64>, DMatrix<f64>>::new_invocation(
+                FunctionInvocation::from(FunctionArgs::Binary(
+                    sink.to_value(),
+                    source.to_value(),
+                    source.to_value(),
+                )),
+            ),
+        );
+        let arity = error.kind_as::<IncorrectNumberOfArguments>().unwrap();
+        assert_eq!((arity.expected, arity.found), (1, 2));
+    }
+}
+
+#[cfg(all(feature = "u8", feature = "add_assign", feature = "div_assign"))]
+mod checked_integer {
+    use super::super::{AddAssignSS, DivAssignSS};
+    use mech_core::{
+        FunctionArgs, MechFunctionFactory, Ref, ToValue, with_reactive_journal_participant,
+    };
+
+    #[test]
+    fn overflow_is_atomic_and_prior_successful_state_remains_restorable() {
+        let sink = Ref::new(40_u8);
+        let sink_alias = sink.clone();
+        let source = Ref::new(1_u8);
+        let function = AddAssignSS::<u8>::new_invocation(
+            FunctionArgs::Unary(sink.to_value(), source.to_value()).into(),
+        )
+        .unwrap();
+        function.solve_result().unwrap();
+        assert_eq!(*sink.borrow(), 41);
+
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*function)?;
+            *source.borrow_mut() = u8::MAX;
+            let error = function.solve_result().unwrap_err();
+            assert_eq!(error.kind_name(), "MathArithmeticOverflow");
+            assert_eq!(*sink.borrow(), 41);
+            let error = match function.stage_register() {
+                Ok(_) => panic!("overflowing assignment unexpectedly staged"),
+                Err(error) => error,
+            };
+            assert_eq!(error.kind_name(), "MathArithmeticOverflow");
+            assert_eq!(*sink.borrow(), 41);
+            *sink.borrow_mut() = 99;
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+
+        assert!(sink.same_handle(&sink_alias));
+        assert_eq!(*sink.borrow(), 41);
+    }
+
+    #[test]
+    fn integer_division_failure_leaves_the_sink_unchanged() {
+        let sink = Ref::new(7_u8);
+        let function = DivAssignSS::<u8>::new_invocation(
+            FunctionArgs::Unary(sink.to_value(), Ref::new(0_u8).to_value()).into(),
+        )
+        .unwrap();
+
+        let error = function.solve_result().unwrap_err();
+        assert_eq!(error.kind_name(), "MathArithmeticOverflow");
+        assert_eq!(*sink.borrow(), 7);
+        let error = match function.stage_register() {
+            Ok(_) => panic!("invalid division unexpectedly staged"),
+            Err(error) => error,
+        };
+        assert_eq!(error.kind_name(), "MathArithmeticOverflow");
+        assert_eq!(*sink.borrow(), 7);
+    }
+}

--- a/machines/range/src/exclusive.rs
+++ b/machines/range/src/exclusive.rs
@@ -65,8 +65,8 @@ where
     Ref<T>: ToValue,
     Ref<naMatrix<T, R1, C1, S1>>: ToValue,
     naMatrix<T, R1, C1, S1>: AsNaKind,
-    naMatrix<T, R1, C1, S1>: FunctionRuntimeType,
-    T: FunctionRuntimeType,
+    naMatrix<T, R1, C1, S1>: FunctionStateBacking,
+    T: FunctionPortBacking,
     #[cfg(feature = "semantic-compiler")]
     naMatrix<T, R1, C1, S1>: CompileConst + ConstElem,
     R1: Dim + 'static,
@@ -79,34 +79,27 @@ where
         T::REPRESENTATION,
     );
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, from, to) = invocation.expect_binary()?;
+        let from: Ref<T> = from.try_ref()?;
+        let to: Ref<T> = to.try_ref()?;
+        let out: Ref<naMatrix<T, R1, C1, S1>> = out.try_ref()?;
+        Ok(Box::new(Self {
+            from,
+            to,
+            out,
+            phantom: PhantomData::default(),
+        }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Binary(out, from, to) => {
-                let from: Ref<T> = from.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let to: Ref<T> = to.try_function_ref(FunctionArgumentRole::Input(1))?;
-                let out: Ref<naMatrix<T, R1, C1, S1>> =
-                    out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(Self {
-                    from,
-                    to,
-                    out,
-                    phantom: PhantomData::default(),
-                }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 3,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 impl<T, R1, C1, S1> MechFunctionImpl for RangeExclusiveScalar<T, naMatrix<T, R1, C1, S1>>
 where
     Ref<naMatrix<T, R1, C1, S1>>: ToValue,
+    naMatrix<T, R1, C1, S1>: FunctionStateBacking,
     Ref<T>: ToValue,
     T: Copy
         + Scalar
@@ -123,6 +116,12 @@ where
     C1: Dim,
     S1: StorageMut<T, R1, C1> + Clone + Debug,
 {
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
+    }
     fn solve_result(&self) -> MResult<()> {
         crate::catalog::validate_range_exclusive(&FunctionArgs::Binary(
             self.out.to_value(),

--- a/machines/range/src/exclusive_increment.rs
+++ b/machines/range/src/exclusive_increment.rs
@@ -70,8 +70,8 @@ where
     Ref<T>: ToValue,
     Ref<naMatrix<T, R1, C1, S1>>: ToValue,
     naMatrix<T, R1, C1, S1>: AsNaKind,
-    naMatrix<T, R1, C1, S1>: FunctionRuntimeType,
-    T: FunctionRuntimeType,
+    naMatrix<T, R1, C1, S1>: FunctionStateBacking,
+    T: FunctionPortBacking,
     #[cfg(feature = "semantic-compiler")]
     naMatrix<T, R1, C1, S1>: CompileConst + ConstElem,
     R1: Dim + 'static,
@@ -85,36 +85,29 @@ where
         T::REPRESENTATION,
     );
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, from, step, to) = invocation.expect_ternary()?;
+        let from: Ref<T> = from.try_ref()?;
+        let step: Ref<T> = step.try_ref()?;
+        let to: Ref<T> = to.try_ref()?;
+        let out: Ref<naMatrix<T, R1, C1, S1>> = out.try_ref()?;
+        Ok(Box::new(Self {
+            from,
+            step,
+            to,
+            out,
+            phantom: PhantomData::default(),
+        }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Ternary(out, from, step, to) => {
-                let from: Ref<T> = from.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let step: Ref<T> = step.try_function_ref(FunctionArgumentRole::Input(1))?;
-                let to: Ref<T> = to.try_function_ref(FunctionArgumentRole::Input(2))?;
-                let out: Ref<naMatrix<T, R1, C1, S1>> =
-                    out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(Self {
-                    from,
-                    step,
-                    to,
-                    out,
-                    phantom: PhantomData::default(),
-                }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 3,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 impl<T, R1, C1, S1> MechFunctionImpl for RangeIncrementExclusiveScalar<T, naMatrix<T, R1, C1, S1>>
 where
     Ref<naMatrix<T, R1, C1, S1>>: ToValue,
+    naMatrix<T, R1, C1, S1>: FunctionStateBacking,
     Ref<T>: ToValue,
     T: Copy
         + Scalar
@@ -131,6 +124,12 @@ where
     C1: Dim,
     S1: StorageMut<T, R1, C1> + Clone + Debug,
 {
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
+    }
     fn solve_result(&self) -> MResult<()> {
         crate::catalog::validate_range_increment_exclusive(&FunctionArgs::Ternary(
             self.out.to_value(),

--- a/machines/range/src/inclusive.rs
+++ b/machines/range/src/inclusive.rs
@@ -65,8 +65,8 @@ where
     Ref<T>: ToValue,
     Ref<naMatrix<T, R1, C1, S1>>: ToValue,
     naMatrix<T, R1, C1, S1>: AsNaKind,
-    naMatrix<T, R1, C1, S1>: FunctionRuntimeType,
-    T: FunctionRuntimeType,
+    naMatrix<T, R1, C1, S1>: FunctionStateBacking,
+    T: FunctionPortBacking,
     #[cfg(feature = "semantic-compiler")]
     naMatrix<T, R1, C1, S1>: CompileConst + ConstElem,
     R1: Dim + 'static,
@@ -79,34 +79,27 @@ where
         T::REPRESENTATION,
     );
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, from, to) = invocation.expect_binary()?;
+        let from: Ref<T> = from.try_ref()?;
+        let to: Ref<T> = to.try_ref()?;
+        let out: Ref<naMatrix<T, R1, C1, S1>> = out.try_ref()?;
+        Ok(Box::new(Self {
+            from,
+            to,
+            out,
+            phantom: PhantomData::default(),
+        }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Binary(out, from, to) => {
-                let from: Ref<T> = from.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let to: Ref<T> = to.try_function_ref(FunctionArgumentRole::Input(1))?;
-                let out: Ref<naMatrix<T, R1, C1, S1>> =
-                    out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(Self {
-                    from,
-                    to,
-                    out,
-                    phantom: PhantomData::default(),
-                }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 3,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 impl<T, R1, C1, S1> MechFunctionImpl for RangeInclusiveScalar<T, naMatrix<T, R1, C1, S1>>
 where
     Ref<naMatrix<T, R1, C1, S1>>: ToValue,
+    naMatrix<T, R1, C1, S1>: FunctionStateBacking,
     Ref<T>: ToValue,
     T: Copy
         + Scalar
@@ -123,6 +116,12 @@ where
     C1: Dim,
     S1: StorageMut<T, R1, C1> + Clone + Debug,
 {
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
+    }
     fn solve_result(&self) -> MResult<()> {
         crate::catalog::validate_range_inclusive(&FunctionArgs::Binary(
             self.out.to_value(),

--- a/machines/range/src/inclusive_increment.rs
+++ b/machines/range/src/inclusive_increment.rs
@@ -70,8 +70,8 @@ where
     Ref<T>: ToValue,
     Ref<naMatrix<T, R1, C1, S1>>: ToValue,
     naMatrix<T, R1, C1, S1>: AsNaKind,
-    naMatrix<T, R1, C1, S1>: FunctionRuntimeType,
-    T: FunctionRuntimeType,
+    naMatrix<T, R1, C1, S1>: FunctionStateBacking,
+    T: FunctionPortBacking,
     #[cfg(feature = "semantic-compiler")]
     naMatrix<T, R1, C1, S1>: CompileConst + ConstElem,
     R1: Dim + 'static,
@@ -85,36 +85,29 @@ where
         T::REPRESENTATION,
     );
 
+    fn new_invocation(invocation: FunctionInvocation) -> MResult<Box<dyn MechFunction>> {
+        let (out, from, step, to) = invocation.expect_ternary()?;
+        let from: Ref<T> = from.try_ref()?;
+        let step: Ref<T> = step.try_ref()?;
+        let to: Ref<T> = to.try_ref()?;
+        let out: Ref<naMatrix<T, R1, C1, S1>> = out.try_ref()?;
+        Ok(Box::new(Self {
+            from,
+            step,
+            to,
+            out,
+            phantom: PhantomData::default(),
+        }))
+    }
+
     fn new(args: FunctionArgs) -> MResult<Box<dyn MechFunction>> {
-        match args {
-            FunctionArgs::Ternary(out, from, step, to) => {
-                let from: Ref<T> = from.try_function_ref(FunctionArgumentRole::Input(0))?;
-                let step: Ref<T> = step.try_function_ref(FunctionArgumentRole::Input(1))?;
-                let to: Ref<T> = to.try_function_ref(FunctionArgumentRole::Input(2))?;
-                let out: Ref<naMatrix<T, R1, C1, S1>> =
-                    out.try_function_ref(FunctionArgumentRole::Output)?;
-                Ok(Box::new(Self {
-                    from,
-                    step,
-                    to,
-                    out,
-                    phantom: PhantomData::default(),
-                }))
-            }
-            _ => Err(MechError::new(
-                IncorrectNumberOfArguments {
-                    expected: 3,
-                    found: args.len(),
-                },
-                None,
-            )
-            .with_compiler_loc()),
-        }
+        Self::new_invocation(args.into())
     }
 }
 impl<T, R1, C1, S1> MechFunctionImpl for RangeIncrementInclusiveScalar<T, naMatrix<T, R1, C1, S1>>
 where
     Ref<naMatrix<T, R1, C1, S1>>: ToValue,
+    naMatrix<T, R1, C1, S1>: FunctionStateBacking,
     Ref<T>: ToValue,
     T: Copy
         + Scalar
@@ -131,6 +124,12 @@ where
     C1: Dim,
     S1: StorageMut<T, R1, C1> + Clone + Debug,
 {
+    fn primary_output_state_port(&self) -> Option<FunctionStatePort<'_>> {
+        Some(FunctionStatePort::from_ref(&self.out))
+    }
+    fn transaction_state_ports(&self) -> MResult<Option<Vec<FunctionStatePort<'_>>>> {
+        Ok(Some(vec![FunctionStatePort::from_ref(&self.out)]))
+    }
     fn solve_result(&self) -> MResult<()> {
         crate::catalog::validate_range_increment_inclusive(&FunctionArgs::Ternary(
             self.out.to_value(),

--- a/machines/range/src/lib.rs
+++ b/machines/range/src/lib.rs
@@ -59,6 +59,9 @@ pub use self::inclusive::*;
 #[cfg(feature = "inclusive")]
 pub use self::inclusive_increment::*;
 
+#[cfg(test)]
+mod port_tests;
+
 use mech_core::MechErrorKind;
 
 // ----------------------------------------------------------------------------

--- a/machines/range/src/port_tests.rs
+++ b/machines/range/src/port_tests.rs
@@ -1,0 +1,389 @@
+#[cfg(all(
+    feature = "f64",
+    feature = "matrixd",
+    feature = "row_vectord",
+    feature = "inclusive",
+    feature = "exclusive",
+    feature = "inclusive_increment",
+    feature = "exclusive_increment"
+))]
+mod dynamic_ranges {
+    use crate::{
+        RangeExclusiveScalar, RangeIncrementExclusiveScalar, RangeIncrementInclusiveScalar,
+        RangeInclusiveScalar,
+    };
+    use mech_core::{
+        EncodedConstant, FunctionArgs, FunctionArgumentRole, FunctionInvocation,
+        IncorrectNumberOfArguments, LegacyValue, MechError, MechFunction, MechFunctionFactory,
+        Ref, RuntimeType, ToValue, decode_encoded_constants, with_reactive_journal_participant,
+    };
+    use nalgebra::{DMatrix, RowDVector};
+
+    fn output(len: usize) -> Ref<DMatrix<f64>> {
+        Ref::new(DMatrix::from_element(1, len, 0.0))
+    }
+
+    fn factory_error(result: Result<Box<dyn MechFunction>, MechError>) -> MechError {
+        match result {
+            Ok(_) => panic!("factory unexpectedly accepted invalid arguments"),
+            Err(error) => error,
+        }
+    }
+
+    fn framed(payload: &[u8]) -> Vec<u8> {
+        let mut framed = (payload.len() as u32).to_le_bytes().to_vec();
+        framed.extend_from_slice(payload);
+        framed
+    }
+
+    fn decoded_scalar_wrapper(reference: bool) -> LegacyValue {
+        let payload = 1.0_f64.to_le_bytes();
+        let (runtime_type, bytes) = if reference {
+            (
+                RuntimeType::Reference(Box::new(RuntimeType::F64)),
+                framed(&payload),
+            )
+        } else {
+            let mut bytes = vec![1];
+            bytes.extend(framed(&payload));
+            (RuntimeType::Option(Box::new(RuntimeType::F64)), bytes)
+        };
+        decode_encoded_constants(&[EncodedConstant {
+            runtime_type,
+            alignment: 8,
+            bytes,
+        }])
+        .unwrap()
+        .pop()
+        .unwrap()
+    }
+
+    fn assert_supplied_output(function: &dyn MechFunction, out: &Ref<DMatrix<f64>>) {
+        assert_eq!(
+            function.reactive_output_cell_ids(),
+            out.to_value().reactive_root_cell_ids(),
+        );
+        let projected = function
+            .out()
+            .try_function_matrix::<f64>(FunctionArgumentRole::Output)
+            .unwrap();
+        let mech_core::matrix::Matrix::DMatrix(projected) = projected else {
+            panic!("range output changed its dynamic matrix representation")
+        };
+        assert!(projected.same_handle(out));
+    }
+
+    #[test]
+    fn all_range_factories_match_the_legacy_adapters() {
+        let from = Ref::new(1.0_f64);
+        let to = Ref::new(3.0_f64);
+        let legacy_out = output(3);
+        let invocation_out = output(3);
+        let legacy = RangeInclusiveScalar::<f64, DMatrix<f64>>::new(FunctionArgs::Binary(
+            legacy_out.to_value(),
+            from.to_value(),
+            to.to_value(),
+        ))
+        .unwrap();
+        let invocation = RangeInclusiveScalar::<f64, DMatrix<f64>>::new_invocation(
+            FunctionArgs::Binary(
+                invocation_out.to_value(),
+                from.to_value(),
+                to.to_value(),
+            )
+            .into(),
+        )
+        .unwrap();
+        legacy.solve_result().unwrap();
+        invocation.solve_result().unwrap();
+        assert_eq!(*legacy_out.borrow(), *invocation_out.borrow());
+        assert_supplied_output(&*legacy, &legacy_out);
+        assert_supplied_output(&*invocation, &invocation_out);
+
+        let exclusive_to = Ref::new(4.0_f64);
+        let legacy_out = output(3);
+        let invocation_out = output(3);
+        let legacy = RangeExclusiveScalar::<f64, DMatrix<f64>>::new(FunctionArgs::Binary(
+            legacy_out.to_value(),
+            from.to_value(),
+            exclusive_to.to_value(),
+        ))
+        .unwrap();
+        let invocation = RangeExclusiveScalar::<f64, DMatrix<f64>>::new_invocation(
+            FunctionArgs::Binary(
+                invocation_out.to_value(),
+                from.to_value(),
+                exclusive_to.to_value(),
+            )
+            .into(),
+        )
+        .unwrap();
+        legacy.solve_result().unwrap();
+        invocation.solve_result().unwrap();
+        assert_eq!(*legacy_out.borrow(), *invocation_out.borrow());
+        assert_supplied_output(&*legacy, &legacy_out);
+        assert_supplied_output(&*invocation, &invocation_out);
+
+        let step = Ref::new(2.0_f64);
+        let inclusive_to = Ref::new(5.0_f64);
+        let legacy_out = output(3);
+        let invocation_out = output(3);
+        let legacy =
+            RangeIncrementInclusiveScalar::<f64, DMatrix<f64>>::new(FunctionArgs::Ternary(
+                legacy_out.to_value(),
+                from.to_value(),
+                step.to_value(),
+                inclusive_to.to_value(),
+            ))
+            .unwrap();
+        let invocation = RangeIncrementInclusiveScalar::<f64, DMatrix<f64>>::new_invocation(
+            FunctionArgs::Ternary(
+                invocation_out.to_value(),
+                from.to_value(),
+                step.to_value(),
+                inclusive_to.to_value(),
+            )
+            .into(),
+        )
+        .unwrap();
+        legacy.solve_result().unwrap();
+        invocation.solve_result().unwrap();
+        assert_eq!(*legacy_out.borrow(), *invocation_out.borrow());
+        assert_supplied_output(&*legacy, &legacy_out);
+        assert_supplied_output(&*invocation, &invocation_out);
+
+        let exclusive_to = Ref::new(7.0_f64);
+        let legacy_out = output(3);
+        let invocation_out = output(3);
+        let legacy =
+            RangeIncrementExclusiveScalar::<f64, DMatrix<f64>>::new(FunctionArgs::Ternary(
+                legacy_out.to_value(),
+                from.to_value(),
+                step.to_value(),
+                exclusive_to.to_value(),
+            ))
+            .unwrap();
+        let invocation = RangeIncrementExclusiveScalar::<f64, DMatrix<f64>>::new_invocation(
+            FunctionArgs::Ternary(
+                invocation_out.to_value(),
+                from.to_value(),
+                step.to_value(),
+                exclusive_to.to_value(),
+            )
+            .into(),
+        )
+        .unwrap();
+        legacy.solve_result().unwrap();
+        invocation.solve_result().unwrap();
+        assert_eq!(*legacy_out.borrow(), *invocation_out.borrow());
+        assert_supplied_output(&*legacy, &legacy_out);
+        assert_supplied_output(&*invocation, &invocation_out);
+    }
+
+    #[test]
+    fn range_ports_reject_wrong_types_storage_and_wrappers() {
+        let out = output(3);
+        let to = Ref::new(3.0_f64);
+        assert!(
+            RangeInclusiveScalar::<f64, DMatrix<f64>>::new_invocation(
+                FunctionArgs::Binary(
+                    out.to_value(),
+                    Ref::new(1_usize).to_value(),
+                    to.to_value(),
+                )
+                .into(),
+            )
+            .is_err()
+        );
+
+        let wrong_out = Ref::new(RowDVector::from_element(3, 0.0_f64));
+        assert!(
+            RangeInclusiveScalar::<f64, DMatrix<f64>>::new_invocation(
+                FunctionArgs::Binary(
+                    wrong_out.to_value(),
+                    Ref::new(1.0_f64).to_value(),
+                    to.to_value(),
+                )
+                .into(),
+            )
+            .is_err()
+        );
+
+        for wrapped in [decoded_scalar_wrapper(false), decoded_scalar_wrapper(true)] {
+            assert!(
+                RangeInclusiveScalar::<f64, DMatrix<f64>>::new_invocation(
+                    FunctionArgs::Binary(out.to_value(), wrapped, to.to_value()).into(),
+                )
+                .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn range_layout_errors_report_the_correct_arities() {
+        let out = output(1);
+        let scalar = Ref::new(1.0_f64);
+        for error in [
+            factory_error(RangeInclusiveScalar::<f64, DMatrix<f64>>::new_invocation(
+                FunctionInvocation::from(FunctionArgs::Unary(
+                    out.to_value(),
+                    scalar.to_value(),
+                )),
+            )),
+            factory_error(RangeExclusiveScalar::<f64, DMatrix<f64>>::new_invocation(
+                FunctionInvocation::from(FunctionArgs::Unary(
+                    out.to_value(),
+                    scalar.to_value(),
+                )),
+            )),
+        ] {
+            let arity = error.kind_as::<IncorrectNumberOfArguments>().unwrap();
+            assert_eq!((arity.expected, arity.found), (2, 1));
+        }
+
+        for error in [
+            factory_error(
+                RangeIncrementInclusiveScalar::<f64, DMatrix<f64>>::new_invocation(
+                    FunctionInvocation::from(FunctionArgs::Binary(
+                        out.to_value(),
+                        scalar.to_value(),
+                        scalar.to_value(),
+                    )),
+                ),
+            ),
+            factory_error(
+                RangeIncrementExclusiveScalar::<f64, DMatrix<f64>>::new_invocation(
+                    FunctionInvocation::from(FunctionArgs::Binary(
+                        out.to_value(),
+                        scalar.to_value(),
+                        scalar.to_value(),
+                    )),
+                ),
+            ),
+        ] {
+            let arity = error.kind_as::<IncorrectNumberOfArguments>().unwrap();
+            assert_eq!((arity.expected, arity.found), (3, 2));
+        }
+    }
+
+    #[test]
+    fn binary_and_incremented_outputs_restore_exact_state() {
+        let binary_out = output(3);
+        let binary_alias = binary_out.clone();
+        let binary = RangeInclusiveScalar::<f64, DMatrix<f64>>::new_invocation(
+            FunctionArgs::Binary(
+                binary_out.to_value(),
+                Ref::new(1.0_f64).to_value(),
+                Ref::new(3.0_f64).to_value(),
+            )
+            .into(),
+        )
+        .unwrap();
+        let stepped_out = output(3);
+        let stepped_alias = stepped_out.clone();
+        let stepped = RangeIncrementInclusiveScalar::<f64, DMatrix<f64>>::new_invocation(
+            FunctionArgs::Ternary(
+                stepped_out.to_value(),
+                Ref::new(1.0_f64).to_value(),
+                Ref::new(2.0_f64).to_value(),
+                Ref::new(5.0_f64).to_value(),
+            )
+            .into(),
+        )
+        .unwrap();
+        binary.solve_result().unwrap();
+        stepped.solve_result().unwrap();
+        let binary_before = binary_out.borrow().clone();
+        let stepped_before = stepped_out.borrow().clone();
+        assert_eq!(
+            binary.reactive_output_cell_ids(),
+            binary.out().reactive_root_cell_ids(),
+        );
+        assert_eq!(
+            stepped.reactive_output_cell_ids(),
+            stepped.out().reactive_root_cell_ids(),
+        );
+
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*binary)?;
+            participant.capture_function_state(&*stepped)?;
+            *binary_out.borrow_mut() = DMatrix::from_element(2, 2, 99.0);
+            *stepped_out.borrow_mut() = DMatrix::from_element(2, 1, 88.0);
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+
+        assert!(binary_out.same_handle(&binary_alias));
+        assert!(stepped_out.same_handle(&stepped_alias));
+        assert_eq!(*binary_out.borrow(), binary_before);
+        assert_eq!(*stepped_out.borrow(), stepped_before);
+    }
+
+    #[test]
+    fn range_shape_failure_is_atomic_and_prior_state_remains_restorable() {
+        let to = Ref::new(3.0_f64);
+        let out = output(3);
+        let out_alias = out.clone();
+        let function = RangeInclusiveScalar::<f64, DMatrix<f64>>::new_invocation(
+            FunctionArgs::Binary(
+                out.to_value(),
+                Ref::new(1.0_f64).to_value(),
+                to.to_value(),
+            )
+            .into(),
+        )
+        .unwrap();
+        function.solve_result().unwrap();
+        let successful = out.borrow().clone();
+
+        with_reactive_journal_participant(|mut participant| {
+            participant.capture_function_state(&*function)?;
+            *to.borrow_mut() = 4.0;
+            let error = function.solve_result().unwrap_err();
+            assert_eq!(error.kind_name(), "FunctionShapeContractViolation");
+            assert_eq!(*out.borrow(), successful);
+            *out.borrow_mut() = DMatrix::from_element(2, 2, -1.0);
+            participant.preflight_restore_before()?;
+            participant.apply_restore_before();
+            Ok(())
+        })
+        .unwrap();
+
+        assert!(out.same_handle(&out_alias));
+        assert_eq!(*out.borrow(), successful);
+    }
+}
+
+#[cfg(all(feature = "f64", feature = "row_vector2", feature = "inclusive"))]
+mod fixed_range {
+    use crate::RangeInclusiveScalar;
+    use mech_core::{FunctionArgs, FunctionArgumentRole, MechFunctionFactory, Ref, ToValue};
+    use nalgebra::RowVector2;
+
+    #[test]
+    fn fixed_row_vector_output_retains_exact_representation_and_handle() {
+        let out = Ref::new(RowVector2::zeros());
+        let function = RangeInclusiveScalar::<f64, RowVector2<f64>>::new_invocation(
+            FunctionArgs::Binary(
+                out.to_value(),
+                Ref::new(1.0_f64).to_value(),
+                Ref::new(2.0_f64).to_value(),
+            )
+            .into(),
+        )
+        .unwrap();
+        function.solve_result().unwrap();
+        assert_eq!(out.borrow().as_slice(), &[1.0, 2.0]);
+
+        let projected = function
+            .out()
+            .try_function_matrix::<f64>(FunctionArgumentRole::Output)
+            .unwrap();
+        let mech_core::matrix::Matrix::RowVector2(projected) = projected else {
+            panic!("fixed range output changed its representation")
+        };
+        assert!(projected.same_handle(&out));
+    }
+}

--- a/src/core/src/function/argument.rs
+++ b/src/core/src/function/argument.rs
@@ -318,6 +318,31 @@ impl FunctionInputPort<'_> {
             FunctionArgumentRole::Input(self.index),
         )
     }
+
+    /// Extracts the exact typed matrix input wrapper without exposing legacy values.
+    ///
+    /// ```compile_fail
+    /// use mech_core::matrix::Matrix;
+    /// use mech_core::{FunctionArgs, FunctionInvocation, LegacyValue};
+    ///
+    /// let invocation = FunctionInvocation::from(FunctionArgs::Unary(
+    ///     LegacyValue::Empty,
+    ///     LegacyValue::Empty,
+    /// ));
+    /// let (_, input) = invocation.expect_unary().unwrap();
+    /// let _: Matrix<LegacyValue> = input.try_matrix::<LegacyValue>().unwrap();
+    /// ```
+    #[cfg(feature = "matrix")]
+    pub fn try_matrix<T>(self) -> MResult<Matrix<T>>
+    where
+        T: FunctionPortBacking + Clone,
+    {
+        self.invocation
+            .args
+            .input_value(self.index)
+            .expect("function input port index remains valid")
+            .try_function_matrix(FunctionArgumentRole::Input(self.index))
+    }
 }
 
 impl fmt::Debug for FunctionInputPort<'_> {
@@ -834,6 +859,74 @@ mod tests {
                 .unwrap()
                 .same_handle(&matrix)
         );
+
+        let wrapped = input.try_matrix::<f64>().unwrap();
+        let Matrix::Matrix2(wrapped) = wrapped else {
+            panic!("matrix input port changed the fixed representation")
+        };
+        assert!(wrapped.same_handle(&matrix));
+    }
+
+    #[cfg(all(
+        feature = "f64",
+        feature = "matrix",
+        feature = "matrixd",
+        feature = "string"
+    ))]
+    #[test]
+    fn matrix_input_ports_preserve_dynamic_handles_and_reject_wrong_values() {
+        use crate::matrix::Matrix;
+        use nalgebra::DMatrix;
+
+        let matrix = Ref::new(DMatrix::from_row_slice(2, 2, &[1.0_f64, 2.0, 3.0, 4.0]));
+        let value = LegacyValue::MatrixF64(Matrix::DMatrix(matrix.clone()));
+        let invocation = FunctionInvocation::from(FunctionArgs::Binary(
+            LegacyValue::Empty,
+            value.clone(),
+            Ref::new(9.0_f64).to_value(),
+        ));
+        let (_, matrix_input, scalar_input) = invocation.expect_binary().unwrap();
+
+        let extracted = matrix_input.try_matrix::<f64>().unwrap();
+        let Matrix::DMatrix(extracted) = extracted else {
+            panic!("matrix input port changed the dynamic representation")
+        };
+        assert!(extracted.same_handle(&matrix));
+
+        let scalar_error = scalar_input.try_matrix::<f64>().unwrap_err();
+        assert_eq!(
+            scalar_error
+                .kind_as::<FunctionArgumentTypeMismatch>()
+                .unwrap()
+                .role,
+            FunctionArgumentRole::Input(1),
+        );
+
+        let string_matrix = LegacyValue::MatrixString(Matrix::DMatrix(Ref::new(
+            DMatrix::from_element(1, 1, "wrong".to_string()),
+        )));
+        let invocation =
+            FunctionInvocation::from(FunctionArgs::Unary(LegacyValue::Empty, string_matrix));
+        let (_, input) = invocation.expect_unary().unwrap();
+        assert!(input.try_matrix::<f64>().is_err());
+    }
+
+    #[cfg(all(feature = "f64", feature = "matrix", feature = "matrix2"))]
+    #[test]
+    fn matrix_input_ports_do_not_traverse_value_wrappers() {
+        use crate::matrix::Matrix;
+        use nalgebra::Matrix2;
+
+        let matrix = LegacyValue::MatrixF64(Matrix::Matrix2(Ref::new(Matrix2::identity())));
+        let typed = LegacyValue::Typed(Box::new(matrix.clone()), matrix.kind());
+        let mutable = LegacyValue::MutableReference(Ref::new(matrix));
+
+        for wrapped in [typed, mutable] {
+            let invocation =
+                FunctionInvocation::from(FunctionArgs::Unary(LegacyValue::Empty, wrapped));
+            let (_, input) = invocation.expect_unary().unwrap();
+            assert!(input.try_matrix::<f64>().is_err());
+        }
     }
 
     #[cfg(feature = "f64")]


### PR DESCRIPTION
## Summary

- adds exact typed `Matrix<T>` extraction to `FunctionInputPort` without exposing `LegacyValue`
- migrates all four range runtime factory families to `FunctionInvocation`
- exposes all range outputs through exact `FunctionStatePort` checkpoints
- migrates scalar and matrix n-choose-k factories and output state to typed ports
- migrates all whole-value and indexed math op-assignment runtime factories through `FunctionInvocation`
- exposes read-modify-write sinks through authoritative `FunctionStatePort` state
- preserves staged register commits, allowed aliasing, source specialization, semantic contracts, checked-operation atomicity, resident execution, dynamic-module behavior, IDs, signatures, and legacy compatibility methods
- corrects legacy manual arity diagnostics for binary range, unary whole-value assignment, and binary indexed assignment factories

## Behavior

| Function family | Factory input | Normal output state |
| --- | --- | --- |
| Inclusive range | Exact scalar ports | Exact matrix state |
| Exclusive range | Exact scalar ports | Exact matrix state |
| Inclusive stepped range | Three exact scalar ports | Exact matrix state |
| Exclusive stepped range | Three exact scalar ports | Exact matrix state |
| Scalar n-choose-k | Exact scalar ports | Exact scalar state |
| Matrix n-choose-k | Exact `Matrix<T>` wrapper plus scalar | Exact `DMatrix<T>` state |
| Whole-value op-assignment | Exact source port | Exact sink state |
| Indexed op-assignment | Exact source and index ports | Exact sink state |
| Staged register assignment | Existing staged commit | Typed reactive identity |
| Source assignment specializer | Existing `LegacyValue` path | Unchanged |
| Catalog validator | Existing `FunctionArgs` contract | Unchanged |
| Dynamic module | Existing ABI | Unchanged |

## Non-goals

- no source-specializer migration
- no catalog or validator rewrite
- no removal of legacy factory/output methods
- no new aggregate or `AnyValue` port
- no resident or dynamic-module changes
- no manifest or workflow changes
- no contract regeneration
- no stack merge or retargeting

## Evidence

- PR8 base SHA: `e4ff3d10959bcc26cb45739fb696e5ac74aecd5c`
- PR9 head SHA: `7041b9c1c7d2df616ad3c747a339f63b9bc2a6d6`
- exactly six commits; the original four range/combinatorics commits retain their reviewed hashes
- formatting, whitespace, warning policy, and the complete local Static Contracts workflow pass
- range: full 15, standard 6, dynamic 5, and u128 boundary 6 tests pass
- combinatorics: full 21, standard 15, scalar-only 10, fixed/dynamic matrix 15, and signed-selection 5 tests pass; dynamic-module compatibility passes
- math full-compiler profile: 52 tests pass, with documentation tests clean
- focused whole-value scalar diagnostics: 6 tests pass
- focused dynamic/indexed op-assignment: 18 tests pass
- checked-u8 op-assignment: 7 tests pass
- the exact narrow math profiles now clear every op-assignment-owned baseline diagnostic; they retain only pre-existing out-of-scope `lib.rs`/`catalog.rs` unused-import warnings, with paired baseline/head evidence
- final-head owner suites pass: core 406, engine 293, and runtime 465 tests
- retirement checker: `LegacyValue` 4,928 reviewed / 4,906 live / 22 removed; `ValueKind` 1,181 / 1,181; `Kind` 162 / 162; zero unreviewed growth
- value-execution, compiler-planning, bytecode-v1, production-routing, function-system source, and function-system consumer contracts pass
- the complete function-system script reproduces only the frozen math compiler-feature assertion also present on PR8; its runtime, source, and compiler cargo checks pass before that assertion
- op-assignment source audit: five invocation-generating macros, five primary output state methods, five transaction state methods, and zero production `FunctionArgs::Unary`/`Binary`, `try_function_ref`, or `try_function_matrix` uses
- the indexed macros cover 32 generated forms across add, subtract, multiply, and divide assignment
- protected diffs are empty for catalogs, operation-specific source specializers, manifests, workflows, engine/runtime, and frozen value/function-system JSON
- selected hosted CI run `33142693656`: all 20 selected jobs, including Static Contracts, Linux, Windows, browser canary, every owner shard, and the PR gate pass; only unrequested full validation is skipped
