### PR TITLE
[v0.4-R2B] refactor(core): describe storage capabilities and identity

### DIFF
--- a/docs/design/type-memory-boundary.md
+++ b/docs/design/type-memory-boundary.md
@@ -1,10 +1,12 @@
 # Type-memory boundary
 
-## 1. Status and R2A scope
+## 1. Status and R2A/R2B scope
 
-R2A defines a read-only semantic projection from a finalized `Schema`, and from
+R2A is complete. It defines a read-only semantic projection from a finalized `Schema`, and from
 that schema plus a validated `ShapeInstance`, into memory-facing contracts.
-It changes no runtime binding, storage, target, or execution behavior.
+R2B defines descriptive capabilities of current value-cell backings and pure
+compatibility and identity relations. Both phases change no runtime binding,
+storage, target, or execution behavior.
 
 The projection has one direction:
 
@@ -142,15 +144,36 @@ no wire format. Canonical schema bytes remain unchanged and authoritative.
 Derived contracts must be recomputed from the schema rather than persisted as
 another compatibility surface.
 
-## 13. R2B handoff
+## 13. R2B storage capabilities and identity
 
-R2B may describe existing storage capabilities and separate logical identity
-from physical storage identity. It must consume this semantic projection
-without moving schema authority into runtime representations.
+R2B describes existing storage capabilities and separates logical cell identity
+from physical storage identity. `StorageCapabilityDescriptor` is derived from
+the actual backing. The public compatibility boundary accepts a finalized
+`Schema` and validated `ShapeInstance`, rederives the R2A contract internally,
+and then checks the backing. Callers cannot pair a schema with a contract
+derived from another schema. The checker remains opt-in and shadow-only.
+
+`same_cell` remains a compatibility alias for physical storage identity. New
+code chooses `same_logical_cell` or `same_storage` explicitly. No public
+physical storage identifier exists, and neither pointers nor runtime
+representations can become logical identity.
+
+### Known transitional mismatch
+
+Current `RowDVector` inference marks both dimensions as turn-varying even
+though its first physical axis is fixed at one. Current `DVector` inference
+likewise marks both dimensions as turn-varying even though its second physical
+axis is fixed at one. R2B deliberately reports both as
+`DynamicAxisUnsupported` during shadow validation; weakening the truthful
+storage descriptors would conceal the mismatch.
+
+R4 must infer each physically invariant vector axis as `Constant(1)` before the
+compatibility boundary becomes authoritative. R2C and R2D must not interpret
+these expected shadow failures as valid storage-incompatibility policy.
 
 ## 14. R2C handoff
 
-R2C may derive memory requirements for operation ports and compare those
+R2C will derive memory requirements for operation ports and compare those
 requirements with storage capabilities. It must not reinterpret schema
 identity or mutate the R2A contract.
 
@@ -167,8 +190,9 @@ metadata.
 
 ## 17. R4 handoff
 
-R4 owns retirement of transitional runtime representations and any binding
-cutover. R2A neither changes nor endorses a runtime representation.
+R4 owns retirement of transitional runtime representations and makes the new
+boundary authoritative during the binding cutover. R2A and R2B neither change
+nor endorse a runtime representation.
 
 ## 18. R5/R6 handoff
 

--- a/src/core/src/cell_binding.rs
+++ b/src/core/src/cell_binding.rs
@@ -101,10 +101,14 @@ pub(crate) trait ErasedCellStorage {
     fn replace(&self, value: &Value) -> MResult<()>;
     fn preflight_replace(&self) -> MResult<()>;
     fn capabilities(&self) -> crate::StorageCapabilityDescriptor;
-    fn detached_clone(&self) -> MResult<Rc<dyn ErasedCellStorage>>;
+    fn detached_clone(&self) -> MResult<DetachedCellStorage>;
     fn same_storage(&self, other: &dyn ErasedCellStorage) -> bool;
     fn borrow_state(&self) -> CellBorrowState;
-    fn logical_cell_id(&self) -> CanonicalCellId;
+}
+
+pub(crate) struct DetachedCellStorage {
+    pub identity: CanonicalCellId,
+    pub storage: Rc<dyn ErasedCellStorage>,
 }
 
 struct ExactCellStorage<T> {
@@ -156,15 +160,18 @@ impl<T: CanonicalCellBacking> ErasedCellStorage for ExactCellStorage<T> {
         crate::runtime_storage::actual_backing_capabilities(T::REPRESENTATION)
     }
 
-    fn detached_clone(&self) -> MResult<Rc<dyn ErasedCellStorage>> {
+    fn detached_clone(&self) -> MResult<DetachedCellStorage> {
         let value = self
             .reference
             .try_borrow()
             .map_err(|_| borrow_conflict(CellAccess::Snapshot))?
             .clone();
-        Ok(Rc::new(Self {
-            reference: Ref::new(value),
-        }))
+        let reference = Ref::new(value);
+        let identity = reference.reactive_cell_id();
+        Ok(DetachedCellStorage {
+            identity,
+            storage: Rc::new(Self { reference }),
+        })
     }
 
     fn same_storage(&self, other: &dyn ErasedCellStorage) -> bool {
@@ -180,10 +187,6 @@ impl<T: CanonicalCellBacking> ErasedCellStorage for ExactCellStorage<T> {
         } else {
             CellBorrowState::Borrowed
         }
-    }
-
-    fn logical_cell_id(&self) -> CanonicalCellId {
-        self.reference.reactive_cell_id()
     }
 }
 
@@ -1062,7 +1065,7 @@ impl ValueCell {
     /// cell identity is deliberately fresh. Source specialization uses this
     /// for full-write outputs whose representation mirrors an input.
     pub fn detached_clone(&self) -> MResult<Self> {
-        let storage = self.binding.storage.detached_clone()?;
+        let detached = self.binding.storage.detached_clone()?;
         let shape = self
             .binding
             .shape
@@ -1071,12 +1074,12 @@ impl ValueCell {
             .clone();
         Ok(Self {
             binding: CellBinding {
-                identity: storage.logical_cell_id(),
+                identity: detached.identity,
                 schema: self.binding.schema,
                 schema_key: self.binding.schema_key,
                 shape: Rc::new(cell::RefCell::new(shape)),
                 schemas: self.binding.schemas.clone(),
-                storage,
+                storage: detached.storage,
                 compiler_children: None,
             },
         })
@@ -1135,10 +1138,22 @@ impl ValueCell {
         self.binding.storage.preflight_replace()
     }
 
-    pub fn same_cell(&self, other: &Self) -> bool {
+    pub fn same_logical_cell(&self, other: &Self) -> bool {
+        self.binding.identity == other.binding.identity
+    }
+
+    pub fn same_storage(&self, other: &Self) -> bool {
         self.binding
             .storage
             .same_storage(other.binding.storage.as_ref())
+    }
+
+    /// Compatibility spelling for physical storage identity.
+    ///
+    /// New code should choose `same_logical_cell` or `same_storage`
+    /// explicitly. This method retains its existing physical-storage meaning.
+    pub fn same_cell(&self, other: &Self) -> bool {
+        self.same_storage(other)
     }
 
     pub fn reactive_cell_id(&self) -> CanonicalCellId {

--- a/src/core/src/cell_binding.rs
+++ b/src/core/src/cell_binding.rs
@@ -100,6 +100,7 @@ pub(crate) trait ErasedCellStorage {
     ) -> MResult<Value>;
     fn replace(&self, value: &Value) -> MResult<()>;
     fn preflight_replace(&self) -> MResult<()>;
+    fn capabilities(&self) -> crate::StorageCapabilityDescriptor;
     fn detached_clone(&self) -> MResult<Rc<dyn ErasedCellStorage>>;
     fn same_storage(&self, other: &dyn ErasedCellStorage) -> bool;
     fn borrow_state(&self) -> CellBorrowState;
@@ -149,6 +150,10 @@ impl<T: CanonicalCellBacking> ErasedCellStorage for ExactCellStorage<T> {
             .try_borrow_mut()
             .map(|_| ())
             .map_err(|_| borrow_conflict(CellAccess::Replace))
+    }
+
+    fn capabilities(&self) -> crate::StorageCapabilityDescriptor {
+        crate::runtime_storage::actual_backing_capabilities(T::REPRESENTATION)
     }
 
     fn detached_clone(&self) -> MResult<Rc<dyn ErasedCellStorage>> {
@@ -961,6 +966,77 @@ impl ValueCell {
             .get(self.binding.schema)
             .expect("value-cell schema remains present");
         self.binding.storage.representation(schema.body())
+    }
+
+    pub fn type_memory_contract(&self) -> MResult<crate::TypeMemoryContract> {
+        let schema = self
+            .binding
+            .schemas
+            .get(self.binding.schema)
+            .ok_or_else(|| {
+                snapshot_failure(SnapshotValueError::UnknownSnapshotSchema {
+                    schema: self.binding.schema,
+                })
+            })?;
+        Ok(schema.type_memory_contract()?)
+    }
+
+    pub fn resolved_type_memory_contract(&self) -> MResult<crate::ResolvedTypeMemoryContract> {
+        let schema = self
+            .binding
+            .schemas
+            .get(self.binding.schema)
+            .ok_or_else(|| {
+                snapshot_failure(SnapshotValueError::UnknownSnapshotSchema {
+                    schema: self.binding.schema,
+                })
+            })?;
+        let shape = self
+            .binding
+            .shape
+            .try_borrow()
+            .map_err(|_| borrow_conflict(CellAccess::Snapshot))?
+            .clone();
+        Ok(schema.resolved_type_memory_contract(&shape)?)
+    }
+
+    pub fn storage_capabilities(&self) -> crate::StorageCapabilityDescriptor {
+        self.binding.storage.capabilities()
+    }
+
+    /// Performs the opt-in shadow check without changing construction or execution.
+    pub fn validate_storage_contract(&self) -> MResult<()> {
+        let schema = self
+            .binding
+            .schemas
+            .get(self.binding.schema)
+            .ok_or_else(|| {
+                snapshot_failure(SnapshotValueError::UnknownSnapshotSchema {
+                    schema: self.binding.schema,
+                })
+            })?;
+        let shape = self
+            .binding
+            .shape
+            .try_borrow()
+            .map_err(|_| borrow_conflict(CellAccess::Snapshot))?
+            .clone();
+        crate::check_schema_storage_compatibility(
+            schema,
+            &shape,
+            &self.binding.storage.capabilities(),
+        )
+        .map_err(|error| match error {
+            crate::SchemaStorageCompatibilityError::Semantic(error) => error.into(),
+            crate::SchemaStorageCompatibilityError::Storage(reason) => MechError::new(
+                ValueCellStorageContractViolation {
+                    schema: self.binding.schema_key,
+                    reason,
+                },
+                None,
+            )
+            .with_compiler_loc(),
+        })
     }
 
     /// Describes whether this cell's schema permits its resolved extents to
@@ -1987,6 +2063,25 @@ impl MechErrorKind for ValueCellBackingMismatch {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ValueCellSnapshotFailure {
     pub error: SnapshotValueError,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ValueCellStorageContractViolation {
+    pub schema: SchemaKey,
+    pub reason: crate::StorageCompatibilityError,
+}
+
+impl MechErrorKind for ValueCellStorageContractViolation {
+    fn name(&self) -> &str {
+        "ValueCellStorageContractViolation"
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "value-cell storage does not satisfy schema {:?}: {}",
+            self.schema, self.reason
+        )
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/core/src/cell_binding.rs
+++ b/src/core/src/cell_binding.rs
@@ -3261,10 +3261,101 @@ mod tests {
         let separate =
             ValueCell::from_ref(Ref::new(7.0_f64), schema.id, schema.shape, schema.schemas)
                 .unwrap();
+        let detached = first.detached_clone().unwrap();
 
+        assert!(first.same_logical_cell(&clone));
+        assert!(first.same_storage(&clone));
         assert!(first.same_cell(&clone));
+        assert!(!first.same_logical_cell(&separate));
+        assert!(!first.same_storage(&separate));
         assert!(!first.same_cell(&separate));
         assert!(first.snapshot_eq(&separate).unwrap());
+        assert!(!first.same_logical_cell(&detached));
+        assert!(!first.same_storage(&detached));
+        assert!(first.snapshot_eq(&detached).unwrap());
+
+        let same_identity_detached_storage = ValueCell {
+            binding: CellBinding {
+                identity: first.binding.identity,
+                ..detached.binding.clone()
+            },
+        };
+        assert!(first.same_logical_cell(&same_identity_detached_storage));
+        assert!(!first.same_storage(&same_identity_detached_storage));
+
+        let different_identity_shared_storage = ValueCell {
+            binding: CellBinding {
+                identity: detached.binding.identity,
+                ..first.binding.clone()
+            },
+        };
+        assert!(!first.same_logical_cell(&different_identity_shared_storage));
+        assert!(first.same_storage(&different_identity_shared_storage));
+
+        for other in [
+            &clone,
+            &separate,
+            &detached,
+            &same_identity_detached_storage,
+            &different_identity_shared_storage,
+        ] {
+            assert_eq!(first.same_cell(other), first.same_storage(other));
+        }
+    }
+
+    fn assert_replace_borrow_conflict_preserves_value<T>(reference: Ref<T>, schema: TestSchema)
+    where
+        T: CanonicalCellBacking,
+    {
+        let cell = ValueCell::from_ref(
+            reference.clone(),
+            schema.id,
+            schema.shape.clone(),
+            schema.schemas.clone(),
+        )
+        .unwrap();
+        let before = cell.detached_clone().unwrap();
+        let replacement = before.snapshot().unwrap();
+        let held = reference.borrow_mut();
+        assert!(cell.replace(&replacement).is_err());
+        drop(held);
+        assert!(cell.snapshot_eq(&before).unwrap());
+        assert!(
+            cell.storage_capabilities()
+                .publication
+                .preserves_previous_on_failure
+        );
+    }
+
+    #[test]
+    fn declared_atomic_publication_preserves_representative_backings_on_borrow_conflict() {
+        #[cfg(feature = "f64")]
+        {
+            let scalar_schema = f64_schema();
+            assert_replace_borrow_conflict_preserves_value(Ref::new(1.25_f64), scalar_schema);
+
+            let canonical_schema = f64_schema();
+            let canonical = f64_value(&canonical_schema, 1.25);
+            assert_replace_borrow_conflict_preserves_value(Ref::new(canonical), canonical_schema);
+        }
+
+        #[cfg(feature = "string")]
+        assert_replace_borrow_conflict_preserves_value(
+            Ref::new("before".to_owned()),
+            test_schema(SchemaBody::String, Box::new([]), &[]),
+        );
+
+        #[cfg(all(feature = "f64", feature = "matrixd"))]
+        assert_replace_borrow_conflict_preserves_value(
+            Ref::new(crate::DMatrix::<f64>::zeros(2, 3)),
+            matrix_schema(2, 3),
+        );
+
+        #[cfg(all(feature = "f64", feature = "matrix2"))]
+        assert_replace_borrow_conflict_preserves_value(
+            Ref::new(crate::Matrix2::<f64>::zeros()),
+            matrix_schema(2, 2),
+        );
     }
 
     #[cfg(feature = "f64")]

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -128,6 +128,7 @@ pub mod read_source;
 #[cfg(feature = "resident-execution")]
 #[doc(hidden)]
 pub mod resident_execution;
+pub(crate) mod runtime_storage;
 pub mod selector;
 pub mod snapshot;
 pub mod state_journal;

--- a/src/core/src/memory_contract/mod.rs
+++ b/src/core/src/memory_contract/mod.rs
@@ -1,5 +1,7 @@
 //! Schema-derived memory-facing semantic obligations.
 
+mod storage_capability;
 mod type_contract;
 
+pub use self::storage_capability::*;
 pub use self::type_contract::*;

--- a/src/core/src/memory_contract/storage_capability.rs
+++ b/src/core/src/memory_contract/storage_capability.rs
@@ -1,0 +1,380 @@
+//! Descriptive storage capabilities and pure schema compatibility checks.
+
+use crate::{
+    ExtentEvolution, MemoryTopology, PayloadAccounting, PopulationAccounting, ResolvedMemoryExtent,
+    ResolvedTypeMemoryContract, ScalarMemoryKind, Schema, SchemaBody, SemanticModelError,
+    ShapeInstance,
+};
+
+#[cfg(feature = "no_std")]
+use alloc::boxed::Box;
+#[cfg(not(feature = "no_std"))]
+use std::boxed::Box;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum StorageElementKind {
+    CanonicalValue,
+    Scalar(ScalarMemoryKind),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum StorageTopology {
+    Opaque,
+    CanonicalValue,
+    Scalar(ScalarMemoryKind),
+    Tagged,
+    Product,
+    DenseSequence { element: StorageElementKind },
+    Columnar,
+    OrderedSet,
+    OrderedMap,
+    ReifiedType,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum StorageExtentCapability {
+    Any,
+    Single,
+    FixedArity(u64),
+    FixedDimensions(Box<[u64]>),
+    ResizableDimensions(Box<[Option<u64>]>),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PositionalAddressingCapability {
+    None,
+    Rank(u64),
+    AnyRank,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct StorageAddressingCapabilities {
+    pub whole_value: bool,
+    pub positional: PositionalAddressingCapability,
+    pub named_members: bool,
+    pub keyed_members: bool,
+    pub arbitrary_regions: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct StorageCanonicalizationCapabilities {
+    pub self_describing: bool,
+    pub recursive: bool,
+    pub tagged: bool,
+    pub ordered_keys: bool,
+    pub unique_keys: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct StorageAccessCapabilities {
+    pub readable: bool,
+    pub writable: bool,
+    pub replaceable: bool,
+    pub region_mutable: bool,
+    pub canonical_snapshot: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct StorageOwnershipCapabilities {
+    pub shared_read: bool,
+    pub exclusive_write: bool,
+    pub owned_value: bool,
+    pub detachable: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct StoragePublicationCapabilities {
+    pub atomic_replace: bool,
+    pub preserves_previous_on_failure: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum StorageAccountingCapability {
+    FixedScalar,
+    CanonicalSnapshot,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StorageCapabilityDescriptor {
+    pub topology: StorageTopology,
+    pub extent: StorageExtentCapability,
+    pub addressing: StorageAddressingCapabilities,
+    pub canonicalization: StorageCanonicalizationCapabilities,
+    pub access: StorageAccessCapabilities,
+    pub ownership: StorageOwnershipCapabilities,
+    pub publication: StoragePublicationCapabilities,
+    pub accounting: StorageAccountingCapability,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum StorageCompatibilityError {
+    OpaqueStorage,
+    TopologyMismatch,
+    ScalarKindMismatch,
+    DenseElementMismatch,
+    ExtentKindMismatch,
+    RankMismatch,
+    AxisMismatch,
+    DynamicAxisUnsupported,
+    PositionalAddressingUnsupported,
+    NamedAddressingUnsupported,
+    KeyedAddressingUnsupported,
+    CanonicalizationUnsupported,
+    AccountingUnsupported,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SchemaStorageCompatibilityError {
+    Semantic(SemanticModelError),
+    Storage(StorageCompatibilityError),
+}
+
+impl From<SemanticModelError> for SchemaStorageCompatibilityError {
+    fn from(error: SemanticModelError) -> Self {
+        Self::Semantic(error)
+    }
+}
+
+impl From<StorageCompatibilityError> for SchemaStorageCompatibilityError {
+    fn from(error: StorageCompatibilityError) -> Self {
+        Self::Storage(error)
+    }
+}
+
+impl core::fmt::Display for StorageCompatibilityError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter.write_str(match self {
+            Self::OpaqueStorage => "storage capabilities are opaque",
+            Self::TopologyMismatch => "storage topology does not satisfy the semantic topology",
+            Self::ScalarKindMismatch => {
+                "storage scalar kind does not match the semantic scalar kind"
+            }
+            Self::DenseElementMismatch => {
+                "dense storage element kind does not match the matrix element schema"
+            }
+            Self::ExtentKindMismatch => "storage extent kind does not satisfy the resolved extent",
+            Self::RankMismatch => "storage rank does not match the resolved rank",
+            Self::AxisMismatch => "storage axis does not match the resolved axis",
+            Self::DynamicAxisUnsupported => {
+                "fixed storage axis cannot satisfy a turn-varying extent"
+            }
+            Self::PositionalAddressingUnsupported => {
+                "storage does not provide the required positional addressing"
+            }
+            Self::NamedAddressingUnsupported => {
+                "storage does not provide required named-member addressing"
+            }
+            Self::KeyedAddressingUnsupported => {
+                "storage does not provide required keyed-member addressing"
+            }
+            Self::CanonicalizationUnsupported => {
+                "storage does not satisfy the semantic canonicalization obligations"
+            }
+            Self::AccountingUnsupported => {
+                "storage accounting does not satisfy the semantic accounting obligations"
+            }
+        })
+    }
+}
+
+#[cfg(any(not(feature = "no_std"), feature = "std"))]
+impl std::error::Error for StorageCompatibilityError {}
+
+fn scalar_kind(body: &SchemaBody) -> Option<ScalarMemoryKind> {
+    match body {
+        SchemaBody::Bool => Some(ScalarMemoryKind::Bool),
+        SchemaBody::UnsignedInteger(width) => Some(ScalarMemoryKind::Unsigned(*width)),
+        SchemaBody::SignedInteger(width) => Some(ScalarMemoryKind::Signed(*width)),
+        SchemaBody::FloatingPoint(width) => Some(ScalarMemoryKind::Floating(*width)),
+        SchemaBody::Complex(width) => Some(ScalarMemoryKind::Complex(*width)),
+        SchemaBody::Rational64 => Some(ScalarMemoryKind::Rational64),
+        SchemaBody::String => Some(ScalarMemoryKind::String),
+        SchemaBody::Id => Some(ScalarMemoryKind::Id),
+        SchemaBody::Index => Some(ScalarMemoryKind::Index),
+        SchemaBody::Atom(_) => Some(ScalarMemoryKind::Atom),
+        _ => None,
+    }
+}
+
+fn check_topology(
+    schema: &SchemaBody,
+    semantic: MemoryTopology,
+    storage: StorageTopology,
+) -> Result<(), StorageCompatibilityError> {
+    if storage == StorageTopology::Opaque {
+        return Err(StorageCompatibilityError::OpaqueStorage);
+    }
+    if storage == StorageTopology::CanonicalValue {
+        return Ok(());
+    }
+
+    match (semantic, storage) {
+        (MemoryTopology::Scalar(expected), StorageTopology::Scalar(found)) => {
+            if expected == found {
+                Ok(())
+            } else {
+                Err(StorageCompatibilityError::ScalarKindMismatch)
+            }
+        }
+        (MemoryTopology::Tagged { .. }, StorageTopology::Tagged)
+        | (MemoryTopology::Product { .. }, StorageTopology::Product)
+        | (MemoryTopology::Columnar { .. }, StorageTopology::Columnar)
+        | (MemoryTopology::OrderedSet, StorageTopology::OrderedSet)
+        | (MemoryTopology::OrderedMap, StorageTopology::OrderedMap)
+        | (MemoryTopology::ReifiedType, StorageTopology::ReifiedType) => Ok(()),
+        (
+            MemoryTopology::DenseSequence { .. },
+            StorageTopology::DenseSequence { element: found },
+        ) => match found {
+            StorageElementKind::CanonicalValue => Ok(()),
+            StorageElementKind::Scalar(found) => {
+                let SchemaBody::Matrix { element, .. } = schema else {
+                    return Err(StorageCompatibilityError::DenseElementMismatch);
+                };
+                if scalar_kind(element) == Some(found) {
+                    Ok(())
+                } else {
+                    Err(StorageCompatibilityError::DenseElementMismatch)
+                }
+            }
+        },
+        _ => Err(StorageCompatibilityError::TopologyMismatch),
+    }
+}
+
+fn fixed_axis_accepts(evolution: ExtentEvolution) -> bool {
+    matches!(
+        evolution,
+        ExtentEvolution::Fixed | ExtentEvolution::ActivationFixed
+    )
+}
+
+fn check_extent(
+    semantic: &ResolvedMemoryExtent,
+    storage: &StorageExtentCapability,
+) -> Result<(), StorageCompatibilityError> {
+    match storage {
+        StorageExtentCapability::Any => Ok(()),
+        StorageExtentCapability::Single if semantic == &ResolvedMemoryExtent::Single => Ok(()),
+        StorageExtentCapability::Single => Err(StorageCompatibilityError::ExtentKindMismatch),
+        StorageExtentCapability::FixedArity(found) => match semantic {
+            ResolvedMemoryExtent::FixedArity(required) if required == found => Ok(()),
+            _ => Err(StorageCompatibilityError::ExtentKindMismatch),
+        },
+        StorageExtentCapability::FixedDimensions(found) => {
+            let ResolvedMemoryExtent::Dimensions(required) = semantic else {
+                return Err(StorageCompatibilityError::ExtentKindMismatch);
+            };
+            if required.len() != found.len() {
+                return Err(StorageCompatibilityError::RankMismatch);
+            }
+            for (required, found) in required.iter().zip(found) {
+                if required.value != *found {
+                    return Err(StorageCompatibilityError::AxisMismatch);
+                }
+                if !fixed_axis_accepts(required.evolution) {
+                    return Err(StorageCompatibilityError::DynamicAxisUnsupported);
+                }
+            }
+            Ok(())
+        }
+        StorageExtentCapability::ResizableDimensions(pattern) => {
+            let ResolvedMemoryExtent::Dimensions(required) = semantic else {
+                return Err(StorageCompatibilityError::ExtentKindMismatch);
+            };
+            if required.len() != pattern.len() {
+                return Err(StorageCompatibilityError::RankMismatch);
+            }
+            for (required, fixed) in required.iter().zip(pattern) {
+                if let Some(fixed) = fixed {
+                    if required.value != *fixed {
+                        return Err(StorageCompatibilityError::AxisMismatch);
+                    }
+                    if !fixed_axis_accepts(required.evolution) {
+                        return Err(StorageCompatibilityError::DynamicAxisUnsupported);
+                    }
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
+fn check_addressing(
+    contract: &ResolvedTypeMemoryContract,
+    storage: &StorageCapabilityDescriptor,
+) -> Result<(), StorageCompatibilityError> {
+    if let Some(required) = contract.addressing.positional_rank {
+        match storage.addressing.positional {
+            PositionalAddressingCapability::AnyRank => {}
+            PositionalAddressingCapability::Rank(found) if found >= required => {}
+            _ => return Err(StorageCompatibilityError::PositionalAddressingUnsupported),
+        }
+    }
+    if contract.addressing.named_members && !storage.addressing.named_members {
+        return Err(StorageCompatibilityError::NamedAddressingUnsupported);
+    }
+    if contract.addressing.keyed_members && !storage.addressing.keyed_members {
+        return Err(StorageCompatibilityError::KeyedAddressingUnsupported);
+    }
+    Ok(())
+}
+
+fn check_canonicalization(
+    contract: &ResolvedTypeMemoryContract,
+    storage: &StorageCapabilityDescriptor,
+) -> Result<(), StorageCompatibilityError> {
+    let required = contract.canonicalization;
+    let found = storage.canonicalization;
+    if (required.self_describing && !found.self_describing)
+        || (required.recursive && !found.recursive)
+        || (required.tagged && !found.tagged)
+        || (required.ordered_keys && !found.ordered_keys)
+        || (required.unique_keys && !found.unique_keys)
+    {
+        Err(StorageCompatibilityError::CanonicalizationUnsupported)
+    } else {
+        Ok(())
+    }
+}
+
+fn check_accounting(
+    contract: &ResolvedTypeMemoryContract,
+    storage: &StorageCapabilityDescriptor,
+) -> Result<(), StorageCompatibilityError> {
+    match storage.accounting {
+        StorageAccountingCapability::CanonicalSnapshot => Ok(()),
+        StorageAccountingCapability::FixedScalar
+            if matches!(contract.topology, MemoryTopology::Scalar(_))
+                && contract.accounting.payload == PayloadAccounting::FixedWidth
+                && contract.accounting.population == PopulationAccounting::Single =>
+        {
+            Ok(())
+        }
+        StorageAccountingCapability::FixedScalar => {
+            Err(StorageCompatibilityError::AccountingUnsupported)
+        }
+    }
+}
+
+pub(crate) fn check_resolved_type_storage_compatibility(
+    schema: &SchemaBody,
+    contract: &ResolvedTypeMemoryContract,
+    storage: &StorageCapabilityDescriptor,
+) -> Result<(), StorageCompatibilityError> {
+    check_topology(schema, contract.topology, storage.topology)?;
+    check_extent(&contract.extent, &storage.extent)?;
+    check_addressing(contract, storage)?;
+    check_canonicalization(contract, storage)?;
+    check_accounting(contract, storage)
+}
+
+pub fn check_schema_storage_compatibility(
+    schema: &Schema,
+    shape: &ShapeInstance,
+    storage: &StorageCapabilityDescriptor,
+) -> Result<(), SchemaStorageCompatibilityError> {
+    let contract = schema.resolved_type_memory_contract(shape)?;
+    check_resolved_type_storage_compatibility(schema.body(), &contract, storage)?;
+    Ok(())
+}

--- a/src/core/src/runtime_storage.rs
+++ b/src/core/src/runtime_storage.rs
@@ -1,0 +1,269 @@
+//! Private adapter from transitional runtime representations to actual backing capabilities.
+
+use crate::{
+    FloatWidth, FunctionMatrixElement, FunctionMatrixRepresentation, FunctionMatrixStoragePattern,
+    FunctionValueRepresentation, IntegerWidth, PositionalAddressingCapability, ScalarMemoryKind,
+    StorageAccessCapabilities, StorageAccountingCapability, StorageAddressingCapabilities,
+    StorageCanonicalizationCapabilities, StorageCapabilityDescriptor, StorageElementKind,
+    StorageExtentCapability, StorageOwnershipCapabilities, StoragePublicationCapabilities,
+    StorageTopology,
+};
+
+#[cfg(feature = "no_std")]
+use alloc::vec;
+#[cfg(not(feature = "no_std"))]
+use std::vec;
+
+const WHOLE_VALUE: StorageAddressingCapabilities = StorageAddressingCapabilities {
+    whole_value: true,
+    positional: PositionalAddressingCapability::None,
+    named_members: false,
+    keyed_members: false,
+    arbitrary_regions: false,
+};
+
+const NO_CANONICALIZATION: StorageCanonicalizationCapabilities =
+    StorageCanonicalizationCapabilities {
+        self_describing: false,
+        recursive: false,
+        tagged: false,
+        ordered_keys: false,
+        unique_keys: false,
+    };
+
+const STANDARD_ACCESS: StorageAccessCapabilities = StorageAccessCapabilities {
+    readable: true,
+    writable: true,
+    replaceable: true,
+    region_mutable: false,
+    canonical_snapshot: true,
+};
+
+const STANDARD_OWNERSHIP: StorageOwnershipCapabilities = StorageOwnershipCapabilities {
+    shared_read: true,
+    exclusive_write: true,
+    owned_value: true,
+    detachable: true,
+};
+
+const ATOMIC_PUBLICATION: StoragePublicationCapabilities = StoragePublicationCapabilities {
+    atomic_replace: true,
+    preserves_previous_on_failure: true,
+};
+
+fn descriptor(
+    topology: StorageTopology,
+    extent: StorageExtentCapability,
+    addressing: StorageAddressingCapabilities,
+    canonicalization: StorageCanonicalizationCapabilities,
+    region_mutable: bool,
+    accounting: StorageAccountingCapability,
+) -> StorageCapabilityDescriptor {
+    StorageCapabilityDescriptor {
+        topology,
+        extent,
+        addressing,
+        canonicalization,
+        access: StorageAccessCapabilities {
+            region_mutable,
+            ..STANDARD_ACCESS
+        },
+        ownership: STANDARD_OWNERSHIP,
+        publication: ATOMIC_PUBLICATION,
+        accounting,
+    }
+}
+
+fn scalar(kind: ScalarMemoryKind) -> StorageCapabilityDescriptor {
+    descriptor(
+        StorageTopology::Scalar(kind),
+        StorageExtentCapability::Single,
+        WHOLE_VALUE,
+        NO_CANONICALIZATION,
+        false,
+        StorageAccountingCapability::FixedScalar,
+    )
+}
+
+fn matrix_element(element: FunctionMatrixElement) -> Option<ScalarMemoryKind> {
+    Some(match element {
+        FunctionMatrixElement::Index => ScalarMemoryKind::Index,
+        FunctionMatrixElement::Bool => ScalarMemoryKind::Bool,
+        FunctionMatrixElement::String => ScalarMemoryKind::String,
+        FunctionMatrixElement::U8 => ScalarMemoryKind::Unsigned(IntegerWidth::W8),
+        FunctionMatrixElement::U16 => ScalarMemoryKind::Unsigned(IntegerWidth::W16),
+        FunctionMatrixElement::U32 => ScalarMemoryKind::Unsigned(IntegerWidth::W32),
+        FunctionMatrixElement::U64 => ScalarMemoryKind::Unsigned(IntegerWidth::W64),
+        FunctionMatrixElement::U128 => ScalarMemoryKind::Unsigned(IntegerWidth::W128),
+        FunctionMatrixElement::I8 => ScalarMemoryKind::Signed(IntegerWidth::W8),
+        FunctionMatrixElement::I16 => ScalarMemoryKind::Signed(IntegerWidth::W16),
+        FunctionMatrixElement::I32 => ScalarMemoryKind::Signed(IntegerWidth::W32),
+        FunctionMatrixElement::I64 => ScalarMemoryKind::Signed(IntegerWidth::W64),
+        FunctionMatrixElement::I128 => ScalarMemoryKind::Signed(IntegerWidth::W128),
+        FunctionMatrixElement::F32 => ScalarMemoryKind::Floating(FloatWidth::W32),
+        FunctionMatrixElement::F64 => ScalarMemoryKind::Floating(FloatWidth::W64),
+        FunctionMatrixElement::C64 => ScalarMemoryKind::Complex(FloatWidth::W64),
+        FunctionMatrixElement::R64 => ScalarMemoryKind::Rational64,
+        FunctionMatrixElement::Value => return None,
+    })
+}
+
+fn matrix_extent(representation: FunctionMatrixRepresentation) -> StorageExtentCapability {
+    use FunctionMatrixRepresentation::*;
+    match representation {
+        Matrix1 => StorageExtentCapability::FixedDimensions(vec![1, 1].into_boxed_slice()),
+        Matrix2 => StorageExtentCapability::FixedDimensions(vec![2, 2].into_boxed_slice()),
+        Matrix3 => StorageExtentCapability::FixedDimensions(vec![3, 3].into_boxed_slice()),
+        Matrix4 => StorageExtentCapability::FixedDimensions(vec![4, 4].into_boxed_slice()),
+        Matrix2x3 => StorageExtentCapability::FixedDimensions(vec![2, 3].into_boxed_slice()),
+        Matrix3x2 => StorageExtentCapability::FixedDimensions(vec![3, 2].into_boxed_slice()),
+        RowVector2 => StorageExtentCapability::FixedDimensions(vec![1, 2].into_boxed_slice()),
+        RowVector3 => StorageExtentCapability::FixedDimensions(vec![1, 3].into_boxed_slice()),
+        RowVector4 => StorageExtentCapability::FixedDimensions(vec![1, 4].into_boxed_slice()),
+        Vector2 => StorageExtentCapability::FixedDimensions(vec![2, 1].into_boxed_slice()),
+        Vector3 => StorageExtentCapability::FixedDimensions(vec![3, 1].into_boxed_slice()),
+        Vector4 => StorageExtentCapability::FixedDimensions(vec![4, 1].into_boxed_slice()),
+        RowVectorD => {
+            StorageExtentCapability::ResizableDimensions(vec![Some(1), None].into_boxed_slice())
+        }
+        VectorD => {
+            StorageExtentCapability::ResizableDimensions(vec![None, Some(1)].into_boxed_slice())
+        }
+        MatrixD => {
+            StorageExtentCapability::ResizableDimensions(vec![None, None].into_boxed_slice())
+        }
+    }
+}
+
+fn matrix(
+    element: FunctionMatrixElement,
+    representation: FunctionMatrixRepresentation,
+) -> StorageCapabilityDescriptor {
+    let Some(element) = matrix_element(element) else {
+        return opaque();
+    };
+    descriptor(
+        StorageTopology::DenseSequence {
+            element: StorageElementKind::Scalar(element),
+        },
+        matrix_extent(representation),
+        StorageAddressingCapabilities {
+            positional: PositionalAddressingCapability::Rank(2),
+            arbitrary_regions: true,
+            ..WHOLE_VALUE
+        },
+        StorageCanonicalizationCapabilities {
+            recursive: true,
+            ..NO_CANONICALIZATION
+        },
+        true,
+        StorageAccountingCapability::CanonicalSnapshot,
+    )
+}
+
+fn opaque() -> StorageCapabilityDescriptor {
+    StorageCapabilityDescriptor {
+        topology: StorageTopology::Opaque,
+        extent: StorageExtentCapability::Any,
+        addressing: WHOLE_VALUE,
+        canonicalization: NO_CANONICALIZATION,
+        access: StorageAccessCapabilities {
+            readable: false,
+            writable: false,
+            replaceable: false,
+            region_mutable: false,
+            canonical_snapshot: false,
+        },
+        ownership: StorageOwnershipCapabilities {
+            shared_read: false,
+            exclusive_write: false,
+            owned_value: false,
+            detachable: false,
+        },
+        publication: StoragePublicationCapabilities {
+            atomic_replace: false,
+            preserves_previous_on_failure: false,
+        },
+        accounting: StorageAccountingCapability::CanonicalSnapshot,
+    }
+}
+
+pub(crate) fn actual_backing_capabilities(
+    representation: FunctionValueRepresentation,
+) -> StorageCapabilityDescriptor {
+    use FunctionValueRepresentation::*;
+    match representation {
+        AnyValue => StorageCapabilityDescriptor {
+            topology: StorageTopology::CanonicalValue,
+            extent: StorageExtentCapability::Any,
+            addressing: StorageAddressingCapabilities {
+                whole_value: true,
+                positional: PositionalAddressingCapability::AnyRank,
+                named_members: true,
+                keyed_members: true,
+                arbitrary_regions: true,
+            },
+            canonicalization: StorageCanonicalizationCapabilities {
+                self_describing: true,
+                recursive: true,
+                tagged: true,
+                ordered_keys: true,
+                unique_keys: true,
+            },
+            access: StorageAccessCapabilities {
+                region_mutable: true,
+                ..STANDARD_ACCESS
+            },
+            ownership: STANDARD_OWNERSHIP,
+            publication: ATOMIC_PUBLICATION,
+            accounting: StorageAccountingCapability::CanonicalSnapshot,
+        },
+        U8 => scalar(ScalarMemoryKind::Unsigned(IntegerWidth::W8)),
+        U16 => scalar(ScalarMemoryKind::Unsigned(IntegerWidth::W16)),
+        U32 => scalar(ScalarMemoryKind::Unsigned(IntegerWidth::W32)),
+        U64 => scalar(ScalarMemoryKind::Unsigned(IntegerWidth::W64)),
+        U128 => scalar(ScalarMemoryKind::Unsigned(IntegerWidth::W128)),
+        I8 => scalar(ScalarMemoryKind::Signed(IntegerWidth::W8)),
+        I16 => scalar(ScalarMemoryKind::Signed(IntegerWidth::W16)),
+        I32 => scalar(ScalarMemoryKind::Signed(IntegerWidth::W32)),
+        I64 => scalar(ScalarMemoryKind::Signed(IntegerWidth::W64)),
+        I128 => scalar(ScalarMemoryKind::Signed(IntegerWidth::W128)),
+        F32 => scalar(ScalarMemoryKind::Floating(FloatWidth::W32)),
+        F64 => scalar(ScalarMemoryKind::Floating(FloatWidth::W64)),
+        C64 => scalar(ScalarMemoryKind::Complex(FloatWidth::W64)),
+        R64 => scalar(ScalarMemoryKind::Rational64),
+        Bool => scalar(ScalarMemoryKind::Bool),
+        Id => scalar(ScalarMemoryKind::Id),
+        Index => scalar(ScalarMemoryKind::Index),
+        Atom => scalar(ScalarMemoryKind::Atom),
+        String => descriptor(
+            StorageTopology::Scalar(ScalarMemoryKind::String),
+            StorageExtentCapability::Single,
+            StorageAddressingCapabilities {
+                positional: PositionalAddressingCapability::Rank(1),
+                arbitrary_regions: true,
+                ..WHOLE_VALUE
+            },
+            NO_CANONICALIZATION,
+            true,
+            StorageAccountingCapability::CanonicalSnapshot,
+        ),
+        Matrix {
+            element,
+            storage: FunctionMatrixStoragePattern::Exact(representation),
+        } => matrix(element, representation),
+        Matrix {
+            storage: FunctionMatrixStoragePattern::AnyStorage,
+            ..
+        }
+        | Empty
+        | Enum
+        | Record
+        | Map
+        | Set
+        | Table
+        | Tuple
+        | Kind
+        | MutableValueCell => opaque(),
+    }
+}

--- a/src/core/src/runtime_storage.rs
+++ b/src/core/src/runtime_storage.rs
@@ -267,3 +267,36 @@ pub(crate) fn actual_backing_capabilities(
         | MutableValueCell => opaque(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn universal_and_abstract_representations_are_classified_by_actual_backing() {
+        assert_eq!(
+            actual_backing_capabilities(FunctionValueRepresentation::AnyValue).topology,
+            StorageTopology::CanonicalValue
+        );
+        for representation in [
+            FunctionValueRepresentation::Empty,
+            FunctionValueRepresentation::Enum,
+            FunctionValueRepresentation::Record,
+            FunctionValueRepresentation::Map,
+            FunctionValueRepresentation::Set,
+            FunctionValueRepresentation::Table,
+            FunctionValueRepresentation::Tuple,
+            FunctionValueRepresentation::Kind,
+            FunctionValueRepresentation::MutableValueCell,
+            FunctionValueRepresentation::Matrix {
+                element: FunctionMatrixElement::F64,
+                storage: FunctionMatrixStoragePattern::AnyStorage,
+            },
+        ] {
+            assert_eq!(
+                actual_backing_capabilities(representation).topology,
+                StorageTopology::Opaque
+            );
+        }
+    }
+}

--- a/src/core/tests/storage_capability.rs
+++ b/src/core/tests/storage_capability.rs
@@ -1,0 +1,778 @@
+#![cfg(feature = "full")]
+
+use mech_core::{
+    snapshot::{MapEntryDraft, NamedValueDraft, SnapshotValidationContext, TableColumnDraft},
+    *,
+};
+#[cfg(feature = "matrix1")]
+use nalgebra::Matrix1;
+#[cfg(feature = "matrix2")]
+use nalgebra::Matrix2;
+#[cfg(feature = "matrix2x3")]
+use nalgebra::Matrix2x3;
+#[cfg(feature = "matrix3")]
+use nalgebra::Matrix3;
+#[cfg(feature = "matrix3x2")]
+use nalgebra::Matrix3x2;
+#[cfg(feature = "matrix4")]
+use nalgebra::Matrix4;
+#[cfg(feature = "row_vector2")]
+use nalgebra::RowVector2;
+#[cfg(feature = "row_vector3")]
+use nalgebra::RowVector3;
+#[cfg(feature = "row_vector4")]
+use nalgebra::RowVector4;
+#[cfg(feature = "vector2")]
+use nalgebra::Vector2;
+#[cfg(feature = "vector3")]
+use nalgebra::Vector3;
+#[cfg(feature = "vector4")]
+use nalgebra::Vector4;
+use nalgebra::{DMatrix, DVector, RowDVector};
+use std::rc::Rc;
+
+fn canonical_cell(body: SchemaBody, data: ValueDataDraft) -> ValueCell {
+    let schema = SchemaDraft {
+        dimension_parameters: Box::new([]),
+        body,
+    }
+    .finalize()
+    .unwrap();
+    let mut builder = SchemaTableBuilder::new();
+    let handle = builder.insert(schema).unwrap();
+    let build = builder.finish().unwrap();
+    let schema = build.resolve(handle).unwrap();
+    let (schemas, _) = build.into_parts();
+    let schemas = Rc::new(schemas);
+    let value = ValueDraft {
+        schema,
+        shape_values: Box::new([]),
+        data,
+    }
+    .finalize(&SnapshotValidationContext::new(&schemas))
+    .unwrap();
+    ValueCell::from_value(value, schemas).unwrap()
+}
+
+fn resolved(body: SchemaBody) -> (Schema, ShapeInstance) {
+    resolved_with(Vec::new(), body, Vec::new())
+}
+
+fn resolved_with(
+    parameters: Vec<DimensionParameterDeclaration>,
+    body: SchemaBody,
+    values: Vec<u64>,
+) -> (Schema, ShapeInstance) {
+    let schema = SchemaDraft {
+        dimension_parameters: parameters.into_boxed_slice(),
+        body,
+    }
+    .finalize()
+    .unwrap();
+    let shape = schema.instantiate_shape(values.into_boxed_slice()).unwrap();
+    (schema, shape)
+}
+
+fn check_fixture_storage_compatibility(
+    schema: &Schema,
+    shape: &ShapeInstance,
+    storage: &StorageCapabilityDescriptor,
+) -> Result<(), StorageCompatibilityError> {
+    match check_schema_storage_compatibility(schema, shape, storage) {
+        Ok(()) => Ok(()),
+        Err(SchemaStorageCompatibilityError::Storage(error)) => Err(error),
+        Err(SchemaStorageCompatibilityError::Semantic(error)) => {
+            panic!("invalid schema/shape fixture: {error:?}")
+        }
+    }
+}
+
+fn parameter(
+    ordinal: u32,
+    lifetime: DimensionLifetime,
+    upper_bound: Option<u64>,
+) -> DimensionParameterDeclaration {
+    DimensionParameterDeclaration {
+        id: DimensionParameterId::new(ordinal),
+        origin: DimensionParameterOrigin::Explicit,
+        lifetime,
+        lower_bound: DimensionExpr::Constant(0),
+        upper_bound: upper_bound.map(DimensionExpr::Constant),
+    }
+}
+
+fn f64_matrix(dimensions: Vec<DimensionExpr>) -> SchemaBody {
+    SchemaBody::Matrix {
+        element: Box::new(SchemaBody::FloatingPoint(FloatWidth::W64)),
+        dimensions: dimensions.into_boxed_slice(),
+    }
+}
+
+fn assert_exact_scalar(cell: ValueCell, expected: ScalarMemoryKind) {
+    let capabilities = cell.storage_capabilities();
+    assert_eq!(capabilities.topology, StorageTopology::Scalar(expected));
+    assert_eq!(capabilities.extent, StorageExtentCapability::Single);
+    assert_eq!(
+        capabilities.addressing.positional,
+        PositionalAddressingCapability::None
+    );
+    assert!(capabilities.addressing.whole_value);
+    assert!(!capabilities.access.region_mutable);
+    assert!(capabilities.access.canonical_snapshot);
+    assert_eq!(
+        capabilities.accounting,
+        StorageAccountingCapability::FixedScalar
+    );
+    assert!(capabilities.ownership.detachable);
+    assert!(capabilities.publication.atomic_replace);
+    cell.validate_storage_contract().unwrap();
+}
+
+#[test]
+fn every_exact_scalar_and_string_backing_reports_its_actual_capabilities() {
+    assert_exact_scalar(
+        ValueCell::from_exact(1_u8).unwrap(),
+        ScalarMemoryKind::Unsigned(IntegerWidth::W8),
+    );
+    assert_exact_scalar(
+        ValueCell::from_exact(1_u16).unwrap(),
+        ScalarMemoryKind::Unsigned(IntegerWidth::W16),
+    );
+    assert_exact_scalar(
+        ValueCell::from_exact(1_u32).unwrap(),
+        ScalarMemoryKind::Unsigned(IntegerWidth::W32),
+    );
+    assert_exact_scalar(
+        ValueCell::from_exact(1_u64).unwrap(),
+        ScalarMemoryKind::Unsigned(IntegerWidth::W64),
+    );
+    assert_exact_scalar(
+        ValueCell::from_exact(1_u128).unwrap(),
+        ScalarMemoryKind::Unsigned(IntegerWidth::W128),
+    );
+    assert_exact_scalar(
+        ValueCell::from_exact(1_i8).unwrap(),
+        ScalarMemoryKind::Signed(IntegerWidth::W8),
+    );
+    assert_exact_scalar(
+        ValueCell::from_exact(1_i16).unwrap(),
+        ScalarMemoryKind::Signed(IntegerWidth::W16),
+    );
+    assert_exact_scalar(
+        ValueCell::from_exact(1_i32).unwrap(),
+        ScalarMemoryKind::Signed(IntegerWidth::W32),
+    );
+    assert_exact_scalar(
+        ValueCell::from_exact(1_i64).unwrap(),
+        ScalarMemoryKind::Signed(IntegerWidth::W64),
+    );
+    assert_exact_scalar(
+        ValueCell::from_exact(1_i128).unwrap(),
+        ScalarMemoryKind::Signed(IntegerWidth::W128),
+    );
+    assert_exact_scalar(
+        ValueCell::from_exact(1_f32).unwrap(),
+        ScalarMemoryKind::Floating(FloatWidth::W32),
+    );
+    assert_exact_scalar(
+        ValueCell::from_exact(1_f64).unwrap(),
+        ScalarMemoryKind::Floating(FloatWidth::W64),
+    );
+    assert_exact_scalar(
+        ValueCell::from_exact(C64::new(1.0, 2.0)).unwrap(),
+        ScalarMemoryKind::Complex(FloatWidth::W64),
+    );
+    assert_exact_scalar(
+        ValueCell::from_exact(R64::new(1, 2)).unwrap(),
+        ScalarMemoryKind::Rational64,
+    );
+    assert_exact_scalar(ValueCell::from_exact(true).unwrap(), ScalarMemoryKind::Bool);
+    assert_exact_scalar(
+        ValueCell::from_exact(1_usize).unwrap(),
+        ScalarMemoryKind::Index,
+    );
+
+    let string = ValueCell::from_exact("text".to_owned()).unwrap();
+    let capabilities = string.storage_capabilities();
+    assert_eq!(
+        capabilities.topology,
+        StorageTopology::Scalar(ScalarMemoryKind::String)
+    );
+    assert_eq!(capabilities.extent, StorageExtentCapability::Single);
+    assert_eq!(
+        capabilities.addressing.positional,
+        PositionalAddressingCapability::Rank(1)
+    );
+    assert!(capabilities.addressing.arbitrary_regions);
+    assert!(capabilities.access.region_mutable);
+    assert_eq!(
+        capabilities.accounting,
+        StorageAccountingCapability::CanonicalSnapshot
+    );
+    string.validate_storage_contract().unwrap();
+}
+
+fn assert_matrix(cell: ValueCell, extent: StorageExtentCapability, element: ScalarMemoryKind) {
+    let capabilities = cell.storage_capabilities();
+    assert_eq!(
+        capabilities.topology,
+        StorageTopology::DenseSequence {
+            element: StorageElementKind::Scalar(element),
+        }
+    );
+    assert_eq!(capabilities.extent, extent);
+    assert_eq!(
+        capabilities.addressing.positional,
+        PositionalAddressingCapability::Rank(2)
+    );
+    assert!(capabilities.addressing.arbitrary_regions);
+    assert!(capabilities.canonicalization.recursive);
+    assert!(capabilities.access.region_mutable);
+    assert_eq!(
+        capabilities.accounting,
+        StorageAccountingCapability::CanonicalSnapshot
+    );
+}
+
+#[test]
+fn every_exact_matrix_class_reports_fixed_or_resizable_axes() {
+    let f64_kind = ScalarMemoryKind::Floating(FloatWidth::W64);
+    #[cfg(any(
+        feature = "matrix1",
+        feature = "matrix2",
+        feature = "matrix3",
+        feature = "matrix4",
+        feature = "matrix2x3",
+        feature = "matrix3x2",
+        feature = "row_vector2",
+        feature = "row_vector3",
+        feature = "row_vector4",
+        feature = "vector2",
+        feature = "vector3",
+        feature = "vector4"
+    ))]
+    macro_rules! fixed {
+        ($value:expr, $rows:expr, $columns:expr) => {{
+            let cell = ValueCell::from_exact($value).unwrap();
+            assert_matrix(
+                cell.clone(),
+                StorageExtentCapability::FixedDimensions(vec![$rows, $columns].into_boxed_slice()),
+                f64_kind,
+            );
+            cell.validate_storage_contract().unwrap();
+        }};
+    }
+    #[cfg(feature = "matrix1")]
+    fixed!(Matrix1::<f64>::zeros(), 1, 1);
+    #[cfg(feature = "matrix2")]
+    fixed!(Matrix2::<f64>::zeros(), 2, 2);
+    #[cfg(feature = "matrix3")]
+    fixed!(Matrix3::<f64>::zeros(), 3, 3);
+    #[cfg(feature = "matrix4")]
+    fixed!(Matrix4::<f64>::zeros(), 4, 4);
+    #[cfg(feature = "matrix2x3")]
+    fixed!(Matrix2x3::<f64>::zeros(), 2, 3);
+    #[cfg(feature = "matrix3x2")]
+    fixed!(Matrix3x2::<f64>::zeros(), 3, 2);
+    #[cfg(feature = "row_vector2")]
+    fixed!(RowVector2::<f64>::zeros(), 1, 2);
+    #[cfg(feature = "row_vector3")]
+    fixed!(RowVector3::<f64>::zeros(), 1, 3);
+    #[cfg(feature = "row_vector4")]
+    fixed!(RowVector4::<f64>::zeros(), 1, 4);
+    #[cfg(feature = "vector2")]
+    fixed!(Vector2::<f64>::zeros(), 2, 1);
+    #[cfg(feature = "vector3")]
+    fixed!(Vector3::<f64>::zeros(), 3, 1);
+    #[cfg(feature = "vector4")]
+    fixed!(Vector4::<f64>::zeros(), 4, 1);
+
+    let row = ValueCell::from_exact(RowDVector::<f64>::zeros(3)).unwrap();
+    assert_matrix(
+        row.clone(),
+        StorageExtentCapability::ResizableDimensions(vec![Some(1), None].into_boxed_slice()),
+        f64_kind,
+    );
+
+    let column = ValueCell::from_exact(DVector::<f64>::zeros(3)).unwrap();
+    assert_matrix(
+        column.clone(),
+        StorageExtentCapability::ResizableDimensions(vec![None, Some(1)].into_boxed_slice()),
+        f64_kind,
+    );
+
+    let matrix = ValueCell::from_exact(DMatrix::<f64>::zeros(2, 3)).unwrap();
+    assert_matrix(
+        matrix.clone(),
+        StorageExtentCapability::ResizableDimensions(vec![None, None].into_boxed_slice()),
+        f64_kind,
+    );
+    matrix.validate_storage_contract().unwrap();
+}
+
+#[test]
+fn inferred_vector_schemas_overstate_fixed_axes_until_r4_cutover() {
+    for cell in [
+        ValueCell::from_exact(RowDVector::<f64>::zeros(3)).unwrap(),
+        ValueCell::from_exact(DVector::<f64>::zeros(3)).unwrap(),
+    ] {
+        let error = cell.validate_storage_contract().unwrap_err();
+        let violation = error
+            .kind_as::<ValueCellStorageContractViolation>()
+            .expect("shadow validation must report a storage-contract violation");
+        assert_eq!(
+            violation.reason,
+            StorageCompatibilityError::DynamicAxisUnsupported
+        );
+    }
+}
+
+#[test]
+fn canonical_value_backing_is_universal_for_scalar_and_aggregate_schemas() {
+    let cases = vec![
+        (SchemaBody::Bool, ValueDataDraft::Bool(true)),
+        (
+            SchemaBody::Matrix {
+                element: Box::new(SchemaBody::Bool),
+                dimensions: vec![DimensionExpr::Constant(1), DimensionExpr::Constant(2)]
+                    .into_boxed_slice(),
+            },
+            ValueDataDraft::Matrix(
+                vec![ValueDataDraft::Bool(true), ValueDataDraft::Bool(false)].into_boxed_slice(),
+            ),
+        ),
+        (
+            SchemaBody::Record(
+                vec![SchemaField {
+                    name: "flag".to_owned(),
+                    schema: SchemaBody::Bool,
+                }]
+                .into_boxed_slice(),
+            ),
+            ValueDataDraft::Record(
+                vec![NamedValueDraft {
+                    name: "flag".to_owned(),
+                    value: ValueDataDraft::Bool(true),
+                }]
+                .into_boxed_slice(),
+            ),
+        ),
+        (
+            SchemaBody::Table {
+                columns: vec![SchemaField {
+                    name: "flag".to_owned(),
+                    schema: SchemaBody::Bool,
+                }]
+                .into_boxed_slice(),
+                rows: DimensionExpr::Constant(1).into(),
+            },
+            ValueDataDraft::Table(
+                vec![TableColumnDraft {
+                    name: "flag".to_owned(),
+                    values: vec![ValueDataDraft::Bool(true)].into_boxed_slice(),
+                }]
+                .into_boxed_slice(),
+            ),
+        ),
+        (
+            SchemaBody::Set {
+                element: Box::new(SchemaBody::Bool),
+                cardinality: DimensionExpr::Constant(1).into(),
+            },
+            ValueDataDraft::Set(vec![ValueDataDraft::Bool(true)].into_boxed_slice()),
+        ),
+        (
+            SchemaBody::Map {
+                key: Box::new(SchemaBody::Bool),
+                value: Box::new(SchemaBody::String),
+                cardinality: DimensionExpr::Constant(1).into(),
+            },
+            ValueDataDraft::Map(
+                vec![MapEntryDraft {
+                    items: vec![
+                        ValueDataDraft::Bool(true),
+                        ValueDataDraft::String("value".to_owned()),
+                    ]
+                    .into_boxed_slice(),
+                }]
+                .into_boxed_slice(),
+            ),
+        ),
+    ];
+
+    for (body, data) in cases {
+        let cell = canonical_cell(body, data);
+        let capabilities = cell.storage_capabilities();
+        assert_eq!(capabilities.topology, StorageTopology::CanonicalValue);
+        assert_eq!(capabilities.extent, StorageExtentCapability::Any);
+        assert_eq!(
+            capabilities.addressing.positional,
+            PositionalAddressingCapability::AnyRank
+        );
+        assert!(capabilities.addressing.named_members);
+        assert!(capabilities.addressing.keyed_members);
+        assert!(capabilities.addressing.arbitrary_regions);
+        assert!(capabilities.canonicalization.self_describing);
+        assert!(capabilities.canonicalization.recursive);
+        assert!(capabilities.canonicalization.tagged);
+        assert!(capabilities.canonicalization.ordered_keys);
+        assert!(capabilities.canonicalization.unique_keys);
+        assert_eq!(
+            capabilities.accounting,
+            StorageAccountingCapability::CanonicalSnapshot
+        );
+        cell.validate_storage_contract().unwrap();
+    }
+}
+
+#[test]
+fn canonical_value_accepts_every_semantic_topology() {
+    let canonical =
+        canonical_cell(SchemaBody::Bool, ValueDataDraft::Bool(true)).storage_capabilities();
+    let bodies = vec![
+        SchemaBody::Dynamic,
+        SchemaBody::Bool,
+        SchemaBody::Enum {
+            key: NominalKey::from_bytes([1; 32]),
+            variants: Box::new([]),
+        },
+        SchemaBody::Tuple(Box::new([])),
+        f64_matrix(vec![DimensionExpr::Constant(1)]),
+        SchemaBody::Table {
+            columns: Box::new([]),
+            rows: DimensionExpr::Constant(0).into(),
+        },
+        SchemaBody::Set {
+            element: Box::new(SchemaBody::Bool),
+            cardinality: DimensionExpr::Constant(0).into(),
+        },
+        SchemaBody::Map {
+            key: Box::new(SchemaBody::Bool),
+            value: Box::new(SchemaBody::Bool),
+            cardinality: DimensionExpr::Constant(0).into(),
+        },
+        SchemaBody::ReifiedType,
+    ];
+    for body in bodies {
+        let (schema, shape) = resolved(body);
+        check_fixture_storage_compatibility(&schema, &shape, &canonical).unwrap();
+    }
+}
+
+#[test]
+fn scalar_and_dense_compatibility_preserve_schema_authority() {
+    let scalar = ValueCell::from_exact(1_f64).unwrap().storage_capabilities();
+    let (f64_schema, f64_shape) = resolved(SchemaBody::FloatingPoint(FloatWidth::W64));
+    check_fixture_storage_compatibility(&f64_schema, &f64_shape, &scalar).unwrap();
+    let (bool_schema, bool_shape) = resolved(SchemaBody::Bool);
+    assert_eq!(
+        check_fixture_storage_compatibility(&bool_schema, &bool_shape, &scalar),
+        Err(StorageCompatibilityError::ScalarKindMismatch)
+    );
+    let (dynamic_schema, dynamic_shape) = resolved(SchemaBody::Dynamic);
+    assert_eq!(
+        check_fixture_storage_compatibility(&dynamic_schema, &dynamic_shape, &scalar),
+        Err(StorageCompatibilityError::TopologyMismatch)
+    );
+
+    let mut matrix = ValueCell::from_exact(DMatrix::<f64>::zeros(2, 2))
+        .unwrap()
+        .storage_capabilities();
+    matrix.extent = StorageExtentCapability::FixedDimensions(vec![2, 2].into_boxed_slice());
+    let (matching_schema, matching_shape) = resolved(f64_matrix(vec![
+        DimensionExpr::Constant(2),
+        DimensionExpr::Constant(2),
+    ]));
+    check_fixture_storage_compatibility(&matching_schema, &matching_shape, &matrix).unwrap();
+    let (wrong_element_schema, wrong_element_shape) = resolved(SchemaBody::Matrix {
+        element: Box::new(SchemaBody::Bool),
+        dimensions: vec![DimensionExpr::Constant(2), DimensionExpr::Constant(2)].into_boxed_slice(),
+    });
+    assert_eq!(
+        check_fixture_storage_compatibility(&wrong_element_schema, &wrong_element_shape, &matrix,),
+        Err(StorageCompatibilityError::DenseElementMismatch)
+    );
+    let (aggregate_schema, aggregate_shape) = resolved(SchemaBody::Matrix {
+        element: Box::new(SchemaBody::Tuple(Box::new([]))),
+        dimensions: vec![DimensionExpr::Constant(2), DimensionExpr::Constant(2)].into_boxed_slice(),
+    });
+    assert_eq!(
+        check_fixture_storage_compatibility(&aggregate_schema, &aggregate_shape, &matrix),
+        Err(StorageCompatibilityError::DenseElementMismatch)
+    );
+    assert_eq!(
+        check_fixture_storage_compatibility(&dynamic_schema, &dynamic_shape, &matrix),
+        Err(StorageCompatibilityError::TopologyMismatch)
+    );
+}
+
+#[test]
+fn public_compatibility_boundary_derives_the_contract_from_its_schema() {
+    let scalar = ValueCell::from_exact(1_f64).unwrap().storage_capabilities();
+    let (f64_schema, f64_shape) = resolved(SchemaBody::FloatingPoint(FloatWidth::W64));
+    check_schema_storage_compatibility(&f64_schema, &f64_shape, &scalar).unwrap();
+
+    let (bool_schema, bool_shape) = resolved(SchemaBody::Bool);
+    assert_eq!(
+        check_schema_storage_compatibility(&bool_schema, &bool_shape, &scalar),
+        Err(SchemaStorageCompatibilityError::Storage(
+            StorageCompatibilityError::ScalarKindMismatch,
+        ))
+    );
+
+    let mut transposed = ValueCell::from_exact(DMatrix::<f64>::zeros(3, 2))
+        .unwrap()
+        .storage_capabilities();
+    transposed.extent = StorageExtentCapability::FixedDimensions(vec![3, 2].into_boxed_slice());
+    let (matrix_schema, matrix_shape) = resolved(f64_matrix(vec![
+        DimensionExpr::Constant(2),
+        DimensionExpr::Constant(3),
+    ]));
+    assert_eq!(
+        check_schema_storage_compatibility(&matrix_schema, &matrix_shape, &transposed),
+        Err(SchemaStorageCompatibilityError::Storage(
+            StorageCompatibilityError::AxisMismatch,
+        ))
+    );
+
+    let parameter_id = DimensionParameterId::new(0);
+    let (_, foreign_shape) = resolved_with(
+        vec![parameter(0, DimensionLifetime::Activation, Some(4))],
+        f64_matrix(vec![
+            DimensionExpr::Parameter(parameter_id),
+            DimensionExpr::Constant(1),
+        ]),
+        vec![2],
+    );
+    assert_eq!(
+        check_schema_storage_compatibility(&f64_schema, &foreign_shape, &scalar),
+        Err(SchemaStorageCompatibilityError::Semantic(
+            SemanticModelError::ShapeParameterCountMismatchV1 {
+                expected: 0,
+                actual: 1,
+            },
+        ))
+    );
+
+    let canonical = canonical_cell(SchemaBody::Bool, ValueDataDraft::Bool(true));
+    check_schema_storage_compatibility(
+        &matrix_schema,
+        &matrix_shape,
+        &canonical.storage_capabilities(),
+    )
+    .unwrap();
+}
+
+#[test]
+fn fixed_and_resizable_axes_enforce_rank_value_and_evolution() {
+    let mut fixed = ValueCell::from_exact(DMatrix::<f64>::zeros(2, 2))
+        .unwrap()
+        .storage_capabilities();
+    fixed.extent = StorageExtentCapability::FixedDimensions(vec![2, 2].into_boxed_slice());
+    let (rank_schema, rank_shape) = resolved(f64_matrix(vec![DimensionExpr::Constant(2)]));
+    assert_eq!(
+        check_fixture_storage_compatibility(&rank_schema, &rank_shape, &fixed),
+        Err(StorageCompatibilityError::RankMismatch)
+    );
+    let (axis_schema, axis_shape) = resolved(f64_matrix(vec![
+        DimensionExpr::Constant(2),
+        DimensionExpr::Constant(3),
+    ]));
+    assert_eq!(
+        check_fixture_storage_compatibility(&axis_schema, &axis_shape, &fixed),
+        Err(StorageCompatibilityError::AxisMismatch)
+    );
+
+    let id = DimensionParameterId::new(0);
+    let (turn_schema, turn_shape) = resolved_with(
+        vec![parameter(0, DimensionLifetime::Turn, Some(4))],
+        f64_matrix(vec![
+            DimensionExpr::Parameter(id),
+            DimensionExpr::Constant(2),
+        ]),
+        vec![2],
+    );
+    assert_eq!(
+        check_fixture_storage_compatibility(&turn_schema, &turn_shape, &fixed),
+        Err(StorageCompatibilityError::DynamicAxisUnsupported)
+    );
+    let (activation_schema, activation_shape) = resolved_with(
+        vec![parameter(0, DimensionLifetime::Activation, Some(4))],
+        f64_matrix(vec![
+            DimensionExpr::Parameter(id),
+            DimensionExpr::Constant(2),
+        ]),
+        vec![2],
+    );
+    check_fixture_storage_compatibility(&activation_schema, &activation_shape, &fixed).unwrap();
+
+    let row = ValueCell::from_exact(RowDVector::<f64>::zeros(3))
+        .unwrap()
+        .storage_capabilities();
+    let (row_schema, row_shape) = resolved_with(
+        vec![parameter(0, DimensionLifetime::Turn, None)],
+        f64_matrix(vec![
+            DimensionExpr::Parameter(id),
+            DimensionExpr::Constant(3),
+        ]),
+        vec![1],
+    );
+    assert_eq!(
+        check_fixture_storage_compatibility(&row_schema, &row_shape, &row),
+        Err(StorageCompatibilityError::DynamicAxisUnsupported)
+    );
+
+    let column = ValueCell::from_exact(DVector::<f64>::zeros(3))
+        .unwrap()
+        .storage_capabilities();
+    let (column_schema, column_shape) = resolved_with(
+        vec![parameter(0, DimensionLifetime::Turn, None)],
+        f64_matrix(vec![
+            DimensionExpr::Constant(3),
+            DimensionExpr::Parameter(id),
+        ]),
+        vec![1],
+    );
+    assert_eq!(
+        check_fixture_storage_compatibility(&column_schema, &column_shape, &column),
+        Err(StorageCompatibilityError::DynamicAxisUnsupported)
+    );
+
+    let dynamic = ValueCell::from_exact(DMatrix::<f64>::zeros(2, 3))
+        .unwrap()
+        .storage_capabilities();
+    let second = DimensionParameterId::new(1);
+    let (dynamic_schema, dynamic_shape) = resolved_with(
+        vec![
+            parameter(0, DimensionLifetime::Turn, Some(8)),
+            parameter(1, DimensionLifetime::Turn, None),
+        ],
+        f64_matrix(vec![
+            DimensionExpr::Parameter(id),
+            DimensionExpr::Parameter(second),
+        ]),
+        vec![2, 3],
+    );
+    check_fixture_storage_compatibility(&dynamic_schema, &dynamic_shape, &dynamic).unwrap();
+}
+
+#[test]
+fn addressing_canonicalization_and_accounting_fail_independently() {
+    let canonical =
+        canonical_cell(SchemaBody::Bool, ValueDataDraft::Bool(true)).storage_capabilities();
+
+    let (tuple_schema, tuple_shape) = resolved(SchemaBody::Tuple(Box::new([])));
+    let mut no_position = canonical.clone();
+    no_position.addressing.positional = PositionalAddressingCapability::None;
+    assert_eq!(
+        check_fixture_storage_compatibility(&tuple_schema, &tuple_shape, &no_position),
+        Err(StorageCompatibilityError::PositionalAddressingUnsupported)
+    );
+
+    let (record_schema, record_shape) = resolved(SchemaBody::Record(Box::new([])));
+    let mut no_names = canonical.clone();
+    no_names.addressing.named_members = false;
+    assert_eq!(
+        check_fixture_storage_compatibility(&record_schema, &record_shape, &no_names),
+        Err(StorageCompatibilityError::NamedAddressingUnsupported)
+    );
+
+    let (set_schema, set_shape) = resolved(SchemaBody::Set {
+        element: Box::new(SchemaBody::Bool),
+        cardinality: DimensionExpr::Constant(0).into(),
+    });
+    let mut no_keys = canonical.clone();
+    no_keys.addressing.keyed_members = false;
+    assert_eq!(
+        check_fixture_storage_compatibility(&set_schema, &set_shape, &no_keys),
+        Err(StorageCompatibilityError::KeyedAddressingUnsupported)
+    );
+    let mut no_recursive = canonical.clone();
+    no_recursive.canonicalization.recursive = false;
+    assert_eq!(
+        check_fixture_storage_compatibility(&set_schema, &set_shape, &no_recursive),
+        Err(StorageCompatibilityError::CanonicalizationUnsupported)
+    );
+
+    let string = ValueCell::from_exact("value".to_owned()).unwrap();
+    let mut fixed_accounting = string.storage_capabilities();
+    fixed_accounting.accounting = StorageAccountingCapability::FixedScalar;
+    let (string_schema, string_shape) = resolved(SchemaBody::String);
+    assert_eq!(
+        check_fixture_storage_compatibility(&string_schema, &string_shape, &fixed_accounting,),
+        Err(StorageCompatibilityError::AccountingUnsupported)
+    );
+    check_fixture_storage_compatibility(&set_schema, &set_shape, &canonical).unwrap();
+}
+
+fn assert_replacement_laws(target: ValueCell, replacement: ValueCell, invalid: ValueCell) {
+    target.replace(&replacement.snapshot().unwrap()).unwrap();
+    assert!(target.snapshot_eq(&replacement).unwrap());
+    let before_failure = target.detached_clone().unwrap();
+    assert!(target.replace(&invalid.snapshot().unwrap()).is_err());
+    assert!(target.snapshot_eq(&before_failure).unwrap());
+    assert!(target.storage_capabilities().ownership.detachable);
+    let detached = target.detached_clone().unwrap();
+    assert!(!target.same_logical_cell(&detached));
+    assert!(!target.same_storage(&detached));
+    assert!(target.snapshot_eq(&detached).unwrap());
+}
+
+#[test]
+fn truthful_descriptors_match_replacement_and_detachment_behavior() {
+    let invalid_string = ValueCell::from_exact("invalid".to_owned()).unwrap();
+    let invalid_bool = ValueCell::from_exact(false).unwrap();
+    assert_replacement_laws(
+        ValueCell::from_exact(1_f64).unwrap(),
+        ValueCell::from_exact(2_f64).unwrap(),
+        invalid_string.clone(),
+    );
+    assert_replacement_laws(
+        ValueCell::from_exact("one".to_owned()).unwrap(),
+        ValueCell::from_exact("two".to_owned()).unwrap(),
+        invalid_bool.clone(),
+    );
+    assert_replacement_laws(
+        ValueCell::from_exact(DMatrix::<f64>::zeros(2, 3)).unwrap(),
+        ValueCell::from_exact(DMatrix::<f64>::from_element(2, 3, 2.0)).unwrap(),
+        invalid_bool.clone(),
+    );
+
+    let record_body = SchemaBody::Record(
+        vec![SchemaField {
+            name: "flag".to_owned(),
+            schema: SchemaBody::Bool,
+        }]
+        .into_boxed_slice(),
+    );
+    let record = |value| {
+        canonical_cell(
+            record_body.clone(),
+            ValueDataDraft::Record(
+                vec![NamedValueDraft {
+                    name: "flag".to_owned(),
+                    value: ValueDataDraft::Bool(value),
+                }]
+                .into_boxed_slice(),
+            ),
+        )
+    };
+    assert_replacement_laws(record(false), record(true), invalid_bool);
+}
+
+#[cfg(feature = "matrix2")]
+#[test]
+fn fixed_matrix_descriptor_matches_replacement_and_detachment_behavior() {
+    assert_replacement_laws(
+        ValueCell::from_exact(Matrix2::<f64>::zeros()).unwrap(),
+        ValueCell::from_exact(Matrix2::<f64>::from_element(2.0)).unwrap(),
+        ValueCell::from_exact(Matrix2::<bool>::from_element(false)).unwrap(),
+    );
+}
+
+#[test]
+fn storage_capability_types_have_no_serde_surface() {
+    let source = include_str!("../src/memory_contract/storage_capability.rs");
+    assert!(!source.contains("Serialize"));
+    assert!(!source.contains("Deserialize"));
+}


### PR DESCRIPTION
## Summary

- define non-serialized storage capability descriptors and a schema-bound compatibility API that derives the R2A type-memory contract internally
- describe existing exact and canonical `ValueCell` backings through a private runtime-storage adapter
- separate logical-cell identity from physical-storage identity while preserving `same_cell` as an exact `same_storage` compatibility alias
- prove capability, compatibility, publication, detachment, and identity laws across exact and canonical backings

## Stack

This is a draft stacked PR on #801 at exact R2A head `2b800bd997fa33fe4a43e6719b762809f92e5935`. R2A remains unmerged by explicit direction. Review only the four-commit R2B diff; no R2C work is included.

## Boundaries

- shadow-only validation; no constructor, binder, target, or execution cutover
- no wire-format, serialization, runtime, engine, host, machine, workflow, roadmap, or package-version change
- exactly four commits, seven changed files, 900 production additions
- `RowDVector` and `DVector` currently expose known shadow-only `DynamicAxisUnsupported` mismatches because schema inference overstates their physically fixed axes; R4 owns the inference correction, and R2C/R2D must not treat these expected failures as policy

## Validation at `76ffd1acafc0d1273e2ba890a39833d585655438`

Passed locally:

- formatting and diff checks
- the R2B behavioral capability suite under `full` and `all-features`
- the full core library behavioral suite under `all-features`
- the bare core test profile
- workspace `no_std`, core Mika, and core Mika+serde compile/profile checks

Passed on the exact immutable head:

- [normal CI: 21/21 jobs](https://github.com/mech-lang/mech/actions/runs/33703366479)
- [Full CI: 81/81 jobs](https://github.com/mech-lang/mech/actions/runs/33703395081)

The previously completed impact-selected owner, source/consumer contract, compatibility, forbidden-surface, and wire-format suites covered the same content before the history-only four-commit fold.

The broad local `mech-core --features full` integration target still hits the unchanged R2A macOS unused-import failure in `stdlib_macro_hygiene.rs`; that file is absent from this diff.