### PR TITLE
[v0.4-R2C] feat(core): derive operation memory requirements

### DIFF
--- a/docs/design/type-memory-boundary.md
+++ b/docs/design/type-memory-boundary.md
@@ -1,12 +1,17 @@
 # Type-memory boundary
 
-## 1. Status and R2A/R2B scope
+## 1. Status and R2A/R2B/R2C scope
 
 R2A is complete. It defines a read-only semantic projection from a finalized `Schema`, and from
 that schema plus a validated `ShapeInstance`, into memory-facing contracts.
 R2B defines descriptive capabilities of current value-cell backings and pure
 compatibility and identity relations. Both phases change no runtime binding,
 storage, target, or execution behavior.
+
+R2C derives memory-facing port requirements from the existing R1 operation
+contract and checks them against R2A and R2B metadata. Its invocation check is
+explicitly opt-in and shadow-only: production signature validation, factory
+selection, target behavior, and execution remain unchanged.
 
 The projection has one direction:
 
@@ -139,10 +144,10 @@ placement.
 
 ## 12. Serialization prohibition
 
-The R2A contract types deliberately implement no serialization traits and have
-no wire format. Canonical schema bytes remain unchanged and authoritative.
-Derived contracts must be recomputed from the schema rather than persisted as
-another compatibility surface.
+The R2A and R2C contract types deliberately implement no serialization traits
+and have no wire format. Canonical schema and operation-contract bytes remain
+unchanged and authoritative. Derived contracts must be recomputed from their
+semantic authorities rather than persisted as another compatibility surface.
 
 ## 13. R2B storage capabilities and identity
 
@@ -171,11 +176,31 @@ R4 must infer each physically invariant vector axis as `Constant(1)` before the
 compatibility boundary becomes authoritative. R2C and R2D must not interpret
 these expected shadow failures as valid storage-incompatibility policy.
 
-## 14. R2C handoff
+## 14. R2C operation memory requirements
 
-R2C will derive memory requirements for operation ports and compare those
-requirements with storage capabilities. It must not reinterpret schema
-identity or mutate the R2A contract.
+R2C derives `OperationMemoryRequirements` from
+`OperationContractDeclaration`. Fixed and variadic inputs use the declaration's
+existing resolution path. Each port preserves access and delivery, while
+ownership, addressing, publication, construction, aliasing, and change
+detection are projected from the existing policy fields. External interaction
+is deliberately excluded because provider protocols are not cell-storage
+requirements.
+
+The public port checker accepts `Schema`, `ShapeInstance`, a derived port
+requirement, and `StorageCapabilityDescriptor`. It resolves the type-memory
+contract once and checks the complete compatibility triangle: semantic type to
+storage, operation-port addressing to semantic addressing, and operation-port
+requirements to storage capabilities. Canonical `Value` storage is mechanically
+universal but cannot authorize positional, collection-entry, or regional access
+that the semantic type does not expose. Stream and Future delivery remain
+visible metadata and are not rejected by this generic storage boundary.
+
+`FunctionInvocation::check_operation_memory_contract` is a separate opt-in
+shadow check. It validates the current single-output compatibility bridge and
+uses `same_storage` for operation alias policy. It is not called from runtime
+signature checks, factories, source specialization, Resident or GPU
+activation, or native planning. R2C does not make these requirements
+authoritative and does not mark R2 complete.
 
 ## 15. R2D closure
 
@@ -191,8 +216,8 @@ metadata.
 ## 17. R4 handoff
 
 R4 owns retirement of transitional runtime representations and makes the new
-boundary authoritative during the binding cutover. R2A and R2B neither change
-nor endorse a runtime representation.
+boundary authoritative during the binding cutover. R2A, R2B, and R2C neither
+change nor endorse a runtime representation.
 
 ## 18. R5/R6 handoff
 
@@ -203,9 +228,9 @@ those mechanisms.
 
 ## 19. Non-goals
 
-R2A does not add storage capability descriptors, operation-port memory
-requirements, compatibility checking, physical layout, allocation, inference,
-conversion, target availability, function binding, `ValueCell` behavior,
+R2C does not add another operation declaration surface, interaction-provider
+requirements, physical layout, allocation, inference, conversion, target
+availability, function binding, production rejection, `ValueCell` mutation,
 Resident or GPU behavior, bytecode, canonical encoding, ABI changes, or
 package-version changes.
 

--- a/src/core/src/function/argument.rs
+++ b/src/core/src/function/argument.rs
@@ -1250,3 +1250,93 @@ impl MechErrorKind for FunctionArgumentTypeMismatch {
         )
     }
 }
+
+#[cfg(all(test, feature = "f64"))]
+mod operation_memory_tests {
+    use super::*;
+    use crate::{
+        AliasPolicy, ChangeDetectionPolicy, DeliveryMode, ExternalInteraction, InputPortLayout,
+        InputPortPolicy, OutputConstruction, OutputPortPolicy, ShapeRule,
+    };
+
+    fn declaration(alias: AliasPolicy) -> OperationContractDeclaration {
+        OperationContractDeclaration {
+            inputs: InputPortLayout::Fixed(
+                vec![InputPortPolicy {
+                    access: crate::AccessMode::Read,
+                    delivery: DeliveryMode::Signal,
+                }]
+                .into_boxed_slice(),
+            ),
+            outputs: vec![OutputPortPolicy {
+                access: crate::AccessMode::Write,
+                delivery: DeliveryMode::Signal,
+                construction: OutputConstruction::FullWrite {
+                    shape: ShapeRule::Declared,
+                },
+                alias,
+                change_detection: ChangeDetectionPolicy::KernelReported,
+            }]
+            .into_boxed_slice(),
+            interaction: ExternalInteraction::Pure,
+        }
+    }
+
+    fn reason(error: MechError) -> FunctionMemoryContractViolationReason {
+        error
+            .kind_as::<FunctionMemoryContractViolation>()
+            .expect("operation memory check returns its structured error")
+            .reason
+            .clone()
+    }
+
+    #[test]
+    fn operation_aliases_follow_storage_when_logical_identity_disagrees() {
+        let first = ValueCell::from_exact(1_f64).unwrap();
+        let detached = first.detached_clone().unwrap();
+        let same_logical_different_storage = ValueCell {
+            binding: crate::cell_binding::CellBinding {
+                identity: first.binding.identity,
+                ..detached.binding.clone()
+            },
+        };
+        let different_logical_same_storage = ValueCell {
+            binding: crate::cell_binding::CellBinding {
+                identity: detached.binding.identity,
+                ..first.binding.clone()
+            },
+        };
+
+        assert!(first.same_logical_cell(&same_logical_different_storage));
+        assert!(!first.same_storage(&same_logical_different_storage));
+        FunctionInvocation::unary(same_logical_different_storage.clone(), first.clone())
+            .check_operation_memory_contract(&declaration(AliasPolicy::NoAlias))
+            .unwrap();
+        assert_eq!(
+            reason(
+                FunctionInvocation::unary(same_logical_different_storage, first.clone())
+                    .check_operation_memory_contract(&declaration(AliasPolicy::InPlaceRequired {
+                        input: 0
+                    },))
+                    .unwrap_err(),
+            ),
+            FunctionMemoryContractViolationReason::InPlaceRequiredViolation { input: 0 }
+        );
+
+        assert!(!first.same_logical_cell(&different_logical_same_storage));
+        assert!(first.same_storage(&different_logical_same_storage));
+        assert_eq!(
+            reason(
+                FunctionInvocation::unary(different_logical_same_storage.clone(), first.clone())
+                    .check_operation_memory_contract(&declaration(AliasPolicy::NoAlias))
+                    .unwrap_err(),
+            ),
+            FunctionMemoryContractViolationReason::NoAliasViolation { input: 0 }
+        );
+        FunctionInvocation::unary(different_logical_same_storage, first)
+            .check_operation_memory_contract(&declaration(AliasPolicy::InPlaceRequired {
+                input: 0,
+            }))
+            .unwrap();
+    }
+}

--- a/src/core/src/function/argument.rs
+++ b/src/core/src/function/argument.rs
@@ -18,9 +18,10 @@ use crate::{BytecodeCompilerContext, Register};
 use crate::{
     CanonicalCellId, FunctionArgumentRole, FunctionMatrixRepresentation, FunctionRuntimeType,
     FunctionSignatureViolation, FunctionValueRepresentation, IncorrectNumberOfArguments, MResult,
-    MechError, MechErrorKind, Ref, RuntimeFunctionContract, RuntimeFunctionInputs,
-    RuntimeFunctionSignature, RuntimeOutputAliasPolicy, SchemaBody, SchemaId, ShapeInstance, Value,
-    ValueCell, ValueData, ValueDataDraft,
+    MechError, MechErrorKind, OperationContractDeclaration, OperationContractError,
+    PortMemoryRequirement, PortStorageCompatibilityError, Ref, RuntimeFunctionContract,
+    RuntimeFunctionInputs, RuntimeFunctionSignature, RuntimeOutputAliasPolicy, SchemaBody,
+    SchemaId, ShapeInstance, StorageTopology, Value, ValueCell, ValueData, ValueDataDraft,
 };
 
 mod function_port_backing {
@@ -428,6 +429,119 @@ impl FunctionInvocation {
         Ok(())
     }
 
+    /// Performs the opt-in operation-memory check without changing production validation.
+    pub fn check_operation_memory_contract(
+        &self,
+        declaration: &OperationContractDeclaration,
+    ) -> MResult<()> {
+        let requirements = declaration
+            .memory_requirements(self.input_count())
+            .map_err(|error| {
+                function_memory_contract_error(
+                    FunctionMemoryContractViolationReason::OperationContractDerivation { error },
+                )
+            })?;
+
+        for (index, (cell, requirement)) in self
+            .inputs
+            .iter()
+            .zip(requirements.inputs.iter())
+            .enumerate()
+        {
+            check_invocation_cell_requirement(cell, requirement).map_err(|error| {
+                function_memory_contract_error(FunctionMemoryContractViolationReason::InputPort {
+                    index,
+                    error,
+                })
+            })?;
+        }
+
+        match requirements.outputs.as_ref() {
+            [] => {
+                let schemas = self.output.schema_table();
+                let schema = schemas
+                    .get(self.output.schema())
+                    .expect("function output schema remains present");
+                let is_unit = matches!(schema.body(), SchemaBody::Tuple(elements) if elements.is_empty())
+                    && self.output.storage_capabilities().topology
+                        == StorageTopology::CanonicalValue;
+                if !is_unit {
+                    return Err(function_memory_contract_error(
+                        FunctionMemoryContractViolationReason::ZeroOutputBridgeIsNotUnit,
+                    ));
+                }
+            }
+            [requirement] => {
+                check_invocation_cell_requirement(&self.output, requirement).map_err(|error| {
+                    function_memory_contract_error(
+                        FunctionMemoryContractViolationReason::OutputPort { error },
+                    )
+                })?;
+                self.check_operation_output_alias(requirement)?;
+            }
+            outputs => {
+                return Err(function_memory_contract_error(
+                    FunctionMemoryContractViolationReason::MultipleSemanticOutputsUnsupported {
+                        outputs: outputs.len(),
+                    },
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn declared_alias_input(&self, input: u16) -> MResult<&ValueCell> {
+        self.inputs.get(input as usize).ok_or_else(|| {
+            function_memory_contract_error(
+                FunctionMemoryContractViolationReason::InvalidDeclaredAliasInput {
+                    input,
+                    inputs: self.input_count(),
+                },
+            )
+        })
+    }
+
+    fn check_operation_output_alias(&self, requirement: &PortMemoryRequirement) -> MResult<()> {
+        let Some(alias) = requirement.alias else {
+            return Ok(());
+        };
+        match alias {
+            crate::AliasPolicy::NoAlias => {
+                for (index, input) in self.inputs.iter().enumerate() {
+                    if self.output.same_storage(input) {
+                        return Err(function_memory_contract_error(
+                            FunctionMemoryContractViolationReason::NoAliasViolation {
+                                input: index,
+                            },
+                        ));
+                    }
+                }
+            }
+            crate::AliasPolicy::MayAlias { input } => {
+                let designated = self.declared_alias_input(input)?;
+                for (index, candidate) in self.inputs.iter().enumerate() {
+                    if self.output.same_storage(candidate) && !designated.same_storage(candidate) {
+                        return Err(function_memory_contract_error(
+                            FunctionMemoryContractViolationReason::MayAliasViolation {
+                                declared_input: input,
+                                unrelated_input: index,
+                            },
+                        ));
+                    }
+                }
+            }
+            crate::AliasPolicy::InPlaceRequired { input } => {
+                let designated = self.declared_alias_input(input)?;
+                if !self.output.same_storage(designated) {
+                    return Err(function_memory_contract_error(
+                        FunctionMemoryContractViolationReason::InPlaceRequiredViolation { input },
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
     pub fn output_cell(&self) -> &ValueCell {
         &self.output
     }
@@ -435,6 +549,27 @@ impl FunctionInvocation {
     pub fn input_cells(&self) -> &[ValueCell] {
         &self.inputs
     }
+}
+
+fn check_invocation_cell_requirement(
+    cell: &ValueCell,
+    requirement: &PortMemoryRequirement,
+) -> Result<(), PortStorageCompatibilityError> {
+    let schemas = cell.schema_table();
+    let schema = schemas
+        .get(cell.schema())
+        .expect("function invocation schema remains present");
+    let shape = cell.shape().clone();
+    crate::check_port_storage_compatibility(
+        schema,
+        &shape,
+        requirement,
+        &cell.storage_capabilities(),
+    )
+}
+
+fn function_memory_contract_error(reason: FunctionMemoryContractViolationReason) -> MechError {
+    MechError::new(FunctionMemoryContractViolation { reason }, None).with_compiler_loc()
 }
 
 pub(crate) fn canonical_matrix_descriptor(
@@ -992,6 +1127,88 @@ pub struct FunctionArgumentAliasViolation {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct FunctionCellAliasViolation {
     pub input: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FunctionMemoryContractViolation {
+    pub reason: FunctionMemoryContractViolationReason,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum FunctionMemoryContractViolationReason {
+    OperationContractDerivation {
+        error: OperationContractError,
+    },
+    InputPort {
+        index: usize,
+        error: PortStorageCompatibilityError,
+    },
+    OutputPort {
+        error: PortStorageCompatibilityError,
+    },
+    ZeroOutputBridgeIsNotUnit,
+    MultipleSemanticOutputsUnsupported {
+        outputs: usize,
+    },
+    InvalidDeclaredAliasInput {
+        input: u16,
+        inputs: usize,
+    },
+    NoAliasViolation {
+        input: usize,
+    },
+    MayAliasViolation {
+        declared_input: u16,
+        unrelated_input: usize,
+    },
+    InPlaceRequiredViolation {
+        input: u16,
+    },
+}
+
+impl MechErrorKind for FunctionMemoryContractViolation {
+    fn name(&self) -> &str {
+        "FunctionMemoryContractViolation"
+    }
+
+    fn message(&self) -> String {
+        match &self.reason {
+            FunctionMemoryContractViolationReason::OperationContractDerivation { error } => {
+                format!("operation memory requirement derivation failed: {error:?}")
+            }
+            FunctionMemoryContractViolationReason::InputPort { index, error } => {
+                format!("input port {index} does not satisfy its memory requirement: {error}")
+            }
+            FunctionMemoryContractViolationReason::OutputPort { error } => {
+                format!("output port does not satisfy its memory requirement: {error}")
+            }
+            FunctionMemoryContractViolationReason::ZeroOutputBridgeIsNotUnit => {
+                "zero-output operation requires a canonical unit compatibility output".to_string()
+            }
+            FunctionMemoryContractViolationReason::MultipleSemanticOutputsUnsupported {
+                outputs,
+            } => {
+                format!("the current invocation bridge cannot represent {outputs} semantic outputs")
+            }
+            FunctionMemoryContractViolationReason::InvalidDeclaredAliasInput { input, inputs } => {
+                format!(
+                    "declared alias input {input} is outside the invocation input count {inputs}"
+                )
+            }
+            FunctionMemoryContractViolationReason::NoAliasViolation { input } => {
+                format!("output shares physical storage with forbidden input {input}")
+            }
+            FunctionMemoryContractViolationReason::MayAliasViolation {
+                declared_input,
+                unrelated_input,
+            } => format!(
+                "output may alias input {declared_input}, but shares unrelated input {unrelated_input} storage"
+            ),
+            FunctionMemoryContractViolationReason::InPlaceRequiredViolation { input } => {
+                format!("output does not share the physical storage required by input {input}")
+            }
+        }
+    }
 }
 
 impl MechErrorKind for FunctionCellAliasViolation {

--- a/src/core/src/memory_contract/mod.rs
+++ b/src/core/src/memory_contract/mod.rs
@@ -1,7 +1,9 @@
 //! Schema-derived memory-facing semantic obligations.
 
+mod operation_requirement;
 mod storage_capability;
 mod type_contract;
 
+pub use self::operation_requirement::*;
 pub use self::storage_capability::*;
 pub use self::type_contract::*;

--- a/src/core/src/memory_contract/operation_requirement.rs
+++ b/src/core/src/memory_contract/operation_requirement.rs
@@ -1,9 +1,11 @@
 //! Memory-facing requirements derived from declared operation ports.
 
 use crate::{
-    AccessMode, AliasPolicy, ChangeDetectionPolicy, DeliveryMode, InputPortPolicy,
-    OperationContractDeclaration, OperationContractError, OutputConstruction, OutputPortPolicy,
-    RegionPolicy,
+    AccessMode, AddressingContract, AliasPolicy, ChangeDetectionPolicy, DeliveryMode,
+    InputPortPolicy, MemoryTopology, OperationContractDeclaration, OperationContractError,
+    OutputConstruction, OutputPortPolicy, PositionalAddressingCapability, RegionPolicy,
+    ResolvedTypeMemoryContract, Schema, SchemaStorageCompatibilityError, ShapeInstance,
+    StorageCapabilityDescriptor,
 };
 
 #[cfg(feature = "no_std")]
@@ -49,6 +51,102 @@ pub struct OperationMemoryRequirements {
     pub inputs: Box<[PortMemoryRequirement]>,
     pub outputs: Box<[PortMemoryRequirement]>,
 }
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PortStorageCompatibilityError {
+    SchemaStorage(SchemaStorageCompatibilityError),
+    SemanticAddressingUnsupported {
+        required: AddressingRequirement,
+        available: AddressingContract,
+    },
+    ReadUnsupported,
+    WriteUnsupported,
+    ReplaceUnsupported,
+    RegionMutationUnsupported,
+    SharedReadUnsupported,
+    ExclusiveWriteUnsupported,
+    OwnedValueUnsupported,
+    WholeValueAddressingUnsupported,
+    PositionalAddressingUnsupported {
+        minimum_rank: u64,
+        available: PositionalAddressingCapability,
+    },
+    CollectionEntryAddressingUnsupported,
+    ArbitraryRegionUnsupported,
+    AtomicPublicationUnsupported,
+    FailureAtomicityUnsupported,
+    CanonicalSnapshotUnsupported,
+    ExactScalarChangeDetectionRequiresScalar,
+}
+
+impl From<SchemaStorageCompatibilityError> for PortStorageCompatibilityError {
+    fn from(error: SchemaStorageCompatibilityError) -> Self {
+        Self::SchemaStorage(error)
+    }
+}
+
+impl core::fmt::Display for PortStorageCompatibilityError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::SchemaStorage(_) => formatter
+                .write_str("schema-derived memory requirements are incompatible with storage"),
+            Self::SemanticAddressingUnsupported {
+                required,
+                available,
+            } => write!(
+                formatter,
+                "semantic addressing {:?} does not support operation requirement {:?}",
+                available, required
+            ),
+            Self::ReadUnsupported => formatter.write_str("storage does not support reading"),
+            Self::WriteUnsupported => formatter.write_str("storage does not support writing"),
+            Self::ReplaceUnsupported => {
+                formatter.write_str("storage does not support whole-value replacement")
+            }
+            Self::RegionMutationUnsupported => {
+                formatter.write_str("storage does not support regional mutation")
+            }
+            Self::SharedReadUnsupported => {
+                formatter.write_str("storage does not support shared-read ownership")
+            }
+            Self::ExclusiveWriteUnsupported => {
+                formatter.write_str("storage does not support exclusive-write ownership")
+            }
+            Self::OwnedValueUnsupported => formatter
+                .write_str("storage provides neither owned-value nor detachable-value access"),
+            Self::WholeValueAddressingUnsupported => {
+                formatter.write_str("storage does not support whole-value addressing")
+            }
+            Self::PositionalAddressingUnsupported {
+                minimum_rank,
+                available,
+            } => write!(
+                formatter,
+                "storage positional addressing {:?} does not satisfy minimum rank {}",
+                available, minimum_rank
+            ),
+            Self::CollectionEntryAddressingUnsupported => {
+                formatter.write_str("storage does not support collection-entry addressing")
+            }
+            Self::ArbitraryRegionUnsupported => {
+                formatter.write_str("storage does not support arbitrary-region addressing")
+            }
+            Self::AtomicPublicationUnsupported => {
+                formatter.write_str("storage does not support atomic replacement publication")
+            }
+            Self::FailureAtomicityUnsupported => formatter
+                .write_str("storage does not preserve the previous value when publication fails"),
+            Self::CanonicalSnapshotUnsupported => {
+                formatter.write_str("storage does not support canonical snapshots")
+            }
+            Self::ExactScalarChangeDetectionRequiresScalar => formatter
+                .write_str("exact-scalar change detection requires a semantic scalar schema"),
+        }
+    }
+}
+
+#[cfg(any(not(feature = "no_std"), feature = "std"))]
+impl std::error::Error for PortStorageCompatibilityError {}
 
 impl OwnershipRequirement {
     fn from_access(access: AccessMode) -> Self {
@@ -129,6 +227,255 @@ impl PortMemoryRequirement {
             change_detection: Some(policy.change_detection),
         })
     }
+}
+
+fn check_access(
+    access: AccessMode,
+    storage: &StorageCapabilityDescriptor,
+) -> Result<(), PortStorageCompatibilityError> {
+    if matches!(
+        access,
+        AccessMode::Read | AccessMode::ReadWrite | AccessMode::Consume
+    ) && !storage.access.readable
+    {
+        return Err(PortStorageCompatibilityError::ReadUnsupported);
+    }
+    if matches!(access, AccessMode::Write | AccessMode::ReadWrite) && !storage.access.writable {
+        return Err(PortStorageCompatibilityError::WriteUnsupported);
+    }
+    Ok(())
+}
+
+fn check_ownership(
+    ownership: OwnershipRequirement,
+    storage: &StorageCapabilityDescriptor,
+) -> Result<(), PortStorageCompatibilityError> {
+    match ownership {
+        OwnershipRequirement::SharedRead if !storage.ownership.shared_read => {
+            Err(PortStorageCompatibilityError::SharedReadUnsupported)
+        }
+        OwnershipRequirement::ExclusiveWrite if !storage.ownership.exclusive_write => {
+            Err(PortStorageCompatibilityError::ExclusiveWriteUnsupported)
+        }
+        OwnershipRequirement::OwnedValue
+            if !storage.ownership.owned_value && !storage.ownership.detachable =>
+        {
+            Err(PortStorageCompatibilityError::OwnedValueUnsupported)
+        }
+        OwnershipRequirement::SharedRead
+        | OwnershipRequirement::ExclusiveWrite
+        | OwnershipRequirement::OwnedValue => Ok(()),
+    }
+}
+
+fn require_readable(
+    storage: &StorageCapabilityDescriptor,
+) -> Result<(), PortStorageCompatibilityError> {
+    if storage.access.readable {
+        Ok(())
+    } else {
+        Err(PortStorageCompatibilityError::ReadUnsupported)
+    }
+}
+
+fn require_writable(
+    storage: &StorageCapabilityDescriptor,
+) -> Result<(), PortStorageCompatibilityError> {
+    if storage.access.writable {
+        Ok(())
+    } else {
+        Err(PortStorageCompatibilityError::WriteUnsupported)
+    }
+}
+
+fn check_construction(
+    construction: Option<&OutputConstruction>,
+    storage: &StorageCapabilityDescriptor,
+) -> Result<(), PortStorageCompatibilityError> {
+    let Some(construction) = construction else {
+        return Ok(());
+    };
+    match construction {
+        OutputConstruction::FullWrite { .. }
+        | OutputConstruction::Replace { .. }
+        | OutputConstruction::Build { .. } => {
+            require_writable(storage)?;
+            if !storage.access.replaceable {
+                return Err(PortStorageCompatibilityError::ReplaceUnsupported);
+            }
+        }
+        OutputConstruction::ReadModifyWrite {
+            regions: RegionPolicy::WholeValue,
+            ..
+        } => {
+            require_readable(storage)?;
+            require_writable(storage)?;
+            if !storage.access.replaceable {
+                return Err(PortStorageCompatibilityError::ReplaceUnsupported);
+            }
+        }
+        OutputConstruction::ReadModifyWrite { .. } => {
+            require_readable(storage)?;
+            require_writable(storage)?;
+            if !storage.access.region_mutable {
+                return Err(PortStorageCompatibilityError::RegionMutationUnsupported);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn check_semantic_addressing(
+    contract: &ResolvedTypeMemoryContract,
+    requirement: AddressingRequirement,
+) -> Result<(), PortStorageCompatibilityError> {
+    let available = contract.addressing;
+    let supported = match requirement {
+        AddressingRequirement::WholeValue => true,
+        AddressingRequirement::Positional { minimum_rank } => {
+            matches!(available.positional_rank, Some(rank) if rank >= minimum_rank)
+        }
+        AddressingRequirement::CollectionEntry => {
+            matches!(available.positional_rank, Some(1..))
+                || available.named_members
+                || available.keyed_members
+        }
+        AddressingRequirement::ArbitraryRegion => {
+            available.positional_rank.is_some()
+                || available.named_members
+                || available.keyed_members
+        }
+    };
+    if supported {
+        Ok(())
+    } else {
+        Err(
+            PortStorageCompatibilityError::SemanticAddressingUnsupported {
+                required: requirement,
+                available,
+            },
+        )
+    }
+}
+
+fn check_storage_addressing(
+    requirement: AddressingRequirement,
+    storage: &StorageCapabilityDescriptor,
+) -> Result<(), PortStorageCompatibilityError> {
+    match requirement {
+        AddressingRequirement::WholeValue if !storage.addressing.whole_value => {
+            Err(PortStorageCompatibilityError::WholeValueAddressingUnsupported)
+        }
+        AddressingRequirement::Positional { minimum_rank } => {
+            let available = storage.addressing.positional;
+            if matches!(available, PositionalAddressingCapability::AnyRank)
+                || matches!(available, PositionalAddressingCapability::Rank(rank) if rank >= minimum_rank)
+            {
+                Ok(())
+            } else {
+                Err(
+                    PortStorageCompatibilityError::PositionalAddressingUnsupported {
+                        minimum_rank,
+                        available,
+                    },
+                )
+            }
+        }
+        AddressingRequirement::CollectionEntry => {
+            let positional = matches!(
+                storage.addressing.positional,
+                PositionalAddressingCapability::AnyRank | PositionalAddressingCapability::Rank(1..)
+            );
+            if positional || storage.addressing.named_members || storage.addressing.keyed_members {
+                Ok(())
+            } else {
+                Err(PortStorageCompatibilityError::CollectionEntryAddressingUnsupported)
+            }
+        }
+        AddressingRequirement::ArbitraryRegion if !storage.addressing.arbitrary_regions => {
+            Err(PortStorageCompatibilityError::ArbitraryRegionUnsupported)
+        }
+        AddressingRequirement::WholeValue | AddressingRequirement::ArbitraryRegion => Ok(()),
+    }
+}
+
+fn check_publication(
+    requirement: PublicationRequirement,
+    storage: &StorageCapabilityDescriptor,
+) -> Result<(), PortStorageCompatibilityError> {
+    if requirement == PublicationRequirement::None {
+        return Ok(());
+    }
+    if !storage.publication.atomic_replace {
+        return Err(PortStorageCompatibilityError::AtomicPublicationUnsupported);
+    }
+    if !storage.publication.preserves_previous_on_failure {
+        return Err(PortStorageCompatibilityError::FailureAtomicityUnsupported);
+    }
+    Ok(())
+}
+
+fn check_change_detection(
+    contract: &ResolvedTypeMemoryContract,
+    policy: Option<ChangeDetectionPolicy>,
+    storage: &StorageCapabilityDescriptor,
+) -> Result<(), PortStorageCompatibilityError> {
+    match policy {
+        None
+        | Some(ChangeDetectionPolicy::KernelReported | ChangeDetectionPolicy::AlwaysChanged) => {
+            Ok(())
+        }
+        Some(ChangeDetectionPolicy::SemanticHash) => {
+            require_readable(storage)?;
+            if storage.access.canonical_snapshot {
+                Ok(())
+            } else {
+                Err(PortStorageCompatibilityError::CanonicalSnapshotUnsupported)
+            }
+        }
+        Some(ChangeDetectionPolicy::ExactScalar) => {
+            if !matches!(contract.topology, MemoryTopology::Scalar(_)) {
+                return Err(
+                    PortStorageCompatibilityError::ExactScalarChangeDetectionRequiresScalar,
+                );
+            }
+            require_readable(storage)?;
+            if storage.access.canonical_snapshot {
+                Ok(())
+            } else {
+                Err(PortStorageCompatibilityError::CanonicalSnapshotUnsupported)
+            }
+        }
+    }
+}
+
+pub fn check_port_storage_compatibility(
+    schema: &Schema,
+    shape: &ShapeInstance,
+    requirement: &PortMemoryRequirement,
+    storage: &StorageCapabilityDescriptor,
+) -> Result<(), PortStorageCompatibilityError> {
+    let contract = schema
+        .resolved_type_memory_contract(shape)
+        .map_err(|error| {
+            PortStorageCompatibilityError::SchemaStorage(SchemaStorageCompatibilityError::Semantic(
+                error,
+            ))
+        })?;
+    crate::check_resolved_type_storage_compatibility(schema.body(), &contract, storage).map_err(
+        |error| {
+            PortStorageCompatibilityError::SchemaStorage(SchemaStorageCompatibilityError::Storage(
+                error,
+            ))
+        },
+    )?;
+    check_semantic_addressing(&contract, requirement.addressing)?;
+    check_access(requirement.access, storage)?;
+    check_ownership(requirement.ownership, storage)?;
+    check_construction(requirement.construction.as_ref(), storage)?;
+    check_storage_addressing(requirement.addressing, storage)?;
+    check_publication(requirement.publication, storage)?;
+    check_change_detection(&contract, requirement.change_detection, storage)
 }
 
 impl OperationContractDeclaration {

--- a/src/core/src/memory_contract/operation_requirement.rs
+++ b/src/core/src/memory_contract/operation_requirement.rs
@@ -1,0 +1,155 @@
+//! Memory-facing requirements derived from declared operation ports.
+
+use crate::{
+    AccessMode, AliasPolicy, ChangeDetectionPolicy, DeliveryMode, InputPortPolicy,
+    OperationContractDeclaration, OperationContractError, OutputConstruction, OutputPortPolicy,
+    RegionPolicy,
+};
+
+#[cfg(feature = "no_std")]
+use alloc::{boxed::Box, vec::Vec};
+#[cfg(not(feature = "no_std"))]
+use std::{boxed::Box, vec::Vec};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OwnershipRequirement {
+    SharedRead,
+    ExclusiveWrite,
+    OwnedValue,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AddressingRequirement {
+    WholeValue,
+    Positional { minimum_rank: u64 },
+    CollectionEntry,
+    ArbitraryRegion,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PublicationRequirement {
+    None,
+    AtomicReplace,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PortMemoryRequirement {
+    pub access: AccessMode,
+    pub delivery: DeliveryMode,
+    pub ownership: OwnershipRequirement,
+    pub construction: Option<OutputConstruction>,
+    pub addressing: AddressingRequirement,
+    pub alias: Option<AliasPolicy>,
+    pub publication: PublicationRequirement,
+    pub change_detection: Option<ChangeDetectionPolicy>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OperationMemoryRequirements {
+    pub inputs: Box<[PortMemoryRequirement]>,
+    pub outputs: Box<[PortMemoryRequirement]>,
+}
+
+impl OwnershipRequirement {
+    fn from_access(access: AccessMode) -> Self {
+        match access {
+            AccessMode::Read => Self::SharedRead,
+            AccessMode::Write | AccessMode::ReadWrite => Self::ExclusiveWrite,
+            AccessMode::Consume => Self::OwnedValue,
+        }
+    }
+}
+
+impl PortMemoryRequirement {
+    pub fn for_input(policy: InputPortPolicy) -> Self {
+        Self {
+            access: policy.access,
+            delivery: policy.delivery,
+            ownership: OwnershipRequirement::from_access(policy.access),
+            construction: None,
+            addressing: AddressingRequirement::WholeValue,
+            alias: None,
+            publication: PublicationRequirement::None,
+            change_detection: None,
+        }
+    }
+
+    pub fn for_output(policy: &OutputPortPolicy) -> Result<Self, OperationContractError> {
+        let addressing = match &policy.construction {
+            OutputConstruction::FullWrite { .. }
+            | OutputConstruction::Replace { .. }
+            | OutputConstruction::Build { .. }
+            | OutputConstruction::ReadModifyWrite {
+                regions: RegionPolicy::WholeValue,
+                ..
+            } => AddressingRequirement::WholeValue,
+            OutputConstruction::ReadModifyWrite {
+                regions: RegionPolicy::IndexedAxis { axis },
+                ..
+            } => {
+                let axis = u64::try_from(*axis).map_err(|_| {
+                    OperationContractError::InvalidCanonicalEncoding {
+                        reason: "indexed-axis rank conversion overflow",
+                    }
+                })?;
+                AddressingRequirement::Positional {
+                    minimum_rank: axis.checked_add(1).ok_or(
+                        OperationContractError::InvalidCanonicalEncoding {
+                            reason: "indexed-axis rank addition overflow",
+                        },
+                    )?,
+                }
+            }
+            OutputConstruction::ReadModifyWrite {
+                regions: RegionPolicy::SingleElement | RegionPolicy::ContiguousRange,
+                ..
+            } => AddressingRequirement::Positional { minimum_rank: 1 },
+            OutputConstruction::ReadModifyWrite {
+                regions: RegionPolicy::RectangularRegion,
+                ..
+            } => AddressingRequirement::Positional { minimum_rank: 2 },
+            OutputConstruction::ReadModifyWrite {
+                regions: RegionPolicy::CollectionEntry,
+                ..
+            } => AddressingRequirement::CollectionEntry,
+            OutputConstruction::ReadModifyWrite {
+                regions: RegionPolicy::Arbitrary,
+                ..
+            } => AddressingRequirement::ArbitraryRegion,
+        };
+
+        Ok(Self {
+            access: policy.access,
+            delivery: policy.delivery,
+            ownership: OwnershipRequirement::from_access(policy.access),
+            construction: Some(policy.construction.clone()),
+            addressing,
+            alias: Some(policy.alias),
+            publication: PublicationRequirement::AtomicReplace,
+            change_detection: Some(policy.change_detection),
+        })
+    }
+}
+
+impl OperationContractDeclaration {
+    pub fn memory_requirements(
+        &self,
+        input_count: usize,
+    ) -> Result<OperationMemoryRequirements, OperationContractError> {
+        let inputs = self
+            .inputs
+            .resolve(input_count)?
+            .iter()
+            .copied()
+            .map(PortMemoryRequirement::for_input)
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        let outputs = self
+            .outputs
+            .iter()
+            .map(PortMemoryRequirement::for_output)
+            .collect::<Result<Vec<_>, _>>()?
+            .into_boxed_slice();
+        Ok(OperationMemoryRequirements { inputs, outputs })
+    }
+}

--- a/src/core/tests/operation_memory_requirement.rs
+++ b/src/core/tests/operation_memory_requirement.rs
@@ -1,0 +1,1100 @@
+#![cfg(feature = "full")]
+
+use mech_core::*;
+use nalgebra::RowDVector;
+
+fn schema_shape(body: SchemaBody) -> (Schema, ShapeInstance) {
+    let schema = SchemaDraft {
+        dimension_parameters: Box::new([]),
+        body,
+    }
+    .finalize()
+    .unwrap();
+    let shape = schema.instantiate_shape(Box::new([])).unwrap();
+    (schema, shape)
+}
+
+fn f64_schema_shape() -> (Schema, ShapeInstance) {
+    schema_shape(SchemaBody::FloatingPoint(FloatWidth::W64))
+}
+
+fn string_schema_shape() -> (Schema, ShapeInstance) {
+    schema_shape(SchemaBody::String)
+}
+
+fn tuple_schema_shape() -> (Schema, ShapeInstance) {
+    schema_shape(SchemaBody::Tuple(
+        vec![SchemaBody::FloatingPoint(FloatWidth::W64)].into_boxed_slice(),
+    ))
+}
+
+fn record_schema_shape() -> (Schema, ShapeInstance) {
+    schema_shape(SchemaBody::Record(
+        vec![SchemaField {
+            name: "value".to_owned(),
+            schema: SchemaBody::FloatingPoint(FloatWidth::W64),
+        }]
+        .into_boxed_slice(),
+    ))
+}
+
+fn set_schema_shape() -> (Schema, ShapeInstance) {
+    schema_shape(SchemaBody::Set {
+        element: Box::new(SchemaBody::FloatingPoint(FloatWidth::W64)),
+        cardinality: DimensionExpr::Constant(1).into(),
+    })
+}
+
+fn table_schema_shape() -> (Schema, ShapeInstance) {
+    schema_shape(SchemaBody::Table {
+        columns: vec![SchemaField {
+            name: "value".to_owned(),
+            schema: SchemaBody::FloatingPoint(FloatWidth::W64),
+        }]
+        .into_boxed_slice(),
+        rows: DimensionExpr::Constant(1).into(),
+    })
+}
+
+fn map_schema_shape() -> (Schema, ShapeInstance) {
+    schema_shape(SchemaBody::Map {
+        key: Box::new(SchemaBody::String),
+        value: Box::new(SchemaBody::FloatingPoint(FloatWidth::W64)),
+        cardinality: DimensionExpr::Constant(1).into(),
+    })
+}
+
+fn matrix_schema_shape(rows: u64, columns: u64) -> (Schema, ShapeInstance) {
+    schema_shape(SchemaBody::Matrix {
+        element: Box::new(SchemaBody::FloatingPoint(FloatWidth::W64)),
+        dimensions: vec![
+            DimensionExpr::Constant(rows),
+            DimensionExpr::Constant(columns),
+        ]
+        .into_boxed_slice(),
+    })
+}
+
+fn universal_storage() -> StorageCapabilityDescriptor {
+    ValueCell::unit().storage_capabilities()
+}
+
+fn input_policy(access: AccessMode, delivery: DeliveryMode) -> InputPortPolicy {
+    InputPortPolicy { access, delivery }
+}
+
+fn shape_contract() -> ShapeContractReference {
+    ShapeContractReference {
+        module_path: vec!["tests".to_string()].into_boxed_slice(),
+        contract_name: "shape".to_string(),
+    }
+}
+
+fn output_policy(
+    access: AccessMode,
+    delivery: DeliveryMode,
+    construction: OutputConstruction,
+    alias: AliasPolicy,
+    change_detection: ChangeDetectionPolicy,
+) -> OutputPortPolicy {
+    OutputPortPolicy {
+        access,
+        delivery,
+        construction,
+        alias,
+        change_detection,
+    }
+}
+
+fn full_output(alias: AliasPolicy) -> OutputPortPolicy {
+    output_policy(
+        AccessMode::Write,
+        DeliveryMode::Signal,
+        OutputConstruction::FullWrite {
+            shape: ShapeRule::Declared,
+        },
+        alias,
+        ChangeDetectionPolicy::KernelReported,
+    )
+}
+
+fn declaration(
+    inputs: Vec<InputPortPolicy>,
+    outputs: Vec<OutputPortPolicy>,
+) -> OperationContractDeclaration {
+    OperationContractDeclaration {
+        inputs: InputPortLayout::Fixed(inputs.into_boxed_slice()),
+        outputs: outputs.into_boxed_slice(),
+        interaction: ExternalInteraction::Pure,
+    }
+}
+
+fn requirement(
+    access: AccessMode,
+    ownership: OwnershipRequirement,
+    construction: Option<OutputConstruction>,
+    addressing: AddressingRequirement,
+    publication: PublicationRequirement,
+    change_detection: Option<ChangeDetectionPolicy>,
+) -> PortMemoryRequirement {
+    PortMemoryRequirement {
+        access,
+        delivery: DeliveryMode::Signal,
+        ownership,
+        construction,
+        addressing,
+        alias: None,
+        publication,
+        change_detection,
+    }
+}
+
+fn read_requirement() -> PortMemoryRequirement {
+    requirement(
+        AccessMode::Read,
+        OwnershipRequirement::SharedRead,
+        None,
+        AddressingRequirement::WholeValue,
+        PublicationRequirement::None,
+        None,
+    )
+}
+
+fn write_requirement(construction: OutputConstruction) -> PortMemoryRequirement {
+    requirement(
+        AccessMode::Write,
+        OwnershipRequirement::ExclusiveWrite,
+        Some(construction),
+        AddressingRequirement::WholeValue,
+        PublicationRequirement::AtomicReplace,
+        Some(ChangeDetectionPolicy::KernelReported),
+    )
+}
+
+fn check(
+    schema: &Schema,
+    shape: &ShapeInstance,
+    requirement: &PortMemoryRequirement,
+    storage: &StorageCapabilityDescriptor,
+) -> Result<(), PortStorageCompatibilityError> {
+    check_port_storage_compatibility(schema, shape, requirement, storage)
+}
+
+fn semantic_addressing_error(
+    schema: &Schema,
+    shape: &ShapeInstance,
+    required: AddressingRequirement,
+) -> PortStorageCompatibilityError {
+    PortStorageCompatibilityError::SemanticAddressingUnsupported {
+        required,
+        available: schema
+            .resolved_type_memory_contract(shape)
+            .unwrap()
+            .addressing,
+    }
+}
+
+#[test]
+fn input_derivation_preserves_access_delivery_and_ownership() {
+    for (access, ownership) in [
+        (AccessMode::Read, OwnershipRequirement::SharedRead),
+        (AccessMode::Write, OwnershipRequirement::ExclusiveWrite),
+        (AccessMode::ReadWrite, OwnershipRequirement::ExclusiveWrite),
+        (AccessMode::Consume, OwnershipRequirement::OwnedValue),
+    ] {
+        for delivery in [
+            DeliveryMode::Signal,
+            DeliveryMode::Stream,
+            DeliveryMode::Future,
+        ] {
+            assert_eq!(
+                PortMemoryRequirement::for_input(input_policy(access, delivery)),
+                PortMemoryRequirement {
+                    access,
+                    delivery,
+                    ownership,
+                    construction: None,
+                    addressing: AddressingRequirement::WholeValue,
+                    alias: None,
+                    publication: PublicationRequirement::None,
+                    change_detection: None,
+                }
+            );
+        }
+    }
+}
+
+#[test]
+fn output_derivation_preserves_declared_policy_and_maps_every_construction() {
+    let cases = [
+        (
+            OutputConstruction::FullWrite {
+                shape: ShapeRule::Declared,
+            },
+            AddressingRequirement::WholeValue,
+        ),
+        (
+            OutputConstruction::Replace {
+                shape: ShapeRule::SameAsInput { input: 0 },
+            },
+            AddressingRequirement::WholeValue,
+        ),
+        (
+            OutputConstruction::Build {
+                postcondition: shape_contract(),
+            },
+            AddressingRequirement::WholeValue,
+        ),
+        (
+            OutputConstruction::ReadModifyWrite {
+                base_input: 0,
+                regions: RegionPolicy::WholeValue,
+            },
+            AddressingRequirement::WholeValue,
+        ),
+        (
+            OutputConstruction::ReadModifyWrite {
+                base_input: 0,
+                regions: RegionPolicy::IndexedAxis { axis: u16::MAX },
+            },
+            AddressingRequirement::Positional {
+                minimum_rank: u16::MAX as u64 + 1,
+            },
+        ),
+        (
+            OutputConstruction::ReadModifyWrite {
+                base_input: 0,
+                regions: RegionPolicy::SingleElement,
+            },
+            AddressingRequirement::Positional { minimum_rank: 1 },
+        ),
+        (
+            OutputConstruction::ReadModifyWrite {
+                base_input: 0,
+                regions: RegionPolicy::ContiguousRange,
+            },
+            AddressingRequirement::Positional { minimum_rank: 1 },
+        ),
+        (
+            OutputConstruction::ReadModifyWrite {
+                base_input: 0,
+                regions: RegionPolicy::RectangularRegion,
+            },
+            AddressingRequirement::Positional { minimum_rank: 2 },
+        ),
+        (
+            OutputConstruction::ReadModifyWrite {
+                base_input: 0,
+                regions: RegionPolicy::CollectionEntry,
+            },
+            AddressingRequirement::CollectionEntry,
+        ),
+        (
+            OutputConstruction::ReadModifyWrite {
+                base_input: 0,
+                regions: RegionPolicy::Arbitrary,
+            },
+            AddressingRequirement::ArbitraryRegion,
+        ),
+    ];
+
+    for (construction, addressing) in cases {
+        for access in [
+            AccessMode::Read,
+            AccessMode::Write,
+            AccessMode::ReadWrite,
+            AccessMode::Consume,
+        ] {
+            for delivery in [
+                DeliveryMode::Signal,
+                DeliveryMode::Stream,
+                DeliveryMode::Future,
+            ] {
+                let policy = output_policy(
+                    access,
+                    delivery,
+                    construction.clone(),
+                    AliasPolicy::MayAlias { input: 0 },
+                    ChangeDetectionPolicy::SemanticHash,
+                );
+                let derived = PortMemoryRequirement::for_output(&policy).unwrap();
+                assert_eq!(derived.access, access);
+                assert_eq!(derived.delivery, delivery);
+                assert_eq!(derived.construction, Some(construction.clone()));
+                assert_eq!(derived.addressing, addressing);
+                assert_eq!(derived.alias, Some(AliasPolicy::MayAlias { input: 0 }));
+                assert_eq!(derived.publication, PublicationRequirement::AtomicReplace);
+                assert_eq!(
+                    derived.change_detection,
+                    Some(ChangeDetectionPolicy::SemanticHash)
+                );
+            }
+        }
+    }
+
+    for alias in [
+        AliasPolicy::NoAlias,
+        AliasPolicy::MayAlias { input: 0 },
+        AliasPolicy::InPlaceRequired { input: 0 },
+    ] {
+        for change_detection in [
+            ChangeDetectionPolicy::KernelReported,
+            ChangeDetectionPolicy::ExactScalar,
+            ChangeDetectionPolicy::SemanticHash,
+            ChangeDetectionPolicy::AlwaysChanged,
+        ] {
+            let policy = output_policy(
+                AccessMode::Write,
+                DeliveryMode::Signal,
+                OutputConstruction::FullWrite {
+                    shape: ShapeRule::Declared,
+                },
+                alias,
+                change_detection,
+            );
+            let derived = PortMemoryRequirement::for_output(&policy).unwrap();
+            assert_eq!(derived.alias, Some(alias));
+            assert_eq!(derived.change_detection, Some(change_detection));
+        }
+    }
+}
+
+#[test]
+fn operation_derivation_uses_fixed_and_variadic_resolution_without_mutation() {
+    let fixed = declaration(
+        vec![input_policy(AccessMode::Read, DeliveryMode::Signal)],
+        vec![],
+    );
+    let before = fixed.clone();
+    assert_eq!(fixed.memory_requirements(1).unwrap().inputs.len(), 1);
+    assert_eq!(fixed, before);
+    assert_eq!(
+        fixed.memory_requirements(0),
+        Err(OperationContractError::PortCountMismatch {
+            direction: PortDirection::Input,
+            expected: 1,
+            actual: 0,
+        })
+    );
+
+    let variadic = OperationContractDeclaration {
+        inputs: InputPortLayout::Variadic {
+            prefix: vec![input_policy(AccessMode::Read, DeliveryMode::Signal)].into_boxed_slice(),
+            repeated: input_policy(AccessMode::Consume, DeliveryMode::Future),
+            min_repetitions: 2,
+        },
+        outputs: vec![full_output(AliasPolicy::NoAlias)].into_boxed_slice(),
+        interaction: ExternalInteraction::Observation(ObservationContract {
+            replay: ObservationReplayPolicy::CaptureAsInputFact,
+        }),
+    };
+    let derived = variadic.memory_requirements(3).unwrap();
+    assert_eq!(derived.inputs.len(), 3);
+    assert_eq!(
+        derived.inputs[0].ownership,
+        OwnershipRequirement::SharedRead
+    );
+    assert_eq!(
+        derived.inputs[1].ownership,
+        OwnershipRequirement::OwnedValue
+    );
+    assert_eq!(derived.inputs[2].delivery, DeliveryMode::Future);
+    assert_eq!(derived.outputs.len(), 1);
+    assert_eq!(
+        variadic.memory_requirements(2),
+        Err(OperationContractError::VariadicInputCount {
+            prefix: 1,
+            minimum_repetitions: 2,
+            actual: 2,
+        })
+    );
+
+    for outputs in 0..=2 {
+        assert_eq!(
+            declaration(vec![], vec![full_output(AliasPolicy::NoAlias); outputs])
+                .memory_requirements(0)
+                .unwrap()
+                .outputs
+                .len(),
+            outputs
+        );
+    }
+}
+
+#[test]
+fn port_checker_rejects_schema_storage_mismatch_before_port_rules() {
+    let (schema, shape) = f64_schema_shape();
+    let storage = ValueCell::from_exact(true).unwrap().storage_capabilities();
+    assert_eq!(
+        check(&schema, &shape, &read_requirement(), &storage),
+        Err(PortStorageCompatibilityError::SchemaStorage(
+            SchemaStorageCompatibilityError::Storage(StorageCompatibilityError::ScalarKindMismatch)
+        ))
+    );
+}
+
+#[test]
+fn port_access_and_ownership_capabilities_fail_independently() {
+    let (schema, shape) = f64_schema_shape();
+    let base = universal_storage();
+
+    let mut storage = base.clone();
+    storage.access.readable = false;
+    assert_eq!(
+        check(&schema, &shape, &read_requirement(), &storage),
+        Err(PortStorageCompatibilityError::ReadUnsupported)
+    );
+
+    let write = requirement(
+        AccessMode::Write,
+        OwnershipRequirement::ExclusiveWrite,
+        None,
+        AddressingRequirement::WholeValue,
+        PublicationRequirement::None,
+        None,
+    );
+    storage = base.clone();
+    storage.access.writable = false;
+    assert_eq!(
+        check(&schema, &shape, &write, &storage),
+        Err(PortStorageCompatibilityError::WriteUnsupported)
+    );
+
+    let read_write = requirement(
+        AccessMode::ReadWrite,
+        OwnershipRequirement::ExclusiveWrite,
+        None,
+        AddressingRequirement::WholeValue,
+        PublicationRequirement::None,
+        None,
+    );
+    storage = base.clone();
+    storage.access.readable = false;
+    assert_eq!(
+        check(&schema, &shape, &read_write, &storage),
+        Err(PortStorageCompatibilityError::ReadUnsupported)
+    );
+
+    let consume = requirement(
+        AccessMode::Consume,
+        OwnershipRequirement::OwnedValue,
+        None,
+        AddressingRequirement::WholeValue,
+        PublicationRequirement::None,
+        None,
+    );
+    storage = base.clone();
+    storage.access.readable = false;
+    assert_eq!(
+        check(&schema, &shape, &consume, &storage),
+        Err(PortStorageCompatibilityError::ReadUnsupported)
+    );
+
+    storage = base.clone();
+    storage.ownership.shared_read = false;
+    assert_eq!(
+        check(&schema, &shape, &read_requirement(), &storage),
+        Err(PortStorageCompatibilityError::SharedReadUnsupported)
+    );
+
+    storage = base.clone();
+    storage.ownership.exclusive_write = false;
+    assert_eq!(
+        check(&schema, &shape, &write, &storage),
+        Err(PortStorageCompatibilityError::ExclusiveWriteUnsupported)
+    );
+
+    storage = base.clone();
+    storage.ownership.owned_value = false;
+    storage.ownership.detachable = false;
+    assert_eq!(
+        check(&schema, &shape, &consume, &storage),
+        Err(PortStorageCompatibilityError::OwnedValueUnsupported)
+    );
+    storage.ownership.detachable = true;
+    check(&schema, &shape, &consume, &storage).unwrap();
+}
+
+#[test]
+fn construction_addressing_and_publication_capabilities_are_explicit() {
+    let (scalar_schema, scalar_shape) = f64_schema_shape();
+    let base = universal_storage();
+    let constructions = [
+        OutputConstruction::FullWrite {
+            shape: ShapeRule::Declared,
+        },
+        OutputConstruction::Replace {
+            shape: ShapeRule::Declared,
+        },
+        OutputConstruction::Build {
+            postcondition: shape_contract(),
+        },
+        OutputConstruction::ReadModifyWrite {
+            base_input: 0,
+            regions: RegionPolicy::WholeValue,
+        },
+    ];
+    for construction in constructions {
+        let requirement = write_requirement(construction);
+        let mut storage = base.clone();
+        storage.access.replaceable = false;
+        assert_eq!(
+            check(&scalar_schema, &scalar_shape, &requirement, &storage),
+            Err(PortStorageCompatibilityError::ReplaceUnsupported)
+        );
+        check(&scalar_schema, &scalar_shape, &requirement, &base).unwrap();
+    }
+
+    let (string_schema, string_shape) = string_schema_shape();
+    let regional = requirement(
+        AccessMode::ReadWrite,
+        OwnershipRequirement::ExclusiveWrite,
+        Some(OutputConstruction::ReadModifyWrite {
+            base_input: 0,
+            regions: RegionPolicy::SingleElement,
+        }),
+        AddressingRequirement::Positional { minimum_rank: 1 },
+        PublicationRequirement::AtomicReplace,
+        Some(ChangeDetectionPolicy::KernelReported),
+    );
+    let mut storage = base.clone();
+    storage.access.region_mutable = false;
+    assert_eq!(
+        check(&string_schema, &string_shape, &regional, &storage),
+        Err(PortStorageCompatibilityError::RegionMutationUnsupported)
+    );
+    check(&string_schema, &string_shape, &regional, &base).unwrap();
+
+    let whole = read_requirement();
+    storage = base.clone();
+    storage.addressing.whole_value = false;
+    assert_eq!(
+        check(&scalar_schema, &scalar_shape, &whole, &storage),
+        Err(PortStorageCompatibilityError::WholeValueAddressingUnsupported)
+    );
+
+    let positional_one = requirement(
+        AccessMode::Read,
+        OwnershipRequirement::SharedRead,
+        None,
+        AddressingRequirement::Positional { minimum_rank: 1 },
+        PublicationRequirement::None,
+        None,
+    );
+    storage = base.clone();
+    storage.addressing.positional = PositionalAddressingCapability::None;
+    assert_eq!(
+        check(&string_schema, &string_shape, &positional_one, &storage),
+        Err(PortStorageCompatibilityError::SchemaStorage(
+            SchemaStorageCompatibilityError::Storage(
+                StorageCompatibilityError::PositionalAddressingUnsupported
+            )
+        ))
+    );
+    storage.addressing.positional = PositionalAddressingCapability::Rank(1);
+    check(&string_schema, &string_shape, &positional_one, &storage).unwrap();
+
+    let (matrix_schema, matrix_shape) = matrix_schema_shape(2, 2);
+    let positional_two = PortMemoryRequirement {
+        addressing: AddressingRequirement::Positional { minimum_rank: 2 },
+        ..positional_one.clone()
+    };
+    assert_eq!(
+        check(&matrix_schema, &matrix_shape, &positional_two, &storage),
+        Err(PortStorageCompatibilityError::SchemaStorage(
+            SchemaStorageCompatibilityError::Storage(
+                StorageCompatibilityError::PositionalAddressingUnsupported
+            )
+        ))
+    );
+    storage.addressing.positional = PositionalAddressingCapability::Rank(2);
+    check(&matrix_schema, &matrix_shape, &positional_two, &storage).unwrap();
+    storage.addressing.positional = PositionalAddressingCapability::AnyRank;
+    check(&matrix_schema, &matrix_shape, &positional_two, &storage).unwrap();
+
+    let arbitrary = PortMemoryRequirement {
+        addressing: AddressingRequirement::ArbitraryRegion,
+        ..positional_one
+    };
+    storage = base.clone();
+    storage.addressing.arbitrary_regions = false;
+    assert_eq!(
+        check(&string_schema, &string_shape, &arbitrary, &storage),
+        Err(PortStorageCompatibilityError::ArbitraryRegionUnsupported)
+    );
+    check(&string_schema, &string_shape, &arbitrary, &base).unwrap();
+
+    let publication = write_requirement(OutputConstruction::FullWrite {
+        shape: ShapeRule::Declared,
+    });
+    storage = base.clone();
+    storage.publication.atomic_replace = false;
+    assert_eq!(
+        check(&scalar_schema, &scalar_shape, &publication, &storage),
+        Err(PortStorageCompatibilityError::AtomicPublicationUnsupported)
+    );
+    storage = base.clone();
+    storage.publication.preserves_previous_on_failure = false;
+    assert_eq!(
+        check(&scalar_schema, &scalar_shape, &publication, &storage),
+        Err(PortStorageCompatibilityError::FailureAtomicityUnsupported)
+    );
+}
+
+#[test]
+fn collection_entry_accepts_positional_named_or_keyed_addressing() {
+    let requirement = requirement(
+        AccessMode::Read,
+        OwnershipRequirement::SharedRead,
+        None,
+        AddressingRequirement::CollectionEntry,
+        PublicationRequirement::None,
+        None,
+    );
+    let mut empty = universal_storage();
+    empty.addressing.positional = PositionalAddressingCapability::None;
+    empty.addressing.named_members = false;
+    empty.addressing.keyed_members = false;
+    let (tuple_schema, tuple_shape) = tuple_schema_shape();
+    assert_eq!(
+        check(&tuple_schema, &tuple_shape, &requirement, &empty),
+        Err(PortStorageCompatibilityError::SchemaStorage(
+            SchemaStorageCompatibilityError::Storage(
+                StorageCompatibilityError::PositionalAddressingUnsupported
+            )
+        ))
+    );
+
+    let mut positional = empty.clone();
+    positional.addressing.positional = PositionalAddressingCapability::Rank(0);
+    assert_eq!(
+        check(&tuple_schema, &tuple_shape, &requirement, &positional),
+        Err(PortStorageCompatibilityError::SchemaStorage(
+            SchemaStorageCompatibilityError::Storage(
+                StorageCompatibilityError::PositionalAddressingUnsupported
+            )
+        ))
+    );
+    positional.addressing.positional = PositionalAddressingCapability::Rank(1);
+    check(&tuple_schema, &tuple_shape, &requirement, &positional).unwrap();
+    positional.addressing.positional = PositionalAddressingCapability::AnyRank;
+    check(&tuple_schema, &tuple_shape, &requirement, &positional).unwrap();
+
+    let (record_schema, record_shape) = record_schema_shape();
+    let mut named = empty.clone();
+    named.addressing.named_members = true;
+    check(&record_schema, &record_shape, &requirement, &named).unwrap();
+
+    let (set_schema, set_shape) = set_schema_shape();
+    let mut keyed = empty;
+    keyed.addressing.keyed_members = true;
+    check(&set_schema, &set_shape, &requirement, &keyed).unwrap();
+}
+
+#[test]
+fn semantic_addressing_completes_the_type_port_storage_triangle() {
+    let storage = universal_storage();
+    let positional_one = requirement(
+        AccessMode::Read,
+        OwnershipRequirement::SharedRead,
+        None,
+        AddressingRequirement::Positional { minimum_rank: 1 },
+        PublicationRequirement::None,
+        None,
+    );
+    let positional_two = PortMemoryRequirement {
+        addressing: AddressingRequirement::Positional { minimum_rank: 2 },
+        ..positional_one.clone()
+    };
+    let collection = PortMemoryRequirement {
+        addressing: AddressingRequirement::CollectionEntry,
+        ..positional_one.clone()
+    };
+    let arbitrary = PortMemoryRequirement {
+        addressing: AddressingRequirement::ArbitraryRegion,
+        ..positional_one.clone()
+    };
+
+    let (string_schema, string_shape) = string_schema_shape();
+    check(&string_schema, &string_shape, &positional_one, &storage).unwrap();
+    check(&string_schema, &string_shape, &arbitrary, &storage).unwrap();
+
+    let (matrix_schema, matrix_shape) = matrix_schema_shape(2, 3);
+    check(&matrix_schema, &matrix_shape, &positional_two, &storage).unwrap();
+    check(&matrix_schema, &matrix_shape, &arbitrary, &storage).unwrap();
+
+    for (schema, shape) in [
+        tuple_schema_shape(),
+        record_schema_shape(),
+        table_schema_shape(),
+        set_schema_shape(),
+        map_schema_shape(),
+    ] {
+        check(&schema, &shape, &collection, &storage).unwrap();
+    }
+
+    let (table_schema, table_shape) = table_schema_shape();
+    check(&table_schema, &table_shape, &positional_two, &storage).unwrap();
+
+    let (scalar_schema, scalar_shape) = f64_schema_shape();
+    for required in [
+        AddressingRequirement::Positional { minimum_rank: 1 },
+        AddressingRequirement::CollectionEntry,
+        AddressingRequirement::ArbitraryRegion,
+    ] {
+        let port = PortMemoryRequirement {
+            addressing: required,
+            ..read_requirement()
+        };
+        assert_eq!(
+            check(&scalar_schema, &scalar_shape, &port, &storage),
+            Err(semantic_addressing_error(
+                &scalar_schema,
+                &scalar_shape,
+                required,
+            ))
+        );
+    }
+
+    let (record_schema, record_shape) = record_schema_shape();
+    assert_eq!(
+        check(&record_schema, &record_shape, &positional_one, &storage,),
+        Err(semantic_addressing_error(
+            &record_schema,
+            &record_shape,
+            positional_one.addressing,
+        ))
+    );
+
+    let (dynamic_schema, dynamic_shape) = schema_shape(SchemaBody::Dynamic);
+    assert_eq!(
+        check(&dynamic_schema, &dynamic_shape, &arbitrary, &storage,),
+        Err(semantic_addressing_error(
+            &dynamic_schema,
+            &dynamic_shape,
+            arbitrary.addressing,
+        ))
+    );
+
+    let (tuple_schema, tuple_shape) = tuple_schema_shape();
+    let mut keyed_only = storage;
+    keyed_only.addressing.positional = PositionalAddressingCapability::None;
+    keyed_only.addressing.named_members = false;
+    keyed_only.addressing.keyed_members = true;
+    assert_eq!(
+        check(&tuple_schema, &tuple_shape, &collection, &keyed_only),
+        Err(PortStorageCompatibilityError::SchemaStorage(
+            SchemaStorageCompatibilityError::Storage(
+                StorageCompatibilityError::PositionalAddressingUnsupported
+            )
+        ))
+    );
+}
+
+#[test]
+fn change_detection_uses_semantic_topology_and_canonical_snapshots() {
+    let (scalar_schema, scalar_shape) = f64_schema_shape();
+    let (matrix_schema, matrix_shape) = matrix_schema_shape(2, 2);
+    let mut storage = universal_storage();
+
+    let semantic_hash = requirement(
+        AccessMode::Write,
+        OwnershipRequirement::ExclusiveWrite,
+        None,
+        AddressingRequirement::WholeValue,
+        PublicationRequirement::None,
+        Some(ChangeDetectionPolicy::SemanticHash),
+    );
+    storage.access.canonical_snapshot = false;
+    assert_eq!(
+        check(&scalar_schema, &scalar_shape, &semantic_hash, &storage),
+        Err(PortStorageCompatibilityError::CanonicalSnapshotUnsupported)
+    );
+    check(
+        &scalar_schema,
+        &scalar_shape,
+        &semantic_hash,
+        &universal_storage(),
+    )
+    .unwrap();
+
+    storage = universal_storage();
+    let exact_scalar = PortMemoryRequirement {
+        change_detection: Some(ChangeDetectionPolicy::ExactScalar),
+        ..semantic_hash.clone()
+    };
+    assert_eq!(
+        check(&matrix_schema, &matrix_shape, &exact_scalar, &storage),
+        Err(PortStorageCompatibilityError::ExactScalarChangeDetectionRequiresScalar)
+    );
+    check(&scalar_schema, &scalar_shape, &exact_scalar, &storage).unwrap();
+    check(
+        &scalar_schema,
+        &scalar_shape,
+        &exact_scalar,
+        &ValueCell::from_exact(1_f64).unwrap().storage_capabilities(),
+    )
+    .unwrap();
+
+    for policy in [
+        ChangeDetectionPolicy::KernelReported,
+        ChangeDetectionPolicy::AlwaysChanged,
+    ] {
+        let no_extra_requirement = PortMemoryRequirement {
+            change_detection: Some(policy),
+            ..semantic_hash.clone()
+        };
+        storage.access.canonical_snapshot = false;
+        check(
+            &scalar_schema,
+            &scalar_shape,
+            &no_extra_requirement,
+            &storage,
+        )
+        .unwrap();
+    }
+
+    for delivery in [
+        DeliveryMode::Signal,
+        DeliveryMode::Stream,
+        DeliveryMode::Future,
+    ] {
+        let delivered = PortMemoryRequirement {
+            delivery,
+            ..read_requirement()
+        };
+        check(
+            &scalar_schema,
+            &scalar_shape,
+            &delivered,
+            &universal_storage(),
+        )
+        .unwrap();
+    }
+}
+
+fn invocation_reason(
+    invocation: &FunctionInvocation,
+    declaration: &OperationContractDeclaration,
+) -> FunctionMemoryContractViolationReason {
+    invocation
+        .check_operation_memory_contract(declaration)
+        .unwrap_err()
+        .kind_as::<FunctionMemoryContractViolation>()
+        .expect("operation-memory errors remain structured")
+        .reason
+        .clone()
+}
+
+#[test]
+fn invocation_validates_ports_and_current_output_bridge() {
+    let input = ValueCell::from_exact(1_f64).unwrap();
+    let output = ValueCell::from_exact(0_f64).unwrap();
+    let invocation = FunctionInvocation::unary(output.clone(), input.clone());
+    let one_output = declaration(
+        vec![input_policy(AccessMode::Read, DeliveryMode::Signal)],
+        vec![full_output(AliasPolicy::NoAlias)],
+    );
+    invocation
+        .check_operation_memory_contract(&one_output)
+        .unwrap();
+
+    let zero_outputs = declaration(vec![], vec![]);
+    FunctionInvocation::nullary(ValueCell::unit())
+        .check_operation_memory_contract(&zero_outputs)
+        .unwrap();
+    assert_eq!(
+        invocation_reason(
+            &FunctionInvocation::nullary(ValueCell::from_exact(0_f64).unwrap()),
+            &zero_outputs,
+        ),
+        FunctionMemoryContractViolationReason::ZeroOutputBridgeIsNotUnit
+    );
+
+    let multiple_outputs = declaration(
+        vec![],
+        vec![
+            full_output(AliasPolicy::NoAlias),
+            full_output(AliasPolicy::NoAlias),
+        ],
+    );
+    assert_eq!(
+        invocation_reason(
+            &FunctionInvocation::nullary(ValueCell::from_exact(0_f64).unwrap()),
+            &multiple_outputs,
+        ),
+        FunctionMemoryContractViolationReason::MultipleSemanticOutputsUnsupported { outputs: 2 }
+    );
+
+    let wrong_arity = declaration(
+        vec![input_policy(AccessMode::Read, DeliveryMode::Signal)],
+        vec![],
+    );
+    assert!(matches!(
+        invocation_reason(
+            &FunctionInvocation::nullary(ValueCell::unit()),
+            &wrong_arity,
+        ),
+        FunctionMemoryContractViolationReason::OperationContractDerivation {
+            error: OperationContractError::PortCountMismatch { .. }
+        }
+    ));
+
+    assert!(input.snapshot_eq(&invocation.input_cells()[0]).unwrap());
+    assert!(output.snapshot_eq(invocation.output_cell()).unwrap());
+}
+
+#[test]
+fn invocation_port_failures_remain_structured_and_vector_mismatch_stays_shadow_only() {
+    let row = ValueCell::from_exact(RowDVector::<f64>::zeros(3)).unwrap();
+    let scalar = ValueCell::from_exact(0_f64).unwrap();
+    let declaration = declaration(
+        vec![input_policy(AccessMode::Read, DeliveryMode::Signal)],
+        vec![full_output(AliasPolicy::NoAlias)],
+    );
+    assert!(matches!(
+        invocation_reason(
+            &FunctionInvocation::unary(scalar.clone(), row.clone()),
+            &declaration,
+        ),
+        FunctionMemoryContractViolationReason::InputPort {
+            index: 0,
+            error: PortStorageCompatibilityError::SchemaStorage(
+                SchemaStorageCompatibilityError::Storage(
+                    StorageCompatibilityError::DynamicAxisUnsupported
+                )
+            )
+        }
+    ));
+    assert!(matches!(
+        invocation_reason(&FunctionInvocation::unary(row, scalar), &declaration,),
+        FunctionMemoryContractViolationReason::OutputPort {
+            error: PortStorageCompatibilityError::SchemaStorage(
+                SchemaStorageCompatibilityError::Storage(
+                    StorageCompatibilityError::DynamicAxisUnsupported
+                )
+            )
+        }
+    ));
+}
+
+#[test]
+fn invocation_alias_policies_use_physical_storage_groups() {
+    let policy = |alias| {
+        declaration(
+            vec![
+                input_policy(AccessMode::Read, DeliveryMode::Signal),
+                input_policy(AccessMode::Read, DeliveryMode::Signal),
+            ],
+            vec![full_output(alias)],
+        )
+    };
+
+    let first = ValueCell::from_exact(1_f64).unwrap();
+    let second = ValueCell::from_exact(2_f64).unwrap();
+    let independent = ValueCell::from_exact(0_f64).unwrap();
+    FunctionInvocation::binary(independent.clone(), first.clone(), second.clone())
+        .check_operation_memory_contract(&policy(AliasPolicy::NoAlias))
+        .unwrap();
+    assert_eq!(
+        invocation_reason(
+            &FunctionInvocation::binary(first.clone(), first.clone(), second.clone()),
+            &policy(AliasPolicy::NoAlias),
+        ),
+        FunctionMemoryContractViolationReason::NoAliasViolation { input: 0 }
+    );
+
+    FunctionInvocation::binary(independent, first.clone(), second.clone())
+        .check_operation_memory_contract(&policy(AliasPolicy::MayAlias { input: 0 }))
+        .unwrap();
+    FunctionInvocation::binary(first.clone(), first.clone(), second.clone())
+        .check_operation_memory_contract(&policy(AliasPolicy::MayAlias { input: 0 }))
+        .unwrap();
+
+    let same_group = first.clone();
+    FunctionInvocation::binary(same_group.clone(), first.clone(), same_group.clone())
+        .check_operation_memory_contract(&policy(AliasPolicy::MayAlias { input: 0 }))
+        .unwrap();
+
+    assert_eq!(
+        invocation_reason(
+            &FunctionInvocation::binary(second.clone(), first.clone(), second.clone()),
+            &policy(AliasPolicy::MayAlias { input: 0 }),
+        ),
+        FunctionMemoryContractViolationReason::MayAliasViolation {
+            declared_input: 0,
+            unrelated_input: 1,
+        }
+    );
+    assert_eq!(
+        invocation_reason(
+            &FunctionInvocation::binary(
+                ValueCell::from_exact(0_f64).unwrap(),
+                first.clone(),
+                second.clone(),
+            ),
+            &policy(AliasPolicy::MayAlias { input: 2 }),
+        ),
+        FunctionMemoryContractViolationReason::InvalidDeclaredAliasInput {
+            input: 2,
+            inputs: 2,
+        }
+    );
+
+    FunctionInvocation::binary(first.clone(), first.clone(), second.clone())
+        .check_operation_memory_contract(&policy(AliasPolicy::InPlaceRequired { input: 0 }))
+        .unwrap();
+    assert_eq!(
+        invocation_reason(
+            &FunctionInvocation::binary(ValueCell::from_exact(0_f64).unwrap(), first, second,),
+            &policy(AliasPolicy::InPlaceRequired { input: 0 }),
+        ),
+        FunctionMemoryContractViolationReason::InPlaceRequiredViolation { input: 0 }
+    );
+}
+
+#[test]
+fn failed_shadow_checks_do_not_mutate_cells() {
+    let input = ValueCell::from_exact(7_f64).unwrap();
+    let output = ValueCell::from_exact(3_f64).unwrap();
+    let before_input = input.detached_clone().unwrap();
+    let before_output = output.detached_clone().unwrap();
+    let before_input_shape = input.shape().clone();
+    let before_output_shape = output.shape().clone();
+    let invocation = FunctionInvocation::unary(output.clone(), input.clone());
+    let declaration = declaration(
+        vec![input_policy(AccessMode::Read, DeliveryMode::Signal)],
+        vec![full_output(AliasPolicy::InPlaceRequired { input: 0 })],
+    );
+
+    assert!(
+        invocation
+            .check_operation_memory_contract(&declaration)
+            .is_err()
+    );
+    assert!(input.snapshot_eq(&before_input).unwrap());
+    assert!(output.snapshot_eq(&before_output).unwrap());
+    assert_eq!(*input.shape(), before_input_shape);
+    assert_eq!(*output.shape(), before_output_shape);
+}
+
+#[test]
+fn r2c_types_are_derived_only_and_do_not_add_serialization() {
+    let source = include_str!("../src/memory_contract/operation_requirement.rs");
+    assert!(!source.contains("Serialize"));
+    assert!(!source.contains("Deserialize"));
+
+    let declaration = declaration(
+        vec![input_policy(AccessMode::Read, DeliveryMode::Signal)],
+        vec![full_output(AliasPolicy::NoAlias)],
+    );
+    let before = declaration.clone();
+    let first = declaration.memory_requirements(1).unwrap();
+    let second = declaration.memory_requirements(1).unwrap();
+    assert_eq!(first, second);
+    assert_eq!(declaration, before);
+
+    let operation_encoding = include_str!("../src/operation_contract/encoding.rs");
+    assert!(!operation_encoding.contains("OperationMemoryRequirements"));
+    assert!(!operation_encoding.contains("PortMemoryRequirement"));
+}


### PR DESCRIPTION
## Summary

- derive non-serialized operation-port memory requirements from the existing R1 `OperationContractDeclaration`, including fixed and variadic inputs
- check the complete semantic-type / operation-port / storage-capability compatibility triangle with structured semantic and backing errors
- add an opt-in, shadow-only `FunctionInvocation` check for the current output bridge and physical-storage alias policy
- prove derivation, semantic addressing, capability, alias, immutability, serialization, and boundary laws

## Stack

This is a draft stacked PR on #803 at exact R2B head `76ffd1acafc0d1273e2ba890a39833d585655438`. R1, R2A, and R2B remain unmerged by explicit direction. Review only the four-commit R2C diff; no R2D or R3 work is included.

## Boundaries

- shadow-only and opt-in; no call from production signature validation, factories, source specialization, Resident/GPU activation, or native planning
- external interaction and delivery-target availability remain outside generic storage requirements
- no wire-format, serialization, operation-contract encoding, artifact, ABI, runtime, engine, host, machine, workflow, roadmap, or package-version change
- R2B vector shadow mismatches remain explicit and are not promoted to policy
- exactly four commits, five changed files, 814 production additions

## Focused revision

The checker now resolves the R2A type-memory contract once and uses it for all three compatibility edges. Canonical `Value` storage remains mechanically universal but no longer authorizes positional, collection-entry, or regional access for a semantic type that does not expose that addressing form. `SemanticAddressingUnsupported` is distinct from the existing backing-capability errors, and exact-scalar change detection reuses the same resolved contract.

Positive addressing fixtures now use String, matrix, tuple, record, table, set, and map schemas. Negative tests prove that canonical backing cannot make F64 positional, collection-addressable, or region-addressable; that records are not positional; that Dynamic is not regional; and that keyed-only backing cannot substitute for tuple positional semantics.

## Validation at `ece67a7206d742801f28a4c59a7d94810d76b4ff`

Passed locally:

- formatting and diff checks
- complete `mech-core --all-features` suite: 215 library tests, 14 R2C integration tests, and all existing integration/doc tests
- bare core test profile
- workspace `no_std`, core Mika, and core Mika+serde compile/profile checks
- serialization and operation-contract encoding isolation guards
- four-commit, file-count, production-size, and allowed-surface checks

Passed remotely on the exact head:

- [normal CI: 21 jobs](https://github.com/mech-lang/mech/actions/runs/33709245443)
- [Full CI: 81 jobs](https://github.com/mech-lang/mech/actions/runs/33709254483)
