### PR TITLE
Vectorize EKF example and migrate scene collections to tables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ compute_backends_native = [
       "mech-runtime/f32", "mech-runtime/f64", "mech-runtime/string", "mech-runtime/matrixd",
       "f32", "row_vectord", "matrixd", "kind_annotation", "convert", "matrix_horzcat", "range_inclusive",
       "math_add", "math_sub", "math_mul", "math_div", "math_mod", "math_sin", "math_cos",
-      "math_ceil",
+      "math_ceil", "math_floor",
       "mech-stdlib/native-plan",
       ]
 base = ["baselib", "pretty_print", "serde", "compiler", "program", "mika",
@@ -243,6 +243,7 @@ math_mul_assign = ["mech-stdlib/math_mul_assign"]
 math_div_assign = ["mech-stdlib/math_div_assign"]
 math_sqrt = ["mech-stdlib/math_sqrt"]
 math_ceil = ["mech-stdlib/math_ceil"]
+math_floor = ["mech-stdlib/math_floor"]
 math_acos = ["mech-stdlib/math_acos"]
 math_acosh = ["mech-stdlib/math_acosh"]
 math_acot = ["mech-stdlib/math_acot"]

--- a/examples/analog-clock/clock.mec
+++ b/examples/analog-clock/clock.mec
@@ -14,61 +14,13 @@ clock-hour-angle := clock-hour * 30
 
 clock-output := (clock-hour, clock-minute, clock-second)
 
-clock-circles := ({
-    id: "clock-center-pin"
-    x: 100
-    y: 100
-    radius: 4
-    fill: "#e25555"
-    stroke: "#e25555"
-    stroke-width: 0
-    opacity: 1
-  }
-)
+clock-circles := |id<string> x<f64> y<f64> radius<f64> fill<string> stroke<string> stroke-width<f64> opacity<f64>|
+  | "clock-center-pin" 100 100 4 "#e25555" "#e25555" 0 1 |
 
-clock-lines := ({
-    id: "clock-hour-hand"
-    x1: 100
-    y1: 100
-    x2: 100
-    y2: 58
-    stroke: "#1d2430"
-    stroke-width: 7
-    line-cap: "round"
-    opacity: 1
-    rotation: clock-hour-angle
-    origin-x: 100
-    origin-y: 100
-  },
-  {
-    id: "clock-minute-hand"
-    x1: 100
-    y1: 100
-    x2: 100
-    y2: 36
-    stroke: "#1d2430"
-    stroke-width: 5
-    line-cap: "round"
-    opacity: 1
-    rotation: clock-minute-angle
-    origin-x: 100
-    origin-y: 100
-  },
-  {
-    id: "clock-second-hand"
-    x1: 100
-    y1: 106
-    x2: 100
-    y2: 28
-    stroke: "#e25555"
-    stroke-width: 2
-    line-cap: "round"
-    opacity: 1
-    rotation: clock-second-angle
-    origin-x: 100
-    origin-y: 100
-  }
-)
+clock-lines := |id<string> x1<f64> y1<f64> x2<f64> y2<f64> stroke<string> stroke-width<f64> line-cap<string> opacity<f64> rotation<f64> origin-x<f64> origin-y<f64>|
+  | "clock-hour-hand" 100 100 100 58 "#1d2430" 7 "round" 1 clock-hour-angle 100 100 |
+  | "clock-minute-hand" 100 100 100 36 "#1d2430" 5 "round" 1 clock-minute-angle 100 100 |
+  | "clock-second-hand" 100 106 100 28 "#e25555" 2 "round" 1 clock-second-angle 100 100 |
 
 clock-scene := {
   width: 200

--- a/examples/ekf/localization.mec
+++ b/examples/ekf/localization.mec
@@ -61,10 +61,18 @@ the same camera and measurement path.
   camera-max-range := 3.6
   camera-range-fade := 0.18
 
+  -- Each row is one camera. Two-element position vectors broadcast across all
+  -- four rows, so geometry never has to split into separate x and y equations.
   cameras := [1.0 1.0
               9.0 1.0
               9.0 9.0
               1.0 9.0]
+  screen-scale := 62.0
+  screen-origin := [120.0
+                    700.0]
+  screen-axis := [1.0
+                 -1.0]
+  camera-screen := screen-origin' + screen-scale * cameras * screen-axis'
 
   -- Scene pointer presses toggle the camera under the cursor. The enable mask
   -- is resident Mech state: it gates the measurement before the EKF input and
@@ -76,11 +84,9 @@ the same camera and measurement path.
   scene-pointer-pressed := @scene/pointer-pressed
   scene-pointer-delta := scene-pointer-pulse - last-scene-pointer-pulse
   scene-pointer-toggle-parity := scene-pointer-delta % 2.0
-  scene-pointer-screen-x := (scene-pointer-position[1] + 1.0) * 430.0
-  scene-pointer-screen-y := (1.0 - scene-pointer-position[2]) * 385.0
-  camera-screen-x := [182.0; 678.0; 678.0; 182.0]
-  camera-screen-y := [638.0; 638.0; 142.0; 142.0]
-  scene-pointer-camera-distance-square := (camera-screen-x - scene-pointer-screen-x) ^ 2 + (camera-screen-y - scene-pointer-screen-y) ^ 2
+  scene-pointer-screen := [430.0; -385.0] * scene-pointer-position + [430.0; 385.0]
+  scene-pointer-camera-offset := camera-screen - scene-pointer-screen'
+  scene-pointer-camera-distance-square := (scene-pointer-camera-offset ^ 2) ** [1.0; 1.0]
   scene-pointer-hit-raw := 484.0 - scene-pointer-camera-distance-square
   scene-pointer-hit-relu := (scene-pointer-hit-raw + (scene-pointer-hit-raw ^ 2) ^ 0.5) / 2.0
   scene-pointer-hit := scene-pointer-hit-relu - (scene-pointer-hit-relu - 1.0 + ((scene-pointer-hit-relu - 1.0) ^ 2) ^ 0.5) / 2.0
@@ -144,37 +150,33 @@ reduction make the corners smooth without position clamps.
   phase-progress := ((drive-phase-index - 1.0) % side-ticks) / side-ticks
   path-parameter := drive-phase + phase-progress
   lookahead-parameter := (path-parameter + 0.15) % 4.0
-  lookahead-relu-0 := (lookahead-parameter + (lookahead-parameter ^ 2) ^ 0.5) / 2.0
-  lookahead-relu-1 := (lookahead-parameter - 1.0 + ((lookahead-parameter - 1.0) ^ 2) ^ 0.5) / 2.0
-  lookahead-relu-2 := (lookahead-parameter - 2.0 + ((lookahead-parameter - 2.0) ^ 2) ^ 0.5) / 2.0
-  lookahead-relu-3 := (lookahead-parameter - 3.0 + ((lookahead-parameter - 3.0) ^ 2) ^ 0.5) / 2.0
-  lookahead-relu-4 := (lookahead-parameter - 4.0 + ((lookahead-parameter - 4.0) ^ 2) ^ 0.5) / 2.0
-  lookahead-clamp-0 := lookahead-relu-0 - lookahead-relu-1
-  lookahead-clamp-1 := lookahead-relu-1 - lookahead-relu-2
-  lookahead-clamp-2 := lookahead-relu-2 - lookahead-relu-3
-  lookahead-clamp-3 := lookahead-relu-3 - lookahead-relu-4
-  target-x := low-bound + field-span * (lookahead-clamp-0 - lookahead-clamp-2)
-  target-y := low-bound + field-span * (lookahead-clamp-1 - lookahead-clamp-3)
+  lookahead-breakpoints := 0.0..=4.0
+  lookahead-offset := lookahead-parameter - lookahead-breakpoints'
+  lookahead-relu := (lookahead-offset + (lookahead-offset ^ 2) ^ 0.5) / 2.0
+  lookahead-clamp := lookahead-relu[1..=4] - lookahead-relu[2..=5]
+  target-position := low-bound + field-span * ([1.0 0.0 -1.0 0.0
+                                                0.0 1.0 0.0 -1.0] ** lookahead-clamp)
   ~truth := [2.5
              2.5
              0.0]
-  simulation-time := next-simulation-step * 0.05
-  target-heading := math/atan2(target-y - truth[2], target-x - truth[1])
+  simulation-time := next-simulation-step * Δt
+  target-offset := target-position - truth[1..=2]
+  target-heading := math/atan2(target-offset[2], target-offset[1])
   heading-error-raw := target-heading - truth[3]
   heading-error := math/atan2(math/sin(heading-error-raw), math/cos(heading-error-raw))
   requested-omega := heading-gain * heading-error
   commanded-omega := (((requested-omega + turn-rate-limit) ^ 2) ^ 0.5 - ((requested-omega - turn-rate-limit) ^ 2) ^ 0.5) / 2.0
   turn-fraction := ((commanded-omega ^ 2) ^ 0.5) / turn-rate-limit
   commanded-speed := cruise-speed * (1.0 - 0.42 * turn-fraction)
-  actual-speed-scale := 0.965 + 0.025 * math/sin(simulation-time * 0.73)
-  actual-omega-scale := 0.99 + 0.01 * math/sin(simulation-time * 0.51 + 0.8)
-  actual-speed := commanded-speed * actual-speed-scale
-  actual-omega := commanded-omega * actual-omega-scale
-  truth-mid-heading := truth[3] + actual-omega * Δt / 2.0
-
-  attempted-truth := truth + [actual-speed * math/cos(truth-mid-heading) * Δt
-                              actual-speed * math/sin(truth-mid-heading) * Δt
-                              actual-omega * Δt]
+  commanded-control := [commanded-speed
+                        commanded-omega]
+  actual-control-scale := [0.965; 0.99] + [0.025; 0.01] * math/sin(simulation-time * [0.73; 0.51] + [0.0; 0.8])
+  actual-control := commanded-control * actual-control-scale
+  truth-mid-heading := truth[3] + actual-control[2] * Δt / 2.0
+  truth-velocity := [math/cos(truth-mid-heading) 0.0
+                     math/sin(truth-mid-heading) 0.0
+                     0.0                           1.0] ** actual-control
+  attempted-truth := truth + truth-velocity * Δt
   next-truth := truth + clock-pulse * (attempted-truth - truth)
 
   truth = next-truth
@@ -233,10 +235,9 @@ than pretending that every camera sees through the entire field.
   camera-dwell-ticks := side-ticks / 2.0
   camera-schedule<[f64]:1,376> := #CameraSchedule(camera-dwell-ticks)
   camera-index := camera-schedule[1,drive-phase-index]
-  active-camera := cameras[camera-index,:]
-  camera-dx-all := cameras[:,1] - attempted-truth[1]
-  camera-dy-all := cameras[:,2] - attempted-truth[2]
-  camera-range-all := (camera-dx-all ^ 2 + camera-dy-all ^ 2) ^ 0.5
+  active-camera := cameras[camera-index,:]'
+  camera-offsets := cameras - attempted-truth[1..=2]'
+  camera-range-all := ((camera-offsets ^ 2) ** [1.0; 1.0]) ^ 0.5
   camera-inside-fade-raw := (camera-max-range - camera-range-all) / camera-range-fade
   camera-inside-fade-relu := (camera-inside-fade-raw + (camera-inside-fade-raw ^ 2) ^ 0.5) / 2.0
   camera-inside-fade-one-relu := (camera-inside-fade-raw - 1.0 + ((camera-inside-fade-raw - 1.0) ^ 2) ^ 0.5) / 2.0
@@ -248,26 +249,22 @@ than pretending that every camera sees through the entire field.
   -- host-side copy of the formula, so every runtime can qualify the hard
   -- sensing contract even when the driven trajectory does not land on an
   -- exact floating-point boundary.
-  camera-boundary-probe-distances := [camera-max-range - camera-range-fade
-                                      camera-max-range
-                                      camera-max-range + 0.000001
-                                      camera-max-range + camera-range-fade]
+  camera-boundary-probe-distances := camera-max-range + [-camera-range-fade; 0.0; 0.000001; camera-range-fade]
   camera-boundary-probe-raw := (camera-max-range - camera-boundary-probe-distances) / camera-range-fade
   camera-boundary-probe-relu := (camera-boundary-probe-raw + (camera-boundary-probe-raw ^ 2) ^ 0.5) / 2.0
   camera-boundary-probe-one-relu := (camera-boundary-probe-raw - 1.0 + ((camera-boundary-probe-raw - 1.0) ^ 2) ^ 0.5) / 2.0
   camera-boundary-probe-visibility := camera-boundary-probe-relu - camera-boundary-probe-one-relu
-  camera-boundary-probe-correction := [11.0 + camera-boundary-probe-visibility[1] * (21.0 - 11.0)
-                                       12.0 + camera-boundary-probe-visibility[2] * (22.0 - 12.0)
-                                       13.0 + camera-boundary-probe-visibility[3] * (23.0 - 13.0)
-                                       14.0 + camera-boundary-probe-visibility[4] * (24.0 - 14.0)]
+  camera-boundary-probe-baseline := [11.0; 12.0; 13.0; 14.0]
+  camera-boundary-probe-target := [21.0; 22.0; 23.0; 24.0]
+  camera-boundary-probe-correction := camera-boundary-probe-baseline + camera-boundary-probe-visibility * (camera-boundary-probe-target - camera-boundary-probe-baseline)
   active-camera-visibility := camera-visibility[camera-index]
-  camera-dx := active-camera[1] - attempted-truth[1]
-  camera-dy := active-camera[2] - attempted-truth[2]
-  camera-range := (camera-dx ^ 2 + camera-dy ^ 2) ^ 0.5
-  measured-range := camera-range + 0.11 * math/sin(simulation-time * 1.57 + camera-index * 0.7)
-  measured-bearing := math/atan2(camera-dy, camera-dx) - attempted-truth[3] + 0.011 * math/sin(simulation-time * 1.91 + camera-index)
-  observation := [measured-range
-                  measured-bearing]
+  camera-offset := active-camera - attempted-truth[1..=2]
+  camera-range-square := [1.0 1.0] ** (camera-offset ^ 2)
+  camera-range := camera-range-square[1] ^ 0.5
+  observation-model := [camera-range
+                        math/atan2(camera-offset[2], camera-offset[1]) - attempted-truth[3]]
+  observation-noise-phase := simulation-time * [1.57; 1.91] + camera-index * [0.7; 1.0]
+  observation := observation-model + [0.11; 0.011] * math/sin(observation-noise-phase)
 
 
 4. Extended Kalman Filter
@@ -280,31 +277,23 @@ stable Joseph form and is symmetrized before becoming the next resident state.
 The ordinary arrays here define 1,000 independent lanes. Lane zero receives the
 exact displayed measurement; the remaining lanes receive deterministic sensor
 perturbations so the work is a real filter ensemble rather than 1,000 copies of
-one arithmetic result. Only lane zero is sampled back for the scene.
+one arithmetic result. Base control, camera, and measurement rows broadcast
+directly across the lane matrices. Only lane zero is sampled back for the scene.
 
   filter-count := 1000.0
   filter-index := 1.0..=filter-count
   filter-phase := 2.0 * 3.141592654 * (filter-index - 1.0) / filter-count
   lane-dt-base := Δt * filter-step-span
-  lane-speed-base := commanded-speed
-  lane-omega-base := commanded-omega
-  lane-camera-x-base := active-camera[1]
-  lane-camera-y-base := active-camera[2]
-  lane-range-base := observation[1]
-  lane-bearing-base := observation[2]
-  lane-visibility-base := active-camera-visibility
-  lane-zero := filter-index * 0.0
-  lane-dt := lane-zero + lane-dt-base
-  lane-speed := lane-zero + lane-speed-base * (1.0 + 0.002 * math/sin(filter-phase * 3.0))
-  lane-omega := lane-zero + lane-omega-base * (1.0 + 0.002 * math/sin(filter-phase * 5.0))
-  lane-camera-x := lane-zero + lane-camera-x-base
-  lane-camera-y := lane-zero + lane-camera-y-base
-  lane-range := lane-zero + lane-range-base + 0.012 * math/sin(filter-phase * 7.0)
-  lane-bearing := lane-zero + lane-bearing-base + 0.0015 * math/sin(filter-phase * 11.0)
-  lane-visibility := lane-zero + lane-visibility-base
-  lane-control := [lane-dt' lane-speed' lane-omega']
-  lane-camera := [lane-camera-x' lane-camera-y']
-  lane-measurement := [lane-range' lane-bearing' lane-visibility']
+  lane-control-base := [lane-dt-base commanded-speed commanded-omega]
+  lane-control-phase := filter-phase' ** [0.0 3.0 5.0]
+  lane-control-scale := 1.0 + math/sin(lane-control-phase) * [0.0 0.002 0.002]
+  lane-control := lane-control-base * lane-control-scale
+  lane-zero := filter-index' * 0.0
+  lane-camera-zero := lane-zero ** [1.0 1.0]
+  lane-camera := lane-camera-zero + active-camera'
+  lane-measurement-base := [observation' active-camera-visibility]
+  lane-measurement-phase := filter-phase' ** [7.0 11.0 0.0]
+  lane-measurement := lane-measurement-base + math/sin(lane-measurement-phase) * [0.012 0.0015 0.0]
 
   @filters/input/control <- lane-control
   @filters/input/camera <- lane-camera
@@ -422,105 +411,99 @@ covariance. Steady footprint guides show each camera's real maximum range.
 Camera rays terminate at simulated truth and fade to exactly zero outside that
 range. Only the scheduled in-range camera's noisy values enter the filter.
 
-  screen-scale := 62.0
-  screen-origin-x := 120.0
-  screen-origin-y := 700.0
-  truth-screen-x := screen-origin-x + next-truth[1] * screen-scale
-  truth-screen-y := screen-origin-y - next-truth[2] * screen-scale
-  display-camera-dx-all := cameras[:,1] - next-truth[1]
-  display-camera-dy-all := cameras[:,2] - next-truth[2]
-  display-camera-range-all := (display-camera-dx-all ^ 2 + display-camera-dy-all ^ 2) ^ 0.5
+  world-positions := [next-truth[1..=2] predicted-estimate[1..=2] corrected-estimate[1..=2]]
+  screen-positions := screen-origin + screen-scale * screen-axis * world-positions
+  truth-screen := screen-positions[:,1]
+  predicted-screen := screen-positions[:,2]
+  estimate-screen := screen-positions[:,3]
+  display-camera-offsets := cameras - next-truth[1..=2]'
+  display-camera-range-all := ((display-camera-offsets ^ 2) ** [1.0; 1.0]) ^ 0.5
   display-camera-inside-fade-raw := (camera-max-range - display-camera-range-all) / camera-range-fade
   display-camera-inside-fade-relu := (display-camera-inside-fade-raw + (display-camera-inside-fade-raw ^ 2) ^ 0.5) / 2.0
   display-camera-inside-fade-one-relu := (display-camera-inside-fade-raw - 1.0 + ((display-camera-inside-fade-raw - 1.0) ^ 2) ^ 0.5) / 2.0
   display-camera-visibility := (display-camera-inside-fade-relu - display-camera-inside-fade-one-relu) * camera-enabled
-  predicted-screen-x := screen-origin-x + predicted-estimate[1] * screen-scale
-  predicted-screen-y := screen-origin-y - predicted-estimate[2] * screen-scale
-  estimate-screen-x := screen-origin-x + corrected-estimate[1] * screen-scale
-  estimate-screen-y := screen-origin-y - corrected-estimate[2] * screen-scale
-
-  position-error-x := corrected-estimate[1] - next-truth[1]
-  position-error-y := corrected-estimate[2] - next-truth[2]
-  position-error := (position-error-x ^ 2 + position-error-y ^ 2) ^ 0.5
+  position-error-vector := corrected-estimate[1..=2] - next-truth[1..=2]
+  position-error-square := [1.0 1.0] ** (position-error-vector ^ 2)
+  position-error := position-error-square[1] ^ 0.5
 
   ellipse-a := corrected-covariance[1,1]
   ellipse-b := corrected-covariance[1,2]
   ellipse-c := corrected-covariance[2,2]
   ellipse-root := (((ellipse-a - ellipse-c) / 2.0) ^ 2 + ellipse-b ^ 2) ^ 0.5
-  ellipse-major := ((ellipse-a + ellipse-c) / 2.0 + ellipse-root) ^ 0.5 * 2.0
-  ellipse-minor := ((ellipse-a + ellipse-c) / 2.0 - ellipse-root) ^ 0.5 * 2.0
+  ellipse-eigenvalues := (ellipse-a + ellipse-c) / 2.0 + [1.0; -1.0] * ellipse-root
+  ellipse-axes := (ellipse-eigenvalues ^ 0.5) * 2.0
   ellipse-rotation := 0.5 * math/atan2(2.0 * ellipse-b, ellipse-a - ellipse-c)
   ellipse-samples := 0..=64
   ellipse-angle := ellipse-samples' * (2.0 * π / 64.0)
-  ellipse-cos := math/cos(ellipse-angle)
-  ellipse-sin := math/sin(ellipse-angle)
   ellipse-display-floor := 0.04
-  display-ellipse-major := (ellipse-major ^ 2 + ellipse-display-floor ^ 2) ^ 0.5
-  display-ellipse-minor := (ellipse-minor ^ 2 + ellipse-display-floor ^ 2) ^ 0.5
-  ellipse-x := estimate-screen-x + screen-scale * (display-ellipse-major * ellipse-cos * math/cos(ellipse-rotation) - display-ellipse-minor * ellipse-sin * math/sin(ellipse-rotation))
-  ellipse-y := estimate-screen-y - screen-scale * (display-ellipse-major * ellipse-cos * math/sin(ellipse-rotation) + display-ellipse-minor * ellipse-sin * math/cos(ellipse-rotation))
-  covariance-ellipse := [ellipse-x ellipse-y]
+  display-ellipse-axes := (ellipse-axes ^ 2 + ellipse-display-floor ^ 2) ^ 0.5
+  ellipse-axis-points := [math/cos(ellipse-angle) math/sin(ellipse-angle)] * display-ellipse-axes'
+  ellipse-rotation-matrix := [ math/cos(ellipse-rotation) math/sin(ellipse-rotation)
+                              -math/sin(ellipse-rotation) math/cos(ellipse-rotation)]
+  covariance-ellipse := estimate-screen' + screen-scale * (ellipse-axis-points ** ellipse-rotation-matrix) * screen-axis'
 
   trail-samples := 1..=376
-  initial-truth-path-x-row := [275.0 | sample <- trail-samples]
-  initial-truth-path-y-row := [545.0 | sample <- trail-samples]
-  initial-estimate-path-x-row := [299.8 | sample <- trail-samples]
-  initial-estimate-path-y-row := [566.7 | sample <- trail-samples]
-  initial-truth-path-x := initial-truth-path-x-row'
-  initial-truth-path-y := initial-truth-path-y-row'
-  initial-estimate-path-x := initial-estimate-path-x-row'
-  initial-estimate-path-y := initial-estimate-path-y-row'
-  ~truth-path := [initial-truth-path-x initial-truth-path-y]
-  ~estimate-path := [initial-estimate-path-x initial-estimate-path-y]
-  truth-screen-point := ([truth-screen-x truth-screen-y])
-  estimate-screen-point := ([estimate-screen-x estimate-screen-y])
-  advanced-truth-path := matrix/vertcat(truth-path[2..=376,:], truth-screen-point)
-  advanced-estimate-path := matrix/vertcat(estimate-path[2..=376,:], estimate-screen-point)
+  trail-zero := trail-samples' * 0.0
+  trail-zero-points := trail-zero ** [1.0 1.0]
+  ~truth-path := trail-zero-points + [275.0 545.0]
+  ~estimate-path := trail-zero-points + [299.8 566.7]
+  advanced-truth-path := matrix/vertcat(truth-path[2..=376,:], truth-screen')
+  advanced-estimate-path := matrix/vertcat(estimate-path[2..=376,:], estimate-screen')
   next-truth-path := truth-path + sample-pulse * (advanced-truth-path - truth-path)
   next-estimate-path := estimate-path + sample-pulse * (advanced-estimate-path - estimate-path)
   truth-path = next-truth-path
   estimate-path = next-estimate-path
 
-  square-guide := [275.0 545.0
-                   585.0 545.0
-                   585.0 235.0
-                   275.0 235.0
-                   275.0 545.0]
+  square-guide-world := [low-bound low-bound
+                         high-bound low-bound
+                         high-bound high-bound
+                         low-bound high-bound
+                         low-bound low-bound]
+  square-guide := screen-origin' + screen-scale * square-guide-world * screen-axis'
 
-  scene-circles := (
-    {id: "camera-range-1", x: 182, y: 638, radius: camera-max-range * screen-scale, fill: "none", stroke: "#f4c95d", stroke-width: 0.8, opacity: 0.16 * camera-enabled[1]},
-    {id: "camera-range-2", x: 678, y: 638, radius: camera-max-range * screen-scale, fill: "none", stroke: "#f4c95d", stroke-width: 0.8, opacity: 0.16 * camera-enabled[2]},
-    {id: "camera-range-3", x: 678, y: 142, radius: camera-max-range * screen-scale, fill: "none", stroke: "#f4c95d", stroke-width: 0.8, opacity: 0.16 * camera-enabled[3]},
-    {id: "camera-range-4", x: 182, y: 142, radius: camera-max-range * screen-scale, fill: "none", stroke: "#f4c95d", stroke-width: 0.8, opacity: 0.16 * camera-enabled[4]},
-    {id: "camera-disabled-1", x: 182, y: 638, radius: 9, fill: "#59616b", stroke: "none", stroke-width: 0, opacity: 1.0 - camera-enabled[1]},
-    {id: "camera-disabled-2", x: 678, y: 638, radius: 9, fill: "#59616b", stroke: "none", stroke-width: 0, opacity: 1.0 - camera-enabled[2]},
-    {id: "camera-disabled-3", x: 678, y: 142, radius: 9, fill: "#59616b", stroke: "none", stroke-width: 0, opacity: 1.0 - camera-enabled[3]},
-    {id: "camera-disabled-4", x: 182, y: 142, radius: 9, fill: "#59616b", stroke: "none", stroke-width: 0, opacity: 1.0 - camera-enabled[4]},
-    {id: "camera-1", x: 182, y: 638, radius: 9, fill: "#f4c95d", stroke: "#fff1b8", stroke-width: 2, opacity: camera-enabled[1]},
-    {id: "camera-2", x: 678, y: 638, radius: 9, fill: "#f4c95d", stroke: "#fff1b8", stroke-width: 2, opacity: camera-enabled[2]},
-    {id: "camera-3", x: 678, y: 142, radius: 9, fill: "#f4c95d", stroke: "#fff1b8", stroke-width: 2, opacity: camera-enabled[3]},
-    {id: "camera-4", x: 182, y: 142, radius: 9, fill: "#f4c95d", stroke: "#fff1b8", stroke-width: 2, opacity: camera-enabled[4]},
-    {id: "truth", x: truth-screen-x, y: truth-screen-y, radius: 8, fill: "#63d6c5", stroke: "#d7fff8", stroke-width: 1.5, opacity: 1},
-    {id: "prediction", x: predicted-screen-x, y: predicted-screen-y, radius: 6, fill: "none", stroke: "#f2b84b", stroke-width: 2, opacity: 1},
-    {id: "estimate", x: estimate-screen-x, y: estimate-screen-y, radius: 7, fill: "#f087b8", stroke: "#ffe1ef", stroke-width: 1.5, opacity: 1},
-    {id: "legend-truth", x: 30, y: 718, radius: 4, fill: "#63d6c5", stroke: "none", stroke-width: 0, opacity: 1},
-    {id: "legend-prediction", x: 205, y: 718, radius: 4, fill: "#f2b84b", stroke: "none", stroke-width: 0, opacity: 1},
-    {id: "legend-estimate", x: 405, y: 718, radius: 4, fill: "#f087b8", stroke: "none", stroke-width: 0, opacity: 1}
-  )
+  camera-range-opacity := 0.16 * camera-enabled
+  camera-disabled-opacity := 1.0 - camera-enabled
+  camera-ray-opacity := 0.4 * display-camera-visibility
+  camera-label-opacity := 0.32 + 0.68 * camera-enabled
+  heading-angles := [next-truth[3] corrected-estimate[3]]
+  heading-unit-vectors := matrix/vertcat(math/cos(heading-angles), math/sin(heading-angles))
+  heading-screen-vectors := screen-axis * heading-unit-vectors * [18.0 16.0]
+  heading-screen-points := [truth-screen estimate-screen] + heading-screen-vectors
 
-  scene-lines := (
-    {id: "frame-top", x1: 120, y1: 80, x2: 740, y2: 80, stroke: "#27313d", stroke-width: 1, line-cap: "butt", opacity: 1, rotation: 0, origin-x: 0, origin-y: 0},
-    {id: "frame-right", x1: 740, y1: 80, x2: 740, y2: 700, stroke: "#27313d", stroke-width: 1, line-cap: "butt", opacity: 1, rotation: 0, origin-x: 0, origin-y: 0},
-    {id: "frame-bottom", x1: 740, y1: 700, x2: 120, y2: 700, stroke: "#27313d", stroke-width: 1, line-cap: "butt", opacity: 1, rotation: 0, origin-x: 0, origin-y: 0},
-    {id: "frame-left", x1: 120, y1: 700, x2: 120, y2: 80, stroke: "#27313d", stroke-width: 1, line-cap: "butt", opacity: 1, rotation: 0, origin-x: 0, origin-y: 0},
-    {id: "ray-1", x1: 182, y1: 638, x2: truth-screen-x, y2: truth-screen-y, stroke: "#d9b652", stroke-width: 0.7, line-cap: "round", opacity: 0.4 * display-camera-visibility[1], rotation: 0, origin-x: 0, origin-y: 0},
-    {id: "ray-2", x1: 678, y1: 638, x2: truth-screen-x, y2: truth-screen-y, stroke: "#d9b652", stroke-width: 0.7, line-cap: "round", opacity: 0.4 * display-camera-visibility[2], rotation: 0, origin-x: 0, origin-y: 0},
-    {id: "ray-3", x1: 678, y1: 142, x2: truth-screen-x, y2: truth-screen-y, stroke: "#d9b652", stroke-width: 0.7, line-cap: "round", opacity: 0.4 * display-camera-visibility[3], rotation: 0, origin-x: 0, origin-y: 0},
-    {id: "ray-4", x1: 182, y1: 142, x2: truth-screen-x, y2: truth-screen-y, stroke: "#d9b652", stroke-width: 0.7, line-cap: "round", opacity: 0.4 * display-camera-visibility[4], rotation: 0, origin-x: 0, origin-y: 0},
-    {id: "truth-heading", x1: truth-screen-x, y1: truth-screen-y, x2: truth-screen-x + 18.0 * math/cos(next-truth[3]), y2: truth-screen-y - 18.0 * math/sin(next-truth[3]), stroke: "#d7fff8", stroke-width: 2, line-cap: "round", opacity: 1, rotation: 0, origin-x: 0, origin-y: 0},
-    {id: "estimate-heading", x1: estimate-screen-x, y1: estimate-screen-y, x2: estimate-screen-x + 16.0 * math/cos(corrected-estimate[3]), y2: estimate-screen-y - 16.0 * math/sin(corrected-estimate[3]), stroke: "#ffe1ef", stroke-width: 1.5, line-cap: "round", opacity: 1, rotation: 0, origin-x: 0, origin-y: 0}
-  )
+  scene-circles := |id<string> x<f64> y<f64> radius<f64> fill<string> stroke<string> stroke-width<f64> opacity<f64>|
+    | "camera-range-1" camera-screen[1,1] camera-screen[1,2] camera-max-range * screen-scale "none" "#f4c95d" 0.8 camera-range-opacity[1] |
+    | "camera-range-2" camera-screen[2,1] camera-screen[2,2] camera-max-range * screen-scale "none" "#f4c95d" 0.8 camera-range-opacity[2] |
+    | "camera-range-3" camera-screen[3,1] camera-screen[3,2] camera-max-range * screen-scale "none" "#f4c95d" 0.8 camera-range-opacity[3] |
+    | "camera-range-4" camera-screen[4,1] camera-screen[4,2] camera-max-range * screen-scale "none" "#f4c95d" 0.8 camera-range-opacity[4] |
+    | "camera-disabled-1" camera-screen[1,1] camera-screen[1,2] 9 "#59616b" "none" 0 camera-disabled-opacity[1] |
+    | "camera-disabled-2" camera-screen[2,1] camera-screen[2,2] 9 "#59616b" "none" 0 camera-disabled-opacity[2] |
+    | "camera-disabled-3" camera-screen[3,1] camera-screen[3,2] 9 "#59616b" "none" 0 camera-disabled-opacity[3] |
+    | "camera-disabled-4" camera-screen[4,1] camera-screen[4,2] 9 "#59616b" "none" 0 camera-disabled-opacity[4] |
+    | "camera-1" camera-screen[1,1] camera-screen[1,2] 9 "#f4c95d" "#fff1b8" 2 camera-enabled[1] |
+    | "camera-2" camera-screen[2,1] camera-screen[2,2] 9 "#f4c95d" "#fff1b8" 2 camera-enabled[2] |
+    | "camera-3" camera-screen[3,1] camera-screen[3,2] 9 "#f4c95d" "#fff1b8" 2 camera-enabled[3] |
+    | "camera-4" camera-screen[4,1] camera-screen[4,2] 9 "#f4c95d" "#fff1b8" 2 camera-enabled[4] |
+    | "truth" truth-screen[1] truth-screen[2] 8 "#63d6c5" "#d7fff8" 1.5 1 |
+    | "prediction" predicted-screen[1] predicted-screen[2] 6 "none" "#f2b84b" 2 1 |
+    | "estimate" estimate-screen[1] estimate-screen[2] 7 "#f087b8" "#ffe1ef" 1.5 1 |
+    | "legend-truth" 30 718 4 "#63d6c5" "none" 0 1 |
+    | "legend-prediction" 205 718 4 "#f2b84b" "none" 0 1 |
+    | "legend-estimate" 405 718 4 "#f087b8" "none" 0 1 |
 
+  scene-lines := |id<string> x1<f64> y1<f64> x2<f64> y2<f64> stroke<string> stroke-width<f64> line-cap<string> opacity<f64> rotation<f64> origin-x<f64> origin-y<f64>|
+    | "frame-top" 120 80 740 80 "#27313d" 1 "butt" 1 0 0 0 |
+    | "frame-right" 740 80 740 700 "#27313d" 1 "butt" 1 0 0 0 |
+    | "frame-bottom" 740 700 120 700 "#27313d" 1 "butt" 1 0 0 0 |
+    | "frame-left" 120 700 120 80 "#27313d" 1 "butt" 1 0 0 0 |
+    | "ray-1" camera-screen[1,1] camera-screen[1,2] truth-screen[1] truth-screen[2] "#d9b652" 0.7 "round" camera-ray-opacity[1] 0 0 0 |
+    | "ray-2" camera-screen[2,1] camera-screen[2,2] truth-screen[1] truth-screen[2] "#d9b652" 0.7 "round" camera-ray-opacity[2] 0 0 0 |
+    | "ray-3" camera-screen[3,1] camera-screen[3,2] truth-screen[1] truth-screen[2] "#d9b652" 0.7 "round" camera-ray-opacity[3] 0 0 0 |
+    | "ray-4" camera-screen[4,1] camera-screen[4,2] truth-screen[1] truth-screen[2] "#d9b652" 0.7 "round" camera-ray-opacity[4] 0 0 0 |
+    | "truth-heading" truth-screen[1] truth-screen[2] heading-screen-points[1,1] heading-screen-points[2,1] "#d7fff8" 2 "round" 1 0 0 0 |
+    | "estimate-heading" estimate-screen[1] estimate-screen[2] heading-screen-points[1,2] heading-screen-points[2,2] "#ffe1ef" 1.5 "round" 1 0 0 0 |
+
+  -- These path records remain a tuple because their positions matrices have
+  -- different shapes; the scalar scene collections below are typed tables.
   scene-line-strips := (
     {id: "square-guide", positions: square-guide, stroke: "#536273", stroke-width: 1, line-cap: "round", line-join: "round", opacity: 0.38, closed: true},
     {id: "truth-path", positions: next-truth-path, stroke: "#63d6c5", stroke-width: 2, line-cap: "round", line-join: "round", opacity: 0.8, closed: false},
@@ -528,19 +511,18 @@ range. Only the scheduled in-range camera's noisy values enter the filter.
     {id: "covariance", positions: covariance-ellipse, stroke: "#f087b8", stroke-width: 1.5, line-cap: "round", line-join: "round", opacity: 0.72, closed: true}
   )
 
-  scene-text := (
-    {id: "eyebrow", x: 24, y: 26, fill: "#8fa3b8", font-size: 12, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "650", text-anchor: "start", opacity: 1, value: "MECH RESIDENT SENSOR FUSION"},
-    {id: "title", x: 24, y: 62, fill: "#edf2f7", font-size: 36, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "620", text-anchor: "start", opacity: 1, value: "Camera EKF Localization"},
-    {id: "state-label", x: 602, y: 58, fill: "#f4c95d", font-size: 13, font-family: "ui-monospace, SFMono-Regular, Menlo, monospace", font-weight: "650", text-anchor: "start", opacity: 1, value: "V/Ω SQUARE-DRIVE FSM"},
-    {id: "camera-label-1", x: 195, y: 636, fill: "#d7c27f", font-size: 11, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "500", text-anchor: "start", opacity: 0.32 + 0.68 * camera-enabled[1], value: "CAM 1"},
-    {id: "camera-label-2", x: 665, y: 636, fill: "#d7c27f", font-size: 11, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "500", text-anchor: "end", opacity: 0.32 + 0.68 * camera-enabled[2], value: "CAM 2"},
-    {id: "camera-label-3", x: 665, y: 140, fill: "#d7c27f", font-size: 11, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "500", text-anchor: "end", opacity: 0.32 + 0.68 * camera-enabled[3], value: "CAM 3"},
-    {id: "camera-label-4", x: 195, y: 140, fill: "#d7c27f", font-size: 11, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "500", text-anchor: "start", opacity: 0.32 + 0.68 * camera-enabled[4], value: "CAM 4"},
-    {id: "legend-truth-label", x: 40, y: 722, fill: "#bdc8d2", font-size: 12, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "400", text-anchor: "start", opacity: 1, value: "actual robot + path"},
-    {id: "legend-prediction-label", x: 215, y: 722, fill: "#bdc8d2", font-size: 12, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "400", text-anchor: "start", opacity: 1, value: "motion prediction"},
-    {id: "legend-estimate-label", x: 415, y: 722, fill: "#bdc8d2", font-size: 12, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "400", text-anchor: "start", opacity: 1, value: "EKF estimate + 2σ covariance"},
-    {id: "note", x: 430, y: 750, fill: "#788a9c", font-size: 11, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "400", text-anchor: "middle", opacity: 1, value: "3.6-unit camera range · prediction-only dead zones · Joseph covariance · bounded v/ω cornering"}
-  )
+  scene-text := |id<string> x<f64> y<f64> fill<string> font-size<f64> font-family<string> font-weight<string> text-anchor<string> opacity<f64> value<string>|
+    | "eyebrow" 24 26 "#8fa3b8" 12 "Inter, ui-sans-serif, system-ui, sans-serif" "650" "start" 1 "MECH RESIDENT SENSOR FUSION" |
+    | "title" 24 62 "#edf2f7" 36 "Inter, ui-sans-serif, system-ui, sans-serif" "620" "start" 1 "Camera EKF Localization" |
+    | "state-label" 602 58 "#f4c95d" 13 "ui-monospace, SFMono-Regular, Menlo, monospace" "650" "start" 1 "V/Ω SQUARE-DRIVE FSM" |
+    | "camera-label-1" 195 636 "#d7c27f" 11 "Inter, ui-sans-serif, system-ui, sans-serif" "500" "start" camera-label-opacity[1] "CAM 1" |
+    | "camera-label-2" 665 636 "#d7c27f" 11 "Inter, ui-sans-serif, system-ui, sans-serif" "500" "end" camera-label-opacity[2] "CAM 2" |
+    | "camera-label-3" 665 140 "#d7c27f" 11 "Inter, ui-sans-serif, system-ui, sans-serif" "500" "end" camera-label-opacity[3] "CAM 3" |
+    | "camera-label-4" 195 140 "#d7c27f" 11 "Inter, ui-sans-serif, system-ui, sans-serif" "500" "start" camera-label-opacity[4] "CAM 4" |
+    | "legend-truth-label" 40 722 "#bdc8d2" 12 "Inter, ui-sans-serif, system-ui, sans-serif" "400" "start" 1 "actual robot + path" |
+    | "legend-prediction-label" 215 722 "#bdc8d2" 12 "Inter, ui-sans-serif, system-ui, sans-serif" "400" "start" 1 "motion prediction" |
+    | "legend-estimate-label" 415 722 "#bdc8d2" 12 "Inter, ui-sans-serif, system-ui, sans-serif" "400" "start" 1 "EKF estimate + 2σ covariance" |
+    | "note" 430 750 "#788a9c" 11 "Inter, ui-sans-serif, system-ui, sans-serif" "400" "middle" 1 "3.6-unit camera range · prediction-only dead zones · Joseph covariance · bounded v/ω cornering" |
 
   field-presentation := {
     width: 860

--- a/examples/ekf/localization.mec
+++ b/examples/ekf/localization.mec
@@ -31,26 +31,23 @@ its measurements are removed before the EKF update. Click it again to restore
 the same camera and measurement path.
 
 @clock := timer://clock/tick{:read(tick)}
-@scene := scene://localization/frame{:read(pointer-pulse), :read(pointer-position), :read(pointer-pressed), :read(pointer-delta-seconds), :write(replace)}
-@filters := compute://filters/kernel{:read(sample/result.0), :read(sample/result.2), :read(turns), :write(input/control), :write(input/camera), :write(input/measurement), :write(turn)}
+@scene := scene://localization/frame{:read(pointer-pulse), :read(pointer-position), :write(replace)}
+@filters := compute://filters/kernel{:read(sample/result.0), :read(turns), :write(input/control), :write(input/camera), :write(input/measurement), :write(turn)}
 
   π := 3.141592654
   ~last-clock-tick := 0.0
   clock-delta := @clock/tick - last-clock-tick
-  clock-delta-positive := (clock-delta + (clock-delta ^ 2) ^ 0.5) / 2.0
-  clock-pulse := clock-delta-positive - (clock-delta-positive - 1.0 + ((clock-delta-positive - 1.0) ^ 2) ^ 0.5) / 2.0
+  clock-pulse := (math/abs(clock-delta) - math/abs(clock-delta - 1.0) + 1.0) / 2.0
   ~requested-compute-turn := 0.0
   ~last-requested-simulation-step := 0.0
   compute-inflight-gap := requested-compute-turn - @filters/turns
-  compute-inflight-gap-absolute := (compute-inflight-gap ^ 2) ^ 0.5
-  compute-idle-raw := 1.0 - compute-inflight-gap-absolute
-  compute-idle := (compute-idle-raw + (compute-idle-raw ^ 2) ^ 0.5) / 2.0
+  compute-idle-raw := 1.0 - math/abs(compute-inflight-gap)
+  compute-idle := (compute-idle-raw + math/abs(compute-idle-raw)) / 2.0
   request-pulse := clock-pulse * compute-idle
   next-requested-compute-turn := requested-compute-turn + request-pulse
   ~last-filter-turn := 0.0
   filter-turn-delta := @filters/turns - last-filter-turn
-  filter-turn-delta-positive := (filter-turn-delta + (filter-turn-delta ^ 2) ^ 0.5) / 2.0
-  sample-pulse := filter-turn-delta-positive - (filter-turn-delta-positive - 1.0 + ((filter-turn-delta-positive - 1.0) ^ 2) ^ 0.5) / 2.0
+  sample-pulse := (math/abs(filter-turn-delta) - math/abs(filter-turn-delta - 1.0) + 1.0) / 2.0
   Δt := 0.05
   cruise-speed := 1.15
   turn-rate-limit := 1.75
@@ -81,15 +78,15 @@ the same camera and measurement path.
   ~last-scene-pointer-pulse := 0.0
   scene-pointer-pulse := @scene/pointer-pulse
   scene-pointer-position := @scene/pointer-position
-  scene-pointer-pressed := @scene/pointer-pressed
   scene-pointer-delta := scene-pointer-pulse - last-scene-pointer-pulse
   scene-pointer-toggle-parity := scene-pointer-delta % 2.0
   scene-pointer-screen := [430.0; -385.0] * scene-pointer-position + [430.0; 385.0]
   scene-pointer-camera-offset := camera-screen - scene-pointer-screen'
   scene-pointer-camera-distance-square := (scene-pointer-camera-offset ^ 2) ** [1.0; 1.0]
   scene-pointer-hit-raw := 484.0 - scene-pointer-camera-distance-square
-  scene-pointer-hit-relu := (scene-pointer-hit-raw + (scene-pointer-hit-raw ^ 2) ^ 0.5) / 2.0
-  scene-pointer-hit := scene-pointer-hit-relu - (scene-pointer-hit-relu - 1.0 + ((scene-pointer-hit-relu - 1.0) ^ 2) ^ 0.5) / 2.0
+  scene-pointer-hit-relu := (scene-pointer-hit-raw + math/abs(scene-pointer-hit-raw)) / 2.0
+  scene-pointer-hit-one-relu := (scene-pointer-hit-raw - 1.0 + math/abs(scene-pointer-hit-raw - 1.0)) / 2.0
+  scene-pointer-hit := scene-pointer-hit-relu - scene-pointer-hit-one-relu
   -- A gesture group coalesces down/up but never crosses into the next press.
   -- Parity still preserves an even count jump if an activation history is
   -- restored or replayed without exposing every intermediate turn.
@@ -102,60 +99,36 @@ the same camera and measurement path.
   last-filter-turn = @filters/turns
 
 
-2. Square-Drive State Machine
+2. Vectorized Square Drive
 -------------------------------------------------------------------------------
 
-The controller is an explicit finite state machine with East, North, West, and
-South states. It emits the repeating phase program consumed once per delivered
-resident turn, independently of the timer's absolute tick values. The phase and
-its within-side progress define a moving point on the requested square. A short
-look-ahead aims the unicycle toward that point, so accumulated motion error is
-corrected instead of being carried into every later side. Its only controls are
-forward velocity `v` and angular velocity `ω`; bounded steering and turn-speed
-reduction make the corners smooth without position clamps.
-
-#SquareDrive(side-ticks<f64>) => <[f64]:1,376>
-  ├ :East(remaining<f64>, side-ticks<f64>, phases<[f64]>)
-  ├ :North(remaining<f64>, side-ticks<f64>, phases<[f64]>)
-  ├ :West(remaining<f64>, side-ticks<f64>, phases<[f64]>)
-  ├ :South(remaining<f64>, side-ticks<f64>, phases<[f64]>)
-  └ :Done(phases<[f64]>).
-
-#SquareDrive(side-ticks<u64>) -> :East(side-ticks, side-ticks, [])
-  :East(remaining, side-ticks, phases)
-    ├ remaining > 0 -> :East(remaining - 1, side-ticks, [phases 0.0])
-    └ * -> :North(side-ticks, side-ticks, phases)
-  :North(remaining, side-ticks, phases)
-    ├ remaining > 0 -> :North(remaining - 1, side-ticks, [phases 1.0])
-    └ * -> :West(side-ticks, side-ticks, phases)
-  :West(remaining, side-ticks, phases)
-    ├ remaining > 0 -> :West(remaining - 1, side-ticks, [phases 2.0])
-    └ * -> :South(side-ticks, side-ticks, phases)
-  :South(remaining, side-ticks, phases)
-    ├ remaining > 0 -> :South(remaining - 1, side-ticks, [phases 3.0])
-    └ * -> :Done(phases)
-  :Done(phases) => phases.
+The delivered simulation step directly indexes the four square sides. The phase
+and its within-side progress define a moving point on the requested square. A
+short look-ahead aims the unicycle toward that point, so accumulated motion
+error is corrected instead of being carried into every later side. Its only
+controls are forward velocity `v` and angular velocity `ω`; bounded steering
+and turn-speed reduction make the corners smooth without position clamps.
 
   side-ticks := 94.0
-  drive-phases<[f64]:1,376> := #SquareDrive(side-ticks)
   lap-ticks := 4.0 * side-ticks
   ~simulation-step := 0.0
   next-simulation-step := simulation-step + clock-pulse
   filter-step-span := next-simulation-step - last-requested-simulation-step
   next-last-requested-simulation-step := last-requested-simulation-step + request-pulse * filter-step-span
-  ~drive-phase-index := 1.0
-  drive-phase := drive-phases[1,drive-phase-index]
-  advanced-drive-phase-index := (drive-phase-index % lap-ticks) + 1.0
-  next-drive-phase-index := drive-phase-index + clock-pulse * (advanced-drive-phase-index - drive-phase-index)
-  phase-progress := ((drive-phase-index - 1.0) % side-ticks) / side-ticks
+  drive-phase := math/floor((simulation-step % lap-ticks) / side-ticks)
+  phase-progress := (simulation-step % side-ticks) / side-ticks
   path-parameter := drive-phase + phase-progress
   lookahead-parameter := (path-parameter + 0.15) % 4.0
-  lookahead-breakpoints := 0.0..=4.0
-  lookahead-offset := lookahead-parameter - lookahead-breakpoints'
-  lookahead-relu := (lookahead-offset + (lookahead-offset ^ 2) ^ 0.5) / 2.0
-  lookahead-clamp := lookahead-relu[1..=4] - lookahead-relu[2..=5]
-  target-position := low-bound + field-span * ([1.0 0.0 -1.0 0.0
-                                                0.0 1.0 0.0 -1.0] ** lookahead-clamp)
+  lookahead-side := math/floor(lookahead-parameter) + 1.0
+  lookahead-progress := lookahead-parameter % 1.0
+  square-waypoints := [0.0 0.0
+                       1.0 0.0
+                       1.0 1.0
+                       0.0 1.0
+                       0.0 0.0]
+  lookahead-origin := square-waypoints[lookahead-side,:]'
+  lookahead-direction := square-waypoints[lookahead-side + 1.0,:]' - lookahead-origin
+  target-position := low-bound + field-span * (lookahead-origin + lookahead-progress * lookahead-direction)
   ~truth := [2.5
              2.5
              0.0]
@@ -165,8 +138,8 @@ reduction make the corners smooth without position clamps.
   heading-error-raw := target-heading - truth[3]
   heading-error := math/atan2(math/sin(heading-error-raw), math/cos(heading-error-raw))
   requested-omega := heading-gain * heading-error
-  commanded-omega := (((requested-omega + turn-rate-limit) ^ 2) ^ 0.5 - ((requested-omega - turn-rate-limit) ^ 2) ^ 0.5) / 2.0
-  turn-fraction := ((commanded-omega ^ 2) ^ 0.5) / turn-rate-limit
+  commanded-omega := (math/abs(requested-omega + turn-rate-limit) - math/abs(requested-omega - turn-rate-limit)) / 2.0
+  turn-fraction := math/abs(commanded-omega) / turn-rate-limit
   commanded-speed := cruise-speed * (1.0 - 0.42 * turn-fraction)
   commanded-control := [commanded-speed
                         commanded-omega]
@@ -181,7 +154,6 @@ reduction make the corners smooth without position clamps.
 
   truth = next-truth
   simulation-step = next-simulation-step
-  drive-phase-index = next-drive-phase-index
   requested-compute-turn = next-requested-compute-turn
   last-requested-simulation-step = next-last-requested-simulation-step
 
@@ -189,78 +161,25 @@ reduction make the corners smooth without position clamps.
 3. Noisy Camera Observations
 -------------------------------------------------------------------------------
 
-The finite-state drive program also determines which nearby corner camera may
-report during each half-side. A camera outside its 3.6-unit range contributes
-exactly zero correction. This produces genuine prediction-only intervals rather
-than pretending that every camera sees through the entire field.
-
-#CameraSchedule(dwell-ticks<f64>) => <[f64]:1,376>
-  ├ :LowerLeft(remaining<f64>, dwell-ticks<f64>, schedule<[f64]>)
-  ├ :LowerRight(remaining<f64>, dwell-ticks<f64>, schedule<[f64]>)
-  ├ :RightLower(remaining<f64>, dwell-ticks<f64>, schedule<[f64]>)
-  ├ :RightUpper(remaining<f64>, dwell-ticks<f64>, schedule<[f64]>)
-  ├ :UpperRight(remaining<f64>, dwell-ticks<f64>, schedule<[f64]>)
-  ├ :UpperLeft(remaining<f64>, dwell-ticks<f64>, schedule<[f64]>)
-  ├ :LeftUpper(remaining<f64>, dwell-ticks<f64>, schedule<[f64]>)
-  ├ :LeftLower(remaining<f64>, dwell-ticks<f64>, schedule<[f64]>)
-  └ :CameraScheduleDone(schedule<[f64]>).
-
-#CameraSchedule(dwell-ticks<u64>) -> :LowerLeft(dwell-ticks, dwell-ticks, [])
-  :LowerLeft(remaining, dwell-ticks, schedule)
-    ├ remaining > 0 -> :LowerLeft(remaining - 1, dwell-ticks, [schedule 1.0])
-    └ * -> :LowerRight(dwell-ticks, dwell-ticks, schedule)
-  :LowerRight(remaining, dwell-ticks, schedule)
-    ├ remaining > 0 -> :LowerRight(remaining - 1, dwell-ticks, [schedule 2.0])
-    └ * -> :RightLower(dwell-ticks, dwell-ticks, schedule)
-  :RightLower(remaining, dwell-ticks, schedule)
-    ├ remaining > 0 -> :RightLower(remaining - 1, dwell-ticks, [schedule 2.0])
-    └ * -> :RightUpper(dwell-ticks, dwell-ticks, schedule)
-  :RightUpper(remaining, dwell-ticks, schedule)
-    ├ remaining > 0 -> :RightUpper(remaining - 1, dwell-ticks, [schedule 3.0])
-    └ * -> :UpperRight(dwell-ticks, dwell-ticks, schedule)
-  :UpperRight(remaining, dwell-ticks, schedule)
-    ├ remaining > 0 -> :UpperRight(remaining - 1, dwell-ticks, [schedule 3.0])
-    └ * -> :UpperLeft(dwell-ticks, dwell-ticks, schedule)
-  :UpperLeft(remaining, dwell-ticks, schedule)
-    ├ remaining > 0 -> :UpperLeft(remaining - 1, dwell-ticks, [schedule 4.0])
-    └ * -> :LeftUpper(dwell-ticks, dwell-ticks, schedule)
-  :LeftUpper(remaining, dwell-ticks, schedule)
-    ├ remaining > 0 -> :LeftUpper(remaining - 1, dwell-ticks, [schedule 4.0])
-    └ * -> :LeftLower(dwell-ticks, dwell-ticks, schedule)
-  :LeftLower(remaining, dwell-ticks, schedule)
-    ├ remaining > 0 -> :LeftLower(remaining - 1, dwell-ticks, [schedule 1.0])
-    └ * -> :CameraScheduleDone(schedule)
-  :CameraScheduleDone(schedule) => schedule.
+The same square phase selects the nearest corner camera during each half-side.
+A camera outside its 3.6-unit range contributes exactly zero correction. This
+produces genuine prediction-only intervals rather than pretending that every
+camera sees through the entire field.
 
   camera-dwell-ticks := side-ticks / 2.0
-  camera-schedule<[f64]:1,376> := #CameraSchedule(camera-dwell-ticks)
-  camera-index := camera-schedule[1,drive-phase-index]
+  camera-index := (math/floor((simulation-step + camera-dwell-ticks) / side-ticks) % 4.0) + 1.0
   active-camera := cameras[camera-index,:]'
   camera-offsets := cameras - attempted-truth[1..=2]'
-  camera-range-all := ((camera-offsets ^ 2) ** [1.0; 1.0]) ^ 0.5
+  camera-range-all := math/sqrt((camera-offsets ^ 2) ** [1.0; 1.0])
   camera-inside-fade-raw := (camera-max-range - camera-range-all) / camera-range-fade
-  camera-inside-fade-relu := (camera-inside-fade-raw + (camera-inside-fade-raw ^ 2) ^ 0.5) / 2.0
-  camera-inside-fade-one-relu := (camera-inside-fade-raw - 1.0 + ((camera-inside-fade-raw - 1.0) ^ 2) ^ 0.5) / 2.0
+  camera-inside-fade-relu := (camera-inside-fade-raw + math/abs(camera-inside-fade-raw)) / 2.0
+  camera-inside-fade-one-relu := (camera-inside-fade-raw - 1.0 + math/abs(camera-inside-fade-raw - 1.0)) / 2.0
   camera-visibility := (camera-inside-fade-relu - camera-inside-fade-one-relu) * camera-enabled
 
-  -- These boundary witnesses exercise the exact same resident visibility
-  -- graph at the inner fade edge, the physical boundary, and two points
-  -- beyond it. They are intentionally ordinary Mech values rather than a
-  -- host-side copy of the formula, so every runtime can qualify the hard
-  -- sensing contract even when the driven trajectory does not land on an
-  -- exact floating-point boundary.
-  camera-boundary-probe-distances := camera-max-range + [-camera-range-fade; 0.0; 0.000001; camera-range-fade]
-  camera-boundary-probe-raw := (camera-max-range - camera-boundary-probe-distances) / camera-range-fade
-  camera-boundary-probe-relu := (camera-boundary-probe-raw + (camera-boundary-probe-raw ^ 2) ^ 0.5) / 2.0
-  camera-boundary-probe-one-relu := (camera-boundary-probe-raw - 1.0 + ((camera-boundary-probe-raw - 1.0) ^ 2) ^ 0.5) / 2.0
-  camera-boundary-probe-visibility := camera-boundary-probe-relu - camera-boundary-probe-one-relu
-  camera-boundary-probe-baseline := [11.0; 12.0; 13.0; 14.0]
-  camera-boundary-probe-target := [21.0; 22.0; 23.0; 24.0]
-  camera-boundary-probe-correction := camera-boundary-probe-baseline + camera-boundary-probe-visibility * (camera-boundary-probe-target - camera-boundary-probe-baseline)
   active-camera-visibility := camera-visibility[camera-index]
   camera-offset := active-camera - attempted-truth[1..=2]
   camera-range-square := [1.0 1.0] ** (camera-offset ^ 2)
-  camera-range := camera-range-square[1] ^ 0.5
+  camera-range := math/sqrt(camera-range-square[1])
   observation-model := [camera-range
                         math/atan2(camera-offset[2], camera-offset[1]) - attempted-truth[3]]
   observation-noise-phase := simulation-time * [1.57; 1.91] + camera-index * [0.7; 1.0]
@@ -282,15 +201,13 @@ directly across the lane matrices. Only lane zero is sampled back for the scene.
 
   filter-count := 1000.0
   filter-index := 1.0..=filter-count
-  filter-phase := 2.0 * 3.141592654 * (filter-index - 1.0) / filter-count
+  filter-phase := 2.0 * π * (filter-index - 1.0) / filter-count
   lane-dt-base := Δt * filter-step-span
   lane-control-base := [lane-dt-base commanded-speed commanded-omega]
   lane-control-phase := filter-phase' ** [0.0 3.0 5.0]
   lane-control-scale := 1.0 + math/sin(lane-control-phase) * [0.0 0.002 0.002]
   lane-control := lane-control-base * lane-control-scale
-  lane-zero := filter-index' * 0.0
-  lane-camera-zero := lane-zero ** [1.0 1.0]
-  lane-camera := lane-camera-zero + active-camera'
+  lane-camera := (1.0 + filter-index' * 0.0) ** active-camera'
   lane-measurement-base := [observation' active-camera-visibility]
   lane-measurement-phase := filter-phase' ** [7.0 11.0 0.0]
   lane-measurement := lane-measurement-base + math/sin(lane-measurement-phase) * [0.012 0.0015 0.0]
@@ -301,7 +218,6 @@ directly across the lane matrices. Only lane zero is sampled back for the scene.
   @filters/turn <- next-requested-compute-turn
 
   filter-sample := @filters/sample/result.0
-  filter-camera-visibility := @filters/sample/result.2
   corrected-estimate := filter-sample[:,1]
   corrected-covariance := filter-sample[:,2..=4]
   predicted-estimate := filter-sample[:,5]
@@ -364,16 +280,6 @@ ekf-batch @compute
   R := [0.0225<f32> 0f32
         0f32 0.0004<f32>]
 
-  -- Qualify the inactive-measurement boundary directly: the camera and prior
-  -- position coincide while visibility is exactly zero. This used to evaluate
-  -- 0 / 0 before the later visibility interpolation could discard the result.
-  inactive-witness-state := [1f32; 1f32; 0f32]
-  inactive-witness-covariance := [0.45<f32> 0f32 0f32
-                                  0f32 0.45<f32> 0f32
-                                  0f32 0f32 0.08<f32>]
-  (inactive-witness-μ, inactive-witness-Σ) := ekf-correct(inactive-witness-state, inactive-witness-covariance, [1f32; 1f32], [0f32; 0f32; 0f32], R)
-  inactive-correction-finite! := math/abs(inactive-witness-μ[1]) <= 3.402823466e38<f32> && math/abs(inactive-witness-μ[2]) <= 3.402823466e38<f32> && math/abs(inactive-witness-μ[3]) <= 3.402823466e38<f32> && inactive-witness-Σ[1,1] > 0f32 && inactive-witness-Σ[2,2] > 0f32 && inactive-witness-Σ[3,3] > 0f32
-
   -- These two fixed-shape calls are the whole filter. The compute host maps
   -- them over the outer lane arrays supplied by the document; increasing the
   -- lane count does not duplicate this source graph.
@@ -382,7 +288,6 @@ ekf-batch @compute
   ~filter-sample := [2.9<f32>  0.45<f32> 0f32       0f32       2.9<f32>
                      2.15<f32> 0f32       0.45<f32> 0f32       2.15<f32>
                      0.16<f32> 0f32       0f32       0.08<f32> 0.16<f32>]
-  ~applied-visibility := 0f32
   μ := filter-sample[:,1]
   Σ := filter-sample[:,2..=4]
   (μ-, Σ-) := ekf-predict(μ, Σ, control, Q)
@@ -396,8 +301,7 @@ ekf-batch @compute
   symmetric-covariance! := math/abs(Σ-next[1,2] - Σ-next[2,1]) <= 0.0001<f32> && math/abs(Σ-next[1,3] - Σ-next[3,1]) <= 0.0001<f32> && math/abs(Σ-next[2,3] - Σ-next[3,2]) <= 0.0001<f32>
 
   filter-sample = [μ-next Σ-next μ-]
-  applied-visibility = γ
-  (filter-sample, filter-sample, applied-visibility)
+  (filter-sample, filter-sample)
 
 
 5. Live Tracking Field
@@ -417,34 +321,33 @@ range. Only the scheduled in-range camera's noisy values enter the filter.
   predicted-screen := screen-positions[:,2]
   estimate-screen := screen-positions[:,3]
   display-camera-offsets := cameras - next-truth[1..=2]'
-  display-camera-range-all := ((display-camera-offsets ^ 2) ** [1.0; 1.0]) ^ 0.5
+  display-camera-range-all := math/sqrt((display-camera-offsets ^ 2) ** [1.0; 1.0])
   display-camera-inside-fade-raw := (camera-max-range - display-camera-range-all) / camera-range-fade
-  display-camera-inside-fade-relu := (display-camera-inside-fade-raw + (display-camera-inside-fade-raw ^ 2) ^ 0.5) / 2.0
-  display-camera-inside-fade-one-relu := (display-camera-inside-fade-raw - 1.0 + ((display-camera-inside-fade-raw - 1.0) ^ 2) ^ 0.5) / 2.0
+  display-camera-inside-fade-relu := (display-camera-inside-fade-raw + math/abs(display-camera-inside-fade-raw)) / 2.0
+  display-camera-inside-fade-one-relu := (display-camera-inside-fade-raw - 1.0 + math/abs(display-camera-inside-fade-raw - 1.0)) / 2.0
   display-camera-visibility := (display-camera-inside-fade-relu - display-camera-inside-fade-one-relu) * camera-enabled
   position-error-vector := corrected-estimate[1..=2] - next-truth[1..=2]
   position-error-square := [1.0 1.0] ** (position-error-vector ^ 2)
-  position-error := position-error-square[1] ^ 0.5
+  position-error := math/sqrt(position-error-square[1])
 
   ellipse-a := corrected-covariance[1,1]
   ellipse-b := corrected-covariance[1,2]
   ellipse-c := corrected-covariance[2,2]
-  ellipse-root := (((ellipse-a - ellipse-c) / 2.0) ^ 2 + ellipse-b ^ 2) ^ 0.5
+  ellipse-root := math/sqrt(((ellipse-a - ellipse-c) / 2.0) ^ 2 + ellipse-b ^ 2)
   ellipse-eigenvalues := (ellipse-a + ellipse-c) / 2.0 + [1.0; -1.0] * ellipse-root
-  ellipse-axes := (ellipse-eigenvalues ^ 0.5) * 2.0
+  ellipse-axes := math/sqrt(ellipse-eigenvalues) * 2.0
   ellipse-rotation := 0.5 * math/atan2(2.0 * ellipse-b, ellipse-a - ellipse-c)
   ellipse-samples := 0..=64
   ellipse-angle := ellipse-samples' * (2.0 * π / 64.0)
   ellipse-display-floor := 0.04
-  display-ellipse-axes := (ellipse-axes ^ 2 + ellipse-display-floor ^ 2) ^ 0.5
+  display-ellipse-axes := math/sqrt(ellipse-axes ^ 2 + ellipse-display-floor ^ 2)
   ellipse-axis-points := [math/cos(ellipse-angle) math/sin(ellipse-angle)] * display-ellipse-axes'
   ellipse-rotation-matrix := [ math/cos(ellipse-rotation) math/sin(ellipse-rotation)
                               -math/sin(ellipse-rotation) math/cos(ellipse-rotation)]
   covariance-ellipse := estimate-screen' + screen-scale * (ellipse-axis-points ** ellipse-rotation-matrix) * screen-axis'
 
   trail-samples := 1..=376
-  trail-zero := trail-samples' * 0.0
-  trail-zero-points := trail-zero ** [1.0 1.0]
+  trail-zero-points := (trail-samples' * 0.0) ** [1.0 1.0]
   ~truth-path := trail-zero-points + [275.0 545.0]
   ~estimate-path := trail-zero-points + [299.8 566.7]
   advanced-truth-path := matrix/vertcat(truth-path[2..=376,:], truth-screen')
@@ -454,11 +357,7 @@ range. Only the scheduled in-range camera's noisy values enter the filter.
   truth-path = next-truth-path
   estimate-path = next-estimate-path
 
-  square-guide-world := [low-bound low-bound
-                         high-bound low-bound
-                         high-bound high-bound
-                         low-bound high-bound
-                         low-bound low-bound]
+  square-guide-world := low-bound + field-span * square-waypoints
   square-guide := screen-origin' + screen-scale * square-guide-world * screen-axis'
 
   camera-range-opacity := 0.16 * camera-enabled
@@ -514,7 +413,7 @@ range. Only the scheduled in-range camera's noisy values enter the filter.
   scene-text := |id<string> x<f64> y<f64> fill<string> font-size<f64> font-family<string> font-weight<string> text-anchor<string> opacity<f64> value<string>|
     | "eyebrow" 24 26 "#8fa3b8" 12 "Inter, ui-sans-serif, system-ui, sans-serif" "650" "start" 1 "MECH RESIDENT SENSOR FUSION" |
     | "title" 24 62 "#edf2f7" 36 "Inter, ui-sans-serif, system-ui, sans-serif" "620" "start" 1 "Camera EKF Localization" |
-    | "state-label" 602 58 "#f4c95d" 13 "ui-monospace, SFMono-Regular, Menlo, monospace" "650" "start" 1 "V/Ω SQUARE-DRIVE FSM" |
+    | "state-label" 602 58 "#f4c95d" 13 "ui-monospace, SFMono-Regular, Menlo, monospace" "650" "start" 1 "V/Ω VECTORIZED SQUARE DRIVE" |
     | "camera-label-1" 195 636 "#d7c27f" 11 "Inter, ui-sans-serif, system-ui, sans-serif" "500" "start" camera-label-opacity[1] "CAM 1" |
     | "camera-label-2" 665 636 "#d7c27f" 11 "Inter, ui-sans-serif, system-ui, sans-serif" "500" "end" camera-label-opacity[2] "CAM 2" |
     | "camera-label-3" 665 140 "#d7c27f" 11 "Inter, ui-sans-serif, system-ui, sans-serif" "500" "end" camera-label-opacity[3] "CAM 3" |

--- a/examples/ekf/localization.mec
+++ b/examples/ekf/localization.mec
@@ -91,6 +91,10 @@ A gesture group coalesces down/up but never crosses into the next press. Parity 
 
 The delivered simulation step directly indexes the four square sides. The phase and its within-side progress define a moving point on the requested square. A short look-ahead aims the unicycle toward that point, so accumulated motion error is corrected instead of being carried into every later side. Its only controls are forward velocity `v` and angular velocity `ω`; bounded steering and turn-speed reduction make the corners smooth without position clamps.
 
+(2.1) Route Phase and Look-ahead Target
+
+The resident simulation step is converted into a lap phase and progress along the current side. Advancing that path parameter slightly selects a look-ahead point between adjacent square waypoints rather than aiming directly at a corner.
+
   side-ticks := 94.0
   lap-ticks := 4.0 * side-ticks
   ~simulation-step := 0.0
@@ -111,6 +115,11 @@ The delivered simulation step directly indexes the four square sides. The phase 
   lookahead-origin := square-waypoints[lookahead-side,:]'
   lookahead-direction := square-waypoints[lookahead-side + 1.0,:]' - lookahead-origin
   target-position := low-bound + field-span * (lookahead-origin + lookahead-progress * lookahead-direction)
+
+(2.2) Feedback Steering
+
+The simulated robot pose is resident state. Expressing the look-ahead target in the robot's heading frame yields a signed angular error; the controller bounds angular velocity and reduces forward speed during sharper turns.
+
   ~truth := [2.5
              2.5
              0.0]
@@ -127,6 +136,11 @@ The delivered simulation step directly indexes the four square sides. The phase 
   commanded-speed := cruise-speed * (1.0 - 0.42 * turn-fraction)
   commanded-control := [commanded-speed
                         commanded-omega]
+
+(2.3) Biased Plant Motion
+
+The plant deliberately does not execute the command perfectly. Smooth scale errors perturb forward and angular velocity, and midpoint integration advances the physical truth only when the clock supplies a pulse.
+
   actual-control-scale := [0.965; 0.99] + [0.025; 0.01] * math/sin(simulation-time * [0.73; 0.51] + [0.0; 0.8])
   actual-control := commanded-control * actual-control-scale
   truth-mid-heading := truth[3] + actual-control[2] * Δt / 2.0
@@ -134,6 +148,10 @@ The delivered simulation step directly indexes the four square sides. The phase 
   truth-velocity := [truth-direction * actual-control[1]; actual-control[2]]
   attempted-truth := truth + truth-velocity * Δt
   next-truth := truth + clock-pulse * (attempted-truth - truth)
+
+(2.4) State Publication
+
+The accepted truth and simulation step become the next resident values. The compute-turn counters advance from the same clock decision so the filter receives each control interval exactly once.
 
   truth = next-truth
   simulation-step = next-simulation-step
@@ -312,6 +330,10 @@ The validated checkpoint becomes the starting point for the next GPU turn and is
 
 The covariance outline is the two-standard-deviation position ellipse calculated from the live 2x2 covariance block. Because finite-range camera updates can make the physical ellipse smaller than a useful screen mark, display axes have a 0.04-unit quadrature floor; this changes only the drawing, never the filter covariance. Steady footprint guides show each camera's real maximum range. Camera rays terminate at simulated truth and fade to exactly zero outside that range. Only the scheduled in-range camera's noisy values enter the filter.
 
+(5.1) Screen-space Sampling
+
+Truth, prediction, and correction are projected into the scene's screen coordinates together. The same sampled state determines camera visibility and the scalar position error reported by the document.
+
   world-positions := [next-truth[1..=2] predicted-estimate[1..=2] corrected-estimate[1..=2]]
   screen-positions := screen-origin + screen-scale * screen-axis * world-positions
   truth-screen := screen-positions[:,1]
@@ -326,6 +348,10 @@ The covariance outline is the two-standard-deviation position ellipse calculated
   position-error-vector := corrected-estimate[1..=2] - next-truth[1..=2]
   position-error-square := [1.0 1.0] ** (position-error-vector ^ 2)
   position-error := math/sqrt(position-error-square[1])
+
+(5.2) Covariance Ellipse
+
+The eigenvalues and orientation of the corrected 2×2 position covariance become the axes and rotation of a two-standard-deviation ellipse. A small display-only floor keeps a highly confident estimate visible without modifying the filter covariance.
 
   ellipse-a := corrected-covariance[1,1]
   ellipse-b := corrected-covariance[1,2]
@@ -344,6 +370,10 @@ The covariance outline is the two-standard-deviation position ellipse calculated
   ellipse-rotation-matrix := [ellipse-rotation-direction; -ellipse-rotation-direction[2] ellipse-rotation-direction[1]]
   covariance-ellipse := estimate-screen' + screen-scale * (ellipse-axis-points ** ellipse-rotation-matrix) * screen-axis'
 
+(5.3) Resident Tracking Trails
+
+Two resident point buffers retain the recent truth and estimate trajectories. A delivered filter sample shifts each trail by one row and appends its newest screen position.
+
   trail-samples := 1..=376
   trail-zero-points := (trail-samples' * 0.0) ** [1.0 1.0]
   ~truth-path := trail-zero-points + [275.0 545.0]
@@ -354,6 +384,10 @@ The covariance outline is the two-standard-deviation position ellipse calculated
   next-estimate-path := estimate-path + sample-pulse * (advanced-estimate-path - estimate-path)
   truth-path = next-truth-path
   estimate-path = next-estimate-path
+
+(5.4) Field and Heading Guides
+
+The square path, camera opacity channels, and heading vectors are calculated once before the scene tables reference them. Disabled cameras keep muted labels while their sensing rings and measurement rays disappear.
 
   square-guide-world := low-bound + field-span * square-waypoints
   square-guide := screen-origin' + screen-scale * square-guide-world * screen-axis'
@@ -367,6 +401,14 @@ The covariance outline is the two-standard-deviation position ellipse calculated
   heading-unit-vectors := math/cos(heading-phase-grid)
   heading-screen-vectors := screen-axis * heading-unit-vectors * [18.0 16.0]
   heading-screen-points := [truth-screen estimate-screen] + heading-screen-vectors
+
+(5.5) Scene Primitives
+
+The scene resource consumes typed tables of drawing primitives. Each table below owns one visual responsibility instead of hiding the whole presentation inside a single uninterrupted code block.
+
+(5.5.1) Circles
+
+Circles draw camera ranges and bodies, the three robot-state markers, and the compact legend keys. Opacity columns connect camera state directly to the rendered result.
 
   scene-circles := |id<string> x<f64> y<f64> radius<f64> fill<*> stroke<*> stroke-width<f64> opacity<f64>|
     | "camera-range-1" camera-screen[1,1] camera-screen[1,2] camera-max-range * screen-scale "none" 0xf4c95d<f64> 0.8 camera-range-opacity[1] |
@@ -388,6 +430,10 @@ The covariance outline is the two-standard-deviation position ellipse calculated
     | "legend-prediction" 205 718 4 0xf2b84b<f64> "none" 0 1 |
     | "legend-estimate" 405 718 4 0xf087b8<f64> "none" 0 1 |
 
+(5.5.2) Fixed Lines
+
+Fixed line segments draw the field frame, camera-to-robot measurement rays, and the truth and estimate heading indicators.
+
   scene-lines := |id<string> x1<f64> y1<f64> x2<f64> y2<f64> stroke<f64> stroke-width<f64> line-cap<string> opacity<f64> rotation<f64> origin-x<f64> origin-y<f64>|
     | "frame-top" 120 80 740 80 0x27313d<f64> 1 "butt" 1 0 0 0 |
     | "frame-right" 740 80 740 700 0x27313d<f64> 1 "butt" 1 0 0 0 |
@@ -400,11 +446,19 @@ The covariance outline is the two-standard-deviation position ellipse calculated
     | "truth-heading" truth-screen[1] truth-screen[2] heading-screen-points[1,1] heading-screen-points[2,1] 0xd7fff8<f64> 2 "round" 1 0 0 0 |
     | "estimate-heading" estimate-screen[1] estimate-screen[2] heading-screen-points[1,2] heading-screen-points[2,2] 0xffe1ef<f64> 1.5 "round" 1 0 0 0 |
 
+(5.5.3) Paths and Covariance
+
+Line strips draw the requested square, both resident trails, and the sampled covariance ellipse from their prepared point matrices.
+
   scene-line-strips := |id<string> positions<*> stroke<f64> stroke-width<f64> line-cap<string> line-join<string> opacity<f64> closed<bool>|
     | "square-guide" square-guide 0x536273<f64> 1 "round" "round" 0.38 true |
     | "truth-path" next-truth-path 0x63d6c5<f64> 2 "round" "round" 0.8 false |
     | "estimate-path" next-estimate-path 0xf087b8<f64> 2 "round" "round" 0.84 false |
     | "covariance" covariance-ellipse 0xf087b8<f64> 1.5 "round" "round" 0.72 true |
+
+(5.5.4) Labels
+
+Text primitives supply the field title, camera labels, and legend descriptions with one shared interface-safe font stack.
 
   sans-serif-font := "Inter, ui-sans-serif, system-ui, sans-serif"
 
@@ -417,6 +471,10 @@ The covariance outline is the two-standard-deviation position ellipse calculated
                 | "legend-truth-label"        40    722    0xbdc8d2  12             sans-serif-font     400              "start"             1                       "actual robot + path"          |
                 | "legend-prediction-label"  215    722    0xbdc8d2  12             sans-serif-font     400              "start"             1                       "motion prediction"            |
                 | "legend-estimate-label"    415    722    0xbdc8d2  12             sans-serif-font     400              "start"             1                       "EKF estimate + 2σ covariance" |
+
+(5.6) Scene Publication
+
+The presentation record gathers the four primitive tables into one scene frame. Replacing the resource frame and returning position error publish the visual and numerical outputs of the same sampled filter state.
 
   field-presentation := {
     width: 860

--- a/examples/ekf/localization.mec
+++ b/examples/ekf/localization.mec
@@ -410,51 +410,54 @@ The scene resource consumes typed tables of drawing primitives. Each table below
 
 Circles draw camera ranges and bodies, the three robot-state markers, and the compact legend keys. Opacity columns connect camera state directly to the rendered result.
 
-  scene-circles := |id<string> x<f64> y<f64> radius<f64> fill<*> stroke<*> stroke-width<f64> opacity<f64>|
-    | "camera-range-1" camera-screen[1,1] camera-screen[1,2] camera-max-range * screen-scale "none" 0xf4c95d<f64> 0.8 camera-range-opacity[1] |
-    | "camera-range-2" camera-screen[2,1] camera-screen[2,2] camera-max-range * screen-scale "none" 0xf4c95d<f64> 0.8 camera-range-opacity[2] |
-    | "camera-range-3" camera-screen[3,1] camera-screen[3,2] camera-max-range * screen-scale "none" 0xf4c95d<f64> 0.8 camera-range-opacity[3] |
-    | "camera-range-4" camera-screen[4,1] camera-screen[4,2] camera-max-range * screen-scale "none" 0xf4c95d<f64> 0.8 camera-range-opacity[4] |
-    | "camera-disabled-1" camera-screen[1,1] camera-screen[1,2] 9 0x59616b<f64> "none" 0 camera-disabled-opacity[1] |
-    | "camera-disabled-2" camera-screen[2,1] camera-screen[2,2] 9 0x59616b<f64> "none" 0 camera-disabled-opacity[2] |
-    | "camera-disabled-3" camera-screen[3,1] camera-screen[3,2] 9 0x59616b<f64> "none" 0 camera-disabled-opacity[3] |
-    | "camera-disabled-4" camera-screen[4,1] camera-screen[4,2] 9 0x59616b<f64> "none" 0 camera-disabled-opacity[4] |
-    | "camera-1" camera-screen[1,1] camera-screen[1,2] 9 0xf4c95d<f64> 0xfff1b8<f64> 2 camera-enabled[1] |
-    | "camera-2" camera-screen[2,1] camera-screen[2,2] 9 0xf4c95d<f64> 0xfff1b8<f64> 2 camera-enabled[2] |
-    | "camera-3" camera-screen[3,1] camera-screen[3,2] 9 0xf4c95d<f64> 0xfff1b8<f64> 2 camera-enabled[3] |
-    | "camera-4" camera-screen[4,1] camera-screen[4,2] 9 0xf4c95d<f64> 0xfff1b8<f64> 2 camera-enabled[4] |
-    | "truth" truth-screen[1] truth-screen[2] 8 0x63d6c5<f64> 0xd7fff8<f64> 1.5 1 |
-    | "prediction" predicted-screen[1] predicted-screen[2] 6 "none" 0xf2b84b<f64> 2 1 |
-    | "estimate" estimate-screen[1] estimate-screen[2] 7 0xf087b8<f64> 0xffe1ef<f64> 1.5 1 |
-    | "legend-truth" 30 718 4 0x63d6c5<f64> "none" 0 1 |
-    | "legend-prediction" 205 718 4 0xf2b84b<f64> "none" 0 1 |
-    | "legend-estimate" 405 718 4 0xf087b8<f64> "none" 0 1 |
+  scene-circles := 
+    | id<string>          x<f64>              y<f64>              radius<f64>                     fill<*>   stroke<*> stroke-width<f64> opacity<f64>               |
+    | "camera-range-1"    camera-screen[1,1]  camera-screen[1,2]  camera-max-range * screen-scale "none"    0xf4c95d  0.8               camera-range-opacity[1]    |
+    | "camera-range-2"    camera-screen[2,1]  camera-screen[2,2]  camera-max-range * screen-scale "none"    0xf4c95d  0.8               camera-range-opacity[2]    |
+    | "camera-range-3"    camera-screen[3,1]  camera-screen[3,2]  camera-max-range * screen-scale "none"    0xf4c95d  0.8               camera-range-opacity[3]    |
+    | "camera-range-4"    camera-screen[4,1]  camera-screen[4,2]  camera-max-range * screen-scale "none"    0xf4c95d  0.8               camera-range-opacity[4]    |
+    | "camera-disabled-1" camera-screen[1,1]  camera-screen[1,2]  9                               0x59616b  "none"    0                 camera-disabled-opacity[1] |
+    | "camera-disabled-2" camera-screen[2,1]  camera-screen[2,2]  9                               0x59616b  "none"    0                 camera-disabled-opacity[2] |
+    | "camera-disabled-3" camera-screen[3,1]  camera-screen[3,2]  9                               0x59616b  "none"    0                 camera-disabled-opacity[3] |
+    | "camera-disabled-4" camera-screen[4,1]  camera-screen[4,2]  9                               0x59616b  "none"    0                 camera-disabled-opacity[4] |
+    | "camera-1"          camera-screen[1,1]  camera-screen[1,2]  9                               0xf4c95d  0xfff1b8  2                 camera-enabled[1]          |
+    | "camera-2"          camera-screen[2,1]  camera-screen[2,2]  9                               0xf4c95d  0xfff1b8  2                 camera-enabled[2]          |
+    | "camera-3"          camera-screen[3,1]  camera-screen[3,2]  9                               0xf4c95d  0xfff1b8  2                 camera-enabled[3]          |
+    | "camera-4"          camera-screen[4,1]  camera-screen[4,2]  9                               0xf4c95d  0xfff1b8  2                 camera-enabled[4]          |
+    | "truth"             truth-screen[1]     truth-screen[2]     8                               0x63d6c5  0xd7fff8  1.5               1                          |
+    | "prediction"        predicted-screen[1] predicted-screen[2] 6                               "none"    0xf2b84b  2                 1                          |
+    | "estimate"          estimate-screen[1]  estimate-screen[2]  7                               0xf087b8  0xffe1ef  1.5               1                          |
+    | "legend-truth"      30                  718                 4                               0x63d6c5  "none"    0                 1                          |
+    | "legend-prediction" 205                 718                 4                               0xf2b84b  "none"    0                 1                          |
+    | "legend-estimate"   405                 718                 4                               0xf087b8  "none"    0                 1                          |
 
 (6.5.2) Fixed Lines
 
 Fixed line segments draw the field frame, camera-to-robot measurement rays, and the truth and estimate heading indicators.
 
-  scene-lines := |id<string> x1<f64> y1<f64> x2<f64> y2<f64> stroke<f64> stroke-width<f64> line-cap<string> opacity<f64> rotation<f64> origin-x<f64> origin-y<f64>|
-    | "frame-top" 120 80 740 80 0x27313d<f64> 1 "butt" 1 0 0 0 |
-    | "frame-right" 740 80 740 700 0x27313d<f64> 1 "butt" 1 0 0 0 |
-    | "frame-bottom" 740 700 120 700 0x27313d<f64> 1 "butt" 1 0 0 0 |
-    | "frame-left" 120 700 120 80 0x27313d<f64> 1 "butt" 1 0 0 0 |
-    | "ray-1" camera-screen[1,1] camera-screen[1,2] truth-screen[1] truth-screen[2] 0xd9b652<f64> 0.7 "round" camera-ray-opacity[1] 0 0 0 |
-    | "ray-2" camera-screen[2,1] camera-screen[2,2] truth-screen[1] truth-screen[2] 0xd9b652<f64> 0.7 "round" camera-ray-opacity[2] 0 0 0 |
-    | "ray-3" camera-screen[3,1] camera-screen[3,2] truth-screen[1] truth-screen[2] 0xd9b652<f64> 0.7 "round" camera-ray-opacity[3] 0 0 0 |
-    | "ray-4" camera-screen[4,1] camera-screen[4,2] truth-screen[1] truth-screen[2] 0xd9b652<f64> 0.7 "round" camera-ray-opacity[4] 0 0 0 |
-    | "truth-heading" truth-screen[1] truth-screen[2] heading-screen-points[1,1] heading-screen-points[2,1] 0xd7fff8<f64> 2 "round" 1 0 0 0 |
-    | "estimate-heading" estimate-screen[1] estimate-screen[2] heading-screen-points[1,2] heading-screen-points[2,2] 0xffe1ef<f64> 1.5 "round" 1 0 0 0 |
+  scene-lines := 
+    | id<string>         x1<f64>            y1<f64>            x2<f64>                    y2<f64>                    stroke<f64>   stroke-width<f64> line-cap<string> opacity<f64>          rotation<f64> origin-x<f64> origin-y<f64>|
+    | "frame-top"        120                80                 740                        80                         0x27313d      1                 "butt"           1                     0             0             0            |
+    | "frame-right"      740                80                 740                        700                        0x27313d      1                 "butt"           1                     0             0             0            |
+    | "frame-bottom"     740                700                120                        700                        0x27313d      1                 "butt"           1                     0             0             0            |
+    | "frame-left"       120                700                120                        80                         0x27313d      1                 "butt"           1                     0             0             0            |
+    | "ray-1"            camera-screen[1,1] camera-screen[1,2] truth-screen[1]            truth-screen[2]            0xd9b652      0.7               "round"          camera-ray-opacity[1] 0             0             0            |
+    | "ray-2"            camera-screen[2,1] camera-screen[2,2] truth-screen[1]            truth-screen[2]            0xd9b652      0.7               "round"          camera-ray-opacity[2] 0             0             0            |
+    | "ray-3"            camera-screen[3,1] camera-screen[3,2] truth-screen[1]            truth-screen[2]            0xd9b652      0.7               "round"          camera-ray-opacity[3] 0             0             0            |
+    | "ray-4"            camera-screen[4,1] camera-screen[4,2] truth-screen[1]            truth-screen[2]            0xd9b652      0.7               "round"          camera-ray-opacity[4] 0             0             0            |
+    | "truth-heading"    truth-screen[1]    truth-screen[2]    heading-screen-points[1,1] heading-screen-points[2,1] 0xd7fff8      2                 "round"          1                     0             0             0            |
+    | "estimate-heading" estimate-screen[1] estimate-screen[2] heading-screen-points[1,2] heading-screen-points[2,2] 0xffe1ef      1.5               "round"          1                     0             0             0            |
 
 (6.5.3) Paths and Covariance
 
 Line strips draw the requested square, both resident trails, and the sampled covariance ellipse from their prepared point matrices.
 
-  scene-line-strips := |id<string> positions<*> stroke<f64> stroke-width<f64> line-cap<string> line-join<string> opacity<f64> closed<bool>|
-    | "square-guide" square-guide 0x536273<f64> 1 "round" "round" 0.38 true |
-    | "truth-path" next-truth-path 0x63d6c5<f64> 2 "round" "round" 0.8 false |
-    | "estimate-path" next-estimate-path 0xf087b8<f64> 2 "round" "round" 0.84 false |
-    | "covariance" covariance-ellipse 0xf087b8<f64> 1.5 "round" "round" 0.72 true |
+  scene-line-strips := 
+    | id<string>      positions<*>       stroke<f64> stroke-width<f64> line-cap<string> line-join<string> opacity<f64> closed<bool>|
+    | "square-guide"  square-guide       0x536273    1                 "round"          "round"           0.38         true        |
+    | "truth-path"    next-truth-path    0x63d6c5    2                 "round"          "round"           0.8          false       |
+    | "estimate-path" next-estimate-path 0xf087b8    2                 "round"          "round"           0.84         false       |
+    | "covariance"    covariance-ellipse 0xf087b8    1.5               "round"          "round"           0.72         true        |
 
 (6.5.4) Labels
 
@@ -462,15 +465,16 @@ Text primitives supply the field title, camera labels, and legend descriptions w
 
   sans-serif-font := "Inter, ui-sans-serif, system-ui, sans-serif"
 
-  scene-text := |id<string>                  x<f64> y<f64> fill<f64>      font-size<f64> font-family<string> font-weight<f64> text-anchor<string> opacity<f64>            value<string>                  |
-                | "title"                     24     62    0xedf2f7  36             sans-serif-font     620              "start"             1                       "Camera EKF Localization"      |
-                | "camera-label-1"           195    636    0xd7c27f  11             sans-serif-font     500              "start"             camera-label-opacity[1] "CAM 1"                        |
-                | "camera-label-2"           665    636    0xd7c27f  11             sans-serif-font     500              "end"               camera-label-opacity[2] "CAM 2"                        |
-                | "camera-label-3"           665    140    0xd7c27f  11             sans-serif-font     500              "end"               camera-label-opacity[3] "CAM 3"                        |
-                | "camera-label-4"           195    140    0xd7c27f  11             sans-serif-font     500              "start"             camera-label-opacity[4] "CAM 4"                        |
-                | "legend-truth-label"        40    722    0xbdc8d2  12             sans-serif-font     400              "start"             1                       "actual robot + path"          |
-                | "legend-prediction-label"  215    722    0xbdc8d2  12             sans-serif-font     400              "start"             1                       "motion prediction"            |
-                | "legend-estimate-label"    415    722    0xbdc8d2  12             sans-serif-font     400              "start"             1                       "EKF estimate + 2σ covariance" |
+  scene-text := 
+    | id<string>                 x<f64> y<f64> fill<f64> font-size<f64> font-family<string> font-weight<f64> text-anchor<string> opacity<f64>            value<string>                  |
+    | "title"                     24     62    0xedf2f7  36             sans-serif-font     620              "start"             1                       "Camera EKF Localization"      |
+    | "camera-label-1"           195    636    0xd7c27f  11             sans-serif-font     500              "start"             camera-label-opacity[1] "CAM 1"                        |
+    | "camera-label-2"           665    636    0xd7c27f  11             sans-serif-font     500              "end"               camera-label-opacity[2] "CAM 2"                        |
+    | "camera-label-3"           665    140    0xd7c27f  11             sans-serif-font     500              "end"               camera-label-opacity[3] "CAM 3"                        |
+    | "camera-label-4"           195    140    0xd7c27f  11             sans-serif-font     500              "start"             camera-label-opacity[4] "CAM 4"                        |
+    | "legend-truth-label"        40    722    0xbdc8d2  12             sans-serif-font     400              "start"             1                       "actual robot + path"          |
+    | "legend-prediction-label"  215    722    0xbdc8d2  12             sans-serif-font     400              "start"             1                       "motion prediction"            |
+    | "legend-estimate-label"    415    722    0xbdc8d2  12             sans-serif-font     400              "start"             1                       "EKF estimate + 2σ covariance" |
 
 (6.6) Scene Publication
 

--- a/examples/ekf/localization.mec
+++ b/examples/ekf/localization.mec
@@ -46,8 +46,8 @@ Click a camera to disable it. Its color mutes, its range ring disappears, and it
   camera-max-range := 3.6
   camera-range-fade := 0.18
 
-  -- Each row is one camera. Two-element position vectors broadcast across all
-  -- four rows, so geometry never has to split into separate x and y equations.
+Each row is one camera. Two-element position vectors broadcast across all four rows, so geometry never has to split into separate x and y equations.
+
   cameras := [1.0 1.0
               9.0 1.0
               9.0 9.0
@@ -59,9 +59,8 @@ Click a camera to disable it. Its color mutes, its range ring disappears, and it
                  -1.0]
   camera-screen := screen-origin' + screen-scale * cameras * screen-axis'
 
-  -- Scene pointer presses toggle the camera under the cursor. The enable mask
-  -- is resident Mech state: it gates the measurement before the EKF input and
-  -- drives the active, muted, range-ring, label, and ray presentation below.
+Scene pointer presses toggle the camera under the cursor. The enable mask is resident Mech state: it gates the measurement before the EKF input and drives the active, muted, range-ring, label, and ray presentation below.
+  
   ~camera-enabled := [1.0; 1.0; 1.0; 1.0]
   ~last-scene-pointer-pulse := 0.0
   scene-pointer-pulse := @scene/pointer-pulse
@@ -75,9 +74,9 @@ Click a camera to disable it. Its color mutes, its range ring disappears, and it
   scene-pointer-hit-clamp-input := [scene-pointer-hit-raw scene-pointer-hit-raw - 1.0]
   scene-pointer-hit-clamp := (scene-pointer-hit-clamp-input + math/abs(scene-pointer-hit-clamp-input)) / 2.0
   scene-pointer-hit := scene-pointer-hit-clamp[:,1] - scene-pointer-hit-clamp[:,2]
-  -- A gesture group coalesces down/up but never crosses into the next press.
-  -- Parity still preserves an even count jump if an activation history is
-  -- restored or replayed without exposing every intermediate turn.
+
+A gesture group coalesces down/up but never crosses into the next press. Parity still preserves an even count jump if an activation history is restored or replayed without exposing every intermediate turn.
+  
   camera-toggle := scene-pointer-toggle-parity * scene-pointer-hit
   next-camera-enabled := camera-enabled + camera-toggle * (1.0 - 2.0 * camera-enabled)
   camera-enabled = next-camera-enabled

--- a/examples/ekf/localization.mec
+++ b/examples/ekf/localization.mec
@@ -4,31 +4,17 @@ section: Examples
 +> math
 ===============================================================================
 
-This resident application localizes a robot from noisy range-and-bearing
-measurements made by four fixed cameras. The cyan robot is simulated truth, the
-amber marker is the motion-model prediction, and the rose robot is the corrected
-EKF estimate. Their rolling paths make tracking error visible instead of hiding
-it in a final scalar.
+This resident application localizes a robot from noisy range-and-bearing measurements made by four fixed cameras. The cyan robot is simulated truth, the amber marker is the motion-model prediction, and the rose robot is the corrected EKF estimate. Their rolling paths make tracking error visible instead of hiding it in a final scalar.
 
-The filter follows the recursive predict/correct formulation and extended
-linearization described by [Welch and Bishop's EKF tutorial](https://www.cs.unc.edu/~welch/media/pdf/kalman_intro.pdf),
-building on [Kalman's original state-space filtering paper](https://doi.org/10.1115/1.3662552).
-The camera observations are generated
-from truth with deterministic noise; the filter receives only commanded motion,
-camera locations, measurements, and covariance models.
+The filter follows the recursive predict/correct formulation and extended linearization described by [Welch and Bishop's EKF tutorial](https://www.cs.unc.edu/~welch/media/pdf/kalman_intro.pdf), building on [Kalman's original state-space filtering paper](https://doi.org/10.1115/1.3662552). The camera observations are generated from truth with deterministic noise; the filter receives only commanded motion, camera locations, measurements, and covariance models.
 
 
 1. Field and Cameras
 -------------------------------------------------------------------------------
 
-The robot drives between 2.5 and 7.5 field units. Cameras surround that square,
-but each has a finite 3.6-unit sensing radius. The uncovered middle of every
-side is an intentional dead zone: covariance grows while no camera can see the
-robot and contracts after the next camera reacquires it.
+The robot drives between 2.5 and 7.5 field units. Cameras surround that square, but each has a finite 3.6-unit sensing radius. The uncovered middle of every side is an intentional dead zone: covariance grows while no camera can see the robot and contracts after the next camera reacquires it.
 
-Click a camera to disable it. Its color mutes, its range ring disappears, and
-its measurements are removed before the EKF update. Click it again to restore
-the same camera and measurement path.
+Click a camera to disable it. Its color mutes, its range ring disappears, and its measurements are removed before the EKF update. Click it again to restore the same camera and measurement path.
 
 @clock := timer://clock/tick{:read(tick)}
 @scene := scene://localization/frame{:read(pointer-pulse), :read(pointer-position), :write(replace)}
@@ -104,12 +90,7 @@ the same camera and measurement path.
 2. Vectorized Square Drive
 -------------------------------------------------------------------------------
 
-The delivered simulation step directly indexes the four square sides. The phase
-and its within-side progress define a moving point on the requested square. A
-short look-ahead aims the unicycle toward that point, so accumulated motion
-error is corrected instead of being carried into every later side. Its only
-controls are forward velocity `v` and angular velocity `ω`; bounded steering
-and turn-speed reduction make the corners smooth without position clamps.
+The delivered simulation step directly indexes the four square sides. The phase and its within-side progress define a moving point on the requested square. A short look-ahead aims the unicycle toward that point, so accumulated motion error is corrected instead of being carried into every later side. Its only controls are forward velocity `v` and angular velocity `ω`; bounded steering and turn-speed reduction make the corners smooth without position clamps.
 
   side-ticks := 94.0
   lap-ticks := 4.0 * side-ticks
@@ -164,10 +145,7 @@ and turn-speed reduction make the corners smooth without position clamps.
 3. Noisy Camera Observations
 -------------------------------------------------------------------------------
 
-The same square phase selects the nearest corner camera during each half-side.
-A camera outside its 3.6-unit range contributes exactly zero correction. This
-produces genuine prediction-only intervals rather than pretending that every
-camera sees through the entire field.
+The same square phase selects the nearest corner camera during each half-side. A camera outside its 3.6-unit range contributes exactly zero correction. This produces genuine prediction-only intervals rather than pretending that every camera sees through the entire field.
 
   camera-dwell-ticks := side-ticks / 2.0
   camera-index := (math/floor((simulation-step + camera-dwell-ticks) / side-ticks) % 4.0) + 1.0
@@ -192,15 +170,7 @@ camera sees through the entire field.
 4. Extended Kalman Filter
 -------------------------------------------------------------------------------
 
-The matrix equations below are the complete filter. The motion model predicts
-once per control interval, then the scheduled range-and-bearing observation may
-correct the state if that camera is in range. Covariance uses the numerically
-stable Joseph form and is symmetrized before becoming the next resident state.
-The ordinary arrays here define 1,000 independent lanes. Lane zero receives the
-exact displayed measurement; the remaining lanes receive deterministic sensor
-perturbations so the work is a real filter ensemble rather than 1,000 copies of
-one arithmetic result. Base control, camera, and measurement rows broadcast
-directly across the lane matrices. Only lane zero is sampled back for the scene.
+The matrix equations below are the complete filter. The motion model predictsv once per control interval, then the scheduled range-and-bearing observation mayv correct the state if that camera is in range. Covariance uses the numericallyv stable Joseph form and is symmetrized before becoming the next resident state.v The ordinary arrays here define 1,000 independent lanes. Lane zero receives thev exact displayed measurement; the remaining lanes receive deterministic sensorv perturbations so the work is a real filter ensemble rather than 1,000 copies ofv one arithmetic result. Base control, camera, and measurement rows broadcastv directly across the lane matrices. Only lane zero is sampled back for the scene.
 
   filter-count := 1000.0
   filter-index := 1.0..=filter-count
@@ -313,13 +283,7 @@ ekf-batch @compute
 5. Live Tracking Field
 -------------------------------------------------------------------------------
 
-The covariance outline is the two-standard-deviation position ellipse calculated
-from the live 2x2 covariance block. Because finite-range camera updates can make
-the physical ellipse smaller than a useful screen mark, display axes have a
-0.04-unit quadrature floor; this changes only the drawing, never the filter
-covariance. Steady footprint guides show each camera's real maximum range.
-Camera rays terminate at simulated truth and fade to exactly zero outside that
-range. Only the scheduled in-range camera's noisy values enter the filter.
+The covariance outline is the two-standard-deviation position ellipse calculated from the live 2x2 covariance block. Because finite-range camera updates can make the physical ellipse smaller than a useful screen mark, display axes have a 0.04-unit quadrature floor; this changes only the drawing, never the filter covariance. Steady footprint guides show each camera's real maximum range. Camera rays terminate at simulated truth and fade to exactly zero outside that range. Only the scheduled in-range camera's noisy values enter the filter.
 
   world-positions := [next-truth[1..=2] predicted-estimate[1..=2] corrected-estimate[1..=2]]
   screen-positions := screen-origin + screen-scale * screen-axis * world-positions
@@ -417,15 +381,15 @@ range. Only the scheduled in-range camera's noisy values enter the filter.
 
   sans-serif-font := "Inter, ui-sans-serif, system-ui, sans-serif"
 
-  scene-text := |id<string>                  x<f64> y<f64> fill<f64> font-size<f64> font-family<string> font-weight<f64> text-anchor<string> opacity<f64>            value<string>                  |
-                | "title"                     24     62    0xedf2f7<f64>  36             sans-serif-font    620              "start"             1                       "Camera EKF Localization"      |
-                | "camera-label-1"           195    636    0xd7c27f<f64>  11             sans-serif-font    500              "start"             camera-label-opacity[1] "CAM 1"                        |
-                | "camera-label-2"           665    636    0xd7c27f<f64>  11             sans-serif-font    500              "end"               camera-label-opacity[2] "CAM 2"                        |
-                | "camera-label-3"           665    140    0xd7c27f<f64>  11             sans-serif-font    500              "end"               camera-label-opacity[3] "CAM 3"                        |
-                | "camera-label-4"           195    140    0xd7c27f<f64>  11             sans-serif-font    500              "start"             camera-label-opacity[4] "CAM 4"                        |
-                | "legend-truth-label"        40    722    0xbdc8d2<f64>  12             sans-serif-font    400              "start"             1                       "actual robot + path"          |
-                | "legend-prediction-label"  215    722    0xbdc8d2<f64>  12             sans-serif-font    400              "start"             1                       "motion prediction"            |
-                | "legend-estimate-label"    415    722    0xbdc8d2<f64>  12             sans-serif-font    400              "start"             1                       "EKF estimate + 2σ covariance" |
+  scene-text := |id<string>                  x<f64> y<f64> fill<f64>      font-size<f64> font-family<string> font-weight<f64> text-anchor<string> opacity<f64>            value<string>                  |
+                | "title"                     24     62    0xedf2f7  36             sans-serif-font     620              "start"             1                       "Camera EKF Localization"      |
+                | "camera-label-1"           195    636    0xd7c27f  11             sans-serif-font     500              "start"             camera-label-opacity[1] "CAM 1"                        |
+                | "camera-label-2"           665    636    0xd7c27f  11             sans-serif-font     500              "end"               camera-label-opacity[2] "CAM 2"                        |
+                | "camera-label-3"           665    140    0xd7c27f  11             sans-serif-font     500              "end"               camera-label-opacity[3] "CAM 3"                        |
+                | "camera-label-4"           195    140    0xd7c27f  11             sans-serif-font     500              "start"             camera-label-opacity[4] "CAM 4"                        |
+                | "legend-truth-label"        40    722    0xbdc8d2  12             sans-serif-font     400              "start"             1                       "actual robot + path"          |
+                | "legend-prediction-label"  215    722    0xbdc8d2  12             sans-serif-font     400              "start"             1                       "motion prediction"            |
+                | "legend-estimate-label"    415    722    0xbdc8d2  12             sans-serif-font     400              "start"             1                       "EKF estimate + 2σ covariance" |
 
   field-presentation := {
     width: 860

--- a/examples/ekf/localization.mec
+++ b/examples/ekf/localization.mec
@@ -1,7 +1,7 @@
 Extended Kalman Filter Localization
 ===============================================================================
 section: Examples
-+> math
++> math/*
 ===============================================================================
 
 This resident application localizes a robot from noisy range-and-bearing measurements made by four fixed cameras. The cyan robot is simulated truth, the amber marker is the motion-model prediction, and the rose robot is the corrected EKF estimate. Their rolling paths make tracking error visible instead of hiding it in a final scalar.
@@ -23,18 +23,18 @@ Click a camera to disable it. Its color mutes, its range ring disappears, and it
   π := 3.141592654
   ~last-clock-tick := 0.0
   clock-delta := @clock/tick - last-clock-tick
-  clock-pulse-distances := math/abs([clock-delta clock-delta - 1.0])
+  clock-pulse-distances := abs([clock-delta clock-delta - 1.0])
   clock-pulse := (clock-pulse-distances[1] - clock-pulse-distances[2] + 1.0) / 2.0
   ~requested-compute-turn := 0.0
   ~last-requested-simulation-step := 0.0
   compute-inflight-gap := requested-compute-turn - @filters/turns
-  compute-idle-raw := 1.0 - math/abs(compute-inflight-gap)
-  compute-idle := (compute-idle-raw + math/abs(compute-idle-raw)) / 2.0
+  compute-idle-raw := 1.0 - abs(compute-inflight-gap)
+  compute-idle := (compute-idle-raw + abs(compute-idle-raw)) / 2.0
   request-pulse := clock-pulse * compute-idle
   next-requested-compute-turn := requested-compute-turn + request-pulse
   ~last-filter-turn := 0.0
   filter-turn-delta := @filters/turns - last-filter-turn
-  sample-pulse-distances := math/abs([filter-turn-delta filter-turn-delta - 1.0])
+  sample-pulse-distances := abs([filter-turn-delta filter-turn-delta - 1.0])
   sample-pulse := (sample-pulse-distances[1] - sample-pulse-distances[2] + 1.0) / 2.0
   Δt := 0.05
   cruise-speed := 1.15
@@ -72,7 +72,7 @@ Scene pointer presses toggle the camera under the cursor. The enable mask is res
   scene-pointer-camera-distance-square := (scene-pointer-camera-offset ^ 2) ** [1.0; 1.0]
   scene-pointer-hit-raw := 484.0 - scene-pointer-camera-distance-square
   scene-pointer-hit-clamp-input := [scene-pointer-hit-raw scene-pointer-hit-raw - 1.0]
-  scene-pointer-hit-clamp := (scene-pointer-hit-clamp-input + math/abs(scene-pointer-hit-clamp-input)) / 2.0
+  scene-pointer-hit-clamp := (scene-pointer-hit-clamp-input + abs(scene-pointer-hit-clamp-input)) / 2.0
   scene-pointer-hit := scene-pointer-hit-clamp[:,1] - scene-pointer-hit-clamp[:,2]
 
 A gesture group coalesces down/up but never crosses into the next press. Parity still preserves an even count jump if an activation history is restored or replayed without exposing every intermediate turn.
@@ -101,11 +101,11 @@ The resident simulation step is converted into a lap phase and progress along th
   next-simulation-step := simulation-step + clock-pulse
   filter-step-span := next-simulation-step - last-requested-simulation-step
   next-last-requested-simulation-step := last-requested-simulation-step + request-pulse * filter-step-span
-  drive-phase := math/floor((simulation-step % lap-ticks) / side-ticks)
+  drive-phase := floor((simulation-step % lap-ticks) / side-ticks)
   phase-progress := (simulation-step % side-ticks) / side-ticks
   path-parameter := drive-phase + phase-progress
   lookahead-parameter := (path-parameter + 0.15) % 4.0
-  lookahead-side := math/floor(lookahead-parameter) + 1.0
+  lookahead-side := floor(lookahead-parameter) + 1.0
   lookahead-progress := lookahead-parameter % 1.0
   square-waypoints := [0.0 0.0
                        1.0 0.0
@@ -125,14 +125,14 @@ The simulated robot pose is resident state. Expressing the look-ahead target in 
              0.0]
   simulation-time := next-simulation-step * Δt
   target-offset := target-position - truth[1..=2]
-  truth-heading-direction := math/cos(truth[3] - [0.0; π / 2.0])
+  truth-heading-direction := cos(truth[3] - [0.0; π / 2.0])
   truth-heading-frame := [truth-heading-direction'; -truth-heading-direction[2] truth-heading-direction[1]]
   target-relative := truth-heading-frame ** target-offset
-  heading-error := math/atan2(target-relative[2], target-relative[1])
+  heading-error := atan2(target-relative[2], target-relative[1])
   requested-omega := heading-gain * heading-error
-  omega-bound-distances := math/abs([requested-omega + turn-rate-limit requested-omega - turn-rate-limit])
+  omega-bound-distances := abs([requested-omega + turn-rate-limit requested-omega - turn-rate-limit])
   commanded-omega := (omega-bound-distances[1] - omega-bound-distances[2]) / 2.0
-  turn-fraction := math/abs(commanded-omega) / turn-rate-limit
+  turn-fraction := abs(commanded-omega) / turn-rate-limit
   commanded-speed := cruise-speed * (1.0 - 0.42 * turn-fraction)
   commanded-control := [commanded-speed
                         commanded-omega]
@@ -141,10 +141,10 @@ The simulated robot pose is resident state. Expressing the look-ahead target in 
 
 The plant deliberately does not execute the command perfectly. Smooth scale errors perturb forward and angular velocity, and midpoint integration advances the physical truth only when the clock supplies a pulse.
 
-  actual-control-scale := [0.965; 0.99] + [0.025; 0.01] * math/sin(simulation-time * [0.73; 0.51] + [0.0; 0.8])
+  actual-control-scale := [0.965; 0.99] + [0.025; 0.01] * sin(simulation-time * [0.73; 0.51] + [0.0; 0.8])
   actual-control := commanded-control * actual-control-scale
   truth-mid-heading := truth[3] + actual-control[2] * Δt / 2.0
-  truth-direction := math/cos(truth-mid-heading - [0.0; π / 2.0])
+  truth-direction := cos(truth-mid-heading - [0.0; π / 2.0])
   truth-velocity := [truth-direction * actual-control[1]; actual-control[2]]
   attempted-truth := truth + truth-velocity * Δt
   next-truth := truth + clock-pulse * (attempted-truth - truth)
@@ -165,23 +165,23 @@ The accepted truth and simulation step become the next resident values. The comp
 The same square phase selects the nearest corner camera during each half-side. A camera outside its 3.6-unit range contributes exactly zero correction. This produces genuine prediction-only intervals rather than pretending that every camera sees through the entire field.
 
   camera-dwell-ticks := side-ticks / 2.0
-  camera-index := (math/floor((simulation-step + camera-dwell-ticks) / side-ticks) % 4.0) + 1.0
+  camera-index := (floor((simulation-step + camera-dwell-ticks) / side-ticks) % 4.0) + 1.0
   active-camera := cameras[camera-index,:]'
   camera-offsets := cameras - attempted-truth[1..=2]'
-  camera-range-all := math/sqrt((camera-offsets ^ 2) ** [1.0; 1.0])
+  camera-range-all := sqrt((camera-offsets ^ 2) ** [1.0; 1.0])
   camera-inside-fade-raw := (camera-max-range - camera-range-all) / camera-range-fade
   camera-visibility-clamp-input := [camera-inside-fade-raw camera-inside-fade-raw - 1.0]
-  camera-visibility-clamp := (camera-visibility-clamp-input + math/abs(camera-visibility-clamp-input)) / 2.0
+  camera-visibility-clamp := (camera-visibility-clamp-input + abs(camera-visibility-clamp-input)) / 2.0
   camera-visibility := (camera-visibility-clamp[:,1] - camera-visibility-clamp[:,2]) * camera-enabled
 
   active-camera-visibility := camera-visibility[camera-index]
   camera-offset := active-camera - attempted-truth[1..=2]
   camera-range-square := [1.0 1.0] ** (camera-offset ^ 2)
-  camera-range := math/sqrt(camera-range-square[1])
+  camera-range := sqrt(camera-range-square[1])
   observation-model := [camera-range
-                        math/atan2(camera-offset[2], camera-offset[1]) - attempted-truth[3]]
+                        atan2(camera-offset[2], camera-offset[1]) - attempted-truth[3]]
   observation-noise-phase := simulation-time * [1.57; 1.91] + camera-index * [0.7; 1.0]
-  observation := observation-model + [0.11; 0.011] * math/sin(observation-noise-phase)
+  observation := observation-model + [0.11; 0.011] * sin(observation-noise-phase)
 
 
 4. GPU Compute
@@ -199,12 +199,12 @@ The base control, camera, and measurement rows broadcast across the lane matrice
   lane-dt-base := Δt * filter-step-span
   lane-control-base := [lane-dt-base commanded-speed commanded-omega]
   lane-control-phase := filter-phase' ** [0.0 3.0 5.0]
-  lane-control-scale := 1.0 + math/sin(lane-control-phase) * [0.0 0.002 0.002]
+  lane-control-scale := 1.0 + sin(lane-control-phase) * [0.0 0.002 0.002]
   lane-control := lane-control-base * lane-control-scale
   lane-camera := (1.0 + filter-index' * 0.0) ** active-camera'
   lane-measurement-base := [observation' active-camera-visibility]
   lane-measurement-phase := filter-phase' ** [7.0 11.0 0.0]
-  lane-measurement := lane-measurement-base + math/sin(lane-measurement-phase) * [0.012 0.0015 0.0]
+  lane-measurement := lane-measurement-base + sin(lane-measurement-phase) * [0.012 0.0015 0.0]
 
 These assignments cross the explicit compute resource boundary. A new turn is requested only after the previous one has completed, which keeps the resident filter state ordered with the simulation.
 
@@ -236,8 +236,8 @@ The predictor advances the state with a midpoint unicycle motion model. Its Jaco
     v := u[2]
     ω := u[3]
     θ := μ[3] + ω * δt / 2f32
-    c := math/cos(θ)
-    s := math/sin(θ)
+    c := cos(θ)
+    s := sin(θ)
     G := [1f32 0f32 -v * s * δt
           0f32 1f32  v * c * δt
           0f32 0f32 1f32]
@@ -257,11 +257,11 @@ The corrector linearizes the range-and-bearing observation around the predicted 
 
   ekf-correct(μ-<[f32]:3,1>, Σ-<[f32]:3,3>, camera<[f32]:2,1>, z<[f32]:3,1>, R<[f32]:2,2>) = (μ+<[f32]:3,1>, Σ+<[f32]:3,3>) :=
     Δ := camera - μ-[1..=2]
-    observation-guard := 1f32 - math/ceil(z[3])
+    observation-guard := 1f32 - ceil(z[3])
     q := Δ · Δ + observation-guard
-    r := math/sqrt(q)
+    r := sqrt(q)
     ẑ := [r
-          math/atan2(Δ[2], Δ[1] + observation-guard) - μ-[3]]
+          atan2(Δ[2], Δ[1] + observation-guard) - μ-[3]]
     H := [-Δ[1] / r -Δ[2] / r 0f32
            Δ[2] / q -Δ[1] / q -1f32]
     S := H ** Σ- ** H' + R
@@ -269,7 +269,7 @@ The corrector linearizes the range-and-bearing observation around the predicted 
     K := (S \ B)'
     νθ := z[2] - ẑ[2]
     ν := [z[1] - ẑ[1]
-          math/atan2(math/sin(νθ), math/cos(νθ))]
+          atan2(sin(νθ), cos(νθ))]
     μ+ := μ- + K ** ν
     I := [1f32 0f32 0f32
           0f32 1f32 0f32
@@ -314,9 +314,9 @@ Each turn is one predictor/corrector recurrence. Multiplying the correction by `
 Before publishing the next checkpoint, the region verifies finite state, positive covariance diagonals, and covariance symmetry. These invariants fail the compute turn instead of allowing a corrupt estimate to become resident.
 
   finite-limit := 3.402823466e38<f32>
-  finite-state! := math/abs(μ-next[1,1]) <= finite-limit && math/abs(μ-next[2,1]) <= finite-limit && math/abs(μ-next[3,1]) <= finite-limit
+  finite-state! := abs(μ-next[1,1]) <= finite-limit && abs(μ-next[2,1]) <= finite-limit && abs(μ-next[3,1]) <= finite-limit
   positive-covariance! := Σ-next[1,1] > 0f32 && Σ-next[2,2] > 0f32 && Σ-next[3,3] > 0f32
-  symmetric-covariance! := math/abs(Σ-next[1,2] - Σ-next[2,1]) <= 0.0001<f32> && math/abs(Σ-next[1,3] - Σ-next[3,1]) <= 0.0001<f32> && math/abs(Σ-next[2,3] - Σ-next[3,2]) <= 0.0001<f32>
+  symmetric-covariance! := abs(Σ-next[1,2] - Σ-next[2,1]) <= 0.0001<f32> && abs(Σ-next[1,3] - Σ-next[3,1]) <= 0.0001<f32> && abs(Σ-next[2,3] - Σ-next[3,2]) <= 0.0001<f32>
 
 The validated checkpoint becomes the starting point for the next GPU turn and is returned with the applied visibility value for document-side sampling.
 
@@ -340,14 +340,14 @@ Truth, prediction, and correction are projected into the scene's screen coordina
   predicted-screen := screen-positions[:,2]
   estimate-screen := screen-positions[:,3]
   display-camera-offsets := cameras - next-truth[1..=2]'
-  display-camera-range-all := math/sqrt((display-camera-offsets ^ 2) ** [1.0; 1.0])
+  display-camera-range-all := sqrt((display-camera-offsets ^ 2) ** [1.0; 1.0])
   display-camera-inside-fade-raw := (camera-max-range - display-camera-range-all) / camera-range-fade
   display-camera-visibility-clamp-input := [display-camera-inside-fade-raw display-camera-inside-fade-raw - 1.0]
-  display-camera-visibility-clamp := (display-camera-visibility-clamp-input + math/abs(display-camera-visibility-clamp-input)) / 2.0
+  display-camera-visibility-clamp := (display-camera-visibility-clamp-input + abs(display-camera-visibility-clamp-input)) / 2.0
   display-camera-visibility := (display-camera-visibility-clamp[:,1] - display-camera-visibility-clamp[:,2]) * camera-enabled
   position-error-vector := corrected-estimate[1..=2] - next-truth[1..=2]
   position-error-square := [1.0 1.0] ** (position-error-vector ^ 2)
-  position-error := math/sqrt(position-error-square[1])
+  position-error := sqrt(position-error-square[1])
 
 (5.2) Covariance Ellipse
 
@@ -356,17 +356,17 @@ The eigenvalues and orientation of the corrected 2×2 position covariance become
   ellipse-a := corrected-covariance[1,1]
   ellipse-b := corrected-covariance[1,2]
   ellipse-c := corrected-covariance[2,2]
-  ellipse-root := math/sqrt(((ellipse-a - ellipse-c) / 2.0) ^ 2 + ellipse-b ^ 2)
+  ellipse-root := sqrt(((ellipse-a - ellipse-c) / 2.0) ^ 2 + ellipse-b ^ 2)
   ellipse-eigenvalues := (ellipse-a + ellipse-c) / 2.0 + [1.0; -1.0] * ellipse-root
-  ellipse-axes := math/sqrt(ellipse-eigenvalues) * 2.0
-  ellipse-rotation := 0.5 * math/atan2(2.0 * ellipse-b, ellipse-a - ellipse-c)
+  ellipse-axes := sqrt(ellipse-eigenvalues) * 2.0
+  ellipse-rotation := 0.5 * atan2(2.0 * ellipse-b, ellipse-a - ellipse-c)
   ellipse-samples := 0..=64
   ellipse-angle := ellipse-samples' * (2.0 * π / 64.0)
   ellipse-display-floor := 0.04
-  display-ellipse-axes := math/sqrt(ellipse-axes ^ 2 + ellipse-display-floor ^ 2)
+  display-ellipse-axes := sqrt(ellipse-axes ^ 2 + ellipse-display-floor ^ 2)
   ellipse-phase-grid := ellipse-angle ** [1.0 1.0] - [0.0 π / 2.0]
-  ellipse-axis-points := math/cos(ellipse-phase-grid) * display-ellipse-axes'
-  ellipse-rotation-direction := math/cos(ellipse-rotation - [0.0 π / 2.0])
+  ellipse-axis-points := cos(ellipse-phase-grid) * display-ellipse-axes'
+  ellipse-rotation-direction := cos(ellipse-rotation - [0.0 π / 2.0])
   ellipse-rotation-matrix := [ellipse-rotation-direction; -ellipse-rotation-direction[2] ellipse-rotation-direction[1]]
   covariance-ellipse := estimate-screen' + screen-scale * (ellipse-axis-points ** ellipse-rotation-matrix) * screen-axis'
 
@@ -398,7 +398,7 @@ The square path, camera opacity channels, and heading vectors are calculated onc
   camera-label-opacity := 0.32 + 0.68 * camera-enabled
   heading-angles := [next-truth[3] corrected-estimate[3]]
   heading-phase-grid := [1.0; 1.0] ** heading-angles - [0.0; π / 2.0]
-  heading-unit-vectors := math/cos(heading-phase-grid)
+  heading-unit-vectors := cos(heading-phase-grid)
   heading-screen-vectors := screen-axis * heading-unit-vectors * [18.0 16.0]
   heading-screen-points := [truth-screen estimate-screen] + heading-screen-vectors
 

--- a/examples/ekf/localization.mec
+++ b/examples/ekf/localization.mec
@@ -166,10 +166,14 @@ The same square phase selects the nearest corner camera during each half-side. A
   observation := observation-model + [0.11; 0.011] * math/sin(observation-noise-phase)
 
 
-4. Extended Kalman Filter
+4. GPU Compute
 -------------------------------------------------------------------------------
 
-The matrix equations below are the complete filter. The motion model predictsv once per control interval, then the scheduled range-and-bearing observation mayv correct the state if that camera is in range. Covariance uses the numericallyv stable Joseph form and is symmetrized before becoming the next resident state.v The ordinary arrays here define 1,000 independent lanes. Lane zero receives thev exact displayed measurement; the remaining lanes receive deterministic sensorv perturbations so the work is a real filter ensemble rather than 1,000 copies ofv one arithmetic result. Base control, camera, and measurement rows broadcastv directly across the lane matrices. Only lane zero is sampled back for the scene.
+The Extended Kalman Filter runs as a named `@compute` region. The document-side program prepares 1,000 independent lanes, sends them through the compute resource, and samples lane zero back into the scene. The other lanes receive deterministic control and sensor perturbations, so this is a genuine filter ensemble rather than 1,000 copies of one arithmetic result.
+
+(4.1) Batch Inputs and Sampled Outputs
+
+The base control, camera, and measurement rows broadcast across the lane matrices. Lane zero keeps the exact displayed measurement while the phase vectors introduce small, repeatable differences in every other lane.
 
   filter-count := 1000.0
   filter-index := 1.0..=filter-count
@@ -184,10 +188,14 @@ The matrix equations below are the complete filter. The motion model predictsv o
   lane-measurement-phase := filter-phase' ** [7.0 11.0 0.0]
   lane-measurement := lane-measurement-base + math/sin(lane-measurement-phase) * [0.012 0.0015 0.0]
 
+These assignments cross the explicit compute resource boundary. A new turn is requested only after the previous one has completed, which keeps the resident filter state ordered with the simulation.
+
   @filters/input/control <- lane-control
   @filters/input/camera <- lane-camera
   @filters/input/measurement <- lane-measurement
   @filters/turn <- next-requested-compute-turn
+
+Only the first lane is sampled for visualization. Its checkpoint contains the corrected state, corrected covariance, and motion-model prediction.
 
   filter-sample := @filters/sample/result.0
   filter-camera-visibility := @filters/sample/result.2
@@ -198,6 +206,12 @@ The matrix equations below are the complete filter. The motion model predictsv o
 
 ekf-batch @compute
 -------------------------------------------------------------------------------
+
+(4.2) Predictor
+
+The predictor advances the state with a midpoint unicycle motion model. Its Jacobians `G` and `V` propagate the previous covariance and control noise into the prior covariance for the next observation.
+
+(4.2.1) Motion and Covariance Propagation
 
   ekf-predict(μ<[f32]:3,1>, Σ<[f32]:3,3>, u<[f32]:3,1>, Q<[f32]:2,2>) = (μ-<[f32]:3,1>, Σ-<[f32]:3,3>) :=
     δt := u[1]
@@ -217,10 +231,12 @@ ekf-batch @compute
                ω * δt]
     Σ- := G ** Σ ** G' + V ** Q ** V'.
 
-  -- Visibility is part of the numerical observation contract, not merely an
-  -- output mask. The inactive guard makes zero-visibility geometry
-  -- nonsingular before divisions and atan2 are evaluated while leaving every
-  -- active measurement's original equations unchanged.
+(4.3) Corrector
+
+The corrector linearizes the range-and-bearing observation around the predicted state, computes the Kalman gain, and applies the wrapped innovation. Visibility is part of the numerical observation contract rather than merely an output mask: the inactive guard keeps zero-visibility geometry nonsingular before any division or `atan2` is evaluated while preserving the active equations.
+
+(4.3.1) Innovation and Joseph Covariance Update
+
   ekf-correct(μ-<[f32]:3,1>, Σ-<[f32]:3,3>, camera<[f32]:2,1>, z<[f32]:3,1>, R<[f32]:2,2>) = (μ+<[f32]:3,1>, Σ+<[f32]:3,3>) :=
     Δ := camera - μ-[1..=2]
     observation-guard := 1f32 - math/ceil(z[3])
@@ -244,6 +260,10 @@ ekf-batch @compute
     Σ-raw := A ** Σ- ** A' + K ** R ** K'
     Σ+ := 0.5<f32> * (Σ-raw + Σ-raw').
 
+(4.4) Resident Filter Recurrence
+
+The compute inputs below establish the fixed shapes and default values used to compile the resident region. The document replaces them with the lane matrices before each turn.
+
   control := [0.05<f32>; 1f32; 0f32]
   camera := [1f32; 1f32]
   measurement := [1f32; 0f32; 0f32]
@@ -253,26 +273,34 @@ ekf-batch @compute
   R := [0.0225<f32> 0f32
         0f32 0.0004<f32>]
 
-  -- These two fixed-shape calls are the whole filter. The compute host maps
-  -- them over the outer lane arrays supplied by the document; increasing the
-  -- lane count does not duplicate this source graph.
-  -- The resident value is the whole filter checkpoint. Its columns are the
-  -- posterior state, its 3x3 covariance, and the prior state.
+The resident checkpoint stores the posterior state, its 3×3 covariance, and the prior state. Increasing the lane count changes the outer data shape without duplicating the predictor or corrector source graph.
+
+(4.4.1) Checkpoint and Filter Step
+
   ~filter-sample := [2.9<f32>  0.45<f32> 0f32       0f32       2.9<f32>
                      2.15<f32> 0f32       0.45<f32> 0f32       2.15<f32>
                      0.16<f32> 0f32       0f32       0.08<f32> 0.16<f32>]
   ~applied-visibility := 0f32
   μ := filter-sample[:,1]
   Σ := filter-sample[:,2..=4]
+
+Each turn is one predictor/corrector recurrence. Multiplying the correction by `γ` selects the posterior when a camera is visible and the prediction when the robot is in a sensing dead zone.
+
   (μ-, Σ-) := ekf-predict(μ, Σ, control, Q)
   (μ+, Σ+) := ekf-correct(μ-, Σ-, camera, measurement, R)
   μ-next := μ- + γ * (μ+ - μ-)
   Σ-next := Σ- + γ * (Σ+ - Σ-)
 
+(4.4.2) Validation and Publication
+
+Before publishing the next checkpoint, the region verifies finite state, positive covariance diagonals, and covariance symmetry. These invariants fail the compute turn instead of allowing a corrupt estimate to become resident.
+
   finite-limit := 3.402823466e38<f32>
   finite-state! := math/abs(μ-next[1,1]) <= finite-limit && math/abs(μ-next[2,1]) <= finite-limit && math/abs(μ-next[3,1]) <= finite-limit
   positive-covariance! := Σ-next[1,1] > 0f32 && Σ-next[2,2] > 0f32 && Σ-next[3,3] > 0f32
   symmetric-covariance! := math/abs(Σ-next[1,2] - Σ-next[2,1]) <= 0.0001<f32> && math/abs(Σ-next[1,3] - Σ-next[3,1]) <= 0.0001<f32> && math/abs(Σ-next[2,3] - Σ-next[3,2]) <= 0.0001<f32>
+
+The validated checkpoint becomes the starting point for the next GPU turn and is returned with the applied visibility value for document-side sampling.
 
   filter-sample = [μ-next Σ-next μ-]
   applied-visibility = γ

--- a/examples/ekf/localization.mec
+++ b/examples/ekf/localization.mec
@@ -18,7 +18,15 @@ Click a camera to disable it. Its color mutes, its range ring disappears, and it
 
 @clock := timer://clock/tick{:read(tick)}
 @scene := scene://localization/frame{:read(pointer-pulse), :read(pointer-position), :write(replace)}
-@filters := compute://filters/kernel{:read(sample/result.0), :read(sample/result.2), :read(turns), :write(input/control), :write(input/camera), :write(input/measurement), :write(turn)}
+@filters := compute://filters/kernel {
+  :read(sample/result.0),
+  :read(sample/result.2),
+  :read(turns),
+  :write(input/control),
+  :write(input/camera),
+  :write(input/measurement),
+  :write(turn)
+}
 
   π := 3.141592654
   ~last-clock-tick := 0.0

--- a/examples/ekf/localization.mec
+++ b/examples/ekf/localization.mec
@@ -413,18 +413,18 @@ range. Only the scheduled in-range camera's noisy values enter the filter.
     {id: "covariance", positions: covariance-ellipse, stroke: "#f087b8", stroke-width: 1.5, line-cap: "round", line-join: "round", opacity: 0.72, closed: true}
   )
 
-  scene-text := |id<string> x<f64> y<f64> fill<string> font-size<f64> font-family<string> font-weight<string> text-anchor<string> opacity<f64> value<string>|
-    | "eyebrow" 24 26 "#8fa3b8" 12 "Inter, ui-sans-serif, system-ui, sans-serif" "650" "start" 1 "MECH RESIDENT SENSOR FUSION" |
-    | "title" 24 62 "#edf2f7" 36 "Inter, ui-sans-serif, system-ui, sans-serif" "620" "start" 1 "Camera EKF Localization" |
-    | "state-label" 602 58 "#f4c95d" 13 "ui-monospace, SFMono-Regular, Menlo, monospace" "650" "start" 1 "V/Ω VECTORIZED SQUARE DRIVE" |
-    | "camera-label-1" 195 636 "#d7c27f" 11 "Inter, ui-sans-serif, system-ui, sans-serif" "500" "start" camera-label-opacity[1] "CAM 1" |
-    | "camera-label-2" 665 636 "#d7c27f" 11 "Inter, ui-sans-serif, system-ui, sans-serif" "500" "end" camera-label-opacity[2] "CAM 2" |
-    | "camera-label-3" 665 140 "#d7c27f" 11 "Inter, ui-sans-serif, system-ui, sans-serif" "500" "end" camera-label-opacity[3] "CAM 3" |
-    | "camera-label-4" 195 140 "#d7c27f" 11 "Inter, ui-sans-serif, system-ui, sans-serif" "500" "start" camera-label-opacity[4] "CAM 4" |
-    | "legend-truth-label" 40 722 "#bdc8d2" 12 "Inter, ui-sans-serif, system-ui, sans-serif" "400" "start" 1 "actual robot + path" |
-    | "legend-prediction-label" 215 722 "#bdc8d2" 12 "Inter, ui-sans-serif, system-ui, sans-serif" "400" "start" 1 "motion prediction" |
-    | "legend-estimate-label" 415 722 "#bdc8d2" 12 "Inter, ui-sans-serif, system-ui, sans-serif" "400" "start" 1 "EKF estimate + 2σ covariance" |
-    | "note" 430 750 "#788a9c" 11 "Inter, ui-sans-serif, system-ui, sans-serif" "400" "middle" 1 "3.6-unit camera range · prediction-only dead zones · Joseph covariance · bounded v/ω cornering" |
+  sans-serif-font := "Inter, ui-sans-serif, system-ui, sans-serif"
+  mono-font := "ui-monospace, SFMono-Regular, Menlo, monospace"
+
+  scene-text := |id<string>                  x<f64> y<f64> fill<string> font-size<f64> font-family<string> font-weight<string> text-anchor<string> opacity<f64>            value<string>                  |
+                | "title"                     24     62    "#edf2f7"  36             sans-serif-font    "620"                "start"             1                       "Camera EKF Localization"      |
+                | "camera-label-1"           195    636    "#d7c27f"  11             sans-serif-font    "500"                "start"             camera-label-opacity[1] "CAM 1"                        |
+                | "camera-label-2"           665    636    "#d7c27f"  11             sans-serif-font    "500"                "end"               camera-label-opacity[2] "CAM 2"                        |
+                | "camera-label-3"           665    140    "#d7c27f"  11             sans-serif-font    "500"                "end"               camera-label-opacity[3] "CAM 3"                        |
+                | "camera-label-4"           195    140    "#d7c27f"  11             sans-serif-font    "500"                "start"             camera-label-opacity[4] "CAM 4"                        |
+                | "legend-truth-label"        40    722    "#bdc8d2"  12             sans-serif-font    "400"                "start"             1                       "actual robot + path"          |
+                | "legend-prediction-label"  215    722    "#bdc8d2"  12             sans-serif-font    "400"                "start"             1                       "motion prediction"            |
+                | "legend-estimate-label"    415    722    "#bdc8d2"  12             sans-serif-font    "400"                "start"             1                       "EKF estimate + 2σ covariance" |
 
   field-presentation := {
     width: 860

--- a/examples/ekf/localization.mec
+++ b/examples/ekf/localization.mec
@@ -32,7 +32,7 @@ the same camera and measurement path.
 
 @clock := timer://clock/tick{:read(tick)}
 @scene := scene://localization/frame{:read(pointer-pulse), :read(pointer-position), :write(replace)}
-@filters := compute://filters/kernel{:read(sample/result.0), :read(turns), :write(input/control), :write(input/camera), :write(input/measurement), :write(turn)}
+@filters := compute://filters/kernel{:read(sample/result.0), :read(sample/result.2), :read(turns), :write(input/control), :write(input/camera), :write(input/measurement), :write(turn)}
 
   π := 3.141592654
   ~last-clock-tick := 0.0
@@ -218,6 +218,7 @@ directly across the lane matrices. Only lane zero is sampled back for the scene.
   @filters/turn <- next-requested-compute-turn
 
   filter-sample := @filters/sample/result.0
+  filter-camera-visibility := @filters/sample/result.2
   corrected-estimate := filter-sample[:,1]
   corrected-covariance := filter-sample[:,2..=4]
   predicted-estimate := filter-sample[:,5]
@@ -288,6 +289,7 @@ ekf-batch @compute
   ~filter-sample := [2.9<f32>  0.45<f32> 0f32       0f32       2.9<f32>
                      2.15<f32> 0f32       0.45<f32> 0f32       2.15<f32>
                      0.16<f32> 0f32       0f32       0.08<f32> 0.16<f32>]
+  ~applied-visibility := 0f32
   μ := filter-sample[:,1]
   Σ := filter-sample[:,2..=4]
   (μ-, Σ-) := ekf-predict(μ, Σ, control, Q)
@@ -301,7 +303,8 @@ ekf-batch @compute
   symmetric-covariance! := math/abs(Σ-next[1,2] - Σ-next[2,1]) <= 0.0001<f32> && math/abs(Σ-next[1,3] - Σ-next[3,1]) <= 0.0001<f32> && math/abs(Σ-next[2,3] - Σ-next[3,2]) <= 0.0001<f32>
 
   filter-sample = [μ-next Σ-next μ-]
-  (filter-sample, filter-sample)
+  applied-visibility = γ
+  (filter-sample, filter-sample, applied-visibility)
 
 
 5. Live Tracking Field

--- a/examples/ekf/localization.mec
+++ b/examples/ekf/localization.mec
@@ -37,7 +37,8 @@ the same camera and measurement path.
   π := 3.141592654
   ~last-clock-tick := 0.0
   clock-delta := @clock/tick - last-clock-tick
-  clock-pulse := (math/abs(clock-delta) - math/abs(clock-delta - 1.0) + 1.0) / 2.0
+  clock-pulse-distances := math/abs([clock-delta clock-delta - 1.0])
+  clock-pulse := (clock-pulse-distances[1] - clock-pulse-distances[2] + 1.0) / 2.0
   ~requested-compute-turn := 0.0
   ~last-requested-simulation-step := 0.0
   compute-inflight-gap := requested-compute-turn - @filters/turns
@@ -47,7 +48,8 @@ the same camera and measurement path.
   next-requested-compute-turn := requested-compute-turn + request-pulse
   ~last-filter-turn := 0.0
   filter-turn-delta := @filters/turns - last-filter-turn
-  sample-pulse := (math/abs(filter-turn-delta) - math/abs(filter-turn-delta - 1.0) + 1.0) / 2.0
+  sample-pulse-distances := math/abs([filter-turn-delta filter-turn-delta - 1.0])
+  sample-pulse := (sample-pulse-distances[1] - sample-pulse-distances[2] + 1.0) / 2.0
   Δt := 0.05
   cruise-speed := 1.15
   turn-rate-limit := 1.75
@@ -84,9 +86,9 @@ the same camera and measurement path.
   scene-pointer-camera-offset := camera-screen - scene-pointer-screen'
   scene-pointer-camera-distance-square := (scene-pointer-camera-offset ^ 2) ** [1.0; 1.0]
   scene-pointer-hit-raw := 484.0 - scene-pointer-camera-distance-square
-  scene-pointer-hit-relu := (scene-pointer-hit-raw + math/abs(scene-pointer-hit-raw)) / 2.0
-  scene-pointer-hit-one-relu := (scene-pointer-hit-raw - 1.0 + math/abs(scene-pointer-hit-raw - 1.0)) / 2.0
-  scene-pointer-hit := scene-pointer-hit-relu - scene-pointer-hit-one-relu
+  scene-pointer-hit-clamp-input := [scene-pointer-hit-raw scene-pointer-hit-raw - 1.0]
+  scene-pointer-hit-clamp := (scene-pointer-hit-clamp-input + math/abs(scene-pointer-hit-clamp-input)) / 2.0
+  scene-pointer-hit := scene-pointer-hit-clamp[:,1] - scene-pointer-hit-clamp[:,2]
   -- A gesture group coalesces down/up but never crosses into the next press.
   -- Parity still preserves an even count jump if an activation history is
   -- restored or replayed without exposing every intermediate turn.
@@ -134,11 +136,13 @@ and turn-speed reduction make the corners smooth without position clamps.
              0.0]
   simulation-time := next-simulation-step * Δt
   target-offset := target-position - truth[1..=2]
-  target-heading := math/atan2(target-offset[2], target-offset[1])
-  heading-error-raw := target-heading - truth[3]
-  heading-error := math/atan2(math/sin(heading-error-raw), math/cos(heading-error-raw))
+  truth-heading-direction := math/cos(truth[3] - [0.0; π / 2.0])
+  truth-heading-frame := [truth-heading-direction'; -truth-heading-direction[2] truth-heading-direction[1]]
+  target-relative := truth-heading-frame ** target-offset
+  heading-error := math/atan2(target-relative[2], target-relative[1])
   requested-omega := heading-gain * heading-error
-  commanded-omega := (math/abs(requested-omega + turn-rate-limit) - math/abs(requested-omega - turn-rate-limit)) / 2.0
+  omega-bound-distances := math/abs([requested-omega + turn-rate-limit requested-omega - turn-rate-limit])
+  commanded-omega := (omega-bound-distances[1] - omega-bound-distances[2]) / 2.0
   turn-fraction := math/abs(commanded-omega) / turn-rate-limit
   commanded-speed := cruise-speed * (1.0 - 0.42 * turn-fraction)
   commanded-control := [commanded-speed
@@ -146,9 +150,8 @@ and turn-speed reduction make the corners smooth without position clamps.
   actual-control-scale := [0.965; 0.99] + [0.025; 0.01] * math/sin(simulation-time * [0.73; 0.51] + [0.0; 0.8])
   actual-control := commanded-control * actual-control-scale
   truth-mid-heading := truth[3] + actual-control[2] * Δt / 2.0
-  truth-velocity := [math/cos(truth-mid-heading) 0.0
-                     math/sin(truth-mid-heading) 0.0
-                     0.0                           1.0] ** actual-control
+  truth-direction := math/cos(truth-mid-heading - [0.0; π / 2.0])
+  truth-velocity := [truth-direction * actual-control[1]; actual-control[2]]
   attempted-truth := truth + truth-velocity * Δt
   next-truth := truth + clock-pulse * (attempted-truth - truth)
 
@@ -172,9 +175,9 @@ camera sees through the entire field.
   camera-offsets := cameras - attempted-truth[1..=2]'
   camera-range-all := math/sqrt((camera-offsets ^ 2) ** [1.0; 1.0])
   camera-inside-fade-raw := (camera-max-range - camera-range-all) / camera-range-fade
-  camera-inside-fade-relu := (camera-inside-fade-raw + math/abs(camera-inside-fade-raw)) / 2.0
-  camera-inside-fade-one-relu := (camera-inside-fade-raw - 1.0 + math/abs(camera-inside-fade-raw - 1.0)) / 2.0
-  camera-visibility := (camera-inside-fade-relu - camera-inside-fade-one-relu) * camera-enabled
+  camera-visibility-clamp-input := [camera-inside-fade-raw camera-inside-fade-raw - 1.0]
+  camera-visibility-clamp := (camera-visibility-clamp-input + math/abs(camera-visibility-clamp-input)) / 2.0
+  camera-visibility := (camera-visibility-clamp[:,1] - camera-visibility-clamp[:,2]) * camera-enabled
 
   active-camera-visibility := camera-visibility[camera-index]
   camera-offset := active-camera - attempted-truth[1..=2]
@@ -326,9 +329,9 @@ range. Only the scheduled in-range camera's noisy values enter the filter.
   display-camera-offsets := cameras - next-truth[1..=2]'
   display-camera-range-all := math/sqrt((display-camera-offsets ^ 2) ** [1.0; 1.0])
   display-camera-inside-fade-raw := (camera-max-range - display-camera-range-all) / camera-range-fade
-  display-camera-inside-fade-relu := (display-camera-inside-fade-raw + math/abs(display-camera-inside-fade-raw)) / 2.0
-  display-camera-inside-fade-one-relu := (display-camera-inside-fade-raw - 1.0 + math/abs(display-camera-inside-fade-raw - 1.0)) / 2.0
-  display-camera-visibility := (display-camera-inside-fade-relu - display-camera-inside-fade-one-relu) * camera-enabled
+  display-camera-visibility-clamp-input := [display-camera-inside-fade-raw display-camera-inside-fade-raw - 1.0]
+  display-camera-visibility-clamp := (display-camera-visibility-clamp-input + math/abs(display-camera-visibility-clamp-input)) / 2.0
+  display-camera-visibility := (display-camera-visibility-clamp[:,1] - display-camera-visibility-clamp[:,2]) * camera-enabled
   position-error-vector := corrected-estimate[1..=2] - next-truth[1..=2]
   position-error-square := [1.0 1.0] ** (position-error-vector ^ 2)
   position-error := math/sqrt(position-error-square[1])
@@ -344,17 +347,18 @@ range. Only the scheduled in-range camera's noisy values enter the filter.
   ellipse-angle := ellipse-samples' * (2.0 * π / 64.0)
   ellipse-display-floor := 0.04
   display-ellipse-axes := math/sqrt(ellipse-axes ^ 2 + ellipse-display-floor ^ 2)
-  ellipse-axis-points := [math/cos(ellipse-angle) math/sin(ellipse-angle)] * display-ellipse-axes'
-  ellipse-rotation-matrix := [ math/cos(ellipse-rotation) math/sin(ellipse-rotation)
-                              -math/sin(ellipse-rotation) math/cos(ellipse-rotation)]
+  ellipse-phase-grid := ellipse-angle ** [1.0 1.0] - [0.0 π / 2.0]
+  ellipse-axis-points := math/cos(ellipse-phase-grid) * display-ellipse-axes'
+  ellipse-rotation-direction := math/cos(ellipse-rotation - [0.0 π / 2.0])
+  ellipse-rotation-matrix := [ellipse-rotation-direction; -ellipse-rotation-direction[2] ellipse-rotation-direction[1]]
   covariance-ellipse := estimate-screen' + screen-scale * (ellipse-axis-points ** ellipse-rotation-matrix) * screen-axis'
 
   trail-samples := 1..=376
   trail-zero-points := (trail-samples' * 0.0) ** [1.0 1.0]
   ~truth-path := trail-zero-points + [275.0 545.0]
   ~estimate-path := trail-zero-points + [299.8 566.7]
-  advanced-truth-path := matrix/vertcat(truth-path[2..=376,:], truth-screen')
-  advanced-estimate-path := matrix/vertcat(estimate-path[2..=376,:], estimate-screen')
+  advanced-truth-path := [truth-path[2..=376,:]; truth-screen']
+  advanced-estimate-path := [estimate-path[2..=376,:]; estimate-screen']
   next-truth-path := truth-path + sample-pulse * (advanced-truth-path - truth-path)
   next-estimate-path := estimate-path + sample-pulse * (advanced-estimate-path - estimate-path)
   truth-path = next-truth-path
@@ -368,68 +372,65 @@ range. Only the scheduled in-range camera's noisy values enter the filter.
   camera-ray-opacity := 0.4 * display-camera-visibility
   camera-label-opacity := 0.32 + 0.68 * camera-enabled
   heading-angles := [next-truth[3] corrected-estimate[3]]
-  heading-unit-vectors := matrix/vertcat(math/cos(heading-angles), math/sin(heading-angles))
+  heading-phase-grid := [1.0; 1.0] ** heading-angles - [0.0; π / 2.0]
+  heading-unit-vectors := math/cos(heading-phase-grid)
   heading-screen-vectors := screen-axis * heading-unit-vectors * [18.0 16.0]
   heading-screen-points := [truth-screen estimate-screen] + heading-screen-vectors
 
-  scene-circles := |id<string> x<f64> y<f64> radius<f64> fill<string> stroke<string> stroke-width<f64> opacity<f64>|
-    | "camera-range-1" camera-screen[1,1] camera-screen[1,2] camera-max-range * screen-scale "none" "#f4c95d" 0.8 camera-range-opacity[1] |
-    | "camera-range-2" camera-screen[2,1] camera-screen[2,2] camera-max-range * screen-scale "none" "#f4c95d" 0.8 camera-range-opacity[2] |
-    | "camera-range-3" camera-screen[3,1] camera-screen[3,2] camera-max-range * screen-scale "none" "#f4c95d" 0.8 camera-range-opacity[3] |
-    | "camera-range-4" camera-screen[4,1] camera-screen[4,2] camera-max-range * screen-scale "none" "#f4c95d" 0.8 camera-range-opacity[4] |
-    | "camera-disabled-1" camera-screen[1,1] camera-screen[1,2] 9 "#59616b" "none" 0 camera-disabled-opacity[1] |
-    | "camera-disabled-2" camera-screen[2,1] camera-screen[2,2] 9 "#59616b" "none" 0 camera-disabled-opacity[2] |
-    | "camera-disabled-3" camera-screen[3,1] camera-screen[3,2] 9 "#59616b" "none" 0 camera-disabled-opacity[3] |
-    | "camera-disabled-4" camera-screen[4,1] camera-screen[4,2] 9 "#59616b" "none" 0 camera-disabled-opacity[4] |
-    | "camera-1" camera-screen[1,1] camera-screen[1,2] 9 "#f4c95d" "#fff1b8" 2 camera-enabled[1] |
-    | "camera-2" camera-screen[2,1] camera-screen[2,2] 9 "#f4c95d" "#fff1b8" 2 camera-enabled[2] |
-    | "camera-3" camera-screen[3,1] camera-screen[3,2] 9 "#f4c95d" "#fff1b8" 2 camera-enabled[3] |
-    | "camera-4" camera-screen[4,1] camera-screen[4,2] 9 "#f4c95d" "#fff1b8" 2 camera-enabled[4] |
-    | "truth" truth-screen[1] truth-screen[2] 8 "#63d6c5" "#d7fff8" 1.5 1 |
-    | "prediction" predicted-screen[1] predicted-screen[2] 6 "none" "#f2b84b" 2 1 |
-    | "estimate" estimate-screen[1] estimate-screen[2] 7 "#f087b8" "#ffe1ef" 1.5 1 |
-    | "legend-truth" 30 718 4 "#63d6c5" "none" 0 1 |
-    | "legend-prediction" 205 718 4 "#f2b84b" "none" 0 1 |
-    | "legend-estimate" 405 718 4 "#f087b8" "none" 0 1 |
+  scene-circles := |id<string> x<f64> y<f64> radius<f64> fill<*> stroke<*> stroke-width<f64> opacity<f64>|
+    | "camera-range-1" camera-screen[1,1] camera-screen[1,2] camera-max-range * screen-scale "none" 0xf4c95d<f64> 0.8 camera-range-opacity[1] |
+    | "camera-range-2" camera-screen[2,1] camera-screen[2,2] camera-max-range * screen-scale "none" 0xf4c95d<f64> 0.8 camera-range-opacity[2] |
+    | "camera-range-3" camera-screen[3,1] camera-screen[3,2] camera-max-range * screen-scale "none" 0xf4c95d<f64> 0.8 camera-range-opacity[3] |
+    | "camera-range-4" camera-screen[4,1] camera-screen[4,2] camera-max-range * screen-scale "none" 0xf4c95d<f64> 0.8 camera-range-opacity[4] |
+    | "camera-disabled-1" camera-screen[1,1] camera-screen[1,2] 9 0x59616b<f64> "none" 0 camera-disabled-opacity[1] |
+    | "camera-disabled-2" camera-screen[2,1] camera-screen[2,2] 9 0x59616b<f64> "none" 0 camera-disabled-opacity[2] |
+    | "camera-disabled-3" camera-screen[3,1] camera-screen[3,2] 9 0x59616b<f64> "none" 0 camera-disabled-opacity[3] |
+    | "camera-disabled-4" camera-screen[4,1] camera-screen[4,2] 9 0x59616b<f64> "none" 0 camera-disabled-opacity[4] |
+    | "camera-1" camera-screen[1,1] camera-screen[1,2] 9 0xf4c95d<f64> 0xfff1b8<f64> 2 camera-enabled[1] |
+    | "camera-2" camera-screen[2,1] camera-screen[2,2] 9 0xf4c95d<f64> 0xfff1b8<f64> 2 camera-enabled[2] |
+    | "camera-3" camera-screen[3,1] camera-screen[3,2] 9 0xf4c95d<f64> 0xfff1b8<f64> 2 camera-enabled[3] |
+    | "camera-4" camera-screen[4,1] camera-screen[4,2] 9 0xf4c95d<f64> 0xfff1b8<f64> 2 camera-enabled[4] |
+    | "truth" truth-screen[1] truth-screen[2] 8 0x63d6c5<f64> 0xd7fff8<f64> 1.5 1 |
+    | "prediction" predicted-screen[1] predicted-screen[2] 6 "none" 0xf2b84b<f64> 2 1 |
+    | "estimate" estimate-screen[1] estimate-screen[2] 7 0xf087b8<f64> 0xffe1ef<f64> 1.5 1 |
+    | "legend-truth" 30 718 4 0x63d6c5<f64> "none" 0 1 |
+    | "legend-prediction" 205 718 4 0xf2b84b<f64> "none" 0 1 |
+    | "legend-estimate" 405 718 4 0xf087b8<f64> "none" 0 1 |
 
-  scene-lines := |id<string> x1<f64> y1<f64> x2<f64> y2<f64> stroke<string> stroke-width<f64> line-cap<string> opacity<f64> rotation<f64> origin-x<f64> origin-y<f64>|
-    | "frame-top" 120 80 740 80 "#27313d" 1 "butt" 1 0 0 0 |
-    | "frame-right" 740 80 740 700 "#27313d" 1 "butt" 1 0 0 0 |
-    | "frame-bottom" 740 700 120 700 "#27313d" 1 "butt" 1 0 0 0 |
-    | "frame-left" 120 700 120 80 "#27313d" 1 "butt" 1 0 0 0 |
-    | "ray-1" camera-screen[1,1] camera-screen[1,2] truth-screen[1] truth-screen[2] "#d9b652" 0.7 "round" camera-ray-opacity[1] 0 0 0 |
-    | "ray-2" camera-screen[2,1] camera-screen[2,2] truth-screen[1] truth-screen[2] "#d9b652" 0.7 "round" camera-ray-opacity[2] 0 0 0 |
-    | "ray-3" camera-screen[3,1] camera-screen[3,2] truth-screen[1] truth-screen[2] "#d9b652" 0.7 "round" camera-ray-opacity[3] 0 0 0 |
-    | "ray-4" camera-screen[4,1] camera-screen[4,2] truth-screen[1] truth-screen[2] "#d9b652" 0.7 "round" camera-ray-opacity[4] 0 0 0 |
-    | "truth-heading" truth-screen[1] truth-screen[2] heading-screen-points[1,1] heading-screen-points[2,1] "#d7fff8" 2 "round" 1 0 0 0 |
-    | "estimate-heading" estimate-screen[1] estimate-screen[2] heading-screen-points[1,2] heading-screen-points[2,2] "#ffe1ef" 1.5 "round" 1 0 0 0 |
+  scene-lines := |id<string> x1<f64> y1<f64> x2<f64> y2<f64> stroke<f64> stroke-width<f64> line-cap<string> opacity<f64> rotation<f64> origin-x<f64> origin-y<f64>|
+    | "frame-top" 120 80 740 80 0x27313d<f64> 1 "butt" 1 0 0 0 |
+    | "frame-right" 740 80 740 700 0x27313d<f64> 1 "butt" 1 0 0 0 |
+    | "frame-bottom" 740 700 120 700 0x27313d<f64> 1 "butt" 1 0 0 0 |
+    | "frame-left" 120 700 120 80 0x27313d<f64> 1 "butt" 1 0 0 0 |
+    | "ray-1" camera-screen[1,1] camera-screen[1,2] truth-screen[1] truth-screen[2] 0xd9b652<f64> 0.7 "round" camera-ray-opacity[1] 0 0 0 |
+    | "ray-2" camera-screen[2,1] camera-screen[2,2] truth-screen[1] truth-screen[2] 0xd9b652<f64> 0.7 "round" camera-ray-opacity[2] 0 0 0 |
+    | "ray-3" camera-screen[3,1] camera-screen[3,2] truth-screen[1] truth-screen[2] 0xd9b652<f64> 0.7 "round" camera-ray-opacity[3] 0 0 0 |
+    | "ray-4" camera-screen[4,1] camera-screen[4,2] truth-screen[1] truth-screen[2] 0xd9b652<f64> 0.7 "round" camera-ray-opacity[4] 0 0 0 |
+    | "truth-heading" truth-screen[1] truth-screen[2] heading-screen-points[1,1] heading-screen-points[2,1] 0xd7fff8<f64> 2 "round" 1 0 0 0 |
+    | "estimate-heading" estimate-screen[1] estimate-screen[2] heading-screen-points[1,2] heading-screen-points[2,2] 0xffe1ef<f64> 1.5 "round" 1 0 0 0 |
 
-  -- These path records remain a tuple because their positions matrices have
-  -- different shapes; the scalar scene collections below are typed tables.
-  scene-line-strips := (
-    {id: "square-guide", positions: square-guide, stroke: "#536273", stroke-width: 1, line-cap: "round", line-join: "round", opacity: 0.38, closed: true},
-    {id: "truth-path", positions: next-truth-path, stroke: "#63d6c5", stroke-width: 2, line-cap: "round", line-join: "round", opacity: 0.8, closed: false},
-    {id: "estimate-path", positions: next-estimate-path, stroke: "#f087b8", stroke-width: 2, line-cap: "round", line-join: "round", opacity: 0.84, closed: false},
-    {id: "covariance", positions: covariance-ellipse, stroke: "#f087b8", stroke-width: 1.5, line-cap: "round", line-join: "round", opacity: 0.72, closed: true}
-  )
+  scene-line-strips := |id<string> positions<*> stroke<f64> stroke-width<f64> line-cap<string> line-join<string> opacity<f64> closed<bool>|
+    | "square-guide" square-guide 0x536273<f64> 1 "round" "round" 0.38 true |
+    | "truth-path" next-truth-path 0x63d6c5<f64> 2 "round" "round" 0.8 false |
+    | "estimate-path" next-estimate-path 0xf087b8<f64> 2 "round" "round" 0.84 false |
+    | "covariance" covariance-ellipse 0xf087b8<f64> 1.5 "round" "round" 0.72 true |
 
   sans-serif-font := "Inter, ui-sans-serif, system-ui, sans-serif"
-  mono-font := "ui-monospace, SFMono-Regular, Menlo, monospace"
 
-  scene-text := |id<string>                  x<f64> y<f64> fill<string> font-size<f64> font-family<string> font-weight<string> text-anchor<string> opacity<f64>            value<string>                  |
-                | "title"                     24     62    "#edf2f7"  36             sans-serif-font    "620"                "start"             1                       "Camera EKF Localization"      |
-                | "camera-label-1"           195    636    "#d7c27f"  11             sans-serif-font    "500"                "start"             camera-label-opacity[1] "CAM 1"                        |
-                | "camera-label-2"           665    636    "#d7c27f"  11             sans-serif-font    "500"                "end"               camera-label-opacity[2] "CAM 2"                        |
-                | "camera-label-3"           665    140    "#d7c27f"  11             sans-serif-font    "500"                "end"               camera-label-opacity[3] "CAM 3"                        |
-                | "camera-label-4"           195    140    "#d7c27f"  11             sans-serif-font    "500"                "start"             camera-label-opacity[4] "CAM 4"                        |
-                | "legend-truth-label"        40    722    "#bdc8d2"  12             sans-serif-font    "400"                "start"             1                       "actual robot + path"          |
-                | "legend-prediction-label"  215    722    "#bdc8d2"  12             sans-serif-font    "400"                "start"             1                       "motion prediction"            |
-                | "legend-estimate-label"    415    722    "#bdc8d2"  12             sans-serif-font    "400"                "start"             1                       "EKF estimate + 2σ covariance" |
+  scene-text := |id<string>                  x<f64> y<f64> fill<f64> font-size<f64> font-family<string> font-weight<f64> text-anchor<string> opacity<f64>            value<string>                  |
+                | "title"                     24     62    0xedf2f7<f64>  36             sans-serif-font    620              "start"             1                       "Camera EKF Localization"      |
+                | "camera-label-1"           195    636    0xd7c27f<f64>  11             sans-serif-font    500              "start"             camera-label-opacity[1] "CAM 1"                        |
+                | "camera-label-2"           665    636    0xd7c27f<f64>  11             sans-serif-font    500              "end"               camera-label-opacity[2] "CAM 2"                        |
+                | "camera-label-3"           665    140    0xd7c27f<f64>  11             sans-serif-font    500              "end"               camera-label-opacity[3] "CAM 3"                        |
+                | "camera-label-4"           195    140    0xd7c27f<f64>  11             sans-serif-font    500              "start"             camera-label-opacity[4] "CAM 4"                        |
+                | "legend-truth-label"        40    722    0xbdc8d2<f64>  12             sans-serif-font    400              "start"             1                       "actual robot + path"          |
+                | "legend-prediction-label"  215    722    0xbdc8d2<f64>  12             sans-serif-font    400              "start"             1                       "motion prediction"            |
+                | "legend-estimate-label"    415    722    0xbdc8d2<f64>  12             sans-serif-font    400              "start"             1                       "EKF estimate + 2σ covariance" |
 
   field-presentation := {
     width: 860
     height: 770
-    background: "#080b12"
+    background: 0x080b12<f64>
     circles: scene-circles
     lines: scene-lines
     line-strips: scene-line-strips

--- a/examples/ekf/localization.mec
+++ b/examples/ekf/localization.mec
@@ -222,14 +222,14 @@ Only the first lane is sampled for visualization. Its checkpoint contains the co
   predicted-estimate := filter-sample[:,5]
 
 
-ekf-batch @compute
+5. ekf-batch @compute
 -------------------------------------------------------------------------------
 
-(4.2) Predictor
+(5.2) Predictor
 
 The predictor advances the state with a midpoint unicycle motion model. Its Jacobians `G` and `V` propagate the previous covariance and control noise into the prior covariance for the next observation.
 
-(4.2.1) Motion and Covariance Propagation
+(5.2.1) Motion and Covariance Propagation
 
   ekf-predict(μ<[f32]:3,1>, Σ<[f32]:3,3>, u<[f32]:3,1>, Q<[f32]:2,2>) = (μ-<[f32]:3,1>, Σ-<[f32]:3,3>) :=
     δt := u[1]
@@ -249,11 +249,11 @@ The predictor advances the state with a midpoint unicycle motion model. Its Jaco
                ω * δt]
     Σ- := G ** Σ ** G' + V ** Q ** V'.
 
-(4.3) Corrector
+(5.3) Corrector
 
 The corrector linearizes the range-and-bearing observation around the predicted state, computes the Kalman gain, and applies the wrapped innovation. Visibility is part of the numerical observation contract rather than merely an output mask: the inactive guard keeps zero-visibility geometry nonsingular before any division or `atan2` is evaluated while preserving the active equations.
 
-(4.3.1) Innovation and Joseph Covariance Update
+(5.3.1) Innovation and Joseph Covariance Update
 
   ekf-correct(μ-<[f32]:3,1>, Σ-<[f32]:3,3>, camera<[f32]:2,1>, z<[f32]:3,1>, R<[f32]:2,2>) = (μ+<[f32]:3,1>, Σ+<[f32]:3,3>) :=
     Δ := camera - μ-[1..=2]
@@ -278,7 +278,7 @@ The corrector linearizes the range-and-bearing observation around the predicted 
     Σ-raw := A ** Σ- ** A' + K ** R ** K'
     Σ+ := 0.5<f32> * (Σ-raw + Σ-raw').
 
-(4.4) Resident Filter Recurrence
+(5.4) Resident Filter Recurrence
 
 The compute inputs below establish the fixed shapes and default values used to compile the resident region. The document replaces them with the lane matrices before each turn.
 
@@ -293,7 +293,7 @@ The compute inputs below establish the fixed shapes and default values used to c
 
 The resident checkpoint stores the posterior state, its 3×3 covariance, and the prior state. Increasing the lane count changes the outer data shape without duplicating the predictor or corrector source graph.
 
-(4.4.1) Checkpoint and Filter Step
+(5.4.1) Checkpoint and Filter Step
 
   ~filter-sample := [2.9<f32>  0.45<f32> 0f32       0f32       2.9<f32>
                      2.15<f32> 0f32       0.45<f32> 0f32       2.15<f32>
@@ -309,7 +309,7 @@ Each turn is one predictor/corrector recurrence. Multiplying the correction by `
   μ-next := μ- + γ * (μ+ - μ-)
   Σ-next := Σ- + γ * (Σ+ - Σ-)
 
-(4.4.2) Validation and Publication
+(5.4.2) Validation and Publication
 
 Before publishing the next checkpoint, the region verifies finite state, positive covariance diagonals, and covariance symmetry. These invariants fail the compute turn instead of allowing a corrupt estimate to become resident.
 
@@ -325,12 +325,12 @@ The validated checkpoint becomes the starting point for the next GPU turn and is
   (filter-sample, filter-sample, applied-visibility)
 
 
-5. Live Tracking Field
+6. Live Tracking Field
 -------------------------------------------------------------------------------
 
 The covariance outline is the two-standard-deviation position ellipse calculated from the live 2x2 covariance block. Because finite-range camera updates can make the physical ellipse smaller than a useful screen mark, display axes have a 0.04-unit quadrature floor; this changes only the drawing, never the filter covariance. Steady footprint guides show each camera's real maximum range. Camera rays terminate at simulated truth and fade to exactly zero outside that range. Only the scheduled in-range camera's noisy values enter the filter.
 
-(5.1) Screen-space Sampling
+(6.1) Screen-space Sampling
 
 Truth, prediction, and correction are projected into the scene's screen coordinates together. The same sampled state determines camera visibility and the scalar position error reported by the document.
 
@@ -349,7 +349,7 @@ Truth, prediction, and correction are projected into the scene's screen coordina
   position-error-square := [1.0 1.0] ** (position-error-vector ^ 2)
   position-error := sqrt(position-error-square[1])
 
-(5.2) Covariance Ellipse
+(6.2) Covariance Ellipse
 
 The eigenvalues and orientation of the corrected 2×2 position covariance become the axes and rotation of a two-standard-deviation ellipse. A small display-only floor keeps a highly confident estimate visible without modifying the filter covariance.
 
@@ -370,7 +370,7 @@ The eigenvalues and orientation of the corrected 2×2 position covariance become
   ellipse-rotation-matrix := [ellipse-rotation-direction; -ellipse-rotation-direction[2] ellipse-rotation-direction[1]]
   covariance-ellipse := estimate-screen' + screen-scale * (ellipse-axis-points ** ellipse-rotation-matrix) * screen-axis'
 
-(5.3) Resident Tracking Trails
+(6.3) Resident Tracking Trails
 
 Two resident point buffers retain the recent truth and estimate trajectories. A delivered filter sample shifts each trail by one row and appends its newest screen position.
 
@@ -385,7 +385,7 @@ Two resident point buffers retain the recent truth and estimate trajectories. A 
   truth-path = next-truth-path
   estimate-path = next-estimate-path
 
-(5.4) Field and Heading Guides
+(6.4) Field and Heading Guides
 
 The square path, camera opacity channels, and heading vectors are calculated once before the scene tables reference them. Disabled cameras keep muted labels while their sensing rings and measurement rays disappear.
 
@@ -402,11 +402,11 @@ The square path, camera opacity channels, and heading vectors are calculated onc
   heading-screen-vectors := screen-axis * heading-unit-vectors * [18.0 16.0]
   heading-screen-points := [truth-screen estimate-screen] + heading-screen-vectors
 
-(5.5) Scene Primitives
+(6.5) Scene Primitives
 
 The scene resource consumes typed tables of drawing primitives. Each table below owns one visual responsibility instead of hiding the whole presentation inside a single uninterrupted code block.
 
-(5.5.1) Circles
+(6.5.1) Circles
 
 Circles draw camera ranges and bodies, the three robot-state markers, and the compact legend keys. Opacity columns connect camera state directly to the rendered result.
 
@@ -430,7 +430,7 @@ Circles draw camera ranges and bodies, the three robot-state markers, and the co
     | "legend-prediction" 205 718 4 0xf2b84b<f64> "none" 0 1 |
     | "legend-estimate" 405 718 4 0xf087b8<f64> "none" 0 1 |
 
-(5.5.2) Fixed Lines
+(6.5.2) Fixed Lines
 
 Fixed line segments draw the field frame, camera-to-robot measurement rays, and the truth and estimate heading indicators.
 
@@ -446,7 +446,7 @@ Fixed line segments draw the field frame, camera-to-robot measurement rays, and 
     | "truth-heading" truth-screen[1] truth-screen[2] heading-screen-points[1,1] heading-screen-points[2,1] 0xd7fff8<f64> 2 "round" 1 0 0 0 |
     | "estimate-heading" estimate-screen[1] estimate-screen[2] heading-screen-points[1,2] heading-screen-points[2,2] 0xffe1ef<f64> 1.5 "round" 1 0 0 0 |
 
-(5.5.3) Paths and Covariance
+(6.5.3) Paths and Covariance
 
 Line strips draw the requested square, both resident trails, and the sampled covariance ellipse from their prepared point matrices.
 
@@ -456,7 +456,7 @@ Line strips draw the requested square, both resident trails, and the sampled cov
     | "estimate-path" next-estimate-path 0xf087b8<f64> 2 "round" "round" 0.84 false |
     | "covariance" covariance-ellipse 0xf087b8<f64> 1.5 "round" "round" 0.72 true |
 
-(5.5.4) Labels
+(6.5.4) Labels
 
 Text primitives supply the field title, camera labels, and legend descriptions with one shared interface-safe font stack.
 
@@ -472,7 +472,7 @@ Text primitives supply the field title, camera labels, and legend descriptions w
                 | "legend-prediction-label"  215    722    0xbdc8d2  12             sans-serif-font     400              "start"             1                       "motion prediction"            |
                 | "legend-estimate-label"    415    722    0xbdc8d2  12             sans-serif-font     400              "start"             1                       "EKF estimate + 2σ covariance" |
 
-(5.6) Scene Publication
+(6.6) Scene Publication
 
 The presentation record gathers the four primitive tables into one scene frame. Replacing the resource frame and returning position error publish the visual and numerical outputs of the same sampled filter state.
 

--- a/examples/ekf/localization.mec
+++ b/examples/ekf/localization.mec
@@ -184,12 +184,12 @@ The same square phase selects the nearest corner camera during each half-side. A
   observation := observation-model + [0.11; 0.011] * sin(observation-noise-phase)
 
 
-4. GPU Compute
+4. Batched Filter Interface
 -------------------------------------------------------------------------------
 
-The Extended Kalman Filter runs as a named `@compute` region. The document-side program prepares 1,000 independent lanes, sends them through the compute resource, and samples lane zero back into the scene. The other lanes receive deterministic control and sensor perturbations, so this is a genuine filter ensemble rather than 1,000 copies of one arithmetic result.
+This document-side graph prepares 1,000 independent lanes, dispatches them to the named `@compute` region below, and samples lane zero back into the scene. The other lanes receive deterministic control and sensor perturbations, so this is a genuine filter ensemble rather than 1,000 copies of one arithmetic result.
 
-(4.1) Batch Inputs and Sampled Outputs
+(4.1) Batch Inputs, Dispatch, and Sampling
 
 The base control, camera, and measurement rows broadcast across the lane matrices. Lane zero keeps the exact displayed measurement while the phase vectors introduce small, repeatable differences in every other lane.
 
@@ -225,11 +225,13 @@ Only the first lane is sampled for visualization. Its checkpoint contains the co
 5. ekf-batch @compute
 -------------------------------------------------------------------------------
 
-(5.2) Predictor
+This is the actual compute region. The predictor, corrector, resident recurrence, and validation below are compiled together for the configured compute backend.
+
+(5.1) Predictor
 
 The predictor advances the state with a midpoint unicycle motion model. Its Jacobians `G` and `V` propagate the previous covariance and control noise into the prior covariance for the next observation.
 
-(5.2.1) Motion and Covariance Propagation
+(5.1.1) Motion and Covariance Propagation
 
   ekf-predict(μ<[f32]:3,1>, Σ<[f32]:3,3>, u<[f32]:3,1>, Q<[f32]:2,2>) = (μ-<[f32]:3,1>, Σ-<[f32]:3,3>) :=
     δt := u[1]
@@ -249,11 +251,11 @@ The predictor advances the state with a midpoint unicycle motion model. Its Jaco
                ω * δt]
     Σ- := G ** Σ ** G' + V ** Q ** V'.
 
-(5.3) Corrector
+(5.2) Corrector
 
 The corrector linearizes the range-and-bearing observation around the predicted state, computes the Kalman gain, and applies the wrapped innovation. Visibility is part of the numerical observation contract rather than merely an output mask: the inactive guard keeps zero-visibility geometry nonsingular before any division or `atan2` is evaluated while preserving the active equations.
 
-(5.3.1) Innovation and Joseph Covariance Update
+(5.2.1) Innovation and Joseph Covariance Update
 
   ekf-correct(μ-<[f32]:3,1>, Σ-<[f32]:3,3>, camera<[f32]:2,1>, z<[f32]:3,1>, R<[f32]:2,2>) = (μ+<[f32]:3,1>, Σ+<[f32]:3,3>) :=
     Δ := camera - μ-[1..=2]
@@ -278,7 +280,7 @@ The corrector linearizes the range-and-bearing observation around the predicted 
     Σ-raw := A ** Σ- ** A' + K ** R ** K'
     Σ+ := 0.5<f32> * (Σ-raw + Σ-raw').
 
-(5.4) Resident Filter Recurrence
+(5.3) Resident Filter Recurrence
 
 The compute inputs below establish the fixed shapes and default values used to compile the resident region. The document replaces them with the lane matrices before each turn.
 
@@ -293,7 +295,7 @@ The compute inputs below establish the fixed shapes and default values used to c
 
 The resident checkpoint stores the posterior state, its 3×3 covariance, and the prior state. Increasing the lane count changes the outer data shape without duplicating the predictor or corrector source graph.
 
-(5.4.1) Checkpoint and Filter Step
+(5.3.1) Checkpoint and Filter Step
 
   ~filter-sample := [2.9<f32>  0.45<f32> 0f32       0f32       2.9<f32>
                      2.15<f32> 0f32       0.45<f32> 0f32       2.15<f32>
@@ -309,7 +311,7 @@ Each turn is one predictor/corrector recurrence. Multiplying the correction by `
   μ-next := μ- + γ * (μ+ - μ-)
   Σ-next := Σ- + γ * (Σ+ - Σ-)
 
-(5.4.2) Validation and Publication
+(5.3.2) Validation and Publication
 
 Before publishing the next checkpoint, the region verifies finite state, positive covariance diagonals, and covariance symmetry. These invariants fail the compute turn instead of allowing a corrupt estimate to become resident.
 

--- a/examples/ekf/localization.mec
+++ b/examples/ekf/localization.mec
@@ -351,7 +351,7 @@ Truth, prediction, and correction are projected into the scene's screen coordina
 
 (6.2) Covariance Ellipse
 
-The eigenvalues and orientation of the corrected 2×2 position covariance become the axes and rotation of a two-standard-deviation ellipse. A small display-only floor keeps a highly confident estimate visible without modifying the filter covariance.
+The eigenvalues and orientation of the corrected `2x2` position covariance become the axes and rotation of a two-standard-deviation ellipse. A small display-only floor keeps a highly confident estimate visible without modifying the filter covariance.
 
   ellipse-a := corrected-covariance[1,1]
   ellipse-b := corrected-covariance[1,2]

--- a/examples/ekf/mech.mcfg
+++ b/examples/ekf/mech.mcfg
@@ -61,8 +61,6 @@ config := {
         paths: [
           "pointer-pulse"
           "pointer-position"
-          "pointer-pressed"
-          "pointer-delta-seconds"
           "replace"
         ]
       }
@@ -75,7 +73,6 @@ config := {
           "input/camera"
           "input/measurement"
           "sample/result.0"
-          "sample/result.2"
           "turns"
           "turn"
         ]

--- a/examples/ekf/mech.mcfg
+++ b/examples/ekf/mech.mcfg
@@ -73,6 +73,7 @@ config := {
           "input/camera"
           "input/measurement"
           "sample/result.0"
+          "sample/result.2"
           "turns"
           "turn"
         ]

--- a/examples/n-body/n-body.mec
+++ b/examples/n-body/n-body.mec
@@ -2,7 +2,7 @@ N-Body Simulation
 ===============================================================================
 section: Examples
 +> combinatorics
-+> math
++> math/*
 +> stats
 ===============================================================================
 
@@ -147,8 +147,8 @@ the center-of-momentum frame without changing any body's heliocentric orbit.
 
   guide-samples := 0..=96
   guide-angle := guide-samples' * (2 * π / 96)
-  guide-cos := math/cos(guide-angle)
-  guide-sin := math/sin(guide-angle)
+  guide-cos := cos(guide-angle)
+  guide-sin := sin(guide-angle)
 
   mercury-guide-x := orbit-a[1] * (guide-cos - orbit-e[1]) * orbit-px[1] + orbit-a[1] * (1 - orbit-e[1] ^ 2) ^ 0.5 * guide-sin * orbit-qx[1]
   mercury-guide-y := orbit-a[1] * (guide-cos - orbit-e[1]) * orbit-py[1] + orbit-a[1] * (1 - orbit-e[1] ^ 2) ^ 0.5 * guide-sin * orbit-qy[1]

--- a/examples/n-body/n-body.mec
+++ b/examples/n-body/n-body.mec
@@ -250,68 +250,56 @@ body's simulated direction from the Sun.
   pluto-guide-scale := 44 / (pluto-guide-x ^ 2 + pluto-guide-y ^ 2 + 0.000001) ^ 0.25
   pluto-guide := [430 + pluto-guide-x * pluto-guide-scale 380 - pluto-guide-y * pluto-guide-scale]
 
-  scene-circles := (
-    {id: "status-light", x: 593, y: 57, radius: 4, fill: "#61d095", stroke: "none", stroke-width: 0, opacity: 1},
-    {id: "legend-sun", x: 28, y: 714, radius: 4, fill: "#ffd166", stroke: "none", stroke-width: 0, opacity: 1},
-    {id: "legend-mercury", x: 92, y: 714, radius: 4, fill: "#b9a99a", stroke: "none", stroke-width: 0, opacity: 1},
-    {id: "legend-venus", x: 179, y: 714, radius: 4, fill: "#e8b86d", stroke: "none", stroke-width: 0, opacity: 1},
-    {id: "legend-earth", x: 247, y: 714, radius: 4, fill: "#55a9ff", stroke: "none", stroke-width: 0, opacity: 1},
-    {id: "legend-mars", x: 314, y: 714, radius: 4, fill: "#e76f51", stroke: "none", stroke-width: 0, opacity: 1},
-    {id: "legend-jupiter", x: 376, y: 714, radius: 4, fill: "#d7b28c", stroke: "none", stroke-width: 0, opacity: 1},
-    {id: "legend-saturn", x: 455, y: 714, radius: 4, fill: "#e7cf8d", stroke: "none", stroke-width: 0, opacity: 1},
-    {id: "legend-uranus", x: 529, y: 714, radius: 4, fill: "#72d6d1", stroke: "none", stroke-width: 0, opacity: 1},
-    {id: "legend-neptune", x: 607, y: 714, radius: 4, fill: "#5677e8", stroke: "none", stroke-width: 0, opacity: 1},
-    {id: "legend-pluto", x: 695, y: 714, radius: 4, fill: "#c9c2b8", stroke: "none", stroke-width: 0, opacity: 1}
-  )
+  scene-circles := |id<string> x<f64> y<f64> radius<f64> fill<string> stroke<string> stroke-width<f64> opacity<f64>|
+    | "status-light" 593 57 4 "#61d095" "none" 0 1 |
+    | "legend-sun" 28 714 4 "#ffd166" "none" 0 1 |
+    | "legend-mercury" 92 714 4 "#b9a99a" "none" 0 1 |
+    | "legend-venus" 179 714 4 "#e8b86d" "none" 0 1 |
+    | "legend-earth" 247 714 4 "#55a9ff" "none" 0 1 |
+    | "legend-mars" 314 714 4 "#e76f51" "none" 0 1 |
+    | "legend-jupiter" 376 714 4 "#d7b28c" "none" 0 1 |
+    | "legend-saturn" 455 714 4 "#e7cf8d" "none" 0 1 |
+    | "legend-uranus" 529 714 4 "#72d6d1" "none" 0 1 |
+    | "legend-neptune" 607 714 4 "#5677e8" "none" 0 1 |
+    | "legend-pluto" 695 714 4 "#c9c2b8" "none" 0 1 |
 
-  scene-line-strips := (
-    {id: "orbit-mercury", positions: mercury-guide, stroke: "#536273", stroke-width: 0.75, line-cap: "round", line-join: "round", opacity: 0.48, closed: true},
-    {id: "orbit-venus", positions: venus-guide, stroke: "#536273", stroke-width: 0.75, line-cap: "round", line-join: "round", opacity: 0.48, closed: true},
-    {id: "orbit-earth", positions: earth-guide, stroke: "#536273", stroke-width: 0.75, line-cap: "round", line-join: "round", opacity: 0.48, closed: true},
-    {id: "orbit-mars", positions: mars-guide, stroke: "#536273", stroke-width: 0.75, line-cap: "round", line-join: "round", opacity: 0.48, closed: true},
-    {id: "orbit-jupiter", positions: jupiter-guide, stroke: "#536273", stroke-width: 0.75, line-cap: "round", line-join: "round", opacity: 0.48, closed: true},
-    {id: "orbit-saturn", positions: saturn-guide, stroke: "#536273", stroke-width: 0.75, line-cap: "round", line-join: "round", opacity: 0.48, closed: true},
-    {id: "orbit-uranus", positions: uranus-guide, stroke: "#536273", stroke-width: 0.75, line-cap: "round", line-join: "round", opacity: 0.48, closed: true},
-    {id: "orbit-neptune", positions: neptune-guide, stroke: "#536273", stroke-width: 0.75, line-cap: "round", line-join: "round", opacity: 0.48, closed: true},
-    {id: "orbit-pluto", positions: pluto-guide, stroke: "#536273", stroke-width: 0.75, line-cap: "round", line-join: "round", opacity: 0.48, closed: true}
-  )
+  scene-line-strips := |id<string> positions<[f64]:97,2> stroke<string> stroke-width<f64> line-cap<string> line-join<string> opacity<f64> closed<bool>|
+    | "orbit-mercury" mercury-guide "#536273" 0.75 "round" "round" 0.48 true |
+    | "orbit-venus" venus-guide "#536273" 0.75 "round" "round" 0.48 true |
+    | "orbit-earth" earth-guide "#536273" 0.75 "round" "round" 0.48 true |
+    | "orbit-mars" mars-guide "#536273" 0.75 "round" "round" 0.48 true |
+    | "orbit-jupiter" jupiter-guide "#536273" 0.75 "round" "round" 0.48 true |
+    | "orbit-saturn" saturn-guide "#536273" 0.75 "round" "round" 0.48 true |
+    | "orbit-uranus" uranus-guide "#536273" 0.75 "round" "round" 0.48 true |
+    | "orbit-neptune" neptune-guide "#536273" 0.75 "round" "round" 0.48 true |
+    | "orbit-pluto" pluto-guide "#536273" 0.75 "round" "round" 0.48 true |
 
-  scene-point-sets := ({
-    id: "body"
-    positions: screen-points
-    radius: 4
-    first-radius: 8
-    fills: ("#ffd166", "#b9a99a", "#e8b86d", "#55a9ff", "#e76f51", "#d7b28c", "#e7cf8d", "#72d6d1", "#5677e8", "#c9c2b8")
-    stroke: "none"
-    stroke-width: 0
-    opacity: 1
-  })
+  scene-point-sets := |id<string> positions<[f64]:10,2> radius<f64> first-radius<f64> fills<(string,string,string,string,string,string,string,string,string,string)> stroke<string> stroke-width<f64> opacity<f64>|
+    | "body" screen-points 4 8 ("#ffd166", "#b9a99a", "#e8b86d", "#55a9ff", "#e76f51", "#d7b28c", "#e7cf8d", "#72d6d1", "#5677e8", "#c9c2b8") "none" 0 1 |
 
-  scene-lines := (
-    {id: "axis-x", x1: 158, y1: 380, x2: 702, y2: 380, stroke: "#344151", stroke-width: 0.5, line-cap: "butt", opacity: 0.5, rotation: 0, origin-x: 0, origin-y: 0},
-    {id: "axis-y", x1: 430, y1: 108, x2: 430, y2: 652, stroke: "#344151", stroke-width: 0.5, line-cap: "butt", opacity: 0.5, rotation: 0, origin-x: 0, origin-y: 0},
-    {id: "frame-top", x1: 130, y1: 80, x2: 730, y2: 80, stroke: "#27313d", stroke-width: 1, line-cap: "butt", opacity: 1, rotation: 0, origin-x: 0, origin-y: 0},
-    {id: "frame-right", x1: 730, y1: 80, x2: 730, y2: 680, stroke: "#27313d", stroke-width: 1, line-cap: "butt", opacity: 1, rotation: 0, origin-x: 0, origin-y: 0},
-    {id: "frame-bottom", x1: 730, y1: 680, x2: 130, y2: 680, stroke: "#27313d", stroke-width: 1, line-cap: "butt", opacity: 1, rotation: 0, origin-x: 0, origin-y: 0},
-    {id: "frame-left", x1: 130, y1: 680, x2: 130, y2: 80, stroke: "#27313d", stroke-width: 1, line-cap: "butt", opacity: 1, rotation: 0, origin-x: 0, origin-y: 0}
-  )
+  scene-lines := |id<string> x1<f64> y1<f64> x2<f64> y2<f64> stroke<string> stroke-width<f64> line-cap<string> opacity<f64> rotation<f64> origin-x<f64> origin-y<f64>|
+    | "axis-x" 158 380 702 380 "#344151" 0.5 "butt" 0.5 0 0 0 |
+    | "axis-y" 430 108 430 652 "#344151" 0.5 "butt" 0.5 0 0 0 |
+    | "frame-top" 130 80 730 80 "#27313d" 1 "butt" 1 0 0 0 |
+    | "frame-right" 730 80 730 680 "#27313d" 1 "butt" 1 0 0 0 |
+    | "frame-bottom" 730 680 130 680 "#27313d" 1 "butt" 1 0 0 0 |
+    | "frame-left" 130 680 130 80 "#27313d" 1 "butt" 1 0 0 0 |
 
-  scene-text := (
-    {id: "eyebrow", x: 24, y: 26, fill: "#8fa3b8", font-size: 12, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "650", text-anchor: "start", opacity: 1, value: "MECH RESIDENT N-BODY MODEL"},
-    {id: "title", x: 24, y: 62, fill: "#edf2f7", font-size: 38, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "620", text-anchor: "start", opacity: 1, value: "Solar-System Orbit Viewer"},
-    {id: "status", x: 604, y: 61, fill: "#aebdca", font-size: 13, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "400", text-anchor: "start", opacity: 1, value: "60 resident simulation steps per second"},
-    {id: "label-sun", x: 37, y: 718, fill: "#bdc8d2", font-size: 12, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "400", text-anchor: "start", opacity: 1, value: "Sun"},
-    {id: "label-mercury", x: 101, y: 718, fill: "#bdc8d2", font-size: 12, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "400", text-anchor: "start", opacity: 1, value: "Mercury"},
-    {id: "label-venus", x: 188, y: 718, fill: "#bdc8d2", font-size: 12, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "400", text-anchor: "start", opacity: 1, value: "Venus"},
-    {id: "label-earth", x: 256, y: 718, fill: "#bdc8d2", font-size: 12, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "400", text-anchor: "start", opacity: 1, value: "Earth"},
-    {id: "label-mars", x: 323, y: 718, fill: "#bdc8d2", font-size: 12, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "400", text-anchor: "start", opacity: 1, value: "Mars"},
-    {id: "label-jupiter", x: 385, y: 718, fill: "#bdc8d2", font-size: 12, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "400", text-anchor: "start", opacity: 1, value: "Jupiter"},
-    {id: "label-saturn", x: 464, y: 718, fill: "#bdc8d2", font-size: 12, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "400", text-anchor: "start", opacity: 1, value: "Saturn"},
-    {id: "label-uranus", x: 538, y: 718, fill: "#bdc8d2", font-size: 12, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "400", text-anchor: "start", opacity: 1, value: "Uranus"},
-    {id: "label-neptune", x: 616, y: 718, fill: "#bdc8d2", font-size: 12, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "400", text-anchor: "start", opacity: 1, value: "Neptune"},
-    {id: "label-pluto", x: 704, y: 718, fill: "#bdc8d2", font-size: 12, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "400", text-anchor: "start", opacity: 1, value: "Pluto"},
-    {id: "scale-note", x: 430, y: 750, fill: "#788a9c", font-size: 11, font-family: "Inter, ui-sans-serif, system-ui, sans-serif", font-weight: "400", text-anchor: "middle", opacity: 1, value: "Live mutual gravity · guides are calculated osculating orbits · square-root radial scale"}
-  )
+  scene-text := |id<string> x<f64> y<f64> fill<string> font-size<f64> font-family<string> font-weight<string> text-anchor<string> opacity<f64> value<string>|
+    | "eyebrow" 24 26 "#8fa3b8" 12 "Inter, ui-sans-serif, system-ui, sans-serif" "650" "start" 1 "MECH RESIDENT N-BODY MODEL" |
+    | "title" 24 62 "#edf2f7" 38 "Inter, ui-sans-serif, system-ui, sans-serif" "620" "start" 1 "Solar-System Orbit Viewer" |
+    | "status" 604 61 "#aebdca" 13 "Inter, ui-sans-serif, system-ui, sans-serif" "400" "start" 1 "60 resident simulation steps per second" |
+    | "label-sun" 37 718 "#bdc8d2" 12 "Inter, ui-sans-serif, system-ui, sans-serif" "400" "start" 1 "Sun" |
+    | "label-mercury" 101 718 "#bdc8d2" 12 "Inter, ui-sans-serif, system-ui, sans-serif" "400" "start" 1 "Mercury" |
+    | "label-venus" 188 718 "#bdc8d2" 12 "Inter, ui-sans-serif, system-ui, sans-serif" "400" "start" 1 "Venus" |
+    | "label-earth" 256 718 "#bdc8d2" 12 "Inter, ui-sans-serif, system-ui, sans-serif" "400" "start" 1 "Earth" |
+    | "label-mars" 323 718 "#bdc8d2" 12 "Inter, ui-sans-serif, system-ui, sans-serif" "400" "start" 1 "Mars" |
+    | "label-jupiter" 385 718 "#bdc8d2" 12 "Inter, ui-sans-serif, system-ui, sans-serif" "400" "start" 1 "Jupiter" |
+    | "label-saturn" 464 718 "#bdc8d2" 12 "Inter, ui-sans-serif, system-ui, sans-serif" "400" "start" 1 "Saturn" |
+    | "label-uranus" 538 718 "#bdc8d2" 12 "Inter, ui-sans-serif, system-ui, sans-serif" "400" "start" 1 "Uranus" |
+    | "label-neptune" 616 718 "#bdc8d2" 12 "Inter, ui-sans-serif, system-ui, sans-serif" "400" "start" 1 "Neptune" |
+    | "label-pluto" 704 718 "#bdc8d2" 12 "Inter, ui-sans-serif, system-ui, sans-serif" "400" "start" 1 "Pluto" |
+    | "scale-note" 430 750 "#788a9c" 11 "Inter, ui-sans-serif, system-ui, sans-serif" "400" "middle" 1 "Live mutual gravity · guides are calculated osculating orbits · square-root radial scale" |
 
   n-body-scene := {
     width: 860

--- a/hosts/scene/Cargo.toml
+++ b/hosts/scene/Cargo.toml
@@ -17,8 +17,8 @@ browser = ["dep:wasm-bindgen", "dep:js-sys", "dep:web-sys", "rich-output"]
 rich-output = ["dep:serde", "dep:serde_json", "mech-runtime/serde"]
 
 [dependencies]
-mech-core = { version = "0.3.5", path = "../../src/core", default-features = false, features = ["f64", "string", "record", "table", "tuple", "matrix", "matrixd"] }
-mech-runtime = { version = "0.3.5", path = "../../src/runtime", default-features = false, features = ["runtime", "f64", "string", "record", "table", "matrixd"] }
+mech-core = { version = "0.3.5", path = "../../src/core", default-features = false, features = ["u32", "f64", "string", "record", "table", "tuple", "matrix", "matrixd"] }
+mech-runtime = { version = "0.3.5", path = "../../src/runtime", default-features = false, features = ["runtime", "u32", "f64", "string", "record", "table", "matrixd"] }
 wasm-bindgen = { version = "0.2.105", optional = true }
 js-sys = { version = "0.3.82", optional = true }
 web-sys = { version = "0.3.82", optional = true, features = ["Window", "Document", "Element", "HtmlElement", "HtmlCanvasElement", "CanvasRenderingContext2d", "SvgElement", "SvgsvgElement", "Node", "NodeList", "DomTokenList", "CssStyleDeclaration"] }

--- a/hosts/scene/Cargo.toml
+++ b/hosts/scene/Cargo.toml
@@ -17,8 +17,8 @@ browser = ["dep:wasm-bindgen", "dep:js-sys", "dep:web-sys", "rich-output"]
 rich-output = ["dep:serde", "dep:serde_json", "mech-runtime/serde"]
 
 [dependencies]
-mech-core = { version = "0.3.5", path = "../../src/core", default-features = false, features = ["f64", "string", "record", "table", "tuple", "matrix", "matrixd"] }
-mech-runtime = { version = "0.3.5", path = "../../src/runtime", default-features = false, features = ["runtime", "f64", "string", "record", "table", "matrixd"] }
+mech-core = { version = "0.3.5", path = "../../src/core", default-features = false, features = ["u64", "i64", "f64", "string", "record", "table", "tuple", "matrix", "matrixd"] }
+mech-runtime = { version = "0.3.5", path = "../../src/runtime", default-features = false, features = ["runtime", "u64", "i64", "f64", "string", "record", "table", "matrixd"] }
 wasm-bindgen = { version = "0.2.105", optional = true }
 js-sys = { version = "0.3.82", optional = true }
 web-sys = { version = "0.3.82", optional = true, features = ["Window", "Document", "Element", "HtmlElement", "HtmlCanvasElement", "CanvasRenderingContext2d", "SvgElement", "SvgsvgElement", "Node", "NodeList", "DomTokenList", "CssStyleDeclaration"] }

--- a/hosts/scene/Cargo.toml
+++ b/hosts/scene/Cargo.toml
@@ -17,8 +17,8 @@ browser = ["dep:wasm-bindgen", "dep:js-sys", "dep:web-sys", "rich-output"]
 rich-output = ["dep:serde", "dep:serde_json", "mech-runtime/serde"]
 
 [dependencies]
-mech-core = { version = "0.3.5", path = "../../src/core", default-features = false, features = ["u64", "i64", "f64", "string", "record", "table", "tuple", "matrix", "matrixd"] }
-mech-runtime = { version = "0.3.5", path = "../../src/runtime", default-features = false, features = ["runtime", "u64", "i64", "f64", "string", "record", "table", "matrixd"] }
+mech-core = { version = "0.3.5", path = "../../src/core", default-features = false, features = ["f64", "string", "record", "table", "tuple", "matrix", "matrixd"] }
+mech-runtime = { version = "0.3.5", path = "../../src/runtime", default-features = false, features = ["runtime", "f64", "string", "record", "table", "matrixd"] }
 wasm-bindgen = { version = "0.2.105", optional = true }
 js-sys = { version = "0.3.82", optional = true }
 web-sys = { version = "0.3.82", optional = true, features = ["Window", "Document", "Element", "HtmlElement", "HtmlCanvasElement", "CanvasRenderingContext2d", "SvgElement", "SvgsvgElement", "Node", "NodeList", "DomTokenList", "CssStyleDeclaration"] }

--- a/hosts/scene/Cargo.toml
+++ b/hosts/scene/Cargo.toml
@@ -17,8 +17,8 @@ browser = ["dep:wasm-bindgen", "dep:js-sys", "dep:web-sys", "rich-output"]
 rich-output = ["dep:serde", "dep:serde_json", "mech-runtime/serde"]
 
 [dependencies]
-mech-core = { version = "0.3.5", path = "../../src/core", default-features = false, features = ["u32", "f64", "string", "record", "table", "tuple", "matrix", "matrixd"] }
-mech-runtime = { version = "0.3.5", path = "../../src/runtime", default-features = false, features = ["runtime", "u32", "f64", "string", "record", "table", "matrixd"] }
+mech-core = { version = "0.3.5", path = "../../src/core", default-features = false, features = ["f64", "string", "record", "table", "tuple", "matrix", "matrixd"] }
+mech-runtime = { version = "0.3.5", path = "../../src/runtime", default-features = false, features = ["runtime", "f64", "string", "record", "table", "matrixd"] }
 wasm-bindgen = { version = "0.2.105", optional = true }
 js-sys = { version = "0.3.82", optional = true }
 web-sys = { version = "0.3.82", optional = true, features = ["Window", "Document", "Element", "HtmlElement", "HtmlCanvasElement", "CanvasRenderingContext2d", "SvgElement", "SvgsvgElement", "Node", "NodeList", "DomTokenList", "CssStyleDeclaration"] }

--- a/hosts/scene/src/schema.rs
+++ b/hosts/scene/src/schema.rs
@@ -108,7 +108,7 @@ impl SceneSnapshot {
         if !height.is_finite() || height <= 0.0 {
             return Err(scene_error("SceneSchema", "scene.height must be positive"));
         }
-        let background = required_string(&record, "background", "scene.background")?;
+        let background = required_paint(&record, "background", "scene.background")?;
         let mut circles = record_value(&record, "circles")
             .map(elements_from_value::<CircleElement>)
             .transpose()?
@@ -198,8 +198,8 @@ impl FromRecord for CircleElement {
                 &format!("circle `{id}` y"),
             )?,
             radius,
-            fill: required_string(record, "fill", &format!("circle `{id}` fill"))?,
-            stroke: required_string(record, "stroke", &format!("circle `{id}` stroke"))?,
+            fill: required_paint(record, "fill", &format!("circle `{id}` fill"))?,
+            stroke: required_paint(record, "stroke", &format!("circle `{id}` stroke"))?,
             stroke_width,
             opacity,
         })
@@ -251,7 +251,7 @@ impl FromRecord for LineElement {
                 required_number(record, "y2", &format!("line `{id}` y2"))?,
                 &format!("line `{id}` y2"),
             )?,
-            stroke: required_string(record, "stroke", &format!("line `{id}` stroke"))?,
+            stroke: required_paint(record, "stroke", &format!("line `{id}` stroke"))?,
             stroke_width,
             line_cap,
             opacity,
@@ -311,14 +311,14 @@ impl FromRecord for TextElement {
                 required_number(record, "y", &format!("text `{id}` y"))?,
                 &format!("text `{id}` y"),
             )?,
-            fill: required_string(record, "fill", &format!("text `{id}` fill"))?,
+            fill: required_paint(record, "fill", &format!("text `{id}` fill"))?,
             font_size,
             font_family: required_string(
                 record,
                 "font-family",
                 &format!("text `{id}` font-family"),
             )?,
-            font_weight: required_string(
+            font_weight: required_font_weight(
                 record,
                 "font-weight",
                 &format!("text `{id}` font-weight"),
@@ -515,7 +515,7 @@ fn point_set_from_record(record: &MechRecord) -> MResult<Vec<CircleElement>> {
             ),
         ));
     }
-    let stroke = required_string(record, "stroke", &format!("point-set `{id}` stroke"))?;
+    let stroke = required_paint(record, "stroke", &format!("point-set `{id}` stroke"))?;
     let stroke_width = required_number(
         record,
         "stroke-width",
@@ -647,7 +647,7 @@ fn line_strip_from_record(record: &MechRecord) -> MResult<LineStripElement> {
     Ok(LineStripElement {
         id,
         positions,
-        stroke: required_string(record, "stroke", "line-strip.stroke")?,
+        stroke: required_paint(record, "stroke", "line-strip.stroke")?,
         stroke_width,
         line_cap,
         line_join,
@@ -785,6 +785,66 @@ fn required_string(record: &MechRecord, field: &str, label: &str) -> MResult<Str
         0,
     )
     .map_err(|_| scene_error("SceneSchema", format!("field `{label}` must be a string")))
+}
+fn required_paint(record: &MechRecord, field: &str, label: &str) -> MResult<String> {
+    let resolved = host_arg_resolved(
+        SCENE_SCHEMA,
+        one_arg(required_value(record, field, label)?),
+        0,
+    )
+    .map_err(|_| {
+        scene_error(
+            "SceneSchema",
+            format!("field `{label}` must be a paint string or u32 RGB color"),
+        )
+    })?;
+    match resolved {
+        LegacyValue::String(value) => Ok(value.borrow().clone()),
+        LegacyValue::U32(value) if *value.borrow() <= 0x00ff_ffff => {
+            Ok(format!("#{:06x}", *value.borrow()))
+        }
+        LegacyValue::F64(value)
+            if value.borrow().is_finite()
+                && value.borrow().fract() == 0.0
+                && (0.0..=16_777_215.0).contains(&*value.borrow()) =>
+        {
+            Ok(format!("#{:06x}", *value.borrow() as u32))
+        }
+        _ => Err(scene_error(
+            "SceneSchema",
+            format!("field `{label}` must be a paint string or 24-bit unsigned RGB color"),
+        )),
+    }
+}
+fn required_font_weight(record: &MechRecord, field: &str, label: &str) -> MResult<String> {
+    let resolved = host_arg_resolved(
+        SCENE_SCHEMA,
+        one_arg(required_value(record, field, label)?),
+        0,
+    )
+    .map_err(|_| {
+        scene_error(
+            "SceneSchema",
+            format!("field `{label}` must be a string, f64, or u32"),
+        )
+    })?;
+    match resolved {
+        LegacyValue::String(value) => Ok(value.borrow().clone()),
+        LegacyValue::U32(value) if (1..=1000).contains(&*value.borrow()) => {
+            Ok(value.borrow().to_string())
+        }
+        LegacyValue::F64(value)
+            if value.borrow().is_finite()
+                && value.borrow().fract() == 0.0
+                && (1.0..=1000.0).contains(&*value.borrow()) =>
+        {
+            Ok(format!("{:.0}", *value.borrow()))
+        }
+        _ => Err(scene_error(
+            "SceneSchema",
+            format!("field `{label}` must be a string or a numeric value from 1 through 1000"),
+        )),
+    }
 }
 fn required_strings(record: &MechRecord, field: &str, label: &str) -> MResult<Vec<String>> {
     strings_from_value(required_value(record, field, label)?, label)

--- a/hosts/scene/src/schema.rs
+++ b/hosts/scene/src/schema.rs
@@ -443,34 +443,52 @@ fn point_set_circles(value: &LegacyValue) -> MResult<Vec<CircleElement>> {
         }
         return Ok(circles);
     }
+    if let Ok(table) = host_arg_table(SCENE_SCHEMA, one_arg(value), 0) {
+        let records = table_records(&table, "point-set", POINT_SET_FIELDS)?;
+        let mut circles = Vec::new();
+        for (row, record) in records.iter().enumerate() {
+            circles.extend(point_set_from_record(record).map_err(|err| {
+                scene_error(
+                    "SceneSchema",
+                    format!("point-set table row {}: {err:?}", row + 1),
+                )
+            })?);
+        }
+        return Ok(circles);
+    }
     if host_arg_record(SCENE_SCHEMA, one_arg(value), 0).is_ok() {
         return point_set_from_record_value(value);
     }
     Err(scene_error(
         "SceneSchema",
         format!(
-            "scene point-sets must be a record or tuple, got {:?}",
+            "scene point-sets must be a record, tuple, or table, got {:?}",
             resolved_for_diagnostic(value)
         ),
     ))
 }
 
+const POINT_SET_FIELDS: &[&str] = &[
+    "id",
+    "positions",
+    "radius",
+    "first-radius",
+    "fills",
+    "stroke",
+    "stroke-width",
+    "opacity",
+];
+
 fn point_set_from_record_value(value: &LegacyValue) -> MResult<Vec<CircleElement>> {
     let record = host_record(value, "scene point-set must be a record")?;
-    const FIELDS: &[&str] = &[
-        "id",
-        "positions",
-        "radius",
-        "first-radius",
-        "fills",
-        "stroke",
-        "stroke-width",
-        "opacity",
-    ];
-    reject_unknown_fields(&record, FIELDS, "point-set")?;
-    let id = required_string(&record, "id", "point-set.id")?;
+    point_set_from_record(&record)
+}
+
+fn point_set_from_record(record: &MechRecord) -> MResult<Vec<CircleElement>> {
+    reject_unknown_fields(record, POINT_SET_FIELDS, "point-set")?;
+    let id = required_string(record, "id", "point-set.id")?;
     validate_id("point-set", &id)?;
-    let positions = required_value(&record, "positions", &format!("point-set `{id}` positions"))?;
+    let positions = required_value(record, "positions", &format!("point-set `{id}` positions"))?;
     let positions = matrix_f64_values(positions, &format!("point-set `{id}` positions"))?;
     if positions.rows == 0 || positions.columns != 2 {
         return Err(scene_error(
@@ -478,15 +496,15 @@ fn point_set_from_record_value(value: &LegacyValue) -> MResult<Vec<CircleElement
             format!("point-set `{id}` positions must be a non-empty f64 matrix with two columns"),
         ));
     }
-    let radius = required_number(&record, "radius", &format!("point-set `{id}` radius"))?;
+    let radius = required_number(record, "radius", &format!("point-set `{id}` radius"))?;
     let first_radius = required_number(
-        &record,
+        record,
         "first-radius",
         &format!("point-set `{id}` first-radius"),
     )?;
     validate_radius(radius, &format!("point-set `{id}` radius"))?;
     validate_radius(first_radius, &format!("point-set `{id}` first-radius"))?;
-    let fills = required_strings(&record, "fills", &format!("point-set `{id}` fills"))?;
+    let fills = required_strings(record, "fills", &format!("point-set `{id}` fills"))?;
     if fills.len() != positions.rows {
         return Err(scene_error(
             "SceneSchema",
@@ -497,14 +515,14 @@ fn point_set_from_record_value(value: &LegacyValue) -> MResult<Vec<CircleElement
             ),
         ));
     }
-    let stroke = required_string(&record, "stroke", &format!("point-set `{id}` stroke"))?;
+    let stroke = required_string(record, "stroke", &format!("point-set `{id}` stroke"))?;
     let stroke_width = required_number(
-        &record,
+        record,
         "stroke-width",
         &format!("point-set `{id}` stroke-width"),
     )?;
     validate_stroke_width(&id, stroke_width)?;
-    let opacity = required_number(&record, "opacity", &format!("point-set `{id}` opacity"))?;
+    let opacity = required_number(record, "opacity", &format!("point-set `{id}` opacity"))?;
     validate_opacity(&id, opacity)?;
 
     let mut circles = Vec::with_capacity(positions.rows);
@@ -545,38 +563,53 @@ fn line_strips_from_value(value: &LegacyValue) -> MResult<Vec<LineStripElement>>
             .map(|value| line_strip_from_record_value(value.as_ref()))
             .collect();
     }
+    if let Ok(table) = host_arg_table(SCENE_SCHEMA, one_arg(value), 0) {
+        return table_records(&table, "line-strip", LINE_STRIP_FIELDS)?
+            .iter()
+            .enumerate()
+            .map(|(row, record)| {
+                line_strip_from_record(record).map_err(|err| {
+                    scene_error(
+                        "SceneSchema",
+                        format!("line-strip table row {}: {err:?}", row + 1),
+                    )
+                })
+            })
+            .collect();
+    }
     if host_arg_record(SCENE_SCHEMA, one_arg(value), 0).is_ok() {
         return Ok(vec![line_strip_from_record_value(value)?]);
     }
     Err(scene_error(
         "SceneSchema",
         format!(
-            "scene line-strips must be a record or tuple, got {:?}",
+            "scene line-strips must be a record, tuple, or table, got {:?}",
             resolved_for_diagnostic(value)
         ),
     ))
 }
 
+const LINE_STRIP_FIELDS: &[&str] = &[
+    "id",
+    "positions",
+    "stroke",
+    "stroke-width",
+    "line-cap",
+    "line-join",
+    "opacity",
+    "closed",
+];
+
 fn line_strip_from_record_value(value: &LegacyValue) -> MResult<LineStripElement> {
     let record = host_record(value, "scene line-strip must be a record")?;
-    const FIELDS: &[&str] = &[
-        "id",
-        "positions",
-        "stroke",
-        "stroke-width",
-        "line-cap",
-        "line-join",
-        "opacity",
-        "closed",
-    ];
-    reject_unknown_fields(&record, FIELDS, "line-strip")?;
-    let id = required_string(&record, "id", "line-strip.id")?;
+    line_strip_from_record(&record)
+}
+
+fn line_strip_from_record(record: &MechRecord) -> MResult<LineStripElement> {
+    reject_unknown_fields(record, LINE_STRIP_FIELDS, "line-strip")?;
+    let id = required_string(record, "id", "line-strip.id")?;
     validate_id("line-strip", &id)?;
-    let positions = required_value(
-        &record,
-        "positions",
-        &format!("line-strip `{id}` positions"),
-    )?;
+    let positions = required_value(record, "positions", &format!("line-strip `{id}` positions"))?;
     let positions = matrix_f64_values(positions, &format!("line-strip `{id}` positions"))?;
     if positions.rows < 2 || positions.columns != 2 {
         return Err(scene_error(
@@ -600,30 +633,26 @@ fn line_strip_from_record_value(value: &LegacyValue) -> MResult<LineStripElement
         })
         .collect::<MResult<Vec<_>>>()?;
     let stroke_width = required_number(
-        &record,
+        record,
         "stroke-width",
         &format!("line-strip `{id}` stroke-width"),
     )?;
     validate_stroke_width(&id, stroke_width)?;
-    let opacity = required_number(&record, "opacity", &format!("line-strip `{id}` opacity"))?;
+    let opacity = required_number(record, "opacity", &format!("line-strip `{id}` opacity"))?;
     validate_opacity(&id, opacity)?;
-    let line_cap = required_string(&record, "line-cap", &format!("line-strip `{id}` line-cap"))?;
+    let line_cap = required_string(record, "line-cap", &format!("line-strip `{id}` line-cap"))?;
     validate_line_cap(&id, &line_cap)?;
-    let line_join = required_string(
-        &record,
-        "line-join",
-        &format!("line-strip `{id}` line-join"),
-    )?;
+    let line_join = required_string(record, "line-join", &format!("line-strip `{id}` line-join"))?;
     validate_line_join(&id, &line_join)?;
     Ok(LineStripElement {
         id,
         positions,
-        stroke: required_string(&record, "stroke", "line-strip.stroke")?,
+        stroke: required_string(record, "stroke", "line-strip.stroke")?,
         stroke_width,
         line_cap,
         line_join,
         opacity,
-        closed: required_bool(&record, "closed", "line-strip.closed")?,
+        closed: required_bool(record, "closed", "line-strip.closed")?,
     })
 }
 
@@ -674,55 +703,68 @@ fn record_element<T: FromRecord>(value: &LegacyValue) -> MResult<T> {
 }
 
 fn table_rows<T: FromRecord>(table: &MechTable) -> MResult<Vec<T>> {
-    for required in T::REQUIRED {
+    table_records(table, T::KIND, T::REQUIRED)?
+        .iter()
+        .enumerate()
+        .map(|(row, record)| {
+            T::from_record(record).map_err(|err| {
+                scene_error(
+                    "SceneSchema",
+                    format!("{} table row {}: {err:?}", T::KIND, row + 1),
+                )
+            })
+        })
+        .collect()
+}
+
+fn table_records(
+    table: &MechTable,
+    kind: &str,
+    required_fields: &[&str],
+) -> MResult<Vec<MechRecord>> {
+    for required in required_fields {
         if !table.col_names.values().any(|name| name == required) {
             return Err(scene_error(
                 "SceneSchema",
-                format!("{} table missing required column `{required}`", T::KIND),
+                format!("{kind} table missing required column `{required}`"),
             ));
         }
     }
     for (col_id, name) in &table.col_names {
-        if !T::REQUIRED.contains(&name.as_str()) {
+        if !required_fields.contains(&name.as_str()) {
             return Err(scene_error(
                 "SceneSchema",
-                format!("{} table unknown column `{name}`", T::KIND),
+                format!("{kind} table unknown column `{name}`"),
             ));
         }
         let Some((_, matrix)) = table.data.get(col_id) else {
             return Err(scene_error(
                 "SceneSchema",
-                format!("{} table column `{name}` has no data", T::KIND),
+                format!("{kind} table column `{name}` has no data"),
             ));
         };
         if matrix.rows() != table.rows {
             return Err(scene_error(
                 "SceneSchema",
                 format!(
-                    "{} table column `{name}` length mismatch: expected {}, got {}",
-                    T::KIND,
+                    "{kind} table column `{name}` length mismatch: expected {}, got {}",
                     table.rows,
                     matrix.rows()
                 ),
             ));
         }
     }
-    let mut out = Vec::with_capacity(table.rows);
+    let mut records = Vec::with_capacity(table.rows);
     for row in 1..=table.rows {
         let record = table.get_record(row).ok_or_else(|| {
             scene_error(
                 "SceneSchema",
-                format!("{} table row {row} could not be materialized", T::KIND),
+                format!("{kind} table row {row} could not be materialized"),
             )
         })?;
-        out.push(T::from_record(&record).map_err(|err| {
-            scene_error(
-                "SceneSchema",
-                format!("{} table row {row}: {err:?}", T::KIND),
-            )
-        })?);
+        records.push(record);
     }
-    Ok(out)
+    Ok(records)
 }
 
 fn record_value<'a>(record: &'a MechRecord, field: &str) -> Option<&'a LegacyValue> {

--- a/hosts/scene/src/schema.rs
+++ b/hosts/scene/src/schema.rs
@@ -795,11 +795,17 @@ fn required_paint(record: &MechRecord, field: &str, label: &str) -> MResult<Stri
     .map_err(|_| {
         scene_error(
             "SceneSchema",
-            format!("field `{label}` must be a paint string or f64 RGB color"),
+            format!("field `{label}` must be a paint string or numeric RGB color"),
         )
     })?;
     match resolved {
         LegacyValue::String(value) => Ok(value.borrow().clone()),
+        LegacyValue::U64(value) if *value.borrow() <= 0x00ff_ffff => {
+            Ok(format!("#{:06x}", *value.borrow()))
+        }
+        LegacyValue::I64(value) if (0..=0x00ff_ffff).contains(&*value.borrow()) => {
+            Ok(format!("#{:06x}", *value.borrow()))
+        }
         LegacyValue::F64(value)
             if value.borrow().is_finite()
                 && value.borrow().fract() == 0.0
@@ -807,9 +813,12 @@ fn required_paint(record: &MechRecord, field: &str, label: &str) -> MResult<Stri
         {
             Ok(format!("#{:06x}", *value.borrow() as u32))
         }
-        _ => Err(scene_error(
+        other => Err(scene_error(
             "SceneSchema",
-            format!("field `{label}` must be a paint string or 24-bit numeric RGB color"),
+            format!(
+                "field `{label}` must be a paint string or 24-bit numeric RGB color, got {:?}",
+                resolved_for_diagnostic(&other)
+            ),
         )),
     }
 }

--- a/hosts/scene/src/schema.rs
+++ b/hosts/scene/src/schema.rs
@@ -795,14 +795,11 @@ fn required_paint(record: &MechRecord, field: &str, label: &str) -> MResult<Stri
     .map_err(|_| {
         scene_error(
             "SceneSchema",
-            format!("field `{label}` must be a paint string or u32 RGB color"),
+            format!("field `{label}` must be a paint string or f64 RGB color"),
         )
     })?;
     match resolved {
         LegacyValue::String(value) => Ok(value.borrow().clone()),
-        LegacyValue::U32(value) if *value.borrow() <= 0x00ff_ffff => {
-            Ok(format!("#{:06x}", *value.borrow()))
-        }
         LegacyValue::F64(value)
             if value.borrow().is_finite()
                 && value.borrow().fract() == 0.0
@@ -812,7 +809,7 @@ fn required_paint(record: &MechRecord, field: &str, label: &str) -> MResult<Stri
         }
         _ => Err(scene_error(
             "SceneSchema",
-            format!("field `{label}` must be a paint string or 24-bit unsigned RGB color"),
+            format!("field `{label}` must be a paint string or 24-bit numeric RGB color"),
         )),
     }
 }
@@ -825,14 +822,11 @@ fn required_font_weight(record: &MechRecord, field: &str, label: &str) -> MResul
     .map_err(|_| {
         scene_error(
             "SceneSchema",
-            format!("field `{label}` must be a string, f64, or u32"),
+            format!("field `{label}` must be a string or f64"),
         )
     })?;
     match resolved {
         LegacyValue::String(value) => Ok(value.borrow().clone()),
-        LegacyValue::U32(value) if (1..=1000).contains(&*value.borrow()) => {
-            Ok(value.borrow().to_string())
-        }
         LegacyValue::F64(value)
             if value.borrow().is_finite()
                 && value.borrow().fract() == 0.0

--- a/hosts/scene/src/schema.rs
+++ b/hosts/scene/src/schema.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use mech_core::{LegacyValue, MResult, MechRecord, MechTable, hash_str};
+use mech_core::{LegacyValue, MResult, MechRecord, MechTable, ValueKind, hash_str};
 use mech_runtime::{
     host_arg_f64, host_arg_matrix_f64, host_arg_matrix_value_matrix, host_arg_optional,
     host_arg_record, host_arg_resolved, host_arg_string, host_arg_table, host_arg_tuple,
@@ -798,29 +798,28 @@ fn required_paint(record: &MechRecord, field: &str, label: &str) -> MResult<Stri
             format!("field `{label}` must be a paint string or numeric RGB color"),
         )
     })?;
-    match resolved {
-        LegacyValue::String(value) => Ok(value.borrow().clone()),
-        LegacyValue::U64(value) if *value.borrow() <= 0x00ff_ffff => {
-            Ok(format!("#{:06x}", *value.borrow()))
-        }
-        LegacyValue::I64(value) if (0..=0x00ff_ffff).contains(&*value.borrow()) => {
-            Ok(format!("#{:06x}", *value.borrow()))
-        }
-        LegacyValue::F64(value)
-            if value.borrow().is_finite()
-                && value.borrow().fract() == 0.0
-                && (0.0..=16_777_215.0).contains(&*value.borrow()) =>
-        {
-            Ok(format!("#{:06x}", *value.borrow() as u32))
-        }
-        other => Err(scene_error(
-            "SceneSchema",
-            format!(
-                "field `{label}` must be a paint string or 24-bit numeric RGB color, got {:?}",
-                resolved_for_diagnostic(&other)
-            ),
-        )),
+    if let LegacyValue::String(value) = resolved {
+        return Ok(value.borrow().clone());
     }
+    let numeric = if matches!(resolved, LegacyValue::Index(_)) {
+        None
+    } else {
+        resolved.convert_to(&ValueKind::F64)
+    };
+    if let Some(LegacyValue::F64(value)) = numeric
+        && value.borrow().is_finite()
+        && value.borrow().fract() == 0.0
+        && (0.0..=16_777_215.0).contains(&*value.borrow())
+    {
+        return Ok(format!("#{:06x}", *value.borrow() as u32));
+    }
+    Err(scene_error(
+        "SceneSchema",
+        format!(
+            "field `{label}` must be a paint string or 24-bit numeric RGB color, got {:?}",
+            resolved_for_diagnostic(&resolved)
+        ),
+    ))
 }
 fn required_font_weight(record: &MechRecord, field: &str, label: &str) -> MResult<String> {
     let resolved = host_arg_resolved(

--- a/hosts/scene/tests/provider.rs
+++ b/hosts/scene/tests/provider.rs
@@ -30,12 +30,6 @@ fn deliver_write(
 fn f(value: f64) -> LegacyValue {
     LegacyValue::F64(Ref::new(value))
 }
-fn u(value: u64) -> LegacyValue {
-    LegacyValue::U64(Ref::new(value))
-}
-fn i(value: i64) -> LegacyValue {
-    LegacyValue::I64(Ref::new(value))
-}
 fn ix(value: usize) -> LegacyValue {
     LegacyValue::Index(Ref::new(value))
 }
@@ -213,7 +207,7 @@ fn numeric_text_paint_and_weight_are_normalized_without_index_coercion() {
         ("id", s("title")),
         ("x", f(10.0)),
         ("y", f(20.0)),
-        ("fill", i(0xedf2f7)),
+        ("fill", f(0xedf2f7 as f64)),
         ("font-size", f(12.0)),
         ("font-family", s("sans-serif")),
         ("font-weight", f(620.0)),
@@ -224,7 +218,7 @@ fn numeric_text_paint_and_weight_are_normalized_without_index_coercion() {
     let scene = record(vec![
         ("width", f(100.0)),
         ("height", f(50.0)),
-        ("background", u(0x080b12)),
+        ("background", f(0x080b12 as f64)),
         ("texts", tuple(vec![numeric_text])),
     ]);
     let scene = SceneSnapshot::from_value(&scene).unwrap();

--- a/hosts/scene/tests/provider.rs
+++ b/hosts/scene/tests/provider.rs
@@ -30,6 +30,12 @@ fn deliver_write(
 fn f(value: f64) -> LegacyValue {
     LegacyValue::F64(Ref::new(value))
 }
+fn u(value: u64) -> LegacyValue {
+    LegacyValue::U64(Ref::new(value))
+}
+fn i(value: i64) -> LegacyValue {
+    LegacyValue::I64(Ref::new(value))
+}
 fn ix(value: usize) -> LegacyValue {
     LegacyValue::Index(Ref::new(value))
 }
@@ -207,7 +213,7 @@ fn numeric_text_paint_and_weight_are_normalized_without_index_coercion() {
         ("id", s("title")),
         ("x", f(10.0)),
         ("y", f(20.0)),
-        ("fill", f(0xedf2f7 as f64)),
+        ("fill", i(0xedf2f7)),
         ("font-size", f(12.0)),
         ("font-family", s("sans-serif")),
         ("font-weight", f(620.0)),
@@ -218,7 +224,7 @@ fn numeric_text_paint_and_weight_are_normalized_without_index_coercion() {
     let scene = record(vec![
         ("width", f(100.0)),
         ("height", f(50.0)),
-        ("background", f(0x080b12 as f64)),
+        ("background", u(0x080b12)),
         ("texts", tuple(vec![numeric_text])),
     ]);
     let scene = SceneSnapshot::from_value(&scene).unwrap();

--- a/hosts/scene/tests/provider.rs
+++ b/hosts/scene/tests/provider.rs
@@ -30,9 +30,6 @@ fn deliver_write(
 fn f(value: f64) -> LegacyValue {
     LegacyValue::F64(Ref::new(value))
 }
-fn u32_value(value: u32) -> LegacyValue {
-    LegacyValue::U32(Ref::new(value))
-}
 fn ix(value: usize) -> LegacyValue {
     LegacyValue::Index(Ref::new(value))
 }
@@ -221,7 +218,7 @@ fn numeric_text_paint_and_weight_are_normalized_without_index_coercion() {
     let scene = record(vec![
         ("width", f(100.0)),
         ("height", f(50.0)),
-        ("background", u32_value(0x080b12)),
+        ("background", f(0x080b12 as f64)),
         ("texts", tuple(vec![numeric_text])),
     ]);
     let scene = SceneSnapshot::from_value(&scene).unwrap();

--- a/hosts/scene/tests/provider.rs
+++ b/hosts/scene/tests/provider.rs
@@ -30,6 +30,12 @@ fn deliver_write(
 fn f(value: f64) -> LegacyValue {
     LegacyValue::F64(Ref::new(value))
 }
+fn u32_value(value: u32) -> LegacyValue {
+    LegacyValue::U32(Ref::new(value))
+}
+fn ix(value: usize) -> LegacyValue {
+    LegacyValue::Index(Ref::new(value))
+}
 fn s(value: &str) -> LegacyValue {
     LegacyValue::String(Ref::new(value.to_string()))
 }
@@ -196,6 +202,71 @@ fn valid_text_scene() {
     ]);
     let scene = SceneSnapshot::from_value(&scene).unwrap();
     assert_eq!(scene.texts[0].value, "Scene label");
+}
+
+#[test]
+fn numeric_text_paint_and_weight_are_normalized_without_index_coercion() {
+    let numeric_text = record(vec![
+        ("id", s("title")),
+        ("x", f(10.0)),
+        ("y", f(20.0)),
+        ("fill", f(0xedf2f7 as f64)),
+        ("font-size", f(12.0)),
+        ("font-family", s("sans-serif")),
+        ("font-weight", f(620.0)),
+        ("text-anchor", s("start")),
+        ("opacity", f(1.0)),
+        ("value", s("Scene label")),
+    ]);
+    let scene = record(vec![
+        ("width", f(100.0)),
+        ("height", f(50.0)),
+        ("background", u32_value(0x080b12)),
+        ("texts", tuple(vec![numeric_text])),
+    ]);
+    let scene = SceneSnapshot::from_value(&scene).unwrap();
+    assert_eq!(scene.background, "#080b12");
+    assert_eq!(scene.texts[0].fill, "#edf2f7");
+    assert_eq!(scene.texts[0].font_weight, "620");
+
+    for (field, value) in [("fill", ix(1)), ("font-weight", ix(500))] {
+        let invalid_text = record(vec![
+            ("id", s("title")),
+            ("x", f(10.0)),
+            ("y", f(20.0)),
+            (
+                "fill",
+                if field == "fill" {
+                    value.clone()
+                } else {
+                    f(0.0)
+                },
+            ),
+            ("font-size", f(12.0)),
+            ("font-family", s("sans-serif")),
+            (
+                "font-weight",
+                if field == "font-weight" {
+                    value
+                } else {
+                    f(500.0)
+                },
+            ),
+            ("text-anchor", s("start")),
+            ("opacity", f(1.0)),
+            ("value", s("Scene label")),
+        ]);
+        let invalid_scene = record(vec![
+            ("width", f(100.0)),
+            ("height", f(50.0)),
+            ("background", s("#000")),
+            ("texts", tuple(vec![invalid_text])),
+        ]);
+        assert!(
+            SceneSnapshot::from_value(&invalid_scene).is_err(),
+            "{field}"
+        );
+    }
 }
 
 #[test]

--- a/hosts/scene/tests/provider.rs
+++ b/hosts/scene/tests/provider.rs
@@ -199,6 +199,19 @@ fn valid_text_scene() {
 }
 
 #[test]
+fn valid_text_table() {
+    let scene = record(vec![
+        ("width", f(100.0)),
+        ("height", f(50.0)),
+        ("background", s("#000")),
+        ("texts", table(vec![text("title"), text("caption")])),
+    ]);
+    let scene = SceneSnapshot::from_value(&scene).unwrap();
+    assert_eq!(scene.texts.len(), 2);
+    assert_eq!(scene.texts[1].id, "caption");
+}
+
+#[test]
 fn point_set_expands_matrix_rows_into_stable_circles() {
     let scene = record(vec![
         ("width", f(100.0)),
@@ -212,6 +225,22 @@ fn point_set_expands_matrix_rows_into_stable_circles() {
     assert_eq!(scene.circles[0].radius, 6.0);
     assert_eq!(scene.circles[0].fill, "gold");
     assert_eq!((scene.circles[1].x, scene.circles[1].y), (20.0, 40.0));
+}
+
+#[test]
+fn point_set_table_expands_every_record() {
+    let scene = record(vec![
+        ("width", f(100.0)),
+        ("height", f(50.0)),
+        ("background", s("#000")),
+        (
+            "point-sets",
+            table(vec![point_set("body"), point_set("marker")]),
+        ),
+    ]);
+    let scene = SceneSnapshot::from_value(&scene).unwrap();
+    assert_eq!(scene.circles.len(), 4);
+    assert_eq!(scene.circles[2].id, "marker-0");
 }
 
 #[test]
@@ -230,6 +259,23 @@ fn line_strip_keeps_matrix_rows_as_one_closed_path() {
         vec![[10.0, 40.0], [20.0, 50.0], [30.0, 60.0]]
     );
     assert!(scene.line_strips[0].closed);
+}
+
+#[test]
+fn line_strip_table_keeps_each_matrix_as_one_path() {
+    let scene = record(vec![
+        ("width", f(100.0)),
+        ("height", f(50.0)),
+        ("background", s("#000")),
+        (
+            "line-strips",
+            table(vec![line_strip("orbit-a"), line_strip("orbit-b")]),
+        ),
+    ]);
+    let scene = SceneSnapshot::from_value(&scene).unwrap();
+    assert_eq!(scene.line_strips.len(), 2);
+    assert_eq!(scene.line_strips[1].id, "orbit-b");
+    assert_eq!(scene.line_strips[1].positions.len(), 3);
 }
 
 #[test]

--- a/include/blog.css
+++ b/include/blog.css
@@ -54,33 +54,6 @@ html[data-mech-shim="blog"] .hero-summary .mech-summary p {
   margin: 0;
 }
 
-/* Preserve the blog's cool, open long-form reading treatment. */
-html[data-mech-shim="blog"]
-  [data-mechdown]
-  :is(.mech-paragraph, .mechdown-paragraph):not(
-    [data-mech-source] *,
-    :where(
-      .mech-summary,
-      .mech-abstract,
-      .mech-block-quote,
-      .mech-info-block,
-      .mech-question-block,
-      .mech-success-block,
-      .mech-warning-block,
-      .mech-error-block,
-      .mech-idea-block,
-      .mech-figure-caption,
-      .mech-footnote,
-      .mech-citation,
-      .mechdown-table,
-      .mech-prompt
-    ) *
-  ) {
-  color: var(--mech-text-body);
-  font-size: 1.06rem;
-  line-height: 1.85;
-}
-
 html[data-mech-shim="blog"] .article-intro li p {
   margin: 0 0 5px;
 }

--- a/include/mech-source.css
+++ b/include/mech-source.css
@@ -487,6 +487,27 @@
     margin-top: 5px;
 }
 
+/* Long host capability sets are source blocks: the declaration owns the
+ * opening brace, each capability gets one indented row, and the closing brace
+ * returns to the declaration column. */
+:where([data-mech-source]).mech-statement-context-block,
+:where([data-mech-source]) .mech-statement-context-block,
+:where([data-mech-source]).mech-context-declaration-block,
+:where([data-mech-source]) .mech-context-declaration-block,
+:where([data-mech-source]).mech-context-capabilities-block,
+:where([data-mech-source]) .mech-context-capabilities-block,
+:where([data-mech-source]).mech-context-capability-row,
+:where([data-mech-source]) .mech-context-capability-row,
+:where([data-mech-source]).mech-context-declaration-block > .mech-context-capabilities-close,
+:where([data-mech-source]) .mech-context-declaration-block > .mech-context-capabilities-close {
+    display: block;
+}
+
+:where([data-mech-source]).mech-context-capabilities-block,
+:where([data-mech-source]) .mech-context-capabilities-block {
+    margin-left: 2ch;
+}
+
 :where([data-mech-source]).mech-fsm-specification-header,
 :where([data-mech-source]) .mech-fsm-specification-header {
     display: inline-flex;

--- a/include/mech-source.css
+++ b/include/mech-source.css
@@ -465,6 +465,28 @@
     display: flex;
 }
 
+/* Table definitions keep the binding on one line, then give the table the
+ * full code-block width from the source margin. */
+:where([data-mech-source]).mech-code:has(> .mech-statement-table-define),
+:where([data-mech-source]) .mech-code:has(> .mech-statement-table-define),
+:where([data-mech-source]).mech-statement-table-define,
+:where([data-mech-source]) .mech-statement-table-define,
+:where([data-mech-source]).mech-variable-define-table,
+:where([data-mech-source]) .mech-variable-define-table,
+:where([data-mech-source]).mech-variable-define-table > .mech-expression,
+:where([data-mech-source]) .mech-variable-define-table > .mech-expression,
+:where([data-mech-source]).mech-variable-define-table > .mech-expression > .mech-structure,
+:where([data-mech-source]) .mech-variable-define-table > .mech-expression > .mech-structure {
+    display: block;
+}
+
+:where([data-mech-source]).mech-variable-define-table .mech-table,
+:where([data-mech-source]) .mech-variable-define-table .mech-table {
+    margin-left: 0;
+    margin-right: auto;
+    margin-top: 5px;
+}
+
 :where([data-mech-source]).mech-fsm-specification-header,
 :where([data-mech-source]) .mech-fsm-specification-header {
     display: inline-flex;

--- a/include/mechdown.css
+++ b/include/mechdown.css
@@ -40,6 +40,10 @@
   --mechdown-shadow: var(--mech-shadow-content-block, 5px 5px 5px rgb(0 0 0 / 70%));
   --mechdown-inline-shadow: var(--mech-shadow-inline-code, 0 0 2px rgb(0 0 0 / 70%));
   --mechdown-table-shadow: var(--mech-shadow-table, 0 1px 4px rgb(0 0 0 / 50%));
+  /* Normalize legacy formatter roles to the live blog presentation. Source
+   * blocks redefine both roles inside data-mech-source. */
+  --text-color-light: var(--mechdown-text);
+  --contrast-color-low: var(--mech-brand-deep, hsl(42 89% 60%));
   color: var(--mechdown-text);
   counter-reset: mechdown-section;
   line-height: 1.7;
@@ -236,6 +240,7 @@
   text-decoration: none;
 }
 
+[data-mechdown] :is(h2, h3, h4, h5, h6):is(:hover, :focus-within),
 [data-mechdown] :is(h2, h3, h4, h5, h6) a:is(:hover, :focus-visible) {
   color: var(--mech-brand-deep, hsl(42 89% 60%));
   outline: none;
@@ -249,6 +254,32 @@
 
 [data-mechdown] .mech-program-subtitle:is(:hover, :focus-within) > a {
   color: var(--mech-brand-deep, hsl(42 89% 60%));
+}
+
+[data-mechdown]
+  :is(.mech-paragraph, .mechdown-paragraph):not(
+    [data-mech-source] *,
+    :where(
+      .mech-summary,
+      .mech-abstract,
+      .mech-block-quote,
+      .mech-info-block,
+      .mech-question-block,
+      .mech-success-block,
+      .mech-warning-block,
+      .mech-error-block,
+      .mech-idea-block,
+      .mech-figure-caption,
+      .mech-footnote,
+      .mech-citation,
+      .mechdown-table,
+      .mech-prompt
+    ) *
+  ) {
+  color: var(--mech-text-body, var(--body-primary, hsl(206 24% 90%)));
+  font-size: 1.06rem;
+  font-weight: 400;
+  line-height: 1.85;
 }
 
 [data-mechdown] .mechdown-paragraph:not([data-mech-source] *),

--- a/include/mechdown.css
+++ b/include/mechdown.css
@@ -7,7 +7,7 @@
  */
 
 [data-mechdown] {
-  --mechdown-text: var(--mech-text-reading, var(--body-primary, hsl(40 100% 95%)));
+  --mechdown-text: var(--mech-text-body, var(--body-primary, hsl(206 24% 90%)));
   --mechdown-heading: var(--mech-text-primary, var(--text-primary, #f3f3e6));
   --mechdown-subheading: var(--mech-text-subheading, var(--text-subheading, rgb(242, 234, 217)));
   --mechdown-text-secondary: var(--mech-text-secondary, var(--text-secondary, #bebcaa));
@@ -247,8 +247,8 @@
   text-decoration: none;
 }
 
-[data-mechdown] .mech-program-subtitle:hover > a {
-  color: var(--mech-syntax-tuple-structure, #ab7ab8);
+[data-mechdown] .mech-program-subtitle:is(:hover, :focus-within) > a {
+  color: var(--mech-brand-deep, hsl(42 89% 60%));
 }
 
 [data-mechdown] .mechdown-paragraph:not([data-mech-source] *),

--- a/include/palette-lookbook.css
+++ b/include/palette-lookbook.css
@@ -15,7 +15,7 @@ html {
 body {
   min-width: 320px;
   margin: 0;
-  color: var(--mech-text-reading);
+  color: var(--mech-text-body);
   background: var(--mech-canvas);
   font-family: Lato, "Helvetica Neue", Arial, sans-serif;
   font-size: 16px;
@@ -223,7 +223,7 @@ pre,
 .hero-deck {
   max-width: 720px;
   margin: 27px auto 0;
-  color: var(--mech-text-reading);
+  color: var(--mech-text-body);
   font-size: 16px;
   line-height: 25px;
 }
@@ -394,7 +394,7 @@ pre,
 .section-heading p {
   max-width: 720px;
   margin: 0;
-  color: var(--mech-text-reading);
+  color: var(--mech-text-body);
   font-size: 16px;
   line-height: 25px;
 }
@@ -539,7 +539,7 @@ pre,
 }
 
 .decision span {
-  color: var(--mech-text-reading);
+  color: var(--mech-text-body);
   font-size: 14px;
 }
 
@@ -697,7 +697,7 @@ pre,
 .type-specimen p {
   max-width: 720px;
   margin: 0;
-  color: var(--mech-text-reading);
+  color: var(--mech-text-body);
   line-height: 25px;
 }
 
@@ -757,7 +757,7 @@ pre,
 
 .prose-link-demo {
   margin: 0;
-  color: var(--mech-text-reading);
+  color: var(--mech-text-body);
 }
 
 .text-link,
@@ -925,7 +925,7 @@ pre,
 
 .inline-code-demo {
   margin: 22px 0 0;
-  color: var(--mech-text-reading);
+  color: var(--mech-text-body);
 }
 
 .inline-code-demo code {
@@ -949,7 +949,7 @@ pre,
 .specimen-list {
   margin: 0;
   padding: 0;
-  color: var(--mech-text-reading);
+  color: var(--mech-text-body);
   list-style: none;
 }
 
@@ -1149,7 +1149,7 @@ pre,
 
 .runtime-error p {
   margin: 14px 0;
-  color: var(--mech-text-reading);
+  color: var(--mech-text-body);
   font-size: 13px;
 }
 
@@ -1217,7 +1217,7 @@ pre,
 }
 
 .data-table td {
-  color: var(--mech-text-reading);
+  color: var(--mech-text-body);
   font-size: 13px;
 }
 

--- a/include/palette.css
+++ b/include/palette.css
@@ -31,11 +31,11 @@
   --mech-control-surface: #171d21;
   --mech-control-border: #777;
 
-  /* Text: prose, shell chrome, code, and captions are separate blog roles. */
-  --mech-text-reading: hsl(40 100% 95%);
+  /* Text: body prose, shell chrome, code, and captions are separate blog roles. */
+  --mech-text-reading: hsl(40 100% 95%); /* warm emphasis and selection text */
   --mech-text-primary: #f3f3e6;
   --mech-text-subheading: rgb(242, 234, 217);
-  --mech-text-body: hsl(206 24% 90%);
+  --mech-text-body: hsl(206 24% 90%); /* paragraphs and long-form copy */
   --mech-text-code: hsl(41 49% 90%);
   --mech-text-code-dark: hsl(41 49% 25%);
   --mech-text-secondary: #bebcaa;

--- a/include/palette.html
+++ b/include/palette.html
@@ -105,10 +105,10 @@
 
         <h3 class="subheading">Text</h3>
         <div class="swatch-grid">
-          <button class="swatch" type="button" data-copy="hsl(40 100% 95%)" aria-label="Copy reading text color"><span class="swatch-color" style="--swatch: var(--mech-text-reading)"></span><span class="swatch-meta"><span class="swatch-name">Reading text</span><span class="swatch-use">Warm long-form prose</span><span class="swatch-value">hsl(40 100% 95%)</span></span></button>
+          <button class="swatch" type="button" data-copy="hsl(40 100% 95%)" aria-label="Copy warm emphasis text color"><span class="swatch-color" style="--swatch: var(--mech-text-reading)"></span><span class="swatch-meta"><span class="swatch-name">Warm emphasis</span><span class="swatch-use">Selection text and editorial highlights</span><span class="swatch-value">hsl(40 100% 95%)</span></span></button>
           <button class="swatch" type="button" data-copy="#f3f3e6" aria-label="Copy heading text color"><span class="swatch-color" style="--swatch: var(--mech-text-primary)"></span><span class="swatch-meta"><span class="swatch-name">Heading text</span><span class="swatch-use">Titles and strong labels</span><span class="swatch-value">#f3f3e6</span></span></button>
           <button class="swatch" type="button" data-copy="rgb(242, 234, 217)" aria-label="Copy subheading text color"><span class="swatch-color" style="--swatch: var(--mech-text-subheading)"></span><span class="swatch-meta"><span class="swatch-name">Subheading text</span><span class="swatch-use">Section and subsection headings</span><span class="swatch-value">rgb(242, 234, 217)</span></span></button>
-          <button class="swatch" type="button" data-copy="hsl(206 24% 90%)" aria-label="Copy shell body text color"><span class="swatch-color" style="--swatch: var(--mech-text-body)"></span><span class="swatch-meta"><span class="swatch-name">Shell body text</span><span class="swatch-use">Cool open-page copy</span><span class="swatch-value">hsl(206 24% 90%)</span></span></button>
+          <button class="swatch" type="button" data-copy="hsl(206 24% 90%)" aria-label="Copy body text color"><span class="swatch-color" style="--swatch: var(--mech-text-body)"></span><span class="swatch-meta"><span class="swatch-name">Body text</span><span class="swatch-use">Paragraphs and long-form copy</span><span class="swatch-value">hsl(206 24% 90%)</span></span></button>
           <button class="swatch" type="button" data-copy="hsl(41 49% 90%)" aria-label="Copy code text color"><span class="swatch-color" style="--swatch: var(--mech-text-code)"></span><span class="swatch-meta"><span class="swatch-name">Code text</span><span class="swatch-use">Unclassified source and output</span><span class="swatch-value">hsl(41 49% 90%)</span></span></button>
           <button class="swatch" type="button" data-copy="#e6edf3" aria-label="Copy console text color"><span class="swatch-color" style="--swatch: var(--mech-console-text)"></span><span class="swatch-meta"><span class="swatch-name">Console text</span><span class="swatch-use">Cool REPL and runtime chrome</span><span class="swatch-value">#e6edf3</span></span></button>
           <button class="swatch" type="button" data-copy="#bebcaa" aria-label="Copy secondary text color"><span class="swatch-color" style="--swatch: var(--mech-text-secondary)"></span><span class="swatch-meta"><span class="swatch-name">Secondary text</span><span class="swatch-use">Supporting descriptions</span><span class="swatch-value">#bebcaa</span></span></button>
@@ -266,13 +266,13 @@
           <div class="type-specimen">
             <p class="display-type">Build the <span>machine.</span></p>
             <h3>Reactive programs, readable systems.</h3>
-            <p>Primary prose uses a calm warm gray. <mark>Highlights carry Mika gold</mark> while inline emphasis stays brighter than surrounding copy without becoming pure white.</p>
+            <p>Primary prose uses the blog's calm cool gray. <mark>Highlights carry Mika gold</mark> while inline emphasis stays warmer than surrounding copy without becoming pure white.</p>
           </div>
           <div class="text-ramp" aria-label="Text color ramp">
-            <div class="text-row" style="--sample:var(--mech-text-reading)"><code>Reading</code><span>Paragraphs and long-form copy</span></div>
+            <div class="text-row" style="--sample:var(--mech-text-reading)"><code>Emphasis</code><span>Warm selection text and editorial highlights</span></div>
             <div class="text-row" style="--sample:var(--mech-text-primary)"><code>Heading</code><span>Titles and strong labels</span></div>
             <div class="text-row" style="--sample:var(--mech-text-subheading)"><code>Subheading</code><span>Section and subsection headings</span></div>
-            <div class="text-row" style="--sample:var(--mech-text-body)"><code>Shell</code><span>Cool open-page copy</span></div>
+            <div class="text-row" style="--sample:var(--mech-text-body)"><code>Body</code><span>Paragraphs and long-form copy</span></div>
             <div class="text-row" style="--sample:var(--mech-text-code)"><code>Code</code><span>Unclassified source and output</span></div>
             <div class="text-row" style="--sample:var(--mech-text-secondary)"><code>Secondary</code><span>Supporting prose</span></div>
             <div class="text-row" style="--sample:var(--mech-text-muted)"><code>Muted</code><span>Metadata and labels</span></div>

--- a/include/style.css
+++ b/include/style.css
@@ -474,7 +474,7 @@ a { color: inherit; text-decoration: none; }
   align-items: center;
   align-self: flex-start;
   background: var(--bg-secondary);
-  border: 1px solid var(--toc-border);
+  border: 1px solid var(--toc-accent);
   border-radius: 999px;
   color: var(--toc-accent);
   cursor: pointer;
@@ -499,7 +499,7 @@ a { color: inherit; text-decoration: none; }
 
 .mech-toc-toggle:hover,
 .mech-toc-toggle:focus-visible {
-  border-color: var(--toc-accent);
+  border-color: var(--toc-border);
   color: var(--toc-accent);
   outline: none;
 }

--- a/machines/math/src/rounding/floor.rs
+++ b/machines/math/src/rounding/floor.rs
@@ -6,7 +6,11 @@ use num_traits::*;
 
 // Floor ------------------------------------------------------------------------
 
-use libm::{floor, floorf};
+#[cfg(feature = "f64")]
+use libm::floor;
+#[cfg(feature = "f32")]
+use libm::floorf;
+#[cfg(feature = "f64")]
 macro_rules! floor_op {
     ($arg:expr, $out:expr) => {
         unsafe {
@@ -15,6 +19,7 @@ macro_rules! floor_op {
     };
 }
 
+#[cfg(feature = "f64")]
 macro_rules! floor_vec_op {
     ($arg:expr, $out:expr) => {
         unsafe {
@@ -25,6 +30,7 @@ macro_rules! floor_vec_op {
     };
 }
 
+#[cfg(feature = "f32")]
 macro_rules! floorf_op {
     ($arg:expr, $out:expr) => {
         unsafe {
@@ -33,6 +39,7 @@ macro_rules! floorf_op {
     };
 }
 
+#[cfg(feature = "f32")]
 macro_rules! floorf_vec_op {
     ($arg:expr, $out:expr) => {
         unsafe {

--- a/scripts/smoke-served-resident-ekf-browser.sh
+++ b/scripts/smoke-served-resident-ekf-browser.sh
@@ -218,7 +218,7 @@ harness = r'''<script>
       return values.length === 15 && values.every(Number.isFinite) ? values : undefined;
     };
     const renderedFilterVisibility = () => {
-      const values = renderedDocumentNumbers("filter-camera-visibility");
+      const values = renderedDocumentNumbers("active-camera-visibility");
       return values.length === 1 && Number.isFinite(values[0]) ? values[0] : undefined;
     };
     const renderedFilterTurn = () => {
@@ -670,13 +670,11 @@ harness = r'''<script>
             rangeOpacity === 0 && rayOpacity === 0 && labelOpacity === 0.32;
           cameraToggleDisabled = cameraToggleVisualStateValid;
         }
-        const pointerPressed = renderedDocumentNumbers("scene-pointer-pressed");
         const pointerPulse = renderedDocumentNumbers("scene-pointer-pulse");
         if (
           cameraToggleDisableReleased && !cameraToggleDisableRetained &&
           cameraToggleStateReadable && enabledMask[0] === 0 &&
           enabledMask.slice(1).every(value => value === 1) &&
-          pointerPressed.length === 1 && pointerPressed[0] === 0 &&
           pointerPulse.length === 1 && pointerPulse[0] === 1 &&
           logicalComputeTurn > cameraToggleDispatchAfterDisableRelease
         ) {
@@ -704,7 +702,6 @@ harness = r'''<script>
         if (
           cameraToggleEnableReleased && cameraToggleStateReadable &&
           enabledMask.every(value => value === 1) &&
-          pointerPressed.length === 1 && pointerPressed[0] === 0 &&
           pointerPulse.length === 1 && pointerPulse[0] === 2 &&
           logicalComputeTurn > cameraToggleDispatchAfterEnableRelease &&
           Number.isFinite(filterVisibility) && filterVisibility > 0

--- a/scripts/smoke-served-resident-ekf-browser.sh
+++ b/scripts/smoke-served-resident-ekf-browser.sh
@@ -218,7 +218,7 @@ harness = r'''<script>
       return values.length === 15 && values.every(Number.isFinite) ? values : undefined;
     };
     const renderedFilterVisibility = () => {
-      const values = renderedDocumentNumbers("active-camera-visibility");
+      const values = renderedDocumentNumbers("filter-camera-visibility");
       return values.length === 1 && Number.isFinite(values[0]) ? values[0] : undefined;
     };
     const renderedFilterTurn = () => {

--- a/scripts/smoke-served-resident-nbody-browser.sh
+++ b/scripts/smoke-served-resident-nbody-browser.sh
@@ -105,7 +105,10 @@ harness = r'''<script>
     let maximumSunOffset = 0;
     let sunEverOffCenter = false;
     let minimumMercuryOffset = Number.POSITIVE_INFINITY;
-    const deadline = Date.now() + 20000;
+    // Table-backed scene collections rebuild more structured data per frame.
+    // Preserve the 600-turn physics proof while allowing slower CI runners to
+    // complete it instead of weakening the number of observed simulation steps.
+    const deadline = Date.now() + 30000;
     window.requestAnimationFrame = (callback) => originalSetTimeout(() => {
       if (root.dataset.mechDone === "true" || root.dataset.mechTimedOut === "true") return;
       callback(performance.now());

--- a/src/core/src/function/resident.rs
+++ b/src/core/src/function/resident.rs
@@ -37,12 +37,14 @@ impl ResidentShape {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ResidentPortLayout {
     pub schema_id: SchemaId,
     pub schema_key: SchemaKey,
     pub kind: ResidentValueKind,
     pub shape: ResidentShape,
+    /// Fully resolved semantic shape for self-describing dynamic values.
+    pub shape_instance: ShapeInstance,
 }
 
 pub struct ResidentKernelBindRequest<'a> {

--- a/src/core/src/legacy_adapter/kind.rs
+++ b/src/core/src/legacy_adapter/kind.rs
@@ -251,7 +251,8 @@ fn schema_body_from_legacy(
         ValueKind::Bool => SchemaBody::Bool,
         ValueKind::Id => SchemaBody::Id,
         ValueKind::Index => SchemaBody::Index,
-        ValueKind::Empty | ValueKind::Any | ValueKind::None | ValueKind::Reference(_) => {
+        ValueKind::Any => SchemaBody::Dynamic,
+        ValueKind::Empty | ValueKind::None | ValueKind::Reference(_) => {
             return Err(SemanticModelError::NonInstantiableLegacyValueKind {
                 kind: legacy_value_kind_tag(kind),
             });

--- a/src/core/src/legacy_adapter/value.rs
+++ b/src/core/src/legacy_adapter/value.rs
@@ -112,6 +112,10 @@ pub enum LegacySnapshotError {
     LegacyTypedSchemaMismatch,
     LegacyIndexOutOfRange,
     LegacyDimensionOutOfRange,
+    DynamicSchemaUnavailable {
+        key: SchemaKey,
+        kind: ValueKind,
+    },
     LegacyRationalOutOfRange,
     LegacyRepresentationUnavailable {
         representation: LegacyRepresentation,
@@ -325,6 +329,8 @@ fn is_matrix_element_schema_mismatch(error: &SnapshotValueError) -> bool {
         path
     } else if let SnapshotValueError::MapEntryArityMismatchV1 { path, .. } = error {
         path
+    } else if let SnapshotValueError::InvalidIndexV1 { path, .. } = error {
+        path
     } else {
         return false;
     };
@@ -398,6 +404,9 @@ fn empty_draft(
     target: &SchemaBody,
     shape_values: &[u64],
 ) -> Result<ValueDataDraft, LegacySnapshotError> {
+    if matches!(target, SchemaBody::Dynamic) {
+        return Ok(ValueDataDraft::Dynamic(None));
+    }
     if matches!(target, SchemaBody::Option(_)) {
         return Ok(ValueDataDraft::Option(OptionDraft {
             present: false,
@@ -453,6 +462,38 @@ fn draft_from_legacy_body(
     validation: &SnapshotValidationContext<'_>,
     context: &mut LegacySnapshotContext<'_>,
 ) -> Result<ValueDataDraft, LegacySnapshotError> {
+    if matches!(target.body, SchemaBody::Dynamic) {
+        if matches!(value, LegacyValue::EmptyKind(ValueKind::Any)) {
+            return Ok(ValueDataDraft::Dynamic(None));
+        }
+        let concrete_kind = value.kind();
+        let concrete_schema = schema_from_legacy_value_kind(&concrete_kind, context.semantic)?;
+        let concrete_key = concrete_schema.key();
+        let concrete_id =
+            validation
+                .schemas()
+                .find_by_key(concrete_key)
+                .ok_or(DynamicSchemaUnavailable {
+                    key: concrete_key,
+                    kind: concrete_kind,
+                })?;
+        let concrete = validation
+            .schemas()
+            .get(concrete_id)
+            .expect("resolved dynamic schema remains present");
+        let data = draft_from_legacy_body(
+            value,
+            LegacyTarget::root(concrete),
+            &[],
+            validation,
+            context,
+        )?;
+        return Ok(ValueDataDraft::Dynamic(Some(Box::new(ValueDraft {
+            schema: concrete_id,
+            shape_values: Box::new([]),
+            data,
+        }))));
+    }
     if let LegacyValue::Typed(inner, legacy_kind) = value {
         let typed_schema = schema_from_legacy_value_kind(legacy_kind, context.semantic)?;
         if typed_schema.key() != target.semantic_key()? {
@@ -1112,6 +1153,13 @@ fn legacy_from_data(
     schemas: &SchemaTable,
     context: &mut dyn LegacyMaterializationContext,
 ) -> Result<LegacyValue, LegacySnapshotError> {
+    if matches!(schema, SchemaBody::Dynamic) {
+        let ValueData::Dynamic(value) = data else {
+            unreachable!("validated dynamic snapshot changed representation")
+        };
+        let value = value.value().ok_or(UnsupportedLegacyMaterialization)?;
+        return legacy_from_snapshot(value, schemas, context);
+    }
     macro_rules! scalar_ref {
         ($feature:literal, $schema:pat, $data:pat => $value:expr, $variant:ident, $repr:ident) => {
             if matches!(schema, $schema) {
@@ -1491,7 +1539,8 @@ fn legacy_from_data(
             // them or retain a second legacy-shaped representation.
             return Err(UnsupportedLegacyMaterialization);
         }
-        (SchemaBody::Bool, _)
+        (SchemaBody::Dynamic, _)
+        | (SchemaBody::Bool, _)
         | (SchemaBody::UnsignedInteger(_), _)
         | (SchemaBody::SignedInteger(_), _)
         | (SchemaBody::FloatingPoint(_), _)
@@ -1651,6 +1700,7 @@ fn value_kind_from_schema(
     context: &mut dyn LegacyMaterializationContext,
 ) -> Result<ValueKind, LegacySnapshotError> {
     Ok(match schema {
+        SchemaBody::Dynamic => ValueKind::Any,
         SchemaBody::Bool => ValueKind::Bool,
         SchemaBody::UnsignedInteger(IntegerWidth::W8) => ValueKind::U8,
         SchemaBody::UnsignedInteger(IntegerWidth::W16) => ValueKind::U16,

--- a/src/core/src/program/bytecode/aggregates.rs
+++ b/src/core/src/program/bytecode/aggregates.rs
@@ -162,7 +162,7 @@ pub fn validate_bytecode_composite_children(
     for (index, (expected, actual)) in expected.iter().zip(children).enumerate() {
         let expected_kind = compiled_child_kind(expected);
         let actual_kind = actual.kind();
-        if actual_kind != expected_kind {
+        if !matches!(expected_kind, ValueKind::Any) && actual_kind != expected_kind {
             return Err(wrong_child_kind(index, &expected_kind, &actual_kind));
         }
     }

--- a/src/core/src/program/bytecode/tests.rs
+++ b/src/core/src/program/bytecode/tests.rs
@@ -3570,7 +3570,7 @@ mod compiler_tests {
         assert_eq!(
             table_constant.runtime_type,
             RuntimeType::Table {
-                columns: vec![(name.to_owned(), matrix_type)],
+                columns: vec![(name.to_owned(), matrix_type.clone())],
                 primary_key: 0,
             }
         );
@@ -3580,6 +3580,33 @@ mod compiler_tests {
         let table = decoded_table.borrow();
         let (_, Matrix::DVector(cells)) = table.data.values().next().unwrap() else {
             panic!("decoded table column did not preserve dynamic cell storage");
+        };
+        assert_fixed(&cells.borrow()[0]);
+
+        let referenced = LegacyValue::MutableReference(Ref::new(fixed.clone()));
+        let mut data = IndexMap::new();
+        data.insert(
+            id,
+            (
+                fixed.kind(),
+                Matrix::DVector(Ref::new(DVector::from_vec(vec![referenced]))),
+            ),
+        );
+        let table = crate::MechTable::new(1, 1, data, HashMap::from([(id, name.to_owned())]));
+        let template = encode(&LegacyValue::Table(Ref::new(table)));
+        assert_eq!(
+            template.runtime_type,
+            RuntimeType::Table {
+                columns: vec![(name.to_owned(), matrix_type)],
+                primary_key: 0,
+            }
+        );
+        let LegacyValue::Table(decoded_table) = decode_one(&template) else {
+            panic!("referenced matrix table template did not decode as a table");
+        };
+        let decoded_table = decoded_table.borrow();
+        let (_, Matrix::DVector(cells)) = decoded_table.data.values().next().unwrap() else {
+            panic!("referenced matrix table template changed column storage");
         };
         assert_fixed(&cells.borrow()[0]);
     }
@@ -4071,6 +4098,37 @@ mod compiler_tests {
             one_column_types
                 .windows(2)
                 .all(|types| types[0] == types[1])
+        );
+    }
+
+    #[cfg(all(
+        feature = "matrix1",
+        feature = "table",
+        feature = "vectord",
+        feature = "u8"
+    ))]
+    #[test]
+    fn table_constant_accepts_fixed_single_cell_column_storage() {
+        let name = "value";
+        let id = hash_str(name);
+        let cell = LegacyValue::U8(Ref::new(7));
+        let mut data = IndexMap::new();
+        data.insert(
+            id,
+            (
+                ValueKind::U8,
+                Matrix::Matrix1(Ref::new(nalgebra::Matrix1::new(cell))),
+            ),
+        );
+        let table = crate::MechTable::new(1, 1, data, HashMap::from([(id, name.to_owned())]));
+
+        let encoded = encode(&LegacyValue::Table(Ref::new(table)));
+        let LegacyValue::Table(decoded) = decode_one(&encoded) else {
+            panic!("single-row table did not decode as a table");
+        };
+        assert_eq!(
+            decoded.borrow().get_record(1).unwrap().get(&id),
+            Some(&LegacyValue::U8(Ref::new(7)))
         );
     }
 }

--- a/src/core/src/program/compiler/constants.rs
+++ b/src/core/src/program/compiler/constants.rs
@@ -1102,14 +1102,8 @@ fn encode_table_constant(
                 "table column name does not match its stable ID",
             ));
         }
-        let Matrix::DVector(values) = column else {
-            return Err(unsupported_constant(
-                RuntimeType::Any,
-                value.kind(),
-                "table columns must use dynamic value vectors",
-            ));
-        };
-        if values.borrow().len() != value.rows {
+        let values = column.as_vec();
+        if values.len() != value.rows {
             return Err(unsupported_constant(
                 RuntimeType::Any,
                 value.kind(),
@@ -1121,8 +1115,18 @@ fn encode_table_constant(
         annotated_cells
             .try_reserve_exact(value.rows)
             .map_err(|_| invalid::<()>("unable to allocate table constant cells").unwrap_err())?;
-        for cell in values.borrow().iter() {
-            annotated_cells.push(encode_annotated_child(cell, &declared_type, context)?);
+        for cell in &values {
+            // CompositePack compiles a table's live cells separately. Its
+            // constant table is only the reconstruction template, so a direct
+            // producer reference must contribute its current payload here
+            // without changing the declared column schema to Reference<T>.
+            let encoded = match cell {
+                LegacyValue::MutableReference(reference) => {
+                    encode_annotated_child(&reference.borrow(), &declared_type, context)?
+                }
+                _ => encode_annotated_child(cell, &declared_type, context)?,
+            };
+            annotated_cells.push(encoded);
         }
         let column_kind = ValueKind::Table(vec![(name.clone(), kind.clone())], value.rows);
         let (column_type, encoded_cells) = finalize_annotated_children(

--- a/src/core/src/program/compiler/constants.rs
+++ b/src/core/src/program/compiler/constants.rs
@@ -1111,6 +1111,20 @@ fn encode_table_constant(
             ));
         }
         let declared_type = runtime_type_from_value_kind(kind)?;
+        if matches!(declared_type, RuntimeType::Any) {
+            // Wildcard columns are reconstructed exclusively from their live
+            // CompositePack children. Keep only zero-sized dynamic
+            // placeholders in the constant template; encoding one concrete
+            // cell type here would incorrectly force every row to share that
+            // schema and matrix shape.
+            columns.push((name.clone(), RuntimeType::Any));
+            column_values.push(
+                (0..value.rows)
+                    .map(|_| encoded_constant(RuntimeType::Any, 1, Vec::new()))
+                    .collect(),
+            );
+            continue;
+        }
         let mut annotated_cells = Vec::new();
         annotated_cells
             .try_reserve_exact(value.rows)

--- a/src/core/src/schema/encoding.rs
+++ b/src/core/src/schema/encoding.rs
@@ -90,6 +90,7 @@ impl Schema {
 fn encode_schema_body(body: &SchemaBody) -> Box<[u8]> {
     let mut writer = CanonicalWriter::new();
     match body {
+        SchemaBody::Dynamic => writer.write_u8(0x14),
         SchemaBody::Bool => writer.write_u8(0x01),
         SchemaBody::UnsignedInteger(width) => {
             writer.write_u8(0x02);

--- a/src/core/src/schema/mod.rs
+++ b/src/core/src/schema/mod.rs
@@ -41,6 +41,10 @@ impl SchemaDraft {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SchemaBody {
+    /// A self-describing value whose concrete schema and shape are carried by
+    /// the value itself. This is the instantiable semantic form of a legacy
+    /// wildcard (`*`) inside heterogeneous aggregates such as table columns.
+    Dynamic,
     Bool,
     UnsignedInteger(IntegerWidth),
     SignedInteger(IntegerWidth),

--- a/src/core/src/schema/shape.rs
+++ b/src/core/src/schema/shape.rs
@@ -181,6 +181,7 @@ fn evaluate_body_extents(body: &SchemaBody, values: &[u64]) -> Result<(), Semant
             evaluate_dimension(cardinality, values)?;
         }
         SchemaBody::Bool
+        | SchemaBody::Dynamic
         | SchemaBody::UnsignedInteger(_)
         | SchemaBody::SignedInteger(_)
         | SchemaBody::FloatingPoint(_)

--- a/src/core/src/schema/validation.rs
+++ b/src/core/src/schema/validation.rs
@@ -76,7 +76,8 @@ fn validate_names_and_keyability(body: &SchemaBody) -> Result<(), SemanticModelE
             }
             validate_names_and_keyability(value)?;
         }
-        SchemaBody::Bool
+        SchemaBody::Dynamic
+        | SchemaBody::Bool
         | SchemaBody::UnsignedInteger(_)
         | SchemaBody::SignedInteger(_)
         | SchemaBody::FloatingPoint(_)
@@ -124,7 +125,8 @@ pub(super) fn is_body_keyable(body: &SchemaBody) -> bool {
         SchemaBody::Option(element) => is_body_keyable(element),
         SchemaBody::Tuple(elements) => elements.iter().all(is_body_keyable),
         SchemaBody::Record(fields) => fields.iter().all(|field| is_body_keyable(&field.schema)),
-        SchemaBody::Complex(_)
+        SchemaBody::Dynamic
+        | SchemaBody::Complex(_)
         | SchemaBody::Matrix { .. }
         | SchemaBody::Table { .. }
         | SchemaBody::Set { .. }
@@ -181,7 +183,8 @@ pub(super) fn collect_body_dimension_references(
             collect_body_dimension_references(value, references);
             collect_dimension_references(cardinality, references);
         }
-        SchemaBody::Bool
+        SchemaBody::Dynamic
+        | SchemaBody::Bool
         | SchemaBody::UnsignedInteger(_)
         | SchemaBody::SignedInteger(_)
         | SchemaBody::FloatingPoint(_)
@@ -209,6 +212,7 @@ fn rewrite_body_dimensions(
     old_to_new: &[Option<DimensionParameterId>],
 ) -> Result<SchemaBody, SemanticModelError> {
     Ok(match body {
+        SchemaBody::Dynamic => SchemaBody::Dynamic,
         SchemaBody::Bool => SchemaBody::Bool,
         SchemaBody::UnsignedInteger(width) => SchemaBody::UnsignedInteger(*width),
         SchemaBody::SignedInteger(width) => SchemaBody::SignedInteger(*width),

--- a/src/core/src/snapshot/data.rs
+++ b/src/core/src/snapshot/data.rs
@@ -149,6 +149,7 @@ const fn gcd(mut left: u64, mut right: u64) -> u64 {
 
 #[derive(Clone, Debug)]
 pub enum ValueData {
+    Dynamic(DynamicValue),
     U8(u8),
     U16(u16),
     U32(u32),
@@ -184,6 +185,7 @@ impl ValueData {
     pub const fn kind(&self) -> super::ValueDataKind {
         use super::ValueDataKind;
         match self {
+            Self::Dynamic(_) => ValueDataKind::Dynamic,
             Self::U8(_) => ValueDataKind::U8,
             Self::U16(_) => ValueDataKind::U16,
             Self::U32(_) => ValueDataKind::U32,
@@ -214,6 +216,22 @@ impl ValueData {
             Self::Map(_) => ValueDataKind::Map,
             Self::Type(_) => ValueDataKind::ReifiedType,
         }
+    }
+}
+
+/// Canonical payload for a self-describing dynamic value.
+///
+/// Composite constants use an empty placeholder and resident reconstruction
+/// replaces it with a nested finalized value before the aggregate is exposed.
+#[derive(Clone, Debug)]
+pub struct DynamicValue {
+    pub(super) value: Option<Box<super::Value>>,
+    pub(super) canonical: Box<[u8]>,
+}
+
+impl DynamicValue {
+    pub fn value(&self) -> Option<&super::Value> {
+        self.value.as_deref()
     }
 }
 

--- a/src/core/src/snapshot/draft.rs
+++ b/src/core/src/snapshot/draft.rs
@@ -29,6 +29,10 @@ impl ValueDraft {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum ValueDataDraft {
+    /// `None` is the wildcard placeholder used by a composite reconstruction
+    /// template. A materialized dynamic value carries its finalized nested
+    /// schema, shape, and payload in `Some`.
+    Dynamic(Option<Box<ValueDraft>>),
     U8(u8),
     U16(u16),
     U32(u32),
@@ -43,7 +47,10 @@ pub enum ValueDataDraft {
     F64(F64Bits),
     Complex32(Complex32Bits),
     Complex64(Complex64Bits),
-    Rational64 { numerator: i64, denominator: u64 },
+    Rational64 {
+        numerator: i64,
+        denominator: u64,
+    },
     Bool(bool),
     String(String),
     Id(u64),
@@ -64,6 +71,7 @@ impl ValueDataDraft {
     pub(crate) const fn kind(&self) -> super::ValueDataKind {
         use super::ValueDataKind;
         match self {
+            Self::Dynamic(_) => ValueDataKind::Dynamic,
             Self::U8(_) => ValueDataKind::U8,
             Self::U16(_) => ValueDataKind::U16,
             Self::U32(_) => ValueDataKind::U32,

--- a/src/core/src/snapshot/encoding.rs
+++ b/src/core/src/snapshot/encoding.rs
@@ -95,6 +95,7 @@ pub(super) fn canonical_material(schema: &SchemaBody, data: &ValueData) -> Box<[
 
 pub(super) fn encode_data(schema: &SchemaBody, data: &ValueData, sink: &mut dyn SnapshotByteSink) {
     match (schema, data) {
+        (SchemaBody::Dynamic, ValueData::Dynamic(value)) => sink.write(&value.canonical),
         (SchemaBody::Bool, ValueData::Bool(value)) => write_u8(sink, u8::from(*value)),
         (SchemaBody::UnsignedInteger(IntegerWidth::W8), ValueData::U8(value)) => {
             write_u8(sink, *value)

--- a/src/core/src/snapshot/error.rs
+++ b/src/core/src/snapshot/error.rs
@@ -7,6 +7,7 @@ use std::{boxed::Box, vec::Vec};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SchemaDataKind {
+    Dynamic,
     Bool,
     UnsignedInteger,
     SignedInteger,
@@ -30,6 +31,7 @@ pub enum SchemaDataKind {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ValueDataKind {
+    Dynamic,
     U8,
     U16,
     U32,
@@ -125,6 +127,10 @@ pub enum SnapshotValueError {
         path: SnapshotPath,
         expected: SchemaDataKind,
         actual: ValueDataKind,
+    },
+    InvalidIndexV1 {
+        path: SnapshotPath,
+        value: u64,
     },
     AggregateArityMismatchV1 {
         path: SnapshotPath,

--- a/src/core/src/snapshot/mod.rs
+++ b/src/core/src/snapshot/mod.rs
@@ -11,9 +11,9 @@ pub use self::constants::{
     ConstantEntry, ConstantHandle, ConstantStore, ConstantStoreBuild, ConstantStoreBuilder,
 };
 pub use self::data::{
-    CanonicalKeyValue, Complex32Bits, Complex64Bits, EnumValue, F32Bits, F64Bits, MapEntryValue,
-    MapValue, MatrixValue, Rational64Value, RecordValue, ReifiedKind, ReifiedType, SetValue,
-    TableValue, ValueData,
+    CanonicalKeyValue, Complex32Bits, Complex64Bits, DynamicValue, EnumValue, F32Bits, F64Bits,
+    MapEntryValue, MapValue, MatrixValue, Rational64Value, RecordValue, ReifiedKind, ReifiedType,
+    SetValue, TableValue, ValueData,
 };
 pub use self::draft::{
     EnumDraft, MapEntryDraft, NamedValueDraft, OptionDraft, ReifiedTypeDraft, TableColumnDraft,
@@ -26,5 +26,6 @@ pub use self::sequence::SequenceView;
 pub use self::validation::{
     SnapshotValidationContext, Value, build_f64_set_snapshot, build_f64_set_snapshot_after_remove,
     f64_set_snapshot_contains, rebuild_composite_snapshot, rebuild_f64_set_snapshot,
+    wrap_resident_dynamic_data,
 };
 pub use crate::{ConstantId, KeyHash, ValueHash};

--- a/src/core/src/snapshot/relations.rs
+++ b/src/core/src/snapshot/relations.rs
@@ -583,7 +583,8 @@ pub(super) fn schema_is_keyable(schema: &SchemaBody) -> bool {
             }
             true
         }
-        SchemaBody::Complex(_)
+        SchemaBody::Dynamic
+        | SchemaBody::Complex(_)
         | SchemaBody::Matrix { .. }
         | SchemaBody::Table { .. }
         | SchemaBody::Set { .. }

--- a/src/core/src/snapshot/sequence.rs
+++ b/src/core/src/snapshot/sequence.rs
@@ -121,4 +121,84 @@ impl SequenceStorage {
             Self::Values(values) => SequenceView::Values(values),
         }
     }
+
+    pub(super) fn len(&self) -> Option<usize> {
+        Some(match self {
+            Self::U8(values) => values.len(),
+            Self::U16(values) => values.len(),
+            Self::U32(values) => values.len(),
+            Self::U64(values) => values.len(),
+            Self::U128(values) => values.len(),
+            Self::I8(values) => values.len(),
+            Self::I16(values) => values.len(),
+            Self::I32(values) => values.len(),
+            Self::I64(values) => values.len(),
+            Self::I128(values) => values.len(),
+            Self::F32(values) => values.len(),
+            Self::F64(values) => values.len(),
+            Self::Complex32(values) => values.len(),
+            Self::Complex64(values) => values.len(),
+            Self::Rational64(values) => values.len(),
+            Self::Bool(values) => values.len(),
+            Self::String(values) => values.len(),
+            Self::Id(values) => values.len(),
+            Self::Index(values) => values.len(),
+            Self::Unit(count) => usize::try_from(*count).ok()?,
+            Self::Values(values) => values.len(),
+        })
+    }
+
+    pub(super) fn rebuild_with_values(&self, values: Vec<ValueData>) -> Option<Self> {
+        macro_rules! pack {
+            ($variant:ident, $target:ident) => {{
+                let values = values
+                    .into_iter()
+                    .map(|value| match value {
+                        ValueData::$variant(value) => Some(value),
+                        _ => None,
+                    })
+                    .collect::<Option<Vec<_>>>()?;
+                Self::$target(values.into_boxed_slice())
+            }};
+        }
+
+        Some(match self {
+            Self::U8(_) => pack!(U8, U8),
+            Self::U16(_) => pack!(U16, U16),
+            Self::U32(_) => pack!(U32, U32),
+            Self::U64(_) => pack!(U64, U64),
+            Self::U128(_) => pack!(U128, U128),
+            Self::I8(_) => pack!(I8, I8),
+            Self::I16(_) => pack!(I16, I16),
+            Self::I32(_) => pack!(I32, I32),
+            Self::I64(_) => pack!(I64, I64),
+            Self::I128(_) => pack!(I128, I128),
+            Self::F32(_) => pack!(F32, F32),
+            Self::F64(_) => pack!(F64, F64),
+            Self::Complex32(_) => pack!(Complex32, Complex32),
+            Self::Complex64(_) => pack!(Complex64, Complex64),
+            Self::Rational64(_) => pack!(Rational64, Rational64),
+            Self::Bool(_) => pack!(Bool, Bool),
+            Self::String(_) => pack!(String, String),
+            Self::Id(_) => pack!(Id, Id),
+            Self::Index(_) => pack!(Index, Index),
+            Self::Unit(_) => {
+                if values.iter().any(|value| !matches!(value, ValueData::Atom)) {
+                    return None;
+                }
+                Self::Unit(u64::try_from(values.len()).ok()?)
+            }
+            Self::Values(expected) => {
+                if expected.len() != values.len()
+                    || expected
+                        .iter()
+                        .zip(values.iter())
+                        .any(|(expected, value)| expected.kind() != value.kind())
+                {
+                    return None;
+                }
+                Self::Values(values.into_boxed_slice())
+            }
+        })
+    }
 }

--- a/src/core/src/snapshot/sequence.rs
+++ b/src/core/src/snapshot/sequence.rs
@@ -92,6 +92,7 @@ impl SequenceStorage {
             SchemaBody::Id => pack!(Id, Id),
             SchemaBody::Index => pack!(Index, Index),
             SchemaBody::Atom(_) => Self::Unit(values.len() as u64),
+            SchemaBody::Dynamic => Self::Values(values.into_boxed_slice()),
             _ => Self::Values(values.into_boxed_slice()),
         }
     }
@@ -190,10 +191,13 @@ impl SequenceStorage {
             }
             Self::Values(expected) => {
                 if expected.len() != values.len()
-                    || expected
-                        .iter()
-                        .zip(values.iter())
-                        .any(|(expected, value)| expected.kind() != value.kind())
+                    || expected.iter().zip(values.iter()).any(|(expected, value)| {
+                        expected.kind() != value.kind()
+                            && !matches!(
+                                (expected, value),
+                                (ValueData::Dynamic(_), ValueData::Dynamic(_))
+                            )
+                    })
                 {
                     return None;
                 }

--- a/src/core/src/snapshot/validation.rs
+++ b/src/core/src/snapshot/validation.rs
@@ -1,7 +1,7 @@
 use super::sequence::SequenceStorage;
 use super::{
-    CanonicalKeyValue, EnumValue, MapValue, MatrixValue, RecordValue, ReifiedKind, ReifiedType,
-    ReifiedTypeDraft, SchemaDataKind, SetValue, SnapshotPath, SnapshotPathSegment,
+    CanonicalKeyValue, DynamicValue, EnumValue, MapValue, MatrixValue, RecordValue, ReifiedKind,
+    ReifiedType, ReifiedTypeDraft, SchemaDataKind, SetValue, SnapshotPath, SnapshotPathSegment,
     SnapshotValueError, TableValue, ValueData, ValueDataDraft, ValueDraft,
 };
 use crate::{
@@ -221,6 +221,10 @@ fn token_data(mut hash: u64, data: &ValueData) -> u64 {
         }};
     }
     match data {
+        ValueData::Dynamic(value) => {
+            hash = token_word(hash, 31);
+            hash = token_bytes(hash, &value.canonical);
+        }
         ValueData::U8(value) => scalar!(1, u64::from(*value)),
         ValueData::U16(value) => scalar!(2, u64::from(*value)),
         ValueData::U32(value) => scalar!(3, u64::from(*value)),
@@ -346,6 +350,44 @@ fn finalized_value(
         data,
         resident_token,
     }
+}
+
+fn dynamic_canonical(value: Option<&Value>, schema: Option<&SchemaBody>) -> Box<[u8]> {
+    let Some(value) = value else {
+        return Vec::from([0]).into_boxed_slice();
+    };
+    let schema = schema.expect("materialized dynamic values carry their concrete schema");
+    let shape = value.shape().canonical_bytes();
+    let payload = super::encoding::canonical_material(schema, value.data());
+    let mut bytes = Vec::with_capacity(
+        1 + value.schema_key().as_bytes().len() + 8 + shape.len() + 8 + payload.len(),
+    );
+    bytes.push(1);
+    bytes.extend_from_slice(value.schema_key().as_bytes());
+    bytes.extend_from_slice(&(shape.len() as u64).to_le_bytes());
+    bytes.extend_from_slice(&shape);
+    bytes.extend_from_slice(&(payload.len() as u64).to_le_bytes());
+    bytes.extend_from_slice(&payload);
+    bytes.into_boxed_slice()
+}
+
+/// Wraps canonical resident data in a self-describing dynamic snapshot cell.
+/// The binder has already validated the schema identity, shape, and physical
+/// representation before this constructor is used.
+#[doc(hidden)]
+pub fn wrap_resident_dynamic_data(
+    schema: SchemaId,
+    schema_key: SchemaKey,
+    shape: ShapeInstance,
+    body: &SchemaBody,
+    data: ValueData,
+) -> ValueData {
+    let value = finalized_value(schema, schema_key, shape, data);
+    let canonical = dynamic_canonical(Some(&value), Some(body));
+    ValueData::Dynamic(DynamicValue {
+        value: Some(Box::new(value)),
+        canonical,
+    })
 }
 
 /// Rebuilds one tuple, record, or table layer from already validated canonical child
@@ -615,10 +657,32 @@ pub(super) fn finalize_data(
     exact!(SchemaBody::Complex(FloatWidth::W64), ValueDataDraft::Complex64(value) => ValueData::Complex64(value));
     exact!(SchemaBody::String, ValueDataDraft::String(value) => ValueData::String(value.into_boxed_str()));
     exact!(SchemaBody::Id, ValueDataDraft::Id(value) => ValueData::Id(value));
-    exact!(SchemaBody::Index, ValueDataDraft::Index(value) => ValueData::Index(value));
+    if matches!(schema, SchemaBody::Index) {
+        if let ValueDataDraft::Index(value) = draft {
+            if value == 0 {
+                return Err(SnapshotValueError::InvalidIndexV1 {
+                    path: path.clone(),
+                    value,
+                });
+            }
+            return Ok(ValueData::Index(value));
+        }
+        return Err(data_mismatch_kind(schema, actual_kind, path));
+    }
     exact!(SchemaBody::Atom(_), ValueDataDraft::Atom => ValueData::Atom);
 
     match (schema, draft) {
+        (SchemaBody::Dynamic, ValueDataDraft::Dynamic(draft)) => {
+            let value = draft
+                .map(|draft| finalize_value(*draft, context).map(Box::new))
+                .transpose()?;
+            let concrete = value
+                .as_deref()
+                .map(|value| value.validate_against(context.schemas))
+                .transpose()?;
+            let canonical = dynamic_canonical(value.as_deref(), concrete.map(Schema::body));
+            Ok(ValueData::Dynamic(DynamicValue { value, canonical }))
+        }
         (
             SchemaBody::Rational64,
             ValueDataDraft::Rational64 {
@@ -981,6 +1045,7 @@ fn data_mismatch_kind(
 
 pub(super) const fn schema_kind(schema: &SchemaBody) -> SchemaDataKind {
     match schema {
+        SchemaBody::Dynamic => SchemaDataKind::Dynamic,
         SchemaBody::Bool => SchemaDataKind::Bool,
         SchemaBody::UnsignedInteger(_) => SchemaDataKind::UnsignedInteger,
         SchemaBody::SignedInteger(_) => SchemaDataKind::SignedInteger,
@@ -1008,6 +1073,34 @@ mod tests {
     use super::*;
     use crate::snapshot::{F64Bits, TableColumnDraft};
     use crate::{SchemaDraft, SchemaField, SchemaTableBuilder};
+
+    #[test]
+    fn index_snapshots_are_one_based() {
+        let schema = SchemaDraft {
+            dimension_parameters: Box::new([]),
+            body: SchemaBody::Index,
+        }
+        .finalize()
+        .unwrap();
+        let mut builder = SchemaTableBuilder::new();
+        let handle = builder.insert(schema).unwrap();
+        let build = builder.finish().unwrap();
+        let schema = build.resolve(handle).unwrap();
+        let (schemas, _) = build.into_parts();
+        let context = SnapshotValidationContext::new(&schemas);
+
+        let draft = |value| ValueDraft {
+            schema,
+            shape_values: Box::new([]),
+            data: ValueDataDraft::Index(value),
+        };
+        assert!(matches!(
+            draft(0).finalize(&context),
+            Err(SnapshotValueError::InvalidIndexV1 { value: 0, .. })
+        ));
+        assert!(draft(1).finalize(&context).is_ok());
+        assert!(draft(u64::MAX).finalize(&context).is_ok());
+    }
 
     #[test]
     fn composite_rebuild_preserves_table_columns_and_storage() {

--- a/src/core/src/snapshot/validation.rs
+++ b/src/core/src/snapshot/validation.rs
@@ -348,7 +348,7 @@ fn finalized_value(
     }
 }
 
-/// Rebuilds one tuple or record layer from already validated canonical child
+/// Rebuilds one tuple, record, or table layer from already validated canonical child
 /// payloads. The template retains the authoritative schema, shape, and record
 /// field ordering; callers may only replace children with the same canonical
 /// representation kinds.
@@ -372,6 +372,33 @@ pub fn rebuild_composite_snapshot(template: &Value, children: Box<[ValueData]>) 
                     .all(|(expected, child)| expected.kind() == child.kind()) =>
         {
             ValueData::Record(RecordValue { fields: children })
+        }
+        ValueData::Table(expected) => {
+            let column_lengths = expected
+                .columns
+                .iter()
+                .map(SequenceStorage::len)
+                .collect::<Option<Vec<_>>>()?;
+            let expected_children = column_lengths
+                .iter()
+                .try_fold(0usize, |total, length| total.checked_add(*length))?;
+            if expected_children != children.len() {
+                return None;
+            }
+            let mut children = children.into_vec().into_iter();
+            let columns = expected
+                .columns
+                .iter()
+                .zip(column_lengths)
+                .map(|(column, length)| {
+                    column.rebuild_with_values(children.by_ref().take(length).collect())
+                })
+                .collect::<Option<Vec<_>>>()?
+                .into_boxed_slice();
+            if children.next().is_some() {
+                return None;
+            }
+            ValueData::Table(TableValue { columns })
         }
         _ => return None,
     };
@@ -973,5 +1000,99 @@ pub(super) const fn schema_kind(schema: &SchemaBody) -> SchemaDataKind {
         SchemaBody::Set { .. } => SchemaDataKind::Set,
         SchemaBody::Map { .. } => SchemaDataKind::Map,
         SchemaBody::ReifiedType => SchemaDataKind::ReifiedType,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::snapshot::{F64Bits, TableColumnDraft};
+    use crate::{SchemaDraft, SchemaField, SchemaTableBuilder};
+
+    #[test]
+    fn composite_rebuild_preserves_table_columns_and_storage() {
+        let schema = SchemaDraft {
+            dimension_parameters: Box::new([]),
+            body: SchemaBody::Table {
+                columns: vec![
+                    SchemaField {
+                        name: "id".to_owned(),
+                        schema: SchemaBody::String,
+                    },
+                    SchemaField {
+                        name: "x".to_owned(),
+                        schema: SchemaBody::FloatingPoint(FloatWidth::W64),
+                    },
+                ]
+                .into_boxed_slice(),
+                rows: crate::DimensionExpr::Constant(2),
+            },
+        }
+        .finalize()
+        .unwrap();
+        let mut builder = SchemaTableBuilder::new();
+        let handle = builder.insert(schema).unwrap();
+        let build = builder.finish().unwrap();
+        let schema = build.resolve(handle).unwrap();
+        let (schemas, _) = build.into_parts();
+        let template = ValueDraft {
+            schema,
+            shape_values: Box::new([]),
+            data: ValueDataDraft::Table(
+                vec![
+                    TableColumnDraft {
+                        name: "id".to_owned(),
+                        values: vec![
+                            ValueDataDraft::String("a".to_owned()),
+                            ValueDataDraft::String("b".to_owned()),
+                        ]
+                        .into_boxed_slice(),
+                    },
+                    TableColumnDraft {
+                        name: "x".to_owned(),
+                        values: vec![
+                            ValueDataDraft::F64(F64Bits::from_f64(1.0)),
+                            ValueDataDraft::F64(F64Bits::from_f64(2.0)),
+                        ]
+                        .into_boxed_slice(),
+                    },
+                ]
+                .into_boxed_slice(),
+            ),
+        }
+        .finalize(&SnapshotValidationContext::new(&schemas))
+        .unwrap();
+
+        let rebuilt = rebuild_composite_snapshot(
+            &template,
+            vec![
+                ValueData::String("c".into()),
+                ValueData::String("d".into()),
+                ValueData::F64(F64Bits::from_f64(3.0)),
+                ValueData::F64(F64Bits::from_f64(4.0)),
+            ]
+            .into_boxed_slice(),
+        )
+        .unwrap();
+        let ValueData::Table(table) = rebuilt.data() else {
+            panic!("rebuilt composite must remain a table");
+        };
+        let super::super::SequenceView::String(ids) = table.column(0).unwrap() else {
+            panic!("string table column changed representation");
+        };
+        assert_eq!(
+            ids.iter().map(|id| id.as_ref()).collect::<Vec<_>>(),
+            ["c", "d"]
+        );
+        let super::super::SequenceView::F64(values) = table.column(1).unwrap() else {
+            panic!("f64 table column changed representation");
+        };
+        assert_eq!(
+            values
+                .iter()
+                .map(|value| value.to_f64())
+                .collect::<Vec<_>>(),
+            [3.0, 4.0]
+        );
     }
 }

--- a/src/core/src/value.rs
+++ b/src/core/src/value.rs
@@ -4254,53 +4254,167 @@ impl LegacyValue {
         }
     }
 
-    pub fn as_index(&self) -> MResult<LegacyValue> {
-        match self.as_usize() {
-            Ok(ix) => Ok(LegacyValue::Index(Ref::new(ix))),
-            #[cfg(not(feature = "matrix"))]
-            Err(_) => Err(
-                MechError::new(CannotConvertToTypeError { target_type: "ix" }, None)
-                    .with_compiler_loc(),
-            ),
-            #[cfg(feature = "matrix")]
-            Err(_) => match self.as_vecusize() {
-                #[cfg(feature = "matrix")]
-                Ok(x) => {
-                    let shape = self.shape();
-                    let out = LegacyValue::MatrixIndex(usize::to_matrix(x, shape[0] * shape[1], 1));
-                    Ok(out)
-                }
-                #[cfg(all(feature = "matrix", feature = "bool"))]
-                Err(_) => match self.as_vecbool() {
-                    Ok(x) => {
-                        let shape = self.shape();
-                        let out = match (shape[0], shape[1]) {
-                            (1, 1) => LegacyValue::Bool(Ref::new(x[0])),
-                            #[cfg(all(feature = "vectord", feature = "bool"))]
-                            _ => LegacyValue::MatrixBool(Matrix::DVector(Ref::new(
-                                DVector::from_vec(x),
-                            ))),
-                            #[cfg(not(all(feature = "vectord", feature = "bool")))]
-                            _ => todo!(),
-                        };
-                        Ok(out)
-                    }
-                    Err(_) => match self.as_bool() {
-                        Ok(x) => Ok(LegacyValue::Bool(x)),
-                        Err(_) => Err(MechError::new(
-                            CannotConvertToTypeError { target_type: "ix" },
-                            None,
-                        )
-                        .with_compiler_loc()),
-                    },
-                },
-                #[cfg(all(feature = "matrix", not(feature = "bool")))]
-                Err(_) => Err(
-                    MechError::new(CannotConvertToTypeError { target_type: "ix" }, None)
-                        .with_compiler_loc(),
-                ),
-            },
+    fn as_one_based_usize(&self) -> Option<usize> {
+        #[cfg(any(feature = "f32", feature = "f64"))]
+        fn positive_float(value: f64) -> Option<usize> {
+            if !value.is_finite() || value < 1.0 || value.fract() != 0.0 {
+                return None;
+            }
+            usize::try_from(value as u128).ok()
         }
+
+        let index = match self {
+            LegacyValue::Index(value) => *value.borrow(),
+            #[cfg(feature = "u8")]
+            LegacyValue::U8(value) => usize::from(*value.borrow()),
+            #[cfg(feature = "u16")]
+            LegacyValue::U16(value) => usize::from(*value.borrow()),
+            #[cfg(feature = "u32")]
+            LegacyValue::U32(value) => usize::try_from(*value.borrow()).ok()?,
+            #[cfg(feature = "u64")]
+            LegacyValue::U64(value) => usize::try_from(*value.borrow()).ok()?,
+            #[cfg(feature = "u128")]
+            LegacyValue::U128(value) => usize::try_from(*value.borrow()).ok()?,
+            #[cfg(feature = "i8")]
+            LegacyValue::I8(value) => usize::try_from(*value.borrow()).ok()?,
+            #[cfg(feature = "i16")]
+            LegacyValue::I16(value) => usize::try_from(*value.borrow()).ok()?,
+            #[cfg(feature = "i32")]
+            LegacyValue::I32(value) => usize::try_from(*value.borrow()).ok()?,
+            #[cfg(feature = "i64")]
+            LegacyValue::I64(value) => usize::try_from(*value.borrow()).ok()?,
+            #[cfg(feature = "i128")]
+            LegacyValue::I128(value) => usize::try_from(*value.borrow()).ok()?,
+            #[cfg(feature = "f32")]
+            LegacyValue::F32(value) => positive_float(f64::from(*value.borrow()))?,
+            #[cfg(feature = "f64")]
+            LegacyValue::F64(value) => positive_float(*value.borrow())?,
+            LegacyValue::MutableReference(value) => value.borrow().as_one_based_usize()?,
+            _ => return None,
+        };
+        (index > 0).then_some(index)
+    }
+
+    #[cfg(feature = "matrix")]
+    fn as_one_based_index_matrix(&self) -> Option<Vec<usize>> {
+        #[cfg(any(feature = "f32", feature = "f64"))]
+        fn positive_float(value: f64) -> Option<usize> {
+            if !value.is_finite() || value < 1.0 || value.fract() != 0.0 {
+                return None;
+            }
+            usize::try_from(value as u128).ok()
+        }
+
+        #[allow(unused_macros)]
+        macro_rules! unsigned_matrix {
+            ($variant:ident) => {
+                if let LegacyValue::$variant(value) = self {
+                    return value
+                        .as_vec()
+                        .into_iter()
+                        .map(|value| usize::try_from(value).ok().filter(|value| *value > 0))
+                        .collect();
+                }
+            };
+        }
+        #[allow(unused_macros)]
+        macro_rules! signed_matrix {
+            ($variant:ident) => {
+                if let LegacyValue::$variant(value) = self {
+                    return value
+                        .as_vec()
+                        .into_iter()
+                        .map(|value| usize::try_from(value).ok().filter(|value| *value > 0))
+                        .collect();
+                }
+            };
+        }
+        #[allow(unused_macros)]
+        macro_rules! float_matrix {
+            ($variant:ident) => {
+                if let LegacyValue::$variant(value) = self {
+                    return value
+                        .as_vec()
+                        .into_iter()
+                        .map(|value| positive_float(f64::from(value)))
+                        .collect();
+                }
+            };
+        }
+
+        if let LegacyValue::MatrixIndex(value) = self {
+            return value
+                .as_vec()
+                .into_iter()
+                .map(|value| (value > 0).then_some(value))
+                .collect();
+        }
+        #[cfg(feature = "u8")]
+        unsigned_matrix!(MatrixU8);
+        #[cfg(feature = "u16")]
+        unsigned_matrix!(MatrixU16);
+        #[cfg(feature = "u32")]
+        unsigned_matrix!(MatrixU32);
+        #[cfg(feature = "u64")]
+        unsigned_matrix!(MatrixU64);
+        #[cfg(feature = "u128")]
+        unsigned_matrix!(MatrixU128);
+        #[cfg(feature = "i8")]
+        signed_matrix!(MatrixI8);
+        #[cfg(feature = "i16")]
+        signed_matrix!(MatrixI16);
+        #[cfg(feature = "i32")]
+        signed_matrix!(MatrixI32);
+        #[cfg(feature = "i64")]
+        signed_matrix!(MatrixI64);
+        #[cfg(feature = "i128")]
+        signed_matrix!(MatrixI128);
+        #[cfg(feature = "f32")]
+        float_matrix!(MatrixF32);
+        #[cfg(feature = "f64")]
+        float_matrix!(MatrixF64);
+        if let LegacyValue::MutableReference(value) = self {
+            return value.borrow().as_one_based_index_matrix();
+        }
+        None
+    }
+
+    pub fn as_index(&self) -> MResult<LegacyValue> {
+        if let Some(index) = self.as_one_based_usize() {
+            return Ok(LegacyValue::Index(Ref::new(index)));
+        }
+        #[cfg(feature = "matrix")]
+        if let Some(indexes) = self.as_one_based_index_matrix() {
+            let shape = self.shape();
+            return Ok(LegacyValue::MatrixIndex(usize::to_matrix(
+                indexes,
+                shape[0] * shape[1],
+                1,
+            )));
+        }
+        #[cfg(all(feature = "matrix", feature = "bool"))]
+        if let Ok(values) = self.as_vecbool() {
+            let shape = self.shape();
+            let out = match (shape[0], shape[1]) {
+                (1, 1) => LegacyValue::Bool(Ref::new(values[0])),
+                #[cfg(feature = "vectord")]
+                _ => LegacyValue::MatrixBool(Matrix::DVector(Ref::new(DVector::from_vec(values)))),
+                #[cfg(not(feature = "vectord"))]
+                _ => todo!(),
+            };
+            return Ok(out);
+        }
+        #[cfg(feature = "bool")]
+        if let Ok(value) = self.as_bool() {
+            return Ok(LegacyValue::Bool(value));
+        }
+        Err(MechError::new(
+            CannotConvertToTypeError {
+                target_type: "ix (1..=max)",
+            },
+            None,
+        )
+        .with_compiler_loc())
     }
 
     pub fn as_usize(&self) -> MResult<usize> {
@@ -4843,6 +4957,19 @@ mod reactive_cell_tests {
 
     fn cell_ids(ids: &[u64]) -> Vec<ReactiveCellId> {
         ids.iter().copied().map(ReactiveCellId::new).collect()
+    }
+
+    #[cfg(feature = "f64")]
+    #[test]
+    fn index_conversion_is_exact_and_one_based() {
+        assert!(matches!(
+            LegacyValue::F64(Ref::new(1.0)).as_index().unwrap(),
+            LegacyValue::Index(value) if *value.borrow() == 1
+        ));
+        for invalid in [0.0, -1.0, 1.5] {
+            assert!(LegacyValue::F64(Ref::new(invalid)).as_index().is_err());
+        }
+        assert!(LegacyValue::Index(Ref::new(0)).as_index().is_err());
     }
 
     #[cfg(feature = "f64")]

--- a/src/core/src/value.rs
+++ b/src/core/src/value.rs
@@ -4305,7 +4305,13 @@ impl LegacyValue {
             usize::try_from(value as u128).ok()
         }
 
-        #[allow(unused_macros)]
+        #[cfg(any(
+            feature = "u8",
+            feature = "u16",
+            feature = "u32",
+            feature = "u64",
+            feature = "u128"
+        ))]
         macro_rules! unsigned_matrix {
             ($variant:ident) => {
                 if let LegacyValue::$variant(value) = self {
@@ -4317,7 +4323,13 @@ impl LegacyValue {
                 }
             };
         }
-        #[allow(unused_macros)]
+        #[cfg(any(
+            feature = "i8",
+            feature = "i16",
+            feature = "i32",
+            feature = "i64",
+            feature = "i128"
+        ))]
         macro_rules! signed_matrix {
             ($variant:ident) => {
                 if let LegacyValue::$variant(value) = self {
@@ -4329,7 +4341,7 @@ impl LegacyValue {
                 }
             };
         }
-        #[allow(unused_macros)]
+        #[cfg(any(feature = "f32", feature = "f64"))]
         macro_rules! float_matrix {
             ($variant:ident) => {
                 if let LegacyValue::$variant(value) = self {

--- a/src/engine/src/activation/captures.rs
+++ b/src/engine/src/activation/captures.rs
@@ -130,7 +130,7 @@ pub(super) fn create_capture_slot_for_kind(
         ValueKind::Bool => Ok(LegacyValue::Bool(Ref::new(false))),
         #[cfg(any(feature = "string", feature = "variable_define"))]
         ValueKind::String => Ok(LegacyValue::String(Ref::new(String::new()))),
-        ValueKind::Index => Ok(LegacyValue::Index(Ref::new(0))),
+        ValueKind::Index => Ok(LegacyValue::Index(Ref::new(1))),
         #[cfg(feature = "atom")]
         ValueKind::Atom(id, _) => Ok(LegacyValue::Atom(Ref::new(MechAtom::new(id)))),
         #[cfg(feature = "tuple")]

--- a/src/engine/src/artifact/compiler.rs
+++ b/src/engine/src/artifact/compiler.rs
@@ -1314,6 +1314,20 @@ fn compile_executable_program_artifact_with_identity(
                             })
                     })
                 });
+                // A one-element matrix row/column is represented by the
+                // legacy intrinsic as a nullary concatenate whose output is
+                // the very same reference as its already-compiled operand.
+                // It is an identity wrapper, not a new producer node. Keep
+                // the prior semantic source so `[a; b]` lowers to the actual
+                // vertical concatenation inputs instead of two source-less
+                // horizontal nodes.
+                if kind == CompiledNodeKind::Combinational
+                    && is_literal_constructor_operation(&semantics.operation)
+                    && matches!(instruction, BytecodeInstruction::RuntimeNullary { .. })
+                    && prior.is_some()
+                {
+                    continue;
+                }
                 if kind == CompiledNodeKind::Combinational
                     && is_literal_constructor_operation(&semantics.operation)
                     && (register_state_indexes[dst as usize].is_some()

--- a/src/engine/src/lib.rs
+++ b/src/engine/src/lib.rs
@@ -222,46 +222,11 @@ pub use crate::intrinsics::table_ops::{
 #[cfg(feature = "matrix_vertcat")]
 pub use crate::intrinsics::vertcat::{MatrixVertCat, VerticalConcatenateDimensionMismatch};
 #[cfg(feature = "semantic-compiler")]
-pub fn load_stdkinds(
-    #[cfg(any(
-        feature = "u8",
-        feature = "u16",
-        feature = "u32",
-        feature = "u64",
-        feature = "u128",
-        feature = "i8",
-        feature = "i16",
-        feature = "i32",
-        feature = "i64",
-        feature = "i128",
-        feature = "f32",
-        feature = "f64",
-        feature = "c64",
-        feature = "r64",
-        feature = "string",
-        feature = "bool"
-    ))]
-    kinds: &mut KindTable,
-    #[cfg(not(any(
-        feature = "u8",
-        feature = "u16",
-        feature = "u32",
-        feature = "u64",
-        feature = "u128",
-        feature = "i8",
-        feature = "i16",
-        feature = "i32",
-        feature = "i64",
-        feature = "i128",
-        feature = "f32",
-        feature = "f64",
-        feature = "c64",
-        feature = "r64",
-        feature = "string",
-        feature = "bool"
-    )))]
-    _: &mut KindTable,
-) {
+pub fn load_stdkinds(kinds: &mut KindTable) {
+    // `ix` is the canonical spelling used by value formatting; `index` is the
+    // long-form alias. Both names denote the same one-based scalar kind.
+    kinds.insert(hash_str("ix"), ValueKind::Index);
+    kinds.insert(hash_str("index"), ValueKind::Index);
     #[cfg(feature = "u8")]
     kinds.insert(hash_str("u8"), ValueKind::U8);
     #[cfg(feature = "u16")]
@@ -294,6 +259,19 @@ pub fn load_stdkinds(
     kinds.insert(hash_str("string"), ValueKind::String);
     #[cfg(feature = "bool")]
     kinds.insert(hash_str("bool"), ValueKind::Bool);
+}
+
+#[cfg(all(test, feature = "semantic-compiler"))]
+mod standard_kind_tests {
+    use super::*;
+
+    #[test]
+    fn ix_and_index_are_aliases() {
+        let mut kinds = KindTable::new();
+        load_stdkinds(&mut kinds);
+        assert_eq!(kinds.get(&hash_str("ix")), Some(&ValueKind::Index));
+        assert_eq!(kinds.get(&hash_str("index")), Some(&ValueKind::Index));
+    }
 }
 
 #[macro_export]

--- a/src/engine/src/resident/composite.rs
+++ b/src/engine/src/resident/composite.rs
@@ -1,4 +1,6 @@
-use mech_core::snapshot::{F64Bits, MatrixValue, rebuild_composite_snapshot};
+use mech_core::snapshot::{
+    F64Bits, MatrixValue, rebuild_composite_snapshot, wrap_resident_dynamic_data,
+};
 use mech_core::{
     AccessMode, AliasPolicy, BoundResidentKernel, ChangeDetectionPolicy, DeliveryMode,
     DimensionExpr, ExternalInteraction, FunctionCatalogBuilder, MResult, OutputConstruction,
@@ -11,7 +13,17 @@ use std::sync::Arc;
 #[derive(Clone, Debug)]
 struct CompositeChildPlan {
     matrix_dimensions: Option<Box<[DimensionExpr]>>,
+    input_is_matrix: bool,
     shape: ResidentShape,
+    dynamic: Option<DynamicChildPlan>,
+}
+
+#[derive(Clone, Debug)]
+struct DynamicChildPlan {
+    schema_id: mech_core::SchemaId,
+    schema_key: mech_core::SchemaKey,
+    shape: ShapeInstance,
+    body: SchemaBody,
 }
 
 #[derive(Clone, Debug)]
@@ -36,6 +48,9 @@ fn port_matches_schema_body(
     input: &mech_core::ResidentPortLayout,
     expected: &SchemaBody,
 ) -> bool {
+    if matches!(expected, SchemaBody::Dynamic) {
+        return true;
+    }
     request
         .schemas
         .get(input.schema_id)
@@ -114,6 +129,7 @@ fn composite_pack_plan(request: &ResidentKernelBindRequest<'_>) -> Option<Compos
             .iter()
             .zip(expected)
             .map(|(input, expected)| {
+                let input_schema = request.schemas.get(input.schema_id)?;
                 let matrix_dimensions = match expected {
                     SchemaBody::Matrix { dimensions, .. } if dimensions.len() == 2 => {
                         Some(dimensions.clone())
@@ -123,7 +139,14 @@ fn composite_pack_plan(request: &ResidentKernelBindRequest<'_>) -> Option<Compos
                 };
                 Some(CompositeChildPlan {
                     matrix_dimensions,
+                    input_is_matrix: matches!(input_schema.body(), SchemaBody::Matrix { .. }),
                     shape: input.shape,
+                    dynamic: matches!(expected, SchemaBody::Dynamic).then(|| DynamicChildPlan {
+                        schema_id: input.schema_id,
+                        schema_key: input.schema_key,
+                        shape: input.shape_instance.clone(),
+                        body: input_schema.body().clone(),
+                    }),
                 })
             })
             .collect::<Option<Vec<_>>>()
@@ -326,7 +349,7 @@ fn composite_child_data(
     input: ResidentValueRef<'_>,
     plan: &CompositeChildPlan,
 ) -> Option<ValueData> {
-    if plan.matrix_dimensions.is_some() {
+    let data = if plan.input_is_matrix {
         let matrix = match input {
             ResidentValueRef::Bool(values) => MatrixValue::from_bool_elements(
                 canonical_matrix_elements(values, plan.shape, |value| match value {
@@ -354,18 +377,29 @@ fn composite_child_data(
                 })?,
             ),
         };
-        return Some(ValueData::Matrix(matrix));
-    }
-    match input {
-        ResidentValueRef::Bool([value]) if *value <= 1 => Some(ValueData::Bool(*value != 0)),
-        ResidentValueRef::Index([value]) => Some(ValueData::Index(*value)),
-        ResidentValueRef::F64([value]) => Some(ValueData::F64(F64Bits::from_f64(*value))),
-        ResidentValueRef::String([value]) => {
-            Some(ValueData::String(value.clone().into_boxed_str()))
-        }
-        ResidentValueRef::Snapshot([Some(value)]) => Some(value.data().clone()),
-        _ => None,
-    }
+        ValueData::Matrix(matrix)
+    } else {
+        match input {
+            ResidentValueRef::Bool([value]) if *value <= 1 => Some(ValueData::Bool(*value != 0)),
+            ResidentValueRef::Index([value]) => Some(ValueData::Index(*value)),
+            ResidentValueRef::F64([value]) => Some(ValueData::F64(F64Bits::from_f64(*value))),
+            ResidentValueRef::String([value]) => {
+                Some(ValueData::String(value.clone().into_boxed_str()))
+            }
+            ResidentValueRef::Snapshot([Some(value)]) => Some(value.data().clone()),
+            _ => None,
+        }?
+    };
+    Some(match &plan.dynamic {
+        Some(dynamic) => wrap_resident_dynamic_data(
+            dynamic.schema_id,
+            dynamic.schema_key,
+            dynamic.shape.clone(),
+            &dynamic.body,
+            data,
+        ),
+        None => data,
+    })
 }
 
 fn composite_pack(
@@ -430,6 +464,11 @@ mod tests {
             schema_key: schemas.entry(schema_id).unwrap().key(),
             kind,
             shape,
+            shape_instance: schemas
+                .get(schema_id)
+                .unwrap()
+                .instantiate_shape(Box::new([]))
+                .unwrap(),
         }
     }
 
@@ -477,7 +516,7 @@ mod tests {
                 contract: &contract,
                 schemas: &schemas,
                 inputs: &good,
-                output,
+                output: output.clone(),
             }
         ));
 
@@ -585,10 +624,12 @@ mod tests {
             matrix_dimensions: Some(
                 vec![DimensionExpr::Constant(2), DimensionExpr::Constant(3)].into_boxed_slice(),
             ),
+            input_is_matrix: true,
             shape: ResidentShape {
                 rows: 2,
                 columns: 3,
             },
+            dynamic: None,
         };
         let Some(ValueData::Matrix(matrix)) =
             composite_child_data(ResidentValueRef::F64(&values), &plan)
@@ -645,10 +686,12 @@ mod tests {
         let mismatched = CompositePackPlan {
             children: vec![CompositeChildPlan {
                 matrix_dimensions: Some(dimensions.clone()),
+                input_is_matrix: true,
                 shape: ResidentShape {
                     rows: 1,
                     columns: 2,
                 },
+                dynamic: None,
             }]
             .into_boxed_slice(),
             table: None,
@@ -661,10 +704,12 @@ mod tests {
         let matching = CompositePackPlan {
             children: vec![CompositeChildPlan {
                 matrix_dimensions: Some(dimensions),
+                input_is_matrix: true,
                 shape: ResidentShape {
                     rows: 1,
                     columns: 3,
                 },
+                dynamic: None,
             }]
             .into_boxed_slice(),
             table: None,

--- a/src/engine/src/resident/composite.rs
+++ b/src/engine/src/resident/composite.rs
@@ -17,6 +17,13 @@ struct CompositeChildPlan {
 #[derive(Clone, Debug)]
 struct CompositePackPlan {
     children: Box<[CompositeChildPlan]>,
+    table: Option<CompositeTablePlan>,
+}
+
+#[derive(Clone, Debug)]
+struct CompositeTablePlan {
+    rows: DimensionExpr,
+    row_count: usize,
 }
 
 pub(crate) fn install(builder: &mut FunctionCatalogBuilder) -> MResult<()> {
@@ -40,22 +47,63 @@ fn composite_children_match_output_schema(request: &ResidentKernelBindRequest<'_
         return false;
     };
     let children = &request.inputs[1..];
-    match output.body() {
-        SchemaBody::Tuple(elements) => {
-            children.len() == elements.len()
-                && children
-                    .iter()
-                    .zip(elements.iter())
-                    .all(|(input, expected)| port_matches_schema_body(request, input, expected))
+    composite_child_schemas(output.body(), children.len()).is_some_and(|(expected, _)| {
+        children
+            .iter()
+            .zip(expected.iter())
+            .all(|(input, expected)| port_matches_schema_body(request, input, expected))
+    })
+}
+
+fn composite_child_schemas(
+    output: &SchemaBody,
+    child_count: usize,
+) -> Option<(Vec<SchemaBody>, Option<CompositeTablePlan>)> {
+    match output {
+        SchemaBody::Tuple(elements) if elements.len() == child_count => {
+            Some((elements.to_vec(), None))
         }
-        SchemaBody::Record(fields) => {
-            children.len() == fields.len()
-                && children
-                    .iter()
-                    .zip(fields.iter())
-                    .all(|(input, field)| port_matches_schema_body(request, input, &field.schema))
+        SchemaBody::Record(fields) if fields.len() == child_count => Some((
+            fields.iter().map(|field| field.schema.clone()).collect(),
+            None,
+        )),
+        SchemaBody::Table { columns, rows } => {
+            if columns.is_empty() {
+                let DimensionExpr::Constant(row_count) = rows else {
+                    return None;
+                };
+                let row_count = usize::try_from(*row_count).ok()?;
+                return (child_count == 0).then(|| {
+                    (
+                        Vec::new(),
+                        Some(CompositeTablePlan {
+                            rows: rows.clone(),
+                            row_count,
+                        }),
+                    )
+                });
+            }
+            if child_count % columns.len() != 0 {
+                return None;
+            }
+            let row_count = child_count / columns.len();
+            if matches!(rows, DimensionExpr::Constant(expected) if usize::try_from(*expected).ok() != Some(row_count))
+            {
+                return None;
+            }
+            let expected = columns
+                .iter()
+                .flat_map(|column| std::iter::repeat_n(column.schema.clone(), row_count))
+                .collect();
+            Some((
+                expected,
+                Some(CompositeTablePlan {
+                    rows: rows.clone(),
+                    row_count,
+                }),
+            ))
         }
-        _ => false,
+        _ => None,
     }
 }
 
@@ -81,20 +129,9 @@ fn composite_pack_plan(request: &ResidentKernelBindRequest<'_>) -> Option<Compos
             .collect::<Option<Vec<_>>>()
             .map(Vec::into_boxed_slice)
     };
-    let children = match output.body() {
-        SchemaBody::Tuple(elements) if elements.len() == request.inputs.len() - 1 => {
-            plans(elements)?
-        }
-        SchemaBody::Record(fields) if fields.len() == request.inputs.len() - 1 => {
-            let expected = fields
-                .iter()
-                .map(|field| field.schema.clone())
-                .collect::<Vec<_>>();
-            plans(&expected)?
-        }
-        _ => return None,
-    };
-    Some(CompositePackPlan { children })
+    let (expected, table) = composite_child_schemas(output.body(), request.inputs.len() - 1)?;
+    let children = plans(&expected)?;
+    Some(CompositePackPlan { children, table })
 }
 
 fn composite_child_layout_supported(
@@ -174,7 +211,7 @@ fn bind_composite_pack(
                 .schemas
                 .get(request.output.schema_id)
                 .map(|schema| schema.body()),
-            Some(SchemaBody::Tuple { .. } | SchemaBody::Record { .. })
+            Some(SchemaBody::Tuple { .. } | SchemaBody::Record { .. } | SchemaBody::Table { .. })
         )
         || contract
             .inputs
@@ -243,8 +280,8 @@ fn retain_empty_matrix_composite(
     Ok(true)
 }
 
-fn composite_matrix_shapes_match_template(shape: &ShapeInstance, plan: &CompositePackPlan) -> bool {
-    plan.children.iter().all(|child| {
+fn composite_shapes_match_template(shape: &ShapeInstance, plan: &CompositePackPlan) -> bool {
+    let matrices_match = plan.children.iter().all(|child| {
         let Some(dimensions) = &child.matrix_dimensions else {
             return true;
         };
@@ -256,7 +293,11 @@ fn composite_matrix_shapes_match_template(shape: &ShapeInstance, plan: &Composit
         };
         u32::try_from(rows).ok() == Some(child.shape.rows)
             && u32::try_from(columns).ok() == Some(child.shape.columns)
-    })
+    });
+    matrices_match
+        && plan.table.as_ref().is_none_or(|table| {
+            shape.resolve_dimension(&table.rows).ok() == u64::try_from(table.row_count).ok()
+        })
 }
 
 fn canonical_matrix_elements<T, U>(
@@ -339,7 +380,7 @@ fn composite_pack(
         .retained_state::<CompositePackPlan>()
         .ok_or(ResidentKernelError::InvalidInput)?;
     if plan.children.len() != inputs.len() - 1
-        || !composite_matrix_shapes_match_template(template.shape(), plan)
+        || !composite_shapes_match_template(template.shape(), plan)
     {
         return Err(ResidentKernelError::InvalidShape);
     }
@@ -452,6 +493,37 @@ mod tests {
                 output,
             }
         ));
+    }
+
+    #[test]
+    fn table_composite_children_follow_column_major_schema_order() {
+        let body = SchemaBody::Table {
+            columns: vec![
+                mech_core::SchemaField {
+                    name: "id".to_owned(),
+                    schema: SchemaBody::String,
+                },
+                mech_core::SchemaField {
+                    name: "x".to_owned(),
+                    schema: SchemaBody::FloatingPoint(mech_core::FloatWidth::W64),
+                },
+            ]
+            .into_boxed_slice(),
+            rows: DimensionExpr::Constant(2),
+        };
+        let (children, table) = composite_child_schemas(&body, 4).unwrap();
+        assert_eq!(
+            children,
+            vec![
+                SchemaBody::String,
+                SchemaBody::String,
+                SchemaBody::FloatingPoint(mech_core::FloatWidth::W64),
+                SchemaBody::FloatingPoint(mech_core::FloatWidth::W64),
+            ]
+        );
+        assert_eq!(table.unwrap().row_count, 2);
+        assert!(composite_child_schemas(&body, 3).is_none());
+        assert!(composite_child_schemas(&body, 6).is_none());
     }
 
     #[test]
@@ -579,8 +651,9 @@ mod tests {
                 },
             }]
             .into_boxed_slice(),
+            table: None,
         };
-        assert!(!composite_matrix_shapes_match_template(
+        assert!(!composite_shapes_match_template(
             &template_shape,
             &mismatched
         ));
@@ -594,10 +667,8 @@ mod tests {
                 },
             }]
             .into_boxed_slice(),
+            table: None,
         };
-        assert!(composite_matrix_shapes_match_template(
-            &template_shape,
-            &matching
-        ));
+        assert!(composite_shapes_match_template(&template_shape, &matching));
     }
 }

--- a/src/engine/src/resident/general/mod.rs
+++ b/src/engine/src/resident/general/mod.rs
@@ -390,7 +390,7 @@ impl TypedResidentArena {
     fn allocate(sizes: ResidentArenaSizes) -> Self {
         Self {
             bools: vec![0; sizes.bools].into_boxed_slice(),
-            indexes: vec![0; sizes.indexes].into_boxed_slice(),
+            indexes: vec![1; sizes.indexes].into_boxed_slice(),
             f64s: vec![0.0; sizes.f64s].into_boxed_slice(),
             strings: vec![String::new(); sizes.strings].into_boxed_slice(),
             snapshots: vec![None; sizes.snapshots].into_boxed_slice(),
@@ -2477,6 +2477,7 @@ fn source_port_layout(
                 schema_key: value.schema_key(),
                 kind: region.kind,
                 shape: region.shape,
+                shape_instance: value.shape().clone(),
             })
         }
         ArtifactSource::Slot(slot) => Ok(slot_port_layout(&layout.slots[slot.get() as usize])),
@@ -2489,6 +2490,7 @@ fn slot_port_layout(slot: &ResolvedSlot) -> ResidentPortLayout {
         schema_key: slot.schema_key,
         kind: slot.region.kind,
         shape: slot.region.shape,
+        shape_instance: slot.shape.clone(),
     }
 }
 

--- a/src/engine/src/resident/numeric.rs
+++ b/src/engine/src/resident/numeric.rs
@@ -34,6 +34,9 @@ pub(crate) fn install(builder: &mut FunctionCatalogBuilder) -> MResult<()> {
     register(builder, &["math"], "mod", bind_remainder)?;
     register(builder, &["math"], "neg", bind_negate)?;
     register(builder, &["math"], "pow", bind_pow)?;
+    register(builder, &["math"], "abs", bind_abs)?;
+    register(builder, &["math"], "floor", bind_floor)?;
+    register(builder, &["math"], "sqrt", bind_sqrt)?;
     register(builder, &["math"], "atan2", bind_atan2)?;
     register(builder, &["math"], "cos", bind_cos)?;
     register(builder, &["math"], "sin", bind_sin)?;
@@ -226,6 +229,12 @@ pub(crate) fn install(builder: &mut FunctionCatalogBuilder) -> MResult<()> {
     register(builder, &runtime, "ModRDS<f64>", bind_remainder)?;
     register(builder, &runtime, "MathCosF64S", bind_cos)?;
     register(builder, &runtime, "MathCosF64VD", bind_cos)?;
+    register(builder, &runtime, "MathAbsF64S", bind_abs)?;
+    register(builder, &runtime, "MathAbsF64VD", bind_abs)?;
+    register(builder, &runtime, "MathFloorF64S", bind_floor)?;
+    register(builder, &runtime, "MathFloorF64VD", bind_floor)?;
+    register(builder, &runtime, "MathSqrtF64S", bind_sqrt)?;
+    register(builder, &runtime, "MathSqrtF64VD", bind_sqrt)?;
     register(builder, &runtime, "MathSinF64S", bind_sin)?;
     register(builder, &runtime, "MathSinF64VD", bind_sin)?;
     register(builder, &runtime, "Atan2F64", bind_atan2)?;
@@ -897,6 +906,24 @@ fn bind_cos(
     request: &ResidentKernelBindRequest<'_>,
 ) -> Result<BoundResidentKernel, ResidentKernelBindError> {
     bind_unary_f64(request, cosine)
+}
+
+fn bind_abs(
+    request: &ResidentKernelBindRequest<'_>,
+) -> Result<BoundResidentKernel, ResidentKernelBindError> {
+    bind_unary_f64(request, absolute)
+}
+
+fn bind_floor(
+    request: &ResidentKernelBindRequest<'_>,
+) -> Result<BoundResidentKernel, ResidentKernelBindError> {
+    bind_unary_f64(request, floor)
+}
+
+fn bind_sqrt(
+    request: &ResidentKernelBindRequest<'_>,
+) -> Result<BoundResidentKernel, ResidentKernelBindError> {
+    bind_unary_f64(request, square_root)
 }
 
 fn bind_sin(
@@ -2443,6 +2470,30 @@ fn cosine(
     unary_f64(inputs, output, f64::cos)
 }
 
+fn absolute(
+    _kernel: &BoundResidentKernel,
+    inputs: &dyn ResidentKernelInputs,
+    output: ResidentValueMut<'_>,
+) -> Result<bool, ResidentKernelError> {
+    unary_f64(inputs, output, f64::abs)
+}
+
+fn floor(
+    _kernel: &BoundResidentKernel,
+    inputs: &dyn ResidentKernelInputs,
+    output: ResidentValueMut<'_>,
+) -> Result<bool, ResidentKernelError> {
+    unary_f64(inputs, output, f64::floor)
+}
+
+fn square_root(
+    _kernel: &BoundResidentKernel,
+    inputs: &dyn ResidentKernelInputs,
+    output: ResidentValueMut<'_>,
+) -> Result<bool, ResidentKernelError> {
+    unary_f64(inputs, output, f64::sqrt)
+}
+
 fn sine(
     _kernel: &BoundResidentKernel,
     inputs: &dyn ResidentKernelInputs,
@@ -3567,6 +3618,25 @@ mod tests {
 
         fn get(&self, index: usize) -> Option<ResidentValueRef<'_>> {
             self.0.get(index).copied()
+        }
+    }
+
+    #[test]
+    fn resident_unary_math_supports_abs_floor_and_sqrt_vectors() {
+        let cases: &[(mech_core::ResidentKernelExecutor, &[f64], &[f64])] = &[
+            (absolute, &[-2.5, 0.0, 3.25], &[2.5, 0.0, 3.25]),
+            (floor, &[-1.2, 0.0, 3.9], &[-2.0, 0.0, 3.0]),
+            (square_root, &[0.0, 4.0, 9.0], &[0.0, 2.0, 3.0]),
+        ];
+        for (executor, input, expected) in cases {
+            let values = [ResidentValueRef::F64(input)];
+            let kernel = BoundResidentKernel::new(*executor, Box::new([]));
+            let mut output = [f64::NAN; 3];
+            assert_eq!(
+                kernel.execute(&Inputs(&values), ResidentValueMut::F64(&mut output)),
+                Ok(true),
+            );
+            assert_eq!(&output, expected);
         }
     }
 

--- a/src/engine/src/resident/numeric.rs
+++ b/src/engine/src/resident/numeric.rs
@@ -1206,20 +1206,40 @@ fn bind_binary(
         &[ResidentValueKind::F64, ResidentValueKind::F64],
         ResidentValueKind::F64,
     )?;
-    let output_len = request
-        .output
-        .shape
-        .len()
-        .ok_or(ResidentKernelBindError::UnsupportedLayout)?;
-    if request.inputs.iter().any(|input| {
-        input
-            .shape
-            .len()
-            .is_none_or(|len| len != 1 && len != output_len)
-    }) {
+    let rows = request.output.shape.rows;
+    let columns = request.output.shape.columns;
+    if request.output.shape.len().is_none() {
         return Err(ResidentKernelBindError::UnsupportedLayout);
     }
-    bound(executor, Vec::<u64>::new().into_boxed_slice())
+    let modes = request
+        .inputs
+        .iter()
+        .map(|input| binary_broadcast_mode(input.shape, request.output.shape))
+        .collect::<Option<Vec<_>>>()
+        .ok_or(ResidentKernelBindError::UnsupportedLayout)?;
+    bound(
+        executor,
+        vec![rows as u64, columns as u64, modes[0], modes[1]].into_boxed_slice(),
+    )
+}
+
+const BINARY_BROADCAST_SCALAR: u64 = 0;
+const BINARY_BROADCAST_EXACT: u64 = 1;
+const BINARY_BROADCAST_COLUMN: u64 = 2;
+const BINARY_BROADCAST_ROW: u64 = 3;
+
+fn binary_broadcast_mode(input: ResidentShape, output: ResidentShape) -> Option<u64> {
+    if input == output {
+        Some(BINARY_BROADCAST_EXACT)
+    } else if input.len() == Some(1) {
+        Some(BINARY_BROADCAST_SCALAR)
+    } else if input.rows == output.rows && input.columns == 1 {
+        Some(BINARY_BROADCAST_COLUMN)
+    } else if input.rows == 1 && input.columns == output.columns {
+        Some(BINARY_BROADCAST_ROW)
+    } else {
+        None
+    }
 }
 
 fn f64_output_change_detection(
@@ -2432,14 +2452,15 @@ fn sine(
 }
 
 fn atan2(
-    _kernel: &BoundResidentKernel,
+    kernel: &BoundResidentKernel,
     inputs: &dyn ResidentKernelInputs,
     output: ResidentValueMut<'_>,
 ) -> Result<bool, ResidentKernelError> {
-    binary_f64(inputs, output, f64::atan2)
+    binary_f64(kernel, inputs, output, f64::atan2)
 }
 
 fn binary_f64(
+    kernel: &BoundResidentKernel,
     inputs: &dyn ResidentKernelInputs,
     output: ResidentValueMut<'_>,
     operation: impl Fn(f64, f64) -> f64,
@@ -2450,58 +2471,112 @@ fn binary_f64(
     let left = f64_input(inputs, 0)?;
     let right = f64_input(inputs, 1)?;
     let output = f64_output(output)?;
-    let output_len = output.len();
-    let pick = |values: &[f64], index: usize| match values.len() {
-        1 => Some(values[0]),
-        len if len == output_len => Some(values[index]),
-        _ => None,
+    let parameters = kernel.parameters();
+    if parameters.is_empty() {
+        let output_len = output.len();
+        let pick = |values: &[f64], index: usize| match values.len() {
+            1 => Some(values[0]),
+            len if len == output_len => Some(values[index]),
+            _ => None,
+        };
+        if pick(left, 0).is_none() || pick(right, 0).is_none() {
+            return Err(ResidentKernelError::InvalidShape);
+        }
+        return Ok(replace_f64(output, |index| {
+            operation(pick(left, index).unwrap(), pick(right, index).unwrap())
+        }));
+    }
+    let [rows, columns, left_mode, right_mode] = parameters else {
+        return Err(ResidentKernelError::InvalidInput);
     };
-    if pick(left, 0).is_none() || pick(right, 0).is_none() {
+    let rows = *rows as usize;
+    let columns = *columns as usize;
+    let output_len = rows
+        .checked_mul(columns)
+        .ok_or(ResidentKernelError::InvalidShape)?;
+    if output.len() != output_len {
         return Err(ResidentKernelError::InvalidShape);
     }
+    validate_binary_broadcast_input(left, *left_mode, rows, columns)?;
+    validate_binary_broadcast_input(right, *right_mode, rows, columns)?;
     Ok(replace_f64(output, |index| {
-        operation(pick(left, index).unwrap(), pick(right, index).unwrap())
+        operation(
+            binary_broadcast_value(left, *left_mode, index, rows),
+            binary_broadcast_value(right, *right_mode, index, rows),
+        )
     }))
 }
 
+fn validate_binary_broadcast_input(
+    values: &[f64],
+    mode: u64,
+    rows: usize,
+    columns: usize,
+) -> Result<(), ResidentKernelError> {
+    let expected = match mode {
+        BINARY_BROADCAST_SCALAR => 1,
+        BINARY_BROADCAST_EXACT => rows
+            .checked_mul(columns)
+            .ok_or(ResidentKernelError::InvalidShape)?,
+        BINARY_BROADCAST_COLUMN => rows,
+        BINARY_BROADCAST_ROW => columns,
+        _ => return Err(ResidentKernelError::InvalidInput),
+    };
+    if values.len() == expected {
+        Ok(())
+    } else {
+        Err(ResidentKernelError::InvalidShape)
+    }
+}
+
+fn binary_broadcast_value(values: &[f64], mode: u64, index: usize, rows: usize) -> f64 {
+    match mode {
+        BINARY_BROADCAST_SCALAR => values[0],
+        BINARY_BROADCAST_EXACT => values[index],
+        BINARY_BROADCAST_COLUMN => values[index % rows],
+        BINARY_BROADCAST_ROW => values[index / rows],
+        _ => unreachable!("validated binary broadcast mode"),
+    }
+}
+
 fn subtract(
-    _kernel: &BoundResidentKernel,
+    kernel: &BoundResidentKernel,
     inputs: &dyn ResidentKernelInputs,
     output: ResidentValueMut<'_>,
 ) -> Result<bool, ResidentKernelError> {
-    binary_f64(inputs, output, |left, right| left - right)
+    binary_f64(kernel, inputs, output, |left, right| left - right)
 }
 
 fn add(
-    _kernel: &BoundResidentKernel,
+    kernel: &BoundResidentKernel,
     inputs: &dyn ResidentKernelInputs,
     output: ResidentValueMut<'_>,
 ) -> Result<bool, ResidentKernelError> {
-    binary_f64(inputs, output, |left, right| left + right)
+    binary_f64(kernel, inputs, output, |left, right| left + right)
 }
 
 fn multiply(
-    _kernel: &BoundResidentKernel,
+    kernel: &BoundResidentKernel,
     inputs: &dyn ResidentKernelInputs,
     output: ResidentValueMut<'_>,
 ) -> Result<bool, ResidentKernelError> {
-    binary_f64(inputs, output, |left, right| left * right)
+    binary_f64(kernel, inputs, output, |left, right| left * right)
 }
 
 fn divide(
-    _kernel: &BoundResidentKernel,
+    kernel: &BoundResidentKernel,
     inputs: &dyn ResidentKernelInputs,
     output: ResidentValueMut<'_>,
 ) -> Result<bool, ResidentKernelError> {
-    binary_f64(inputs, output, |left, right| left / right)
+    binary_f64(kernel, inputs, output, |left, right| left / right)
 }
 
 fn remainder(
-    _kernel: &BoundResidentKernel,
+    kernel: &BoundResidentKernel,
     inputs: &dyn ResidentKernelInputs,
     output: ResidentValueMut<'_>,
 ) -> Result<bool, ResidentKernelError> {
-    binary_f64(inputs, output, |left, right| left % right)
+    binary_f64(kernel, inputs, output, |left, right| left % right)
 }
 
 fn binary_f64_comparison(
@@ -2759,11 +2834,11 @@ fn strict_not_equal(
 }
 
 fn power(
-    _kernel: &BoundResidentKernel,
+    kernel: &BoundResidentKernel,
     inputs: &dyn ResidentKernelInputs,
     output: ResidentValueMut<'_>,
 ) -> Result<bool, ResidentKernelError> {
-    binary_f64(inputs, output, f64::powf)
+    binary_f64(kernel, inputs, output, f64::powf)
 }
 
 fn multiply_rows(
@@ -3569,6 +3644,120 @@ mod tests {
         );
         assert_eq!(column_output, [3.0, 7.0]);
         assert_eq!(row_output, [4.0, 6.0]);
+    }
+
+    #[test]
+    fn binary_arithmetic_broadcasts_rows_columns_and_outer_vectors() {
+        let matrix = [1.0, 4.0, 2.0, 5.0, 3.0, 6.0];
+        let row = [10.0, 20.0, 30.0];
+        let column = [10.0, 100.0];
+
+        let row_inputs = [ResidentValueRef::F64(&matrix), ResidentValueRef::F64(&row)];
+        let row_kernel = BoundResidentKernel::new(
+            add,
+            Box::new([2, 3, BINARY_BROADCAST_EXACT, BINARY_BROADCAST_ROW]),
+        );
+        let mut row_output = [0.0; 6];
+        assert_eq!(
+            row_kernel.execute(&Inputs(&row_inputs), ResidentValueMut::F64(&mut row_output),),
+            Ok(true),
+        );
+        assert_eq!(row_output, [11.0, 14.0, 22.0, 25.0, 33.0, 36.0]);
+
+        let column_inputs = [
+            ResidentValueRef::F64(&column),
+            ResidentValueRef::F64(&matrix),
+        ];
+        let column_kernel = BoundResidentKernel::new(
+            subtract,
+            Box::new([2, 3, BINARY_BROADCAST_COLUMN, BINARY_BROADCAST_EXACT]),
+        );
+        let mut column_output = [0.0; 6];
+        assert_eq!(
+            column_kernel.execute(
+                &Inputs(&column_inputs),
+                ResidentValueMut::F64(&mut column_output),
+            ),
+            Ok(true),
+        );
+        assert_eq!(column_output, [9.0, 96.0, 8.0, 95.0, 7.0, 94.0]);
+
+        let outer_inputs = [ResidentValueRef::F64(&column), ResidentValueRef::F64(&row)];
+        let outer_kernel = BoundResidentKernel::new(
+            add,
+            Box::new([2, 3, BINARY_BROADCAST_COLUMN, BINARY_BROADCAST_ROW]),
+        );
+        let mut outer_output = [0.0; 6];
+        assert_eq!(
+            outer_kernel.execute(
+                &Inputs(&outer_inputs),
+                ResidentValueMut::F64(&mut outer_output),
+            ),
+            Ok(true),
+        );
+        assert_eq!(outer_output, [20.0, 110.0, 30.0, 120.0, 40.0, 130.0]);
+
+        let empty_inputs = [ResidentValueRef::F64(&[]), ResidentValueRef::F64(&row)];
+        let empty_kernel = BoundResidentKernel::new(
+            add,
+            Box::new([0, 3, BINARY_BROADCAST_EXACT, BINARY_BROADCAST_ROW]),
+        );
+        let mut empty_output = [];
+        assert_eq!(
+            empty_kernel.execute(
+                &Inputs(&empty_inputs),
+                ResidentValueMut::F64(&mut empty_output),
+            ),
+            Ok(false),
+        );
+    }
+
+    #[test]
+    fn binary_broadcast_layout_selection_preserves_vector_orientation() {
+        let output = ResidentShape {
+            rows: 2,
+            columns: 3,
+        };
+        assert_eq!(
+            binary_broadcast_mode(
+                ResidentShape {
+                    rows: 2,
+                    columns: 3,
+                },
+                output,
+            ),
+            Some(BINARY_BROADCAST_EXACT),
+        );
+        assert_eq!(
+            binary_broadcast_mode(
+                ResidentShape {
+                    rows: 2,
+                    columns: 1,
+                },
+                output,
+            ),
+            Some(BINARY_BROADCAST_COLUMN),
+        );
+        assert_eq!(
+            binary_broadcast_mode(
+                ResidentShape {
+                    rows: 1,
+                    columns: 3,
+                },
+                output,
+            ),
+            Some(BINARY_BROADCAST_ROW),
+        );
+        assert_eq!(
+            binary_broadcast_mode(
+                ResidentShape {
+                    rows: 1,
+                    columns: 2,
+                },
+                output,
+            ),
+            None,
+        );
     }
 
     #[test]

--- a/src/engine/src/resident/numeric.rs
+++ b/src/engine/src/resident/numeric.rs
@@ -3899,6 +3899,11 @@ mod tests {
             schema_key: schemas.entry(schema_id).unwrap().key(),
             kind: ResidentValueKind::F64,
             shape,
+            shape_instance: schemas
+                .get(schema_id)
+                .unwrap()
+                .instantiate_shape(Box::new([]))
+                .unwrap(),
         };
         let row_shape = ResidentShape {
             rows: 1,
@@ -4145,17 +4150,29 @@ mod tests {
 
     #[test]
     fn strict_identity_distinguishes_scalar_from_one_by_one_matrix() {
+        let shape_instance = || {
+            mech_core::SchemaDraft {
+                dimension_parameters: Box::new([]),
+                body: SchemaBody::FloatingPoint(mech_core::FloatWidth::W64),
+            }
+            .finalize()
+            .unwrap()
+            .instantiate_shape(Box::new([]))
+            .unwrap()
+        };
         let scalar = mech_core::ResidentPortLayout {
             schema_id: mech_core::SchemaId::new(1),
             schema_key: mech_core::SchemaKey::from_bytes([1; 32]),
             kind: ResidentValueKind::F64,
             shape: ResidentShape::SCALAR,
+            shape_instance: shape_instance(),
         };
         let matrix = mech_core::ResidentPortLayout {
             schema_id: mech_core::SchemaId::new(2),
             schema_key: mech_core::SchemaKey::from_bytes([2; 32]),
             kind: ResidentValueKind::F64,
             shape: ResidentShape::SCALAR,
+            shape_instance: shape_instance(),
         };
         assert!(!strict_inputs_share_identity(&scalar, &matrix));
     }
@@ -4196,12 +4213,22 @@ mod tests {
             schema_key: schemas.entry(scalar).unwrap().key(),
             kind: ResidentValueKind::F64,
             shape: ResidentShape::SCALAR,
+            shape_instance: schemas
+                .get(scalar)
+                .unwrap()
+                .instantiate_shape(Box::new([]))
+                .unwrap(),
         };
         let output = mech_core::ResidentPortLayout {
             schema_id: matrix,
             schema_key: schemas.entry(matrix).unwrap().key(),
             kind: ResidentValueKind::F64,
             shape: ResidentShape::SCALAR,
+            shape_instance: schemas
+                .get(matrix)
+                .unwrap()
+                .instantiate_shape(Box::new([]))
+                .unwrap(),
         };
         let contract = ResolvedOperationContract::Declared(mech_core::DeclaredOperationContract {
             inputs: vec![mech_core::ResolvedInputPort {
@@ -4292,6 +4319,11 @@ mod tests {
                 schema_key: schemas.entry(schema_id).unwrap().key(),
                 kind: ResidentValueKind::F64,
                 shape: ResidentShape::SCALAR,
+                shape_instance: schemas
+                    .get(schema_id)
+                    .unwrap()
+                    .instantiate_shape(Box::new([]))
+                    .unwrap(),
             };
             let request = ResidentKernelBindRequest {
                 contract: &contract,

--- a/src/engine/src/structures.rs
+++ b/src/engine/src/structures.rs
@@ -556,9 +556,29 @@ fn handle_column_kind(
             );
         }
 
-        x => {
-            println!("Unsupported kind in table column: {:?}", x);
-            todo!()
+        declared_kind => {
+            let values = val.as_vec();
+            for value in &values {
+                let actual_kind = value.deref_kind();
+                if actual_kind != declared_kind {
+                    return Err(MechError::new(
+                        TableColumnKindMismatchError {
+                            column_id: id,
+                            expected_kind: declared_kind.clone(),
+                            actual_kind,
+                        },
+                        None,
+                    )
+                    .with_compiler_loc());
+                }
+            }
+            data_map.insert(
+                id,
+                (
+                    declared_kind,
+                    LegacyValue::to_matrix(values.clone(), values.len(), 1),
+                ),
+            );
         }
     }
 

--- a/src/engine/src/structures.rs
+++ b/src/engine/src/structures.rs
@@ -545,6 +545,23 @@ fn handle_column_kind(
                 ),
             );
         }
+        ValueKind::Index => {
+            let source_values = val.as_vec();
+            let mut values = Vec::with_capacity(source_values.len());
+            for value in source_values {
+                let LegacyValue::Index(index) = value.as_index()? else {
+                    unreachable!("numeric index conversion returned a non-index scalar")
+                };
+                values.push(LegacyValue::Index(index));
+            }
+            data_map.insert(
+                id,
+                (
+                    ValueKind::Index,
+                    LegacyValue::to_matrix(values.clone(), values.len(), 1),
+                ),
+            );
+        }
         ValueKind::Any => {
             let vals: Vec<LegacyValue> = val.as_vec().iter().map(|x| x.clone()).collect();
             data_map.insert(

--- a/src/runtime/src/input.rs
+++ b/src/runtime/src/input.rs
@@ -184,6 +184,10 @@ impl RuntimeHostInputValue {
                 "RuntimeHostInputValueUnsupported",
                 "f64 host input values require the `f64` feature",
             )),
+            RuntimeHostInputValue::Index(0) => Err(input_error(
+                "RuntimeHostInputValueInvalid",
+                "index host input values must be in 1..=max",
+            )),
             RuntimeHostInputValue::Index(value) => Ok(LegacyValue::Index(Ref::new(value))),
             #[cfg(feature = "matrix")]
             RuntimeHostInputValue::BoolMatrix {
@@ -208,6 +212,12 @@ impl RuntimeHostInputValue {
                 values,
             } => {
                 validate_matrix_input(rows, columns, values.len())?;
+                if values.contains(&0) {
+                    return Err(input_error(
+                        "RuntimeHostInputValueInvalid",
+                        "index matrix host input values must be in 1..=max",
+                    ));
+                }
                 Ok(LegacyValue::MatrixIndex(ValueMatrix::from_vec(
                     values, rows, columns,
                 )))
@@ -580,6 +590,21 @@ mod tests {
         assert_send_sync::<RuntimeHostInputValue>();
         assert_send_sync::<RuntimeHostInput>();
         assert_send_sync::<RuntimeIngress>();
+    }
+
+    #[test]
+    fn detached_indexes_are_one_based() {
+        assert!(RuntimeHostInputValue::Index(0).into_mech_value().is_err());
+        assert!(
+            RuntimeHostInputValue::IndexMatrix {
+                rows: 1,
+                columns: 2,
+                values: vec![1, 0],
+            }
+            .into_mech_value()
+            .is_err()
+        );
+        assert!(RuntimeHostInputValue::Index(1).into_mech_value().is_ok());
     }
 
     #[test]

--- a/src/runtime/src/runtime/program/tests.rs
+++ b/src/runtime/src/runtime/program/tests.rs
@@ -2220,7 +2220,7 @@ fn resident_observation_profile_covers_scalars_and_dense_matrices() {
         crate::RuntimeHostInputValue::Bool(true),
     );
     assert_typed_observation_round_trip(
-        LegacyValue::Index(Ref::new(0)),
+        LegacyValue::Index(Ref::new(1)),
         crate::RuntimeHostInputValue::Index(7),
     );
     assert_typed_observation_round_trip(
@@ -2236,7 +2236,7 @@ fn resident_observation_profile_covers_scalars_and_dense_matrices() {
         },
     );
     assert_typed_observation_round_trip(
-        LegacyValue::MatrixIndex(ValueMatrix::from_vec(vec![0; 4], 2, 2)),
+        LegacyValue::MatrixIndex(ValueMatrix::from_vec(vec![1; 4], 2, 2)),
         crate::RuntimeHostInputValue::IndexMatrix {
             rows: 2,
             columns: 2,

--- a/src/runtime/src/runtime/program/tests.rs
+++ b/src/runtime/src/runtime/program/tests.rs
@@ -392,7 +392,13 @@ fn product_scene_point_set_positions(value: &LegacyValue) -> Vec<f64> {
             };
             record.clone()
         }
-        other => panic!("scene point-sets must contain a record, got {other:?}"),
+        LegacyValue::Table(table) if table.borrow().rows == 1 => Ref::new(
+            table
+                .borrow()
+                .get_record(1)
+                .expect("scene point-set table row"),
+        ),
+        other => panic!("scene point-sets must contain one record, got {other:?}"),
     };
     let point_set = point_set.borrow();
     product_scene_matrix_values(

--- a/src/runtime/src/snapshot/tests.rs
+++ b/src/runtime/src/snapshot/tests.rs
@@ -13,7 +13,7 @@ use crate::RuntimeValueSnapshot;
 fn runtime_value_snapshot_is_empty_matches_value_empty() {
     assert!(RuntimeValueSnapshot::empty().is_empty());
 
-    let non_empty = RuntimeValueSnapshot::try_capture(&LegacyValue::Index(Ref::new(0))).unwrap();
+    let non_empty = RuntimeValueSnapshot::try_capture(&LegacyValue::Index(Ref::new(1))).unwrap();
     assert!(!non_empty.is_empty());
 }
 

--- a/src/stdlib/Cargo.toml
+++ b/src/stdlib/Cargo.toml
@@ -183,7 +183,7 @@ math_default = [
   "mech-math", "mech-math/math_default",
   "math_add", "math_sub", "math_mul", "math_div", "math_pow", "math_mod",
   "math_neg", "math_add_assign", "math_sub_assign", "math_mul_assign",
-  "math_div_assign", "math_sqrt", "math_ceil", "math_acos", "math_acosh", "math_acot",
+  "math_div_assign", "math_sqrt", "math_ceil", "math_floor", "math_acos", "math_acosh", "math_acot",
   "math_acsc", "math_asec", "math_asin", "math_asinh", "math_atan",
   "math_atan2", "math_atanh", "math_cos", "math_cosh", "math_cot",
   "math_csc", "math_sec", "math_sin", "math_sinh", "math_tan", "math_tanh",
@@ -227,6 +227,7 @@ math_mul_assign = ["mech-math", "mech-math/mul_assign", "mech-engine/math_mul_as
 math_div_assign = ["mech-math", "mech-math/div_assign", "mech-engine/math_div_assign"]
 math_sqrt = ["mech-math", "mech-math/sqrt", "mech-engine/math_sqrt"]
 math_ceil = ["mech-math", "mech-math/ceil"]
+math_floor = ["mech-math", "mech-math/floor"]
 math_acos = ["mech-math", "mech-math/acos", "mech-engine/math_acos"]
 math_acosh = ["mech-math", "mech-math/acosh", "mech-engine/math_acosh"]
 math_acot = ["mech-math", "mech-math/acot", "mech-engine/math_acot"]

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -2832,6 +2832,10 @@ impl Formatter {
                 ..
             })
         );
+        let is_block_context = matches!(
+            node,
+            Statement::ContextDeclaration(context) if context.capabilities.len() > 3
+        );
         let s = match node {
             Statement::ImportDeclaration(import) => format!("+> {}", import.specifier.to_string()),
             Statement::ExportDeclaration(export) => format!("<+ {}", export.name.to_string()),
@@ -2852,7 +2856,7 @@ impl Formatter {
                     ContextBase::ResourceUri(uri) => uri.to_string(),
                     ContextBase::Context(name) => format!("@{}", name.to_string()),
                 };
-                let capabilities_text = context
+                let capabilities = context
                     .capabilities
                     .iter()
                     .map(|capability| {
@@ -2862,12 +2866,13 @@ impl Formatter {
                         };
                         format!(":{}({})", capability.operation.to_string(), scope)
                     })
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                let capabilities_text = if capabilities_text.is_empty() {
+                    .collect::<Vec<_>>();
+                let capabilities_text = if capabilities.is_empty() {
                     String::new()
+                } else if is_block_context {
+                    format!(" {{\n  {}\n}}", capabilities.join(",\n  "))
                 } else {
-                    format!(" {{ {} }}", capabilities_text)
+                    format!(" {{ {} }}", capabilities.join(", "))
                 };
                 if self.html {
                     let base_html = match &context.base {
@@ -2900,29 +2905,54 @@ impl Formatter {
                     let capabilities_html = context
                         .capabilities
                         .iter()
-                        .map(|capability| {
+                        .enumerate()
+                        .map(|(index, capability)| {
                             let scope = match &capability.scope {
                                 ContextCapabilityScope::Path(path) => path.to_string(),
                                 ContextCapabilityScope::Wildcard(_) => "*".to_string(),
                             };
-                            format!(
+                            let capability_html = format!(
                                 "<span class=\"mech-context-capability\"><span class=\"mech-atom-sigil\">:</span><span class=\"mech-atom-name\">{}</span><span class=\"mech-left-paren\">(</span><span class=\"mech-context-path\">{}</span><span class=\"mech-right-paren\">)</span></span>",
                                 capability.operation.to_string(),
                                 escape_html_text(&scope)
-                            )
+                            );
+                            if is_block_context {
+                                let separator = if index + 1 == context.capabilities.len() {
+                                    ""
+                                } else {
+                                    "<span class=\"mech-context-capability-separator\">,</span>"
+                                };
+                                format!(
+                                    "<span class=\"mech-context-capability-row\">{}{}</span>",
+                                    capability_html, separator
+                                )
+                            } else {
+                                capability_html
+                            }
                         })
-                        .collect::<Vec<_>>()
-                        .join("<span class=\"mech-context-capability-separator\">, </span>");
+                        .collect::<Vec<_>>();
                     let capabilities_html = if capabilities_html.is_empty() {
                         String::new()
+                    } else if is_block_context {
+                        format!(
+                            " <span class=\"mech-context-capabilities-open\">{{</span><span class=\"mech-context-capabilities mech-context-capabilities-block\">{}</span><span class=\"mech-context-capabilities-close\">}}</span>",
+                            capabilities_html.join("")
+                        )
                     } else {
                         format!(
                             " <span class=\"mech-context-capabilities\"><span class=\"mech-context-capabilities-open\">{{</span>{}<span class=\"mech-context-capabilities-close\">}}</span></span>",
-                            capabilities_html
+                            capabilities_html.join(
+                                "<span class=\"mech-context-capability-separator\">, </span>"
+                            )
                         )
                     };
                     format!(
-                        "<span class=\"mech-context-declaration\"><span class=\"mech-context-name\">@{}</span><span class=\"mech-define-op\">:=</span><span class=\"mech-context-base\">{}</span>{}</span>",
+                        "<span class=\"mech-context-declaration{}\"><span class=\"mech-context-name\">@{}</span><span class=\"mech-define-op\">:=</span><span class=\"mech-context-base\">{}</span>{}</span>",
+                        if is_block_context {
+                            " mech-context-declaration-block"
+                        } else {
+                            ""
+                        },
                         context.name.to_string(),
                         base_html,
                         capabilities_html
@@ -2940,6 +2970,8 @@ impl Formatter {
         if self.html {
             let class = if is_table_define {
                 "mech-statement mech-statement-table-define"
+            } else if is_block_context {
+                "mech-statement mech-statement-context-block"
             } else {
                 "mech-statement"
             };

--- a/src/syntax/src/formatter.rs
+++ b/src/syntax/src/formatter.rs
@@ -2726,12 +2726,18 @@ impl Formatter {
         } else {
             "".to_string()
         };
+        let is_table = matches!(&node.expression, Expression::Structure(Structure::Table(_)));
         let var = self.var(&node.var);
         let expression = self.expression(&node.expression);
         if self.html {
+            let class = if is_table {
+                "mech-variable-define mech-variable-define-table"
+            } else {
+                "mech-variable-define"
+            };
             format!(
-                "<span class=\"mech-variable-define\"><span class=\"mech-variable-mutable\">{}</span>{}<span class=\"mech-variable-define-op\">:=</span>{}</span>",
-                mutable, var, expression
+                "<span class=\"{}\"><span class=\"mech-variable-mutable\">{}</span>{}<span class=\"mech-variable-define-op\">:=</span>{}</span>",
+                class, mutable, var, expression
             )
         } else {
             format!("{}{} {} {}", mutable, var, ":=", expression)
@@ -2819,6 +2825,13 @@ impl Formatter {
     }
 
     pub fn statement(&mut self, node: &Statement) -> String {
+        let is_table_define = matches!(
+            node,
+            Statement::VariableDefine(VariableDefine {
+                expression: Expression::Structure(Structure::Table(_)),
+                ..
+            })
+        );
         let s = match node {
             Statement::ImportDeclaration(import) => format!("+> {}", import.specifier.to_string()),
             Statement::ExportDeclaration(export) => format!("<+ {}", export.name.to_string()),
@@ -2925,7 +2938,12 @@ impl Formatter {
             }
         };
         if self.html {
-            format!("<span class=\"mech-statement\">{}</span>", s)
+            let class = if is_table_define {
+                "mech-statement mech-statement-table-define"
+            } else {
+                "mech-statement"
+            };
+            format!("<span class=\"{}\">{}</span>", class, s)
         } else {
             format!("{}", s)
         }

--- a/src/syntax/src/statements.rs
+++ b/src/syntax/src/statements.rs
@@ -453,10 +453,13 @@ pub fn context_declaration(input: ParseString) -> ParseResult<ContextDeclaration
     let (input, _) = define_operator(input)?;
     let (input, base) = alt((context_base_resource_uri, context_base_context))(input)?;
     let (input, capabilities) = opt(|input| {
+        let (input, _) = whitespace0(input)?;
         let (input, _) = left_brace(input)?;
+        let (input, _) = whitespace0(input)?;
         let (input, capabilities) =
             separated_list1(list_separator, context_capability_declaration)(input)?;
         let (input, _) = opt(list_separator)(input)?;
+        let (input, _) = whitespace0(input)?;
         let (input, _) = right_brace(input)?;
         Ok((input, capabilities))
     })(input)?;

--- a/src/syntax/tests/context_parser.rs
+++ b/src/syntax/tests/context_parser.rs
@@ -46,6 +46,23 @@ fn parses_context_declaration_with_resource_base() {
 }
 
 #[test]
+fn parses_multiline_context_capabilities_after_a_spaced_resource_base() {
+    let stmts = statements(
+        "@filters := compute://filters/kernel {\n  :read(sample/result.0),\n  :read(sample/result.2),\n  :read(turns),\n  :write(input/control),\n  :write(input/camera),\n  :write(input/measurement),\n  :write(turn)\n}",
+    );
+
+    assert_eq!(stmts.len(), 1);
+    match &stmts[0] {
+        Statement::ContextDeclaration(context) => {
+            assert_eq!(context.capabilities.len(), 7);
+            assert_eq!(context.capabilities[0].operation.to_string(), "read");
+            assert_eq!(context.capabilities[6].operation.to_string(), "write");
+        }
+        other => panic!("expected context declaration, got {other:?}"),
+    }
+}
+
+#[test]
 fn parses_context_declaration_with_context_base() {
     let stmts = statements("@users := @main{:read(users/*)}");
     match &stmts[0] {

--- a/src/syntax/tests/formatter.rs
+++ b/src/syntax/tests/formatter.rs
@@ -342,6 +342,29 @@ fn formatter_exposes_every_context_declaration_color_role() {
 }
 
 #[test]
+fn formatter_breaks_long_context_capability_sets_into_indented_rows() {
+    let statement = first_statement(
+        "@filters := compute://filters/kernel{:read(sample/result.0), :read(sample/result.2), :read(turns), :write(input/control), :write(input/camera), :write(input/measurement), :write(turn)}",
+    );
+    let expected = "@filters := compute://filters/kernel {\n  :read(sample/result.0),\n  :read(sample/result.2),\n  :read(turns),\n  :write(input/control),\n  :write(input/camera),\n  :write(input/measurement),\n  :write(turn)\n}";
+
+    assert_eq!(Formatter::new().statement(&statement), expected);
+
+    let mut formatter = Formatter::new();
+    formatter.html = true;
+    let html = formatter.statement(&statement);
+    assert!(
+        html.contains("class=\"mech-statement mech-statement-context-block\""),
+        "{html}",
+    );
+    assert!(
+        html.contains("mech-context-capabilities mech-context-capabilities-block"),
+        "{html}",
+    );
+    assert_eq!(html.matches("mech-context-capability-row").count(), 7);
+}
+
+#[test]
 fn formatter_marks_table_definitions_for_full_width_block_layout() {
     let statement = first_statement("scene := |id<string> x<f64>|\n         | \"robot\" 1 |");
     let mut formatter = Formatter::new();

--- a/src/syntax/tests/formatter.rs
+++ b/src/syntax/tests/formatter.rs
@@ -342,6 +342,24 @@ fn formatter_exposes_every_context_declaration_color_role() {
 }
 
 #[test]
+fn formatter_marks_table_definitions_for_full_width_block_layout() {
+    let statement = first_statement("scene := |id<string> x<f64>|\n         | \"robot\" 1 |");
+    let mut formatter = Formatter::new();
+    formatter.html = true;
+    let html = formatter.statement(&statement);
+
+    assert!(
+        html.contains("class=\"mech-statement mech-statement-table-define\""),
+        "{html}",
+    );
+    assert!(
+        html.contains("class=\"mech-variable-define mech-variable-define-table\""),
+        "{html}",
+    );
+    assert!(html.contains("<table class=\"mech-table\">"), "{html}");
+}
+
+#[test]
 fn formatter_marks_inline_grammar_sequence_punctuation() {
     let grammar = Grammar {
         rules: vec![Rule {

--- a/src/wasm/Cargo.toml
+++ b/src/wasm/Cargo.toml
@@ -81,7 +81,7 @@ browser_project = ["browser_project_core", "source", "sample_hold", "state_step"
 browser_compute = [
   "compiler", "f32", "f64", "row_vectord", "matrixd", "kind_annotation", "convert", "matrix_horzcat", "range_inclusive",
   "mech-runtime/compute",
-  "math_abs", "math_add", "math_sub", "math_mul", "math_div", "math_pow", "math_sqrt", "math_ceil", "math_atan2", "math_sin", "math_cos",
+  "math_abs", "math_add", "math_sub", "math_mul", "math_div", "math_pow", "math_sqrt", "math_ceil", "math_floor", "math_atan2", "math_sin", "math_cos",
   "variables", "variable_define", "variable_assign", "tuple",
   "mech-stdlib/native-plan", "dep:mech-compute", "dep:mech-gpu", "mech-gpu/runtime-host",
 ]
@@ -226,7 +226,7 @@ math_default = ["math_ops_default", "math_root_default", "math_rounding_default"
 math = ["formulas", "functions"]
 math_ops_default = ["math_add", "math_sub", "math_mul", "math_div", "math_pow", "math_mod", "math_neg"]
 math_root_default = ["math_sqrt"]
-math_rounding_default = ["math_ceil"]
+math_rounding_default = ["math_ceil", "math_floor"]
 math_ops_assign_default = ["math_add_assign", "math_sub_assign", "math_mul_assign", "math_div_assign"]
 math_trig_default = ["math_acos", "math_acosh", "math_acot", "math_acsc", "math_asec", "math_asin", "math_asinh", "math_atan", "math_atan2", "math_atanh", "math_cos", "math_cosh", "math_cot", "math_csc", "math_sec", "math_sin", "math_sinh", "math_tan", "math_tanh"]
 math_trig = ["math"]
@@ -266,6 +266,7 @@ math_mod = ["math_ops", "mech-stdlib/math_mod"]
 math_neg = ["math_ops", "mech-stdlib/math_neg"]
 math_sqrt = ["math_root", "mech-stdlib/math_sqrt"]
 math_ceil = ["math", "mech-stdlib/math_ceil"]
+math_floor = ["math", "mech-stdlib/math_floor"]
 
 # Set
 set_default = ["set_membership_default", "set_modify_default",

--- a/src/wasm/src/project.rs
+++ b/src/wasm/src/project.rs
@@ -4492,8 +4492,8 @@ rows := |id<string> x<f64>|
         };
         assert_eq!(
             runtime.program_execution_info().observation_count,
-            5,
-            "the resident artifact must observe the timer, two pointer fields, compute completion, and packed sample"
+            6,
+            "the resident artifact must observe the timer, two pointer fields, compute completion, packed sample, and sampled visibility"
         );
         assert!(scene_backend.latest().is_none());
         let pi = 3.141592654_f64;

--- a/src/wasm/src/project.rs
+++ b/src/wasm/src/project.rs
@@ -4354,6 +4354,16 @@ rows := |id<string> x<f64>|
             !source.contains("innovation-inverse") && !source.contains("innovation-determinant"),
             "the example must not expand a matrix inverse by hand",
         );
+        assert!(
+            !source.contains("matrix/vertcat")
+                && source.contains("advanced-truth-path := [truth-path[2..=376,:]; truth-screen']"),
+            "vertical concatenation must use matrix literal syntax",
+        );
+        assert!(
+            source.contains("scene-line-strips := |id<string> positions<*>")
+                && source.contains("scene-text := |id<string>"),
+            "scene collections must remain table values",
+        );
         let sources = HashMap::from([("localization.mec".to_string(), source.clone())]);
         let timer_factory = TestManualTimerHostFactory::new();
         let timer_driver = timer_factory.driver.clone();

--- a/src/wasm/src/project.rs
+++ b/src/wasm/src/project.rs
@@ -4377,9 +4377,14 @@ rows := |id<string> x<f64>|
                 && source.contains("advanced-truth-path := [truth-path[2..=376,:]; truth-screen']"),
             "vertical concatenation must use matrix literal syntax",
         );
+        let compact_source = source
+            .chars()
+            .filter(|character| !character.is_whitespace())
+            .collect::<String>();
         assert!(
-            source.contains("scene-line-strips := |id<string> positions<*>")
-                && source.contains("scene-text := |id<string>"),
+            compact_source.contains("scene-line-strips:=|id<string>positions<*>")
+                && compact_source.contains("scene-text:=|id<string>x<f64>y<f64>fill<f64>")
+                && compact_source.contains("font-weight<f64>"),
             "scene collections must remain table values",
         );
         let sources = HashMap::from([("localization.mec".to_string(), source.clone())]);

--- a/src/wasm/src/project.rs
+++ b/src/wasm/src/project.rs
@@ -4178,7 +4178,7 @@ scene := {
 
     #[cfg(not(feature = "browser_compute"))]
     #[test]
-    fn unsupported_generic_table_project_fails_closed_without_legacy_execution() {
+    fn generic_table_project_runs_without_legacy_execution() {
         let document = parse_config_document(
             "generic-table.mcfg",
             r#"config := { hosts: [] run: { paths: ["generic-table.mec"] grants: [] } }"#,
@@ -4198,12 +4198,9 @@ rows := |id<string> x<f64>|
             .source_resolver(project_source_resolver(&sources).unwrap())
             .build()
             .unwrap();
-        let error = run_project_sources(&mut runtime, &document).unwrap_err();
-        assert_production_route_failed_closed(
-            &runtime,
-            &error,
-            ResidentRouteFailureClass::SemanticUnsupported,
-        );
+        run_project_sources(&mut runtime, &document).unwrap();
+        assert_eq!(runtime.program_route(), RuntimeProgramRoute::ResidentPure);
+        runtime.root_symbol_value("rows").unwrap();
     }
 
     #[cfg(all(feature = "browser_host_timer", feature = "browser_host_scene"))]
@@ -4235,7 +4232,6 @@ rows := |id<string> x<f64>|
             self.0.lock().unwrap().snapshot()
         }
 
-        #[cfg(feature = "browser_compute")]
         fn publish_steps(&self, count: usize) -> mech_core::MResult<usize> {
             self.0.lock().unwrap().publish_steps(count)
         }
@@ -4273,11 +4269,16 @@ rows := |id<string> x<f64>|
 
     #[cfg(all(feature = "browser_host_timer", feature = "browser_host_scene"))]
     impl TestManualTimerHostFactory {
+        #[cfg(feature = "browser_compute")]
         fn new() -> Self {
+            Self::with_instance("clock")
+        }
+
+        fn with_instance(instance: &str) -> Self {
             Self {
                 manifest: mech_timer::timer_host_manifest().unwrap(),
                 driver: SharedManualTimerInputDriver::new(
-                    "clock",
+                    instance,
                     60,
                     1,
                     mech_timer::TimerQueuePolicy::Latest,
@@ -4491,8 +4492,8 @@ rows := |id<string> x<f64>|
         };
         assert_eq!(
             runtime.program_execution_info().observation_count,
-            7,
-            "the resident artifact must observe the timer, four pointer fields, compute completion, and packed sample"
+            5,
+            "the resident artifact must observe the timer, two pointer fields, compute completion, and packed sample"
         );
         assert!(scene_backend.latest().is_none());
         let pi = 3.141592654_f64;
@@ -4505,7 +4506,6 @@ rows := |id<string> x<f64>|
         let field_span = high_bound - low_bound;
         let side_ticks = 94_usize;
         let lap_ticks = side_ticks * 4;
-        let camera_dwell_ticks = side_ticks / 2;
         let camera_max_range = 3.6_f64;
         let camera_range_fade = 0.18_f64;
         let mut expected_truth = [2.5_f64, 2.5_f64, 0.0_f64];
@@ -4533,7 +4533,6 @@ rows := |id<string> x<f64>|
 
         let positive_part = |value: f64| (value + value.abs()) / 2.0;
         let clamp_unit = |value: f64| positive_part(value) - positive_part(value - 1.0);
-        let camera_schedule = [0_usize, 1, 1, 2, 2, 3, 3, 0];
         let mut saw_prediction_only_turn = false;
         let mut saw_camera_update = false;
         let mut saw_faded_camera_update = false;
@@ -4544,7 +4543,7 @@ rows := |id<string> x<f64>|
 
         // Publish five scheduler steps at a time. The configured latest-value
         // policy delivers only one packet, whose absolute tick jumps by five.
-        // The finite-state phase, camera schedule, and filter must nevertheless
+        // The vectorized phase, camera selection, and filter must nevertheless
         // advance exactly once per accepted resident packet. A full lap plus
         // part of the next side exercises every camera and every dead zone.
         for turn in 1..=420 {
@@ -4657,7 +4656,7 @@ rows := |id<string> x<f64>|
                 motion_jacobian * expected_covariance * motion_jacobian.transpose()
                     + control_jacobian * process_covariance * control_jacobian.transpose();
 
-            let camera_index = camera_schedule[(delivered_turn % lap_ticks) / camera_dwell_ticks];
+            let camera_index = ((delivered_turn + side_ticks / 2) / side_ticks) % 4;
             let active_camera = camera_positions[camera_index];
             let truth_dx = active_camera[0] - expected_truth[0];
             let truth_dy = active_camera[1] - expected_truth[1];
@@ -4952,7 +4951,7 @@ rows := |id<string> x<f64>|
 
     #[cfg(all(feature = "browser_host_timer", feature = "browser_host_scene"))]
     #[test]
-    fn unsupported_timer_table_scene_fails_before_effects_or_legacy_execution() {
+    fn timer_table_scene_runs_residently_and_publishes_its_tables() {
         let document = generic_fixture_document();
         let source_paths = required_path_strings(include_str!(
             "../tests/fixtures/generic-timer-table-scene/mech.mcfg"
@@ -4961,10 +4960,12 @@ rows := |id<string> x<f64>|
         assert_eq!(source_paths, vec!["table-scene.mec".to_string()]);
 
         let scene_backend = mech_scene::RecordingSceneBackend::new();
+        let timer_factory = TestManualTimerHostFactory::with_instance("tick");
+        let timer_driver = timer_factory.driver.clone();
         let mut builder = browser_runtime_builder()
             .source_resolver(project_source_resolver(&generic_fixture_sources()).unwrap())
             .host_input_capacity(16)
-            .host_factory(Box::new(TestManualTimerHostFactory::new()))
+            .host_factory(Box::new(timer_factory))
             .unwrap()
             .host_factory(Box::new(
                 mech_scene::SceneHostFactory::with_backend(scene_backend.clone()).unwrap(),
@@ -4977,13 +4978,18 @@ rows := |id<string> x<f64>|
             builder = builder.run_resource_grant(grant.clone());
         }
         let mut runtime = builder.build().unwrap();
-        let error = run_project_sources(&mut runtime, &document).unwrap_err();
-        assert_production_route_failed_closed(
-            &runtime,
-            &error,
-            ResidentRouteFailureClass::SemanticUnsupported,
+        run_project_sources(&mut runtime, &document).unwrap();
+        assert_eq!(
+            runtime.program_route(),
+            RuntimeProgramRoute::ResidentExternal
         );
-        assert_eq!(scene_backend.generation(), 0);
+        runtime.start_input_drivers().unwrap();
+        assert_eq!(timer_driver.publish_steps(1).unwrap(), 1);
+        runtime.drain_host_inputs(1).unwrap();
+        let scene = scene_backend.latest().unwrap();
+        assert_eq!(scene.circles.len(), 2);
+        assert_eq!(scene.lines.len(), 3);
+        assert_eq!(scene_backend.generation(), 1);
     }
 
     #[test]

--- a/src/wasm/src/project.rs
+++ b/src/wasm/src/project.rs
@@ -3247,9 +3247,9 @@ phase"#;
     }
 
     #[test]
-    fn encoded_document_controller_accepts_resident_atan2() {
+    fn encoded_document_controller_accepts_wildcard_imported_resident_atan2() {
         let tree = mech_syntax::parser::parse(
-            "Resident Atan2\n================\n+> math\n================\n\nangle := math/atan2(1.0, 0.0)\nangle",
+            "Resident Atan2\n================\n+> math/*\n================\n\nangle := atan2(1.0, 0.0)\nangle",
         )
         .unwrap();
         let module = ["math".to_string()];
@@ -4347,9 +4347,27 @@ rows := |id<string> x<f64>|
             "the Kalman gain must use the language's matrix solve operation",
         );
         assert!(
-            source.contains("observation-guard := 1f32 - math/ceil(z[3])"),
+            source.contains("observation-guard := 1f32 - ceil(z[3])"),
             "only a fully invisible camera may perturb singular observation geometry",
         );
+        assert!(
+            source.contains("+> math/*"),
+            "the EKF document must import the math module's public functions",
+        );
+        for qualified in [
+            "math/abs(",
+            "math/atan2(",
+            "math/ceil(",
+            "math/cos(",
+            "math/floor(",
+            "math/sin(",
+            "math/sqrt(",
+        ] {
+            assert!(
+                !source.contains(qualified),
+                "wildcard-imported math calls must be unqualified: {qualified}",
+            );
+        }
         assert!(
             !source.contains("innovation-inverse") && !source.contains("innovation-determinant"),
             "the example must not expand a matrix inverse by hand",

--- a/tests/style_layer_contract.rs
+++ b/tests/style_layer_contract.rs
@@ -170,6 +170,7 @@ fn page_variants_do_not_own_source_or_repl_components() {
 fn mechdown_layer_owns_the_portable_editorial_hierarchy() {
     let css = include("mechdown.css");
     for contract in [
+        "--mechdown-text: var(--mech-text-body, var(--body-primary, hsl(206 24% 90%)))",
         "counter-reset: mechdown-section",
         ".mechdown-section.mechdown-titled-section {\n  counter-increment: mechdown-section",
         ".mechdown-section > h2::before",
@@ -180,12 +181,18 @@ fn mechdown_layer_owns_the_portable_editorial_hierarchy() {
         "border: 1px solid var(--mechdown-accent)",
         "--mechdown-inline-code: var(--mech-syntax-variable, var(--var-name-color, #eddaf1))",
         "color: var(--mechdown-inline-code)",
+        ".mech-program-subtitle:is(:hover, :focus-within) > a",
+        "color: var(--mech-brand-deep, hsl(42 89% 60%))",
     ] {
         assert!(
             css.contains(contract),
             "Mechdown lost editorial style {contract}"
         );
     }
+    assert!(
+        !css.contains(".mech-program-subtitle:hover > a {\n  color: var(--mech-syntax"),
+        "section heading hover must not use a syntax color"
+    );
 }
 
 #[test]

--- a/tests/style_layer_contract.rs
+++ b/tests/style_layer_contract.rs
@@ -122,6 +122,9 @@ fn source_layer_keeps_the_structured_syntax_highlighting_contract() {
         ".mech-function-name",
         ".mech-matrix",
         ".mech-table",
+        ".mech-statement-table-define",
+        ".mech-variable-define-table",
+        "margin-left: 0",
     ] {
         assert!(css.contains(token), "source layer lost {token}");
     }
@@ -171,6 +174,8 @@ fn mechdown_layer_owns_the_portable_editorial_hierarchy() {
     let css = include("mechdown.css");
     for contract in [
         "--mechdown-text: var(--mech-text-body, var(--body-primary, hsl(206 24% 90%)))",
+        "--text-color-light: var(--mechdown-text)",
+        "--contrast-color-low: var(--mech-brand-deep, hsl(42 89% 60%))",
         "counter-reset: mechdown-section",
         ".mechdown-section.mechdown-titled-section {\n  counter-increment: mechdown-section",
         ".mechdown-section > h2::before",
@@ -183,6 +188,11 @@ fn mechdown_layer_owns_the_portable_editorial_hierarchy() {
         "color: var(--mechdown-inline-code)",
         ".mech-program-subtitle:is(:hover, :focus-within) > a",
         "color: var(--mech-brand-deep, hsl(42 89% 60%))",
+        ":is(.mech-paragraph, .mechdown-paragraph):not(",
+        "color: var(--mech-text-body, var(--body-primary, hsl(206 24% 90%)))",
+        "font-size: 1.06rem",
+        "font-weight: 400",
+        "line-height: 1.85",
     ] {
         assert!(
             css.contains(contract),
@@ -192,6 +202,10 @@ fn mechdown_layer_owns_the_portable_editorial_hierarchy() {
     assert!(
         !css.contains(".mech-program-subtitle:hover > a {\n  color: var(--mech-syntax"),
         "section heading hover must not use a syntax color"
+    );
+    assert!(
+        !include("blog.css").contains("Preserve the blog's cool, open long-form reading treatment"),
+        "long-form prose styling belongs to the shared Mechdown layer"
     );
 }
 
@@ -503,9 +517,6 @@ fn established_blog_color_and_component_details_are_preserved() {
         ".hero-summary .mech-summary",
         "border-top: 1px dotted var(--hero-accent)",
         "color: var(--hero-text-secondary)",
-        "color: var(--mech-text-body)",
-        "font-size: 1.06rem",
-        "line-height: 1.85",
         "scrollbar-color: var(--mech-scrollbar) transparent",
         "background: var(--mech-scrollbar-hover)",
         ".mech-image,",
@@ -513,9 +524,6 @@ fn established_blog_color_and_component_details_are_preserved() {
         "width: min(48%, 520px)",
         "body.narrow-content .mech-float",
         "@container (max-width: 980px)",
-        ".mech-summary,",
-        ".mechdown-table,",
-        ".mech-prompt",
         "grid-template-columns: var(--toc-width) minmax(0, 1fr)",
         ".article-layout:is(.hide-toc, .no-sections, .has-empty-toc)",
         "@media (max-width: 900px)",
@@ -526,6 +534,10 @@ fn established_blog_color_and_component_details_are_preserved() {
     let mechdown = include("mechdown.css");
     for contract in [
         ".mech-hyperlink,",
+        "color: var(--mech-text-body, var(--body-primary, hsl(206 24% 90%)))",
+        "font-size: 1.06rem",
+        "font-weight: 400",
+        "line-height: 1.85",
         ".mech-section-reference-link",
         "text-decoration-style: dotted",
         "text-underline-offset: 3px",

--- a/tests/style_layer_contract.rs
+++ b/tests/style_layer_contract.rs
@@ -124,6 +124,8 @@ fn source_layer_keeps_the_structured_syntax_highlighting_contract() {
         ".mech-table",
         ".mech-statement-table-define",
         ".mech-variable-define-table",
+        ".mech-statement-context-block",
+        ".mech-context-capabilities-block",
         "margin-left: 0",
     ] {
         assert!(css.contains(token), "source layer lost {token}");

--- a/tests/style_layer_contract.rs
+++ b/tests/style_layer_contract.rs
@@ -287,6 +287,11 @@ fn document_controller_keeps_toc_and_error_activity_state_continuous() {
     assert!(controller.contains("mech-console-error-count"));
 
     let page = include("style.css");
+    assert!(page.contains(".mech-toc-toggle {"));
+    assert!(page.contains("border: 1px solid var(--toc-accent)"));
+    assert!(page.contains(
+        ".mech-toc-toggle:hover,\n.mech-toc-toggle:focus-visible {\n  border-color: var(--toc-border)"
+    ));
     assert!(page.contains(".toc li.expanded > .toc-sub"));
     assert!(page.contains("border-left: 1px dotted var(--toc-accent-soft)"));
     assert!(page.contains(".article-layout.is-toc-open > .main-content"));


### PR DESCRIPTION
## Summary

- vectorize the EKF example's geometry, motion, observation, lane, trail, and rendering equations outside the filter itself
- add resident scalar, exact-shape, row, and column broadcasting for f64 binary arithmetic
- migrate homogeneous scene collections in EKF, n-body, and analog-clock examples from record tuples to typed tables
- extend scene and resident APIs for table-backed point sets, line strips, matrix-valued cells, and live composite table reconstruction
- retain the EKF line-strip tuple because its path matrices have genuinely different shapes

## Verification

- 420-step EKF browser oracle
- n-body resident integration
- analog-clock browser integration
- all 41 mech-scene tests
- resident broadcasting and composite-table tests
- core table encoding and snapshot reconstruction tests
- cargo fmt and git diff checks
