### PR TITLE
[v0.4-R2A] feat(core): derive type-memory contracts from schemas

### DIFF
--- a/docs/design/index.mec
+++ b/docs/design/index.mec
@@ -10,3 +10,4 @@ Design Documents
 - [Value-resident execution architecture](/design/value-resident-execution.html)
 - [Immutable value semantics and migration contract](/design/value-semantics-and-migration.html)
 - [Program artifact resident activation contract](/design/program-artifact-resident-activation.html)
+- [Type-memory boundary](/design/type-memory-boundary.html)

--- a/docs/design/type-memory-boundary.md
+++ b/docs/design/type-memory-boundary.md
@@ -1,0 +1,194 @@
+# Type-memory boundary
+
+## 1. Status and R2A scope
+
+R2A defines a read-only semantic projection from a finalized `Schema`, and from
+that schema plus a validated `ShapeInstance`, into memory-facing contracts.
+It changes no runtime binding, storage, target, or execution behavior.
+
+The projection has one direction:
+
+```text
+finalized Schema ---------------------> TypeMemoryContract
+       |
+       +-- revalidated ShapeInstance -> ResolvedTypeMemoryContract
+```
+
+The contracts describe obligations that a later storage implementation must
+satisfy. They are derived metadata, not another type system.
+
+## 2. Sources of authority
+
+`Schema` remains the sole authority for semantic type, child structure,
+nominal identity, field and variant names, equality, `SchemaKey`, and canonical
+encoding. `ShapeInstance` supplies dimension-parameter values only after the
+target schema validates them. Consumers that need children or names continue
+to traverse `SchemaBody`.
+
+## 3. One-way boundary
+
+There is no conversion from either memory contract back to a schema. Contract
+derivation does not cache data in `Schema`, and the contracts have no encoder
+or decoder. A contract cannot create or alter a schema or shape.
+
+## 4. TypeMemoryContract
+
+`TypeMemoryContract` records:
+
+- logical memory topology;
+- symbolic extent and its maximum evolution class;
+- positional, named, or keyed addressing obligations;
+- canonicalization obligations;
+- payload, population, and auxiliary accounting classes.
+
+It retains dimension and cardinality expressions only where a later phase must
+resolve extent. It does not copy nominal keys, names, or complete child
+contracts.
+
+## 5. ResolvedTypeMemoryContract
+
+`ResolvedTypeMemoryContract` has the same topology and obligations, but its
+extent contains checked values resolved through a shape revalidated by the
+target schema. Matrix axes retain independent evolution classes. Dynamic
+collection extents retain an optional resolved upper bound; they do not invent
+a current cardinality that is absent from `ShapeInstance`.
+
+## 6. Complete SchemaBody mapping
+
+| Schema body | Topology | Extent | Payload / population | Auxiliary |
+| --- | --- | --- | --- | --- |
+| `Dynamic` | `Dynamic` | `Single` | self-describing / single | none |
+| `Bool` | scalar Boolean | `Single` | fixed-width / single | none |
+| unsigned integer | scalar unsigned width | `Single` | fixed-width / single | none |
+| signed integer | scalar signed width | `Single` | fixed-width / single | none |
+| floating point | scalar floating width | `Single` | fixed-width / single | none |
+| complex | scalar complex width | `Single` | fixed-width / single | none |
+| `Rational64` | scalar rational | `Single` | fixed-width / single | none |
+| `String` | scalar string | `Single` | variable-width / single | none |
+| `Id` | scalar id | `Single` | fixed-width / single | none |
+| `Index` | scalar index | `Single` | fixed-width / single | none |
+| `Atom` | scalar atom | `Single` | fixed-width / single | none |
+| enum | tagged, variant count | `Single` | recursive / single | tag |
+| option | tagged, two variants | `Single` | recursive / single | tag |
+| tuple | unnamed product | fixed arity | recursive / fixed arity | none |
+| record | named product | fixed arity | recursive / fixed arity | none |
+| matrix | dense sequence, rank | dimensions | recursive / shape-resolved | none |
+| table | columnar, column count | row cardinality | recursive / exact or value cardinality | column directory |
+| set | ordered set | cardinality | recursive / exact or value cardinality | ordered index |
+| map | ordered map | cardinality | recursive / exact or value cardinality | ordered index |
+| `ReifiedType` | reified type | `Single` | self-describing / single | none |
+
+`Dynamic` and `ReifiedType` are self-describing. Enum and option values are
+recursive and tagged. Products, dense sequences, columnar values, sets, and
+maps are recursive. Sets and maps require ordered, unique keys.
+
+## 7. Extent evolution
+
+Evolution is ordered as:
+
+```text
+Fixed < ActivationFixed < TurnBounded < TurnUnbounded
+```
+
+Constants are fixed. Activation parameters are activation-fixed. Turn
+parameters are turn-bounded when they have an upper bound and turn-unbounded
+otherwise. `Add`, `Multiply`, `Min`, and `Max` take the maximum evolution of
+their operands. Exact cardinality follows its expression. Bounded dynamic
+cardinality is at least turn-bounded; unbounded dynamic cardinality is
+turn-unbounded. Composite evolution joins the extent with every nested child.
+String payload length is variable-width accounting, not extent evolution.
+
+Finalized schemas cannot retain holes or compile-time parameters. Resolution
+reports existing structured semantic errors for invalid or overflowing
+expressions.
+
+## 8. Addressing semantics
+
+Whole-value access is universal and is not represented by a flag. Strings and
+tuples have positional rank one. Matrices use their dimension count as rank.
+Tables have positional rank two and named members. Records have named members.
+Sets and maps have keyed members. The contract records obligations, not an
+offset, stride, index implementation, or physical lookup structure.
+
+## 9. Canonicalization obligations
+
+Self-describing values carry enough semantic information to identify their
+concrete value form. Recursive values require child canonicalization. Tagged
+values preserve their discriminant. Ordered collections preserve canonical key
+order, and unique-key collections cannot retain duplicates. These are logical
+requirements and do not prescribe a representation.
+
+## 10. Accounting obligations
+
+Payload accounting distinguishes fixed-width, variable-width, recursive, and
+self-describing values. Population accounting distinguishes single values,
+fixed products, shape-resolved sequences, exact cardinalities, and
+value-supplied dynamic cardinalities. Auxiliary accounting identifies tags,
+ordered indexes, and table column directories. R2A supplies classifications,
+not byte counts or budget enforcement.
+
+## 11. Semantic identity versus physical storage
+
+Schema equality and `SchemaKey` define semantic type identity. Logical value
+identity remains governed by the value model. A pointer is never semantic
+identity, and runtime representation is never logical value identity. Neither
+contract contains pointers, runtime cells, owners, targets, factories, or
+placement.
+
+## 12. Serialization prohibition
+
+The R2A contract types deliberately implement no serialization traits and have
+no wire format. Canonical schema bytes remain unchanged and authoritative.
+Derived contracts must be recomputed from the schema rather than persisted as
+another compatibility surface.
+
+## 13. R2B handoff
+
+R2B may describe existing storage capabilities and separate logical identity
+from physical storage identity. It must consume this semantic projection
+without moving schema authority into runtime representations.
+
+## 14. R2C handoff
+
+R2C may derive memory requirements for operation ports and compare those
+requirements with storage capabilities. It must not reinterpret schema
+identity or mutate the R2A contract.
+
+## 15. R2D closure
+
+R2D owns shadow conformance, architecture enforcement, CI integration, and R2
+roadmap closure. R2A alone does not mark R2 complete.
+
+## 16. R3 handoff
+
+R3 may use the boundary while tightening inference and conversion semantics.
+It must treat schema as the type authority and the memory contract as derived
+metadata.
+
+## 17. R4 handoff
+
+R4 owns retirement of transitional runtime representations and any binding
+cutover. R2A neither changes nor endorses a runtime representation.
+
+## 18. R5/R6 handoff
+
+R5 owns deterministic physical layout and resource planning, including sizes,
+alignment, strides, placement, and allocation plans. R6 owns allocators,
+backing, reuse, reclamation, and resource enforcement. R2A contains none of
+those mechanisms.
+
+## 19. Non-goals
+
+R2A does not add storage capability descriptors, operation-port memory
+requirements, compatibility checking, physical layout, allocation, inference,
+conversion, target availability, function binding, `ValueCell` behavior,
+Resident or GPU behavior, bytecode, canonical encoding, ABI changes, or
+package-version changes.
+
+## 20. R2A acceptance criteria
+
+R2A is complete when every current `SchemaBody` variant derives a total
+contract, extent evolution propagates recursively, supplied shapes are
+revalidated against the target schema, checked resolution rejects invalid
+dimensions, schema identity and canonical bytes are invariant, the new public
+types are not deserializable, and no runtime or wire-format behavior changes.

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -115,6 +115,7 @@ pub mod execution;
 pub mod function;
 #[path = "function/signature.rs"]
 mod function_signature;
+pub mod memory_contract;
 #[cfg(feature = "mika")]
 pub mod mika;
 pub mod nodes;
@@ -142,6 +143,7 @@ pub use self::execution::*;
 pub use self::function::*;
 #[cfg(not(feature = "functions"))]
 pub use self::function_signature::*;
+pub use self::memory_contract::*;
 #[cfg(feature = "mika")]
 pub use self::mika::*;
 pub use self::nodes::*;

--- a/src/core/src/memory_contract/mod.rs
+++ b/src/core/src/memory_contract/mod.rs
@@ -1,0 +1,5 @@
+//! Schema-derived memory-facing semantic obligations.
+
+mod type_contract;
+
+pub use self::type_contract::*;

--- a/src/core/src/memory_contract/type_contract.rs
+++ b/src/core/src/memory_contract/type_contract.rs
@@ -1,0 +1,650 @@
+//! Pure type-memory contract derivation.
+
+use crate::{
+    CardinalitySpec, DimensionExpr, DimensionLifetime, DimensionParameter, ExtentEvolution,
+    FloatWidth, IntegerWidth, SchemaBody, SemanticModelError, ShapeInstance,
+};
+
+#[cfg(feature = "no_std")]
+use alloc::{boxed::Box, vec::Vec};
+#[cfg(not(feature = "no_std"))]
+use std::{boxed::Box, vec::Vec};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ScalarMemoryKind {
+    Bool,
+    Unsigned(IntegerWidth),
+    Signed(IntegerWidth),
+    Floating(FloatWidth),
+    Complex(FloatWidth),
+    Rational64,
+    String,
+    Id,
+    Index,
+    Atom,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MemoryTopology {
+    Dynamic,
+    Scalar(ScalarMemoryKind),
+    Tagged { variants: u64 },
+    Product { members: u64, named: bool },
+    DenseSequence { rank: u64 },
+    Columnar { columns: u64 },
+    OrderedSet,
+    OrderedMap,
+    ReifiedType,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum MemoryExtent {
+    Single,
+    FixedArity(u64),
+    Dimensions(Box<[DimensionExpr]>),
+    Cardinality(CardinalitySpec),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ResolvedAxisExtent {
+    pub value: u64,
+    pub evolution: ExtentEvolution,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ResolvedMemoryExtent {
+    Single,
+    FixedArity(u64),
+    Dimensions(Box<[ResolvedAxisExtent]>),
+    ExactCardinality(u64),
+    DynamicCardinality { upper_bound: Option<u64> },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AddressingContract {
+    pub positional_rank: Option<u64>,
+    pub named_members: bool,
+    pub keyed_members: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CanonicalizationContract {
+    pub self_describing: bool,
+    pub recursive: bool,
+    pub tagged: bool,
+    pub ordered_keys: bool,
+    pub unique_keys: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PayloadAccounting {
+    FixedWidth,
+    VariableWidth,
+    Recursive,
+    SelfDescribing,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PopulationAccounting {
+    Single,
+    FixedArity,
+    ShapeResolved,
+    ExactCardinality,
+    ValueCardinality,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AuxiliaryAccounting {
+    pub tag: bool,
+    pub ordered_index: bool,
+    pub column_directory: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AccountingContract {
+    pub payload: PayloadAccounting,
+    pub population: PopulationAccounting,
+    pub auxiliary: AuxiliaryAccounting,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TypeMemoryContract {
+    pub topology: MemoryTopology,
+    pub extent: MemoryExtent,
+    pub extent_evolution: ExtentEvolution,
+    pub addressing: AddressingContract,
+    pub canonicalization: CanonicalizationContract,
+    pub accounting: AccountingContract,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResolvedTypeMemoryContract {
+    pub topology: MemoryTopology,
+    pub extent: ResolvedMemoryExtent,
+    pub extent_evolution: ExtentEvolution,
+    pub addressing: AddressingContract,
+    pub canonicalization: CanonicalizationContract,
+    pub accounting: AccountingContract,
+}
+
+const NO_ADDRESSING: AddressingContract = AddressingContract {
+    positional_rank: None,
+    named_members: false,
+    keyed_members: false,
+};
+
+const NO_CANONICALIZATION: CanonicalizationContract = CanonicalizationContract {
+    self_describing: false,
+    recursive: false,
+    tagged: false,
+    ordered_keys: false,
+    unique_keys: false,
+};
+
+const NO_AUXILIARY: AuxiliaryAccounting = AuxiliaryAccounting {
+    tag: false,
+    ordered_index: false,
+    column_directory: false,
+};
+
+fn checked_len(length: usize) -> Result<u64, SemanticModelError> {
+    u64::try_from(length).map_err(|_| SemanticModelError::DimensionOverflowV1)
+}
+
+fn join_evolution(left: ExtentEvolution, right: ExtentEvolution) -> ExtentEvolution {
+    use ExtentEvolution::{ActivationFixed, Fixed, TurnBounded, TurnUnbounded};
+
+    match (left, right) {
+        (TurnUnbounded, _) | (_, TurnUnbounded) => TurnUnbounded,
+        (TurnBounded, _) | (_, TurnBounded) => TurnBounded,
+        (ActivationFixed, _) | (_, ActivationFixed) => ActivationFixed,
+        (Fixed, Fixed) => Fixed,
+    }
+}
+
+fn dimension_evolution(
+    expression: &DimensionExpr,
+    parameters: &[DimensionParameter],
+) -> Result<ExtentEvolution, SemanticModelError> {
+    match expression {
+        DimensionExpr::Hole => {
+            debug_assert!(false, "finalized schemas cannot retain dimension holes");
+            Err(SemanticModelError::UnresolvedDimensionHole)
+        }
+        DimensionExpr::Constant(_) => Ok(ExtentEvolution::Fixed),
+        DimensionExpr::Parameter(id) => {
+            let parameter = parameters
+                .get(id.get() as usize)
+                .ok_or(SemanticModelError::UnknownDimensionParameterV1 { id: *id })?;
+            match parameter.lifetime() {
+                DimensionLifetime::CompileTime => {
+                    debug_assert!(
+                        false,
+                        "finalized schemas cannot retain compile-time parameters"
+                    );
+                    Err(SemanticModelError::CompileTimeDimensionParameterV1)
+                }
+                DimensionLifetime::Activation => Ok(ExtentEvolution::ActivationFixed),
+                DimensionLifetime::Turn if parameter.upper_bound().is_some() => {
+                    Ok(ExtentEvolution::TurnBounded)
+                }
+                DimensionLifetime::Turn => Ok(ExtentEvolution::TurnUnbounded),
+            }
+        }
+        DimensionExpr::Add(operands)
+        | DimensionExpr::Multiply(operands)
+        | DimensionExpr::Min(operands)
+        | DimensionExpr::Max(operands) => {
+            operands
+                .iter()
+                .try_fold(ExtentEvolution::Fixed, |evolution, operand| {
+                    Ok(join_evolution(
+                        evolution,
+                        dimension_evolution(operand, parameters)?,
+                    ))
+                })
+        }
+    }
+}
+
+fn cardinality_evolution(
+    cardinality: &CardinalitySpec,
+    parameters: &[DimensionParameter],
+) -> Result<ExtentEvolution, SemanticModelError> {
+    match cardinality {
+        CardinalitySpec::Exact(expression) => dimension_evolution(expression, parameters),
+        CardinalitySpec::Dynamic {
+            upper_bound: Some(expression),
+        } => Ok(join_evolution(
+            ExtentEvolution::TurnBounded,
+            dimension_evolution(expression, parameters)?,
+        )),
+        CardinalitySpec::Dynamic { upper_bound: None } => Ok(ExtentEvolution::TurnUnbounded),
+    }
+}
+
+fn body_evolution(
+    body: &SchemaBody,
+    parameters: &[DimensionParameter],
+) -> Result<ExtentEvolution, SemanticModelError> {
+    match body {
+        SchemaBody::Dynamic => Ok(ExtentEvolution::TurnUnbounded),
+        SchemaBody::Bool
+        | SchemaBody::UnsignedInteger(_)
+        | SchemaBody::SignedInteger(_)
+        | SchemaBody::FloatingPoint(_)
+        | SchemaBody::Complex(_)
+        | SchemaBody::Rational64
+        | SchemaBody::String
+        | SchemaBody::Id
+        | SchemaBody::Index
+        | SchemaBody::Atom(_)
+        | SchemaBody::ReifiedType => Ok(ExtentEvolution::Fixed),
+        SchemaBody::Enum { variants, .. } => {
+            variants
+                .iter()
+                .try_fold(
+                    ExtentEvolution::Fixed,
+                    |evolution, variant| match &variant.payload {
+                        Some(payload) => Ok(join_evolution(
+                            evolution,
+                            body_evolution(payload, parameters)?,
+                        )),
+                        None => Ok(evolution),
+                    },
+                )
+        }
+        SchemaBody::Option(element) => body_evolution(element, parameters),
+        SchemaBody::Tuple(elements) => {
+            elements
+                .iter()
+                .try_fold(ExtentEvolution::Fixed, |evolution, element| {
+                    Ok(join_evolution(
+                        evolution,
+                        body_evolution(element, parameters)?,
+                    ))
+                })
+        }
+        SchemaBody::Record(fields) => {
+            fields
+                .iter()
+                .try_fold(ExtentEvolution::Fixed, |evolution, field| {
+                    Ok(join_evolution(
+                        evolution,
+                        body_evolution(&field.schema, parameters)?,
+                    ))
+                })
+        }
+        SchemaBody::Matrix {
+            element,
+            dimensions,
+        } => {
+            let dimension_evolution =
+                dimensions
+                    .iter()
+                    .try_fold(ExtentEvolution::Fixed, |evolution, dimension| {
+                        Ok(join_evolution(
+                            evolution,
+                            dimension_evolution(dimension, parameters)?,
+                        ))
+                    })?;
+            Ok(join_evolution(
+                dimension_evolution,
+                body_evolution(element, parameters)?,
+            ))
+        }
+        SchemaBody::Table { columns, rows } => columns.iter().try_fold(
+            cardinality_evolution(rows, parameters)?,
+            |evolution, column| {
+                Ok(join_evolution(
+                    evolution,
+                    body_evolution(&column.schema, parameters)?,
+                ))
+            },
+        ),
+        SchemaBody::Set {
+            element,
+            cardinality,
+        } => Ok(join_evolution(
+            cardinality_evolution(cardinality, parameters)?,
+            body_evolution(element, parameters)?,
+        )),
+        SchemaBody::Map {
+            key,
+            value,
+            cardinality,
+        } => Ok(join_evolution(
+            cardinality_evolution(cardinality, parameters)?,
+            join_evolution(
+                body_evolution(key, parameters)?,
+                body_evolution(value, parameters)?,
+            ),
+        )),
+    }
+}
+
+fn accounting(
+    payload: PayloadAccounting,
+    population: PopulationAccounting,
+    auxiliary: AuxiliaryAccounting,
+) -> AccountingContract {
+    AccountingContract {
+        payload,
+        population,
+        auxiliary,
+    }
+}
+
+fn fixed_scalar(kind: ScalarMemoryKind) -> TypeMemoryContract {
+    TypeMemoryContract {
+        topology: MemoryTopology::Scalar(kind),
+        extent: MemoryExtent::Single,
+        extent_evolution: ExtentEvolution::Fixed,
+        addressing: NO_ADDRESSING,
+        canonicalization: NO_CANONICALIZATION,
+        accounting: accounting(
+            PayloadAccounting::FixedWidth,
+            PopulationAccounting::Single,
+            NO_AUXILIARY,
+        ),
+    }
+}
+
+pub(crate) fn derive_type_memory_contract(
+    body: &SchemaBody,
+    parameters: &[DimensionParameter],
+) -> Result<TypeMemoryContract, SemanticModelError> {
+    let contract = match body {
+        SchemaBody::Dynamic => TypeMemoryContract {
+            topology: MemoryTopology::Dynamic,
+            extent: MemoryExtent::Single,
+            extent_evolution: ExtentEvolution::TurnUnbounded,
+            addressing: NO_ADDRESSING,
+            canonicalization: CanonicalizationContract {
+                self_describing: true,
+                recursive: true,
+                ..NO_CANONICALIZATION
+            },
+            accounting: accounting(
+                PayloadAccounting::SelfDescribing,
+                PopulationAccounting::Single,
+                NO_AUXILIARY,
+            ),
+        },
+        SchemaBody::Bool => fixed_scalar(ScalarMemoryKind::Bool),
+        SchemaBody::UnsignedInteger(width) => fixed_scalar(ScalarMemoryKind::Unsigned(*width)),
+        SchemaBody::SignedInteger(width) => fixed_scalar(ScalarMemoryKind::Signed(*width)),
+        SchemaBody::FloatingPoint(width) => fixed_scalar(ScalarMemoryKind::Floating(*width)),
+        SchemaBody::Complex(width) => fixed_scalar(ScalarMemoryKind::Complex(*width)),
+        SchemaBody::Rational64 => fixed_scalar(ScalarMemoryKind::Rational64),
+        SchemaBody::String => TypeMemoryContract {
+            addressing: AddressingContract {
+                positional_rank: Some(1),
+                ..NO_ADDRESSING
+            },
+            accounting: accounting(
+                PayloadAccounting::VariableWidth,
+                PopulationAccounting::Single,
+                NO_AUXILIARY,
+            ),
+            ..fixed_scalar(ScalarMemoryKind::String)
+        },
+        SchemaBody::Id => fixed_scalar(ScalarMemoryKind::Id),
+        SchemaBody::Index => fixed_scalar(ScalarMemoryKind::Index),
+        SchemaBody::Atom(_) => fixed_scalar(ScalarMemoryKind::Atom),
+        SchemaBody::Enum { variants, .. } => TypeMemoryContract {
+            topology: MemoryTopology::Tagged {
+                variants: checked_len(variants.len())?,
+            },
+            extent: MemoryExtent::Single,
+            extent_evolution: body_evolution(body, parameters)?,
+            addressing: NO_ADDRESSING,
+            canonicalization: CanonicalizationContract {
+                recursive: true,
+                tagged: true,
+                ..NO_CANONICALIZATION
+            },
+            accounting: accounting(
+                PayloadAccounting::Recursive,
+                PopulationAccounting::Single,
+                AuxiliaryAccounting {
+                    tag: true,
+                    ..NO_AUXILIARY
+                },
+            ),
+        },
+        SchemaBody::Option(_) => TypeMemoryContract {
+            topology: MemoryTopology::Tagged { variants: 2 },
+            extent: MemoryExtent::Single,
+            extent_evolution: body_evolution(body, parameters)?,
+            addressing: NO_ADDRESSING,
+            canonicalization: CanonicalizationContract {
+                recursive: true,
+                tagged: true,
+                ..NO_CANONICALIZATION
+            },
+            accounting: accounting(
+                PayloadAccounting::Recursive,
+                PopulationAccounting::Single,
+                AuxiliaryAccounting {
+                    tag: true,
+                    ..NO_AUXILIARY
+                },
+            ),
+        },
+        SchemaBody::Tuple(elements) => {
+            let members = checked_len(elements.len())?;
+            TypeMemoryContract {
+                topology: MemoryTopology::Product {
+                    members,
+                    named: false,
+                },
+                extent: MemoryExtent::FixedArity(members),
+                extent_evolution: body_evolution(body, parameters)?,
+                addressing: AddressingContract {
+                    positional_rank: Some(1),
+                    ..NO_ADDRESSING
+                },
+                canonicalization: CanonicalizationContract {
+                    recursive: true,
+                    ..NO_CANONICALIZATION
+                },
+                accounting: accounting(
+                    PayloadAccounting::Recursive,
+                    PopulationAccounting::FixedArity,
+                    NO_AUXILIARY,
+                ),
+            }
+        }
+        SchemaBody::Record(fields) => {
+            let members = checked_len(fields.len())?;
+            TypeMemoryContract {
+                topology: MemoryTopology::Product {
+                    members,
+                    named: true,
+                },
+                extent: MemoryExtent::FixedArity(members),
+                extent_evolution: body_evolution(body, parameters)?,
+                addressing: AddressingContract {
+                    named_members: true,
+                    ..NO_ADDRESSING
+                },
+                canonicalization: CanonicalizationContract {
+                    recursive: true,
+                    ..NO_CANONICALIZATION
+                },
+                accounting: accounting(
+                    PayloadAccounting::Recursive,
+                    PopulationAccounting::FixedArity,
+                    NO_AUXILIARY,
+                ),
+            }
+        }
+        SchemaBody::Matrix { dimensions, .. } => {
+            let rank = checked_len(dimensions.len())?;
+            TypeMemoryContract {
+                topology: MemoryTopology::DenseSequence { rank },
+                extent: MemoryExtent::Dimensions(dimensions.clone()),
+                extent_evolution: body_evolution(body, parameters)?,
+                addressing: AddressingContract {
+                    positional_rank: Some(rank),
+                    ..NO_ADDRESSING
+                },
+                canonicalization: CanonicalizationContract {
+                    recursive: true,
+                    ..NO_CANONICALIZATION
+                },
+                accounting: accounting(
+                    PayloadAccounting::Recursive,
+                    PopulationAccounting::ShapeResolved,
+                    NO_AUXILIARY,
+                ),
+            }
+        }
+        SchemaBody::Table { columns, rows } => TypeMemoryContract {
+            topology: MemoryTopology::Columnar {
+                columns: checked_len(columns.len())?,
+            },
+            extent: MemoryExtent::Cardinality(rows.clone()),
+            extent_evolution: body_evolution(body, parameters)?,
+            addressing: AddressingContract {
+                positional_rank: Some(2),
+                named_members: true,
+                ..NO_ADDRESSING
+            },
+            canonicalization: CanonicalizationContract {
+                recursive: true,
+                ..NO_CANONICALIZATION
+            },
+            accounting: accounting(
+                PayloadAccounting::Recursive,
+                match rows {
+                    CardinalitySpec::Exact(_) => PopulationAccounting::ExactCardinality,
+                    CardinalitySpec::Dynamic { .. } => PopulationAccounting::ValueCardinality,
+                },
+                AuxiliaryAccounting {
+                    column_directory: true,
+                    ..NO_AUXILIARY
+                },
+            ),
+        },
+        SchemaBody::Set { cardinality, .. } => TypeMemoryContract {
+            topology: MemoryTopology::OrderedSet,
+            extent: MemoryExtent::Cardinality(cardinality.clone()),
+            extent_evolution: body_evolution(body, parameters)?,
+            addressing: AddressingContract {
+                keyed_members: true,
+                ..NO_ADDRESSING
+            },
+            canonicalization: CanonicalizationContract {
+                recursive: true,
+                ordered_keys: true,
+                unique_keys: true,
+                ..NO_CANONICALIZATION
+            },
+            accounting: accounting(
+                PayloadAccounting::Recursive,
+                match cardinality {
+                    CardinalitySpec::Exact(_) => PopulationAccounting::ExactCardinality,
+                    CardinalitySpec::Dynamic { .. } => PopulationAccounting::ValueCardinality,
+                },
+                AuxiliaryAccounting {
+                    ordered_index: true,
+                    ..NO_AUXILIARY
+                },
+            ),
+        },
+        SchemaBody::Map { cardinality, .. } => TypeMemoryContract {
+            topology: MemoryTopology::OrderedMap,
+            extent: MemoryExtent::Cardinality(cardinality.clone()),
+            extent_evolution: body_evolution(body, parameters)?,
+            addressing: AddressingContract {
+                keyed_members: true,
+                ..NO_ADDRESSING
+            },
+            canonicalization: CanonicalizationContract {
+                recursive: true,
+                ordered_keys: true,
+                unique_keys: true,
+                ..NO_CANONICALIZATION
+            },
+            accounting: accounting(
+                PayloadAccounting::Recursive,
+                match cardinality {
+                    CardinalitySpec::Exact(_) => PopulationAccounting::ExactCardinality,
+                    CardinalitySpec::Dynamic { .. } => PopulationAccounting::ValueCardinality,
+                },
+                AuxiliaryAccounting {
+                    ordered_index: true,
+                    ..NO_AUXILIARY
+                },
+            ),
+        },
+        SchemaBody::ReifiedType => TypeMemoryContract {
+            topology: MemoryTopology::ReifiedType,
+            extent: MemoryExtent::Single,
+            extent_evolution: ExtentEvolution::Fixed,
+            addressing: NO_ADDRESSING,
+            canonicalization: CanonicalizationContract {
+                self_describing: true,
+                ..NO_CANONICALIZATION
+            },
+            accounting: accounting(
+                PayloadAccounting::SelfDescribing,
+                PopulationAccounting::Single,
+                NO_AUXILIARY,
+            ),
+        },
+    };
+
+    Ok(contract)
+}
+
+fn resolve_extent(
+    extent: &MemoryExtent,
+    parameters: &[DimensionParameter],
+    shape: &ShapeInstance,
+) -> Result<ResolvedMemoryExtent, SemanticModelError> {
+    match extent {
+        MemoryExtent::Single => Ok(ResolvedMemoryExtent::Single),
+        MemoryExtent::FixedArity(arity) => Ok(ResolvedMemoryExtent::FixedArity(*arity)),
+        MemoryExtent::Dimensions(dimensions) => {
+            let mut resolved = Vec::with_capacity(dimensions.len());
+            for dimension in dimensions {
+                resolved.push(ResolvedAxisExtent {
+                    value: shape.resolve_dimension(dimension)?,
+                    evolution: dimension_evolution(dimension, parameters)?,
+                });
+            }
+            Ok(ResolvedMemoryExtent::Dimensions(
+                resolved.into_boxed_slice(),
+            ))
+        }
+        MemoryExtent::Cardinality(CardinalitySpec::Exact(expression)) => Ok(
+            ResolvedMemoryExtent::ExactCardinality(shape.resolve_dimension(expression)?),
+        ),
+        MemoryExtent::Cardinality(CardinalitySpec::Dynamic { upper_bound }) => {
+            Ok(ResolvedMemoryExtent::DynamicCardinality {
+                upper_bound: upper_bound
+                    .as_ref()
+                    .map(|bound| shape.resolve_dimension(bound))
+                    .transpose()?,
+            })
+        }
+    }
+}
+
+pub(crate) fn resolve_type_memory_contract(
+    contract: TypeMemoryContract,
+    parameters: &[DimensionParameter],
+    shape: &ShapeInstance,
+) -> Result<ResolvedTypeMemoryContract, SemanticModelError> {
+    Ok(ResolvedTypeMemoryContract {
+        extent: resolve_extent(&contract.extent, parameters, shape)?,
+        topology: contract.topology,
+        extent_evolution: contract.extent_evolution,
+        addressing: contract.addressing,
+        canonicalization: contract.canonicalization,
+        accounting: contract.accounting,
+    })
+}

--- a/src/core/src/schema/mod.rs
+++ b/src/core/src/schema/mod.rs
@@ -57,6 +57,25 @@ impl SchemaDraft {
     }
 }
 
+impl Schema {
+    pub fn type_memory_contract(&self) -> Result<crate::TypeMemoryContract, SemanticModelError> {
+        crate::memory_contract::derive_type_memory_contract(&self.body, &self.dimension_parameters)
+    }
+
+    pub fn resolved_type_memory_contract(
+        &self,
+        shape: &crate::ShapeInstance,
+    ) -> Result<crate::ResolvedTypeMemoryContract, SemanticModelError> {
+        let validated_shape =
+            self.instantiate_shape(shape.parameter_values().to_vec().into_boxed_slice())?;
+        crate::memory_contract::resolve_type_memory_contract(
+            self.type_memory_contract()?,
+            &self.dimension_parameters,
+            &validated_shape,
+        )
+    }
+}
+
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SchemaBody {

--- a/src/core/tests/type_memory_contract.rs
+++ b/src/core/tests/type_memory_contract.rs
@@ -1,0 +1,897 @@
+use mech_core::*;
+
+fn nominal_key(byte: u8) -> NominalKey {
+    NominalKey::from_bytes([byte; 32])
+}
+
+fn schema(body: SchemaBody) -> Schema {
+    SchemaDraft {
+        dimension_parameters: Vec::new().into_boxed_slice(),
+        body,
+    }
+    .finalize()
+    .unwrap()
+}
+
+fn parameter(
+    ordinal: u32,
+    lifetime: DimensionLifetime,
+    lower: u64,
+    upper: Option<u64>,
+) -> DimensionParameterDeclaration {
+    DimensionParameterDeclaration {
+        id: DimensionParameterId::new(ordinal),
+        origin: DimensionParameterOrigin::Explicit,
+        lifetime,
+        lower_bound: DimensionExpr::Constant(lower),
+        upper_bound: upper.map(DimensionExpr::Constant),
+    }
+}
+
+fn parameterized_schema(
+    parameters: Vec<DimensionParameterDeclaration>,
+    body: SchemaBody,
+) -> Schema {
+    SchemaDraft {
+        dimension_parameters: parameters.into_boxed_slice(),
+        body,
+    }
+    .finalize()
+    .unwrap()
+}
+
+fn addressing(
+    positional_rank: Option<u64>,
+    named_members: bool,
+    keyed_members: bool,
+) -> AddressingContract {
+    AddressingContract {
+        positional_rank,
+        named_members,
+        keyed_members,
+    }
+}
+
+fn canonicalization(
+    self_describing: bool,
+    recursive: bool,
+    tagged: bool,
+    ordered_keys: bool,
+    unique_keys: bool,
+) -> CanonicalizationContract {
+    CanonicalizationContract {
+        self_describing,
+        recursive,
+        tagged,
+        ordered_keys,
+        unique_keys,
+    }
+}
+
+fn accounting(
+    payload: PayloadAccounting,
+    population: PopulationAccounting,
+    tag: bool,
+    ordered_index: bool,
+    column_directory: bool,
+) -> AccountingContract {
+    AccountingContract {
+        payload,
+        population,
+        auxiliary: AuxiliaryAccounting {
+            tag,
+            ordered_index,
+            column_directory,
+        },
+    }
+}
+
+fn expected(
+    topology: MemoryTopology,
+    extent: MemoryExtent,
+    extent_evolution: ExtentEvolution,
+    addressing: AddressingContract,
+    canonicalization: CanonicalizationContract,
+    accounting: AccountingContract,
+) -> TypeMemoryContract {
+    TypeMemoryContract {
+        topology,
+        extent,
+        extent_evolution,
+        addressing,
+        canonicalization,
+        accounting,
+    }
+}
+
+fn scalar_expected(kind: ScalarMemoryKind) -> TypeMemoryContract {
+    expected(
+        MemoryTopology::Scalar(kind),
+        MemoryExtent::Single,
+        ExtentEvolution::Fixed,
+        addressing(None, false, false),
+        canonicalization(false, false, false, false, false),
+        accounting(
+            PayloadAccounting::FixedWidth,
+            PopulationAccounting::Single,
+            false,
+            false,
+            false,
+        ),
+    )
+}
+
+#[test]
+fn every_schema_body_variant_has_the_complete_declared_mapping() {
+    let scalar_cases = [
+        (SchemaBody::Bool, ScalarMemoryKind::Bool),
+        (
+            SchemaBody::UnsignedInteger(IntegerWidth::W16),
+            ScalarMemoryKind::Unsigned(IntegerWidth::W16),
+        ),
+        (
+            SchemaBody::SignedInteger(IntegerWidth::W32),
+            ScalarMemoryKind::Signed(IntegerWidth::W32),
+        ),
+        (
+            SchemaBody::FloatingPoint(FloatWidth::W32),
+            ScalarMemoryKind::Floating(FloatWidth::W32),
+        ),
+        (
+            SchemaBody::Complex(FloatWidth::W64),
+            ScalarMemoryKind::Complex(FloatWidth::W64),
+        ),
+        (SchemaBody::Rational64, ScalarMemoryKind::Rational64),
+        (SchemaBody::Id, ScalarMemoryKind::Id),
+        (SchemaBody::Index, ScalarMemoryKind::Index),
+        (SchemaBody::Atom(nominal_key(1)), ScalarMemoryKind::Atom),
+    ];
+    for (body, kind) in scalar_cases {
+        assert_eq!(
+            schema(body).type_memory_contract().unwrap(),
+            scalar_expected(kind)
+        );
+    }
+
+    assert_eq!(
+        schema(SchemaBody::Dynamic).type_memory_contract().unwrap(),
+        expected(
+            MemoryTopology::Dynamic,
+            MemoryExtent::Single,
+            ExtentEvolution::TurnUnbounded,
+            addressing(None, false, false),
+            canonicalization(true, true, false, false, false),
+            accounting(
+                PayloadAccounting::SelfDescribing,
+                PopulationAccounting::Single,
+                false,
+                false,
+                false,
+            ),
+        )
+    );
+
+    assert_eq!(
+        schema(SchemaBody::String).type_memory_contract().unwrap(),
+        expected(
+            MemoryTopology::Scalar(ScalarMemoryKind::String),
+            MemoryExtent::Single,
+            ExtentEvolution::Fixed,
+            addressing(Some(1), false, false),
+            canonicalization(false, false, false, false, false),
+            accounting(
+                PayloadAccounting::VariableWidth,
+                PopulationAccounting::Single,
+                false,
+                false,
+                false,
+            ),
+        )
+    );
+
+    assert_eq!(
+        schema(SchemaBody::Enum {
+            key: nominal_key(2),
+            variants: vec![
+                EnumVariantSchema {
+                    name: "none".to_owned(),
+                    payload: None,
+                },
+                EnumVariantSchema {
+                    name: "some".to_owned(),
+                    payload: Some(SchemaBody::Bool),
+                },
+            ]
+            .into_boxed_slice(),
+        })
+        .type_memory_contract()
+        .unwrap(),
+        expected(
+            MemoryTopology::Tagged { variants: 2 },
+            MemoryExtent::Single,
+            ExtentEvolution::Fixed,
+            addressing(None, false, false),
+            canonicalization(false, true, true, false, false),
+            accounting(
+                PayloadAccounting::Recursive,
+                PopulationAccounting::Single,
+                true,
+                false,
+                false,
+            ),
+        )
+    );
+
+    assert_eq!(
+        schema(SchemaBody::Option(Box::new(SchemaBody::String)))
+            .type_memory_contract()
+            .unwrap(),
+        expected(
+            MemoryTopology::Tagged { variants: 2 },
+            MemoryExtent::Single,
+            ExtentEvolution::Fixed,
+            addressing(None, false, false),
+            canonicalization(false, true, true, false, false),
+            accounting(
+                PayloadAccounting::Recursive,
+                PopulationAccounting::Single,
+                true,
+                false,
+                false,
+            ),
+        )
+    );
+
+    assert_eq!(
+        schema(SchemaBody::Tuple(
+            vec![SchemaBody::Bool, SchemaBody::String].into_boxed_slice(),
+        ))
+        .type_memory_contract()
+        .unwrap(),
+        expected(
+            MemoryTopology::Product {
+                members: 2,
+                named: false,
+            },
+            MemoryExtent::FixedArity(2),
+            ExtentEvolution::Fixed,
+            addressing(Some(1), false, false),
+            canonicalization(false, true, false, false, false),
+            accounting(
+                PayloadAccounting::Recursive,
+                PopulationAccounting::FixedArity,
+                false,
+                false,
+                false,
+            ),
+        )
+    );
+
+    assert_eq!(
+        schema(SchemaBody::Record(
+            vec![
+                SchemaField {
+                    name: "left".to_owned(),
+                    schema: SchemaBody::Bool,
+                },
+                SchemaField {
+                    name: "right".to_owned(),
+                    schema: SchemaBody::String,
+                },
+            ]
+            .into_boxed_slice(),
+        ))
+        .type_memory_contract()
+        .unwrap(),
+        expected(
+            MemoryTopology::Product {
+                members: 2,
+                named: true,
+            },
+            MemoryExtent::FixedArity(2),
+            ExtentEvolution::Fixed,
+            addressing(None, true, false),
+            canonicalization(false, true, false, false, false),
+            accounting(
+                PayloadAccounting::Recursive,
+                PopulationAccounting::FixedArity,
+                false,
+                false,
+                false,
+            ),
+        )
+    );
+
+    let dimensions =
+        vec![DimensionExpr::Constant(2), DimensionExpr::Constant(3)].into_boxed_slice();
+    assert_eq!(
+        schema(SchemaBody::Matrix {
+            element: Box::new(SchemaBody::Bool),
+            dimensions: dimensions.clone(),
+        })
+        .type_memory_contract()
+        .unwrap(),
+        expected(
+            MemoryTopology::DenseSequence { rank: 2 },
+            MemoryExtent::Dimensions(dimensions),
+            ExtentEvolution::Fixed,
+            addressing(Some(2), false, false),
+            canonicalization(false, true, false, false, false),
+            accounting(
+                PayloadAccounting::Recursive,
+                PopulationAccounting::ShapeResolved,
+                false,
+                false,
+                false,
+            ),
+        )
+    );
+
+    let exact_rows = CardinalitySpec::Exact(DimensionExpr::Constant(5));
+    assert_eq!(
+        schema(SchemaBody::Table {
+            columns: vec![SchemaField {
+                name: "value".to_owned(),
+                schema: SchemaBody::Bool,
+            }]
+            .into_boxed_slice(),
+            rows: exact_rows.clone(),
+        })
+        .type_memory_contract()
+        .unwrap(),
+        expected(
+            MemoryTopology::Columnar { columns: 1 },
+            MemoryExtent::Cardinality(exact_rows),
+            ExtentEvolution::Fixed,
+            addressing(Some(2), true, false),
+            canonicalization(false, true, false, false, false),
+            accounting(
+                PayloadAccounting::Recursive,
+                PopulationAccounting::ExactCardinality,
+                false,
+                false,
+                true,
+            ),
+        )
+    );
+
+    let exact_set = CardinalitySpec::Exact(DimensionExpr::Constant(2));
+    assert_eq!(
+        schema(SchemaBody::Set {
+            element: Box::new(SchemaBody::String),
+            cardinality: exact_set.clone(),
+        })
+        .type_memory_contract()
+        .unwrap(),
+        expected(
+            MemoryTopology::OrderedSet,
+            MemoryExtent::Cardinality(exact_set),
+            ExtentEvolution::Fixed,
+            addressing(None, false, true),
+            canonicalization(false, true, false, true, true),
+            accounting(
+                PayloadAccounting::Recursive,
+                PopulationAccounting::ExactCardinality,
+                false,
+                true,
+                false,
+            ),
+        )
+    );
+
+    let dynamic_map = CardinalitySpec::Dynamic { upper_bound: None };
+    assert_eq!(
+        schema(SchemaBody::Map {
+            key: Box::new(SchemaBody::Bool),
+            value: Box::new(SchemaBody::String),
+            cardinality: dynamic_map.clone(),
+        })
+        .type_memory_contract()
+        .unwrap(),
+        expected(
+            MemoryTopology::OrderedMap,
+            MemoryExtent::Cardinality(dynamic_map),
+            ExtentEvolution::TurnUnbounded,
+            addressing(None, false, true),
+            canonicalization(false, true, false, true, true),
+            accounting(
+                PayloadAccounting::Recursive,
+                PopulationAccounting::ValueCardinality,
+                false,
+                true,
+                false,
+            ),
+        )
+    );
+
+    assert_eq!(
+        schema(SchemaBody::ReifiedType)
+            .type_memory_contract()
+            .unwrap(),
+        expected(
+            MemoryTopology::ReifiedType,
+            MemoryExtent::Single,
+            ExtentEvolution::Fixed,
+            addressing(None, false, false),
+            canonicalization(true, false, false, false, false),
+            accounting(
+                PayloadAccounting::SelfDescribing,
+                PopulationAccounting::Single,
+                false,
+                false,
+                false,
+            ),
+        )
+    );
+}
+
+#[test]
+fn nested_contracts_propagate_evolution_without_copying_child_structure() {
+    let turn = DimensionParameterId::new(0);
+    let record = parameterized_schema(
+        vec![parameter(0, DimensionLifetime::Turn, 1, None)],
+        SchemaBody::Record(
+            vec![SchemaField {
+                name: "samples".to_owned(),
+                schema: SchemaBody::Matrix {
+                    element: Box::new(SchemaBody::Bool),
+                    dimensions: vec![DimensionExpr::Parameter(turn)].into_boxed_slice(),
+                },
+            }]
+            .into_boxed_slice(),
+        ),
+    );
+    assert_eq!(
+        record.type_memory_contract().unwrap(),
+        expected(
+            MemoryTopology::Product {
+                members: 1,
+                named: true,
+            },
+            MemoryExtent::FixedArity(1),
+            ExtentEvolution::TurnUnbounded,
+            addressing(None, true, false),
+            canonicalization(false, true, false, false, false),
+            accounting(
+                PayloadAccounting::Recursive,
+                PopulationAccounting::FixedArity,
+                false,
+                false,
+                false,
+            ),
+        )
+    );
+
+    let matrix_of_string = schema(SchemaBody::Matrix {
+        element: Box::new(SchemaBody::String),
+        dimensions: vec![DimensionExpr::Constant(2)].into_boxed_slice(),
+    });
+    assert_eq!(
+        matrix_of_string.type_memory_contract().unwrap(),
+        expected(
+            MemoryTopology::DenseSequence { rank: 1 },
+            MemoryExtent::Dimensions(vec![DimensionExpr::Constant(2)].into_boxed_slice(),),
+            ExtentEvolution::Fixed,
+            addressing(Some(1), false, false),
+            canonicalization(false, true, false, false, false),
+            accounting(
+                PayloadAccounting::Recursive,
+                PopulationAccounting::ShapeResolved,
+                false,
+                false,
+                false,
+            ),
+        )
+    );
+
+    let table_with_dynamic_column = schema(SchemaBody::Table {
+        columns: vec![SchemaField {
+            name: "any".to_owned(),
+            schema: SchemaBody::Dynamic,
+        }]
+        .into_boxed_slice(),
+        rows: DimensionExpr::Constant(1).into(),
+    });
+    assert_eq!(
+        table_with_dynamic_column.type_memory_contract().unwrap(),
+        expected(
+            MemoryTopology::Columnar { columns: 1 },
+            MemoryExtent::Cardinality(CardinalitySpec::Exact(DimensionExpr::Constant(1))),
+            ExtentEvolution::TurnUnbounded,
+            addressing(Some(2), true, false),
+            canonicalization(false, true, false, false, false),
+            accounting(
+                PayloadAccounting::Recursive,
+                PopulationAccounting::ExactCardinality,
+                false,
+                false,
+                true,
+            ),
+        )
+    );
+
+    let set_of_tuple_keys = schema(SchemaBody::Set {
+        element: Box::new(SchemaBody::Tuple(
+            vec![SchemaBody::Bool, SchemaBody::String].into_boxed_slice(),
+        )),
+        cardinality: DimensionExpr::Constant(3).into(),
+    });
+    assert_eq!(
+        set_of_tuple_keys.type_memory_contract().unwrap(),
+        expected(
+            MemoryTopology::OrderedSet,
+            MemoryExtent::Cardinality(CardinalitySpec::Exact(DimensionExpr::Constant(3))),
+            ExtentEvolution::Fixed,
+            addressing(None, false, true),
+            canonicalization(false, true, false, true, true),
+            accounting(
+                PayloadAccounting::Recursive,
+                PopulationAccounting::ExactCardinality,
+                false,
+                true,
+                false,
+            ),
+        )
+    );
+
+    let map_with_recursive_values = schema(SchemaBody::Map {
+        key: Box::new(SchemaBody::String),
+        value: Box::new(SchemaBody::Option(Box::new(SchemaBody::Tuple(
+            vec![SchemaBody::Bool, SchemaBody::String].into_boxed_slice(),
+        )))),
+        cardinality: DimensionExpr::Constant(1).into(),
+    });
+    assert_eq!(
+        map_with_recursive_values.type_memory_contract().unwrap(),
+        expected(
+            MemoryTopology::OrderedMap,
+            MemoryExtent::Cardinality(CardinalitySpec::Exact(DimensionExpr::Constant(1))),
+            ExtentEvolution::Fixed,
+            addressing(None, false, true),
+            canonicalization(false, true, false, true, true),
+            accounting(
+                PayloadAccounting::Recursive,
+                PopulationAccounting::ExactCardinality,
+                false,
+                true,
+                false,
+            ),
+        )
+    );
+
+    let enum_with_dynamic_collection = schema(SchemaBody::Enum {
+        key: nominal_key(3),
+        variants: vec![EnumVariantSchema {
+            name: "values".to_owned(),
+            payload: Some(SchemaBody::Set {
+                element: Box::new(SchemaBody::Bool),
+                cardinality: CardinalitySpec::Dynamic { upper_bound: None },
+            }),
+        }]
+        .into_boxed_slice(),
+    });
+    assert_eq!(
+        enum_with_dynamic_collection.type_memory_contract().unwrap(),
+        expected(
+            MemoryTopology::Tagged { variants: 1 },
+            MemoryExtent::Single,
+            ExtentEvolution::TurnUnbounded,
+            addressing(None, false, false),
+            canonicalization(false, true, true, false, false),
+            accounting(
+                PayloadAccounting::Recursive,
+                PopulationAccounting::Single,
+                true,
+                false,
+                false,
+            ),
+        )
+    );
+
+    let bounded = DimensionParameterId::new(0);
+    let option_with_bounded_matrix = parameterized_schema(
+        vec![parameter(0, DimensionLifetime::Turn, 1, Some(8))],
+        SchemaBody::Option(Box::new(SchemaBody::Matrix {
+            element: Box::new(SchemaBody::Bool),
+            dimensions: vec![DimensionExpr::Parameter(bounded)].into_boxed_slice(),
+        })),
+    );
+    assert_eq!(
+        option_with_bounded_matrix.type_memory_contract().unwrap(),
+        expected(
+            MemoryTopology::Tagged { variants: 2 },
+            MemoryExtent::Single,
+            ExtentEvolution::TurnBounded,
+            addressing(None, false, false),
+            canonicalization(false, true, true, false, false),
+            accounting(
+                PayloadAccounting::Recursive,
+                PopulationAccounting::Single,
+                true,
+                false,
+                false,
+            ),
+        )
+    );
+}
+
+#[test]
+fn dimension_operators_resolve_with_independent_axis_evolution() {
+    let activation = DimensionParameterId::new(0);
+    let bounded = DimensionParameterId::new(1);
+    let unbounded = DimensionParameterId::new(2);
+    let dimensions = vec![
+        DimensionExpr::Constant(2),
+        DimensionExpr::Parameter(activation),
+        DimensionExpr::Parameter(bounded),
+        DimensionExpr::Parameter(unbounded),
+        DimensionExpr::Add(
+            vec![
+                DimensionExpr::Parameter(activation),
+                DimensionExpr::Constant(1),
+            ]
+            .into_boxed_slice(),
+        ),
+        DimensionExpr::Multiply(
+            vec![
+                DimensionExpr::Parameter(bounded),
+                DimensionExpr::Constant(2),
+            ]
+            .into_boxed_slice(),
+        ),
+        DimensionExpr::Min(
+            vec![
+                DimensionExpr::Parameter(activation),
+                DimensionExpr::Parameter(bounded),
+            ]
+            .into_boxed_slice(),
+        ),
+        DimensionExpr::Max(
+            vec![
+                DimensionExpr::Parameter(bounded),
+                DimensionExpr::Parameter(unbounded),
+            ]
+            .into_boxed_slice(),
+        ),
+    ];
+    let matrix = parameterized_schema(
+        vec![
+            parameter(0, DimensionLifetime::Activation, 1, None),
+            parameter(1, DimensionLifetime::Turn, 1, Some(10)),
+            parameter(2, DimensionLifetime::Turn, 1, None),
+        ],
+        SchemaBody::Matrix {
+            element: Box::new(SchemaBody::Bool),
+            dimensions: dimensions.into_boxed_slice(),
+        },
+    );
+    let shape = matrix
+        .instantiate_shape(vec![3, 4, 5].into_boxed_slice())
+        .unwrap();
+    let contract = matrix.resolved_type_memory_contract(&shape).unwrap();
+    assert_eq!(
+        contract,
+        ResolvedTypeMemoryContract {
+            topology: MemoryTopology::DenseSequence { rank: 8 },
+            extent: ResolvedMemoryExtent::Dimensions(
+                vec![
+                    ResolvedAxisExtent {
+                        value: 2,
+                        evolution: ExtentEvolution::Fixed,
+                    },
+                    ResolvedAxisExtent {
+                        value: 3,
+                        evolution: ExtentEvolution::ActivationFixed,
+                    },
+                    ResolvedAxisExtent {
+                        value: 4,
+                        evolution: ExtentEvolution::TurnBounded,
+                    },
+                    ResolvedAxisExtent {
+                        value: 5,
+                        evolution: ExtentEvolution::TurnUnbounded,
+                    },
+                    ResolvedAxisExtent {
+                        value: 4,
+                        evolution: ExtentEvolution::ActivationFixed,
+                    },
+                    ResolvedAxisExtent {
+                        value: 8,
+                        evolution: ExtentEvolution::TurnBounded,
+                    },
+                    ResolvedAxisExtent {
+                        value: 3,
+                        evolution: ExtentEvolution::TurnBounded,
+                    },
+                    ResolvedAxisExtent {
+                        value: 5,
+                        evolution: ExtentEvolution::TurnUnbounded,
+                    },
+                ]
+                .into_boxed_slice(),
+            ),
+            extent_evolution: ExtentEvolution::TurnUnbounded,
+            addressing: addressing(Some(8), false, false),
+            canonicalization: canonicalization(false, true, false, false, false),
+            accounting: accounting(
+                PayloadAccounting::Recursive,
+                PopulationAccounting::ShapeResolved,
+                false,
+                false,
+                false,
+            ),
+        }
+    );
+}
+
+#[test]
+fn exact_and_dynamic_cardinalities_resolve_without_inventing_population() {
+    let activation = DimensionParameterId::new(0);
+    let exact = parameterized_schema(
+        vec![parameter(0, DimensionLifetime::Activation, 0, Some(10))],
+        SchemaBody::Set {
+            element: Box::new(SchemaBody::Bool),
+            cardinality: CardinalitySpec::Exact(DimensionExpr::Parameter(activation)),
+        },
+    );
+    let exact_shape = exact.instantiate_shape(vec![4].into_boxed_slice()).unwrap();
+    let exact_contract = exact.resolved_type_memory_contract(&exact_shape).unwrap();
+    assert_eq!(
+        exact_contract.extent,
+        ResolvedMemoryExtent::ExactCardinality(4)
+    );
+    assert_eq!(
+        exact_contract.extent_evolution,
+        ExtentEvolution::ActivationFixed
+    );
+
+    let bounded = parameterized_schema(
+        vec![parameter(0, DimensionLifetime::Activation, 0, Some(10))],
+        SchemaBody::Map {
+            key: Box::new(SchemaBody::Bool),
+            value: Box::new(SchemaBody::String),
+            cardinality: CardinalitySpec::Dynamic {
+                upper_bound: Some(DimensionExpr::Parameter(activation)),
+            },
+        },
+    );
+    let bounded_shape = bounded
+        .instantiate_shape(vec![7].into_boxed_slice())
+        .unwrap();
+    let bounded_contract = bounded
+        .resolved_type_memory_contract(&bounded_shape)
+        .unwrap();
+    assert_eq!(
+        bounded_contract.extent,
+        ResolvedMemoryExtent::DynamicCardinality {
+            upper_bound: Some(7),
+        }
+    );
+    assert_eq!(
+        bounded_contract.extent_evolution,
+        ExtentEvolution::TurnBounded
+    );
+
+    let unbounded = schema(SchemaBody::Set {
+        element: Box::new(SchemaBody::Bool),
+        cardinality: CardinalitySpec::Dynamic { upper_bound: None },
+    });
+    let unbounded_shape = unbounded
+        .instantiate_shape(Vec::new().into_boxed_slice())
+        .unwrap();
+    assert_eq!(
+        unbounded
+            .resolved_type_memory_contract(&unbounded_shape)
+            .unwrap()
+            .extent,
+        ResolvedMemoryExtent::DynamicCardinality { upper_bound: None }
+    );
+}
+
+#[test]
+fn resolution_revalidates_foreign_shapes_and_checked_arithmetic() {
+    let id = DimensionParameterId::new(0);
+    let source = parameterized_schema(
+        vec![parameter(0, DimensionLifetime::Turn, 0, Some(10))],
+        SchemaBody::Matrix {
+            element: Box::new(SchemaBody::Bool),
+            dimensions: vec![DimensionExpr::Parameter(id)].into_boxed_slice(),
+        },
+    );
+    let foreign_shape = source
+        .instantiate_shape(vec![9].into_boxed_slice())
+        .unwrap();
+    let narrower = parameterized_schema(
+        vec![parameter(0, DimensionLifetime::Turn, 0, Some(4))],
+        SchemaBody::Matrix {
+            element: Box::new(SchemaBody::Bool),
+            dimensions: vec![DimensionExpr::Parameter(id)].into_boxed_slice(),
+        },
+    );
+    assert!(matches!(
+        narrower.resolved_type_memory_contract(&foreign_shape),
+        Err(SemanticModelError::ShapeBoundViolationV1 { value: 9, .. })
+    ));
+
+    let wide_source = parameterized_schema(
+        vec![parameter(0, DimensionLifetime::Turn, 0, None)],
+        SchemaBody::Matrix {
+            element: Box::new(SchemaBody::Bool),
+            dimensions: vec![DimensionExpr::Parameter(id)].into_boxed_slice(),
+        },
+    );
+    let maximum_shape = wide_source
+        .instantiate_shape(vec![u64::MAX].into_boxed_slice())
+        .unwrap();
+    let overflow = parameterized_schema(
+        vec![parameter(0, DimensionLifetime::Turn, 0, None)],
+        SchemaBody::Table {
+            columns: Vec::new().into_boxed_slice(),
+            rows: CardinalitySpec::Exact(DimensionExpr::Multiply(
+                vec![DimensionExpr::Parameter(id), DimensionExpr::Constant(2)].into_boxed_slice(),
+            )),
+        },
+    );
+    assert!(matches!(
+        overflow.resolved_type_memory_contract(&maximum_shape),
+        Err(SemanticModelError::DimensionOverflowV1)
+    ));
+}
+
+#[test]
+fn derivation_preserves_schema_keys_and_canonical_bytes() {
+    let representative_schemas = vec![
+        schema(SchemaBody::Bool),
+        schema(SchemaBody::Matrix {
+            element: Box::new(SchemaBody::String),
+            dimensions: vec![DimensionExpr::Constant(2), DimensionExpr::Constant(1)]
+                .into_boxed_slice(),
+        }),
+        schema(SchemaBody::Record(
+            vec![SchemaField {
+                name: "value".to_owned(),
+                schema: SchemaBody::String,
+            }]
+            .into_boxed_slice(),
+        )),
+        schema(SchemaBody::Set {
+            element: Box::new(SchemaBody::Bool),
+            cardinality: DimensionExpr::Constant(2).into(),
+        }),
+        schema(SchemaBody::Map {
+            key: Box::new(SchemaBody::String),
+            value: Box::new(SchemaBody::Bool),
+            cardinality: CardinalitySpec::Dynamic { upper_bound: None },
+        }),
+        schema(SchemaBody::Table {
+            columns: vec![SchemaField {
+                name: "value".to_owned(),
+                schema: SchemaBody::Bool,
+            }]
+            .into_boxed_slice(),
+            rows: DimensionExpr::Constant(1).into(),
+        }),
+    ];
+
+    for schema in representative_schemas {
+        let key_before = schema.key();
+        let bytes_before = schema.canonical_bytes();
+        let shape = schema
+            .instantiate_shape(Vec::new().into_boxed_slice())
+            .unwrap();
+        let _type_contract = schema.type_memory_contract().unwrap();
+        let _resolved_contract = schema.resolved_type_memory_contract(&shape).unwrap();
+        assert_eq!(schema.key(), key_before);
+        assert_eq!(schema.canonical_bytes(), bytes_before);
+    }
+}
+
+#[test]
+fn memory_contract_types_do_not_acquire_serde_derives() {
+    let module_source = include_str!("../src/memory_contract/mod.rs");
+    let contract_source = include_str!("../src/memory_contract/type_contract.rs");
+    for forbidden in ["Serialize", "Deserialize"] {
+        assert!(!module_source.contains(forbidden));
+        assert!(!contract_source.contains(forbidden));
+    }
+}


### PR DESCRIPTION
## Summary

- adds a pure TypeMemoryContract derived from finalized Schema
- adds ResolvedTypeMemoryContract derived from Schema and a revalidated ShapeInstance
- classifies topology, extent evolution, addressing, canonicalization, and accounting obligations
- covers every current SchemaBody variant
- adds no runtime, storage, target, or wire-format behavior

This is stacked on PR #798 and targets `codex/v0.4-canonical-contract-closure` until R1 merges.

## Authority

- Schema remains type, child-structure, nominal-identity, and SchemaKey authority
- ShapeInstance supplies validated dimension values
- the new contract is derived metadata only
- runtime representation and pointers are not semantic identity

## Non-goals

- no storage capability descriptors
- no operation-port requirements
- no function-binding cutover
- no ValueCell changes
- no Resident/GPU changes
- no inference, physical layout, planning, or allocation
- no bytecode, canonical encoding, ABI, or package-version change

## Validation

- `R2A_BASE_SHA=e4f914c05819881b4ef3b645689db92846a4b8eb`
- final head: `2b800bd997fa33fe4a43e6719b762809f92e5935`
- `cargo +nightly-2026-03-03 fmt --all -- --check`: passed
- `python3 scripts/check-r1-compatibility-closure.py`: passed
- `cargo +nightly-2026-03-03 test --locked -p mech-core --features full`: inherited base failure in `src/core/tests/stdlib_macro_hygiene.rs` because twelve nalgebra imports are unused under denied warnings; the untouched R1 base fails identically and R2A does not change that file
- `cargo +nightly-2026-03-03 test --locked -p mech-core --features full --test type_memory_contract`: passed, 7 tests
- `cargo +nightly-2026-03-03 check --locked --no-default-features --features no_std`: passed
- `cargo +nightly-2026-03-03 check --locked -p mech-core --no-default-features --features mika`: passed
- `cargo +nightly-2026-03-03 check --locked -p mech-core --no-default-features --features "mika serde"`: passed
- `git diff --check`: passed
- forbidden runtime-surface diff guard: passed
- wire-format-surface diff guard: passed
- impact classifier: matched `docs` and `mech-core`, selected 14 cross-cutting owner shards, and did not require Full CI
- all 14 selected owner shards passed: browser, build, bytecode, console, core, engine, runtime, scene, stdlib, syntax, terminal, time, timer, and wasm
- changed files: 7
- production-code additions: 676
- commits: exactly 3

## Handoff

- R2B describes existing storage capabilities and separates logical from physical identity
- R2C derives operation memory requirements
- R2D adds shadow conformance, architecture enforcement, and roadmap closure

This PR does not claim R2 is complete.
