### PR TITLE
fix(ci): qualify complete Windows product build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,7 @@ jobs:
     needs: impact
     if: needs.impact.outputs.windows_canary_required == 'true'
     runs-on: windows-latest
-    timeout-minutes: 12
+    timeout-minutes: 45
     env:
       CARGO_TERM_COLOR: always
       CARGO_INCREMENTAL: 0
@@ -269,15 +269,28 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
       - name: Install Rust nightly-2026-03-03
-        run: rustup toolchain install nightly-2026-03-03 --profile minimal
-      - name: Build the standard Windows command and exercise a source path
+        run: |
+          rustup toolchain install nightly-2026-03-03 --profile minimal
+          rustup default nightly-2026-03-03
+          rustup target add wasm32-unknown-unknown
+      - name: Install wasm-pack v0.15.0
         shell: pwsh
         run: |
-          cargo +nightly-2026-03-03 build --locked --bin mech
+          $archive = Join-Path $env:RUNNER_TEMP "wasm-pack.tar.gz"
+          $install = Join-Path $env:RUNNER_TEMP "wasm-pack"
+          Invoke-WebRequest `
+            -Uri "https://github.com/wasm-bindgen/wasm-pack/releases/download/v0.15.0/wasm-pack-v0.15.0-x86_64-pc-windows-msvc.tar.gz" `
+            -OutFile $archive
+          New-Item -ItemType Directory -Force $install | Out-Null
+          tar.exe -xzf $archive -C $install --strip-components=1
+          Add-Content $env:GITHUB_PATH $install
+      - name: Build the complete Windows product and exercise a source path
+        shell: pwsh
+        run: |
+          ./scripts/build-mech.ps1
+          target/release/mech.exe --version | Select-String -SimpleMatch '(standard)'
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          target/debug/mech.exe --version | Select-String -SimpleMatch '(standard)'
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          target/debug/mech.exe run tests/fixtures/standard-resident-scalar.mec
+          target/release/mech.exe run tests/fixtures/standard-resident-scalar.mec
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
   browser-standard-canary:

--- a/scripts/check-interactive-architecture.py
+++ b/scripts/check-interactive-architecture.py
@@ -130,4 +130,17 @@ build_wasm = text("scripts/build-wasm.py")
 for profile in ("browser", "browser-compute", "browser-compute-canary"):
     if f'"{profile}"' not in build_wasm:
         fail(f"unified WASM builder is missing the `{profile}` profile")
+
+ci = text(".github/workflows/ci.yml")
+windows_job = re.search(
+    r"(?ms)^  standard-windows:\n(?P<body>.*?)(?=^  [a-z][a-z0-9-]*:\n)",
+    ci,
+)
+if windows_job is None:
+    fail("the required standard Windows job is missing")
+windows_body = windows_job.group("body")
+if "./scripts/build-mech.ps1" not in windows_body:
+    fail("the standard Windows gate must execute the complete product build script")
+if "target/release/mech.exe" not in windows_body:
+    fail("the standard Windows gate must exercise the release product artifact")
 print("interactive architecture contract passed")

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -10,10 +10,12 @@ use std::sync::{
 };
 use std::time::{Duration, Instant};
 
-use colored::*;
+use colored::{ColoredString, Colorize};
 use ignore::WalkBuilder;
 use mech_browser::BrowserRuntimeInjectionConfig;
-use mech_core::*;
+use mech_core::{
+    GenericError, MResult, MechError, MechErrorKind, MechSourceCode, compress_and_encode,
+};
 use mech_runtime::{
     DefaultIdGenerator, EventId, EventSink, FS_IMPORT, FS_LIST, FS_READ, FS_RESOLVE, FS_SERVE,
     FS_WATCH, HostFilesystemAuthority, ModuleBuildOptions, RuntimeConfig, RuntimeEvent,
@@ -27,7 +29,10 @@ use mech_syntax::{
 };
 use warp::Filter;
 
-use crate::*;
+use crate::{
+    HostAuthorityInjection, inject_browser_host_config_script,
+    inject_host_authority_injection_script,
+};
 
 const SERVER_SHUTDOWN_GRACE: Duration = Duration::from_secs(2);
 


### PR DESCRIPTION
Fix the Windows `build-mech.ps1` failure exposed after #811.

- replace overlapping glob imports in `serve.rs` with explicit dependencies
- make the required Windows canary execute `scripts/build-mech.ps1` itself
- exercise the resulting release executable and source path
- add a static architecture contract so the real product-build gate cannot be silently replaced

Verified locally with the complete macOS product analogue (`scripts/build-mech.sh`), release warnings-as-errors check, warning-policy contract, interactive architecture contract, workflow YAML parsing, formatter check, and resident source smoke test.